### PR TITLE
Render release notes as Markdown

### DIFF
--- a/crates/agent-gui/src/index.css
+++ b/crates/agent-gui/src/index.css
@@ -426,6 +426,37 @@
     margin-bottom: 0;
   }
 
+  .release-notes-markdown {
+    @apply text-xs leading-relaxed text-muted-foreground;
+  }
+  .release-notes-markdown p {
+    @apply my-2 text-xs leading-relaxed text-muted-foreground;
+  }
+  .release-notes-markdown [data-streamdown="heading-1"] {
+    @apply mb-2 mt-3 text-sm font-semibold text-foreground;
+  }
+  .release-notes-markdown [data-streamdown="heading-2"] {
+    @apply mb-2 mt-3 text-sm font-semibold text-foreground;
+  }
+  .release-notes-markdown [data-streamdown="heading-3"] {
+    @apply mb-1.5 mt-3 text-xs font-semibold text-foreground;
+  }
+  .release-notes-markdown [data-streamdown="unordered-list"] {
+    @apply my-2 ml-0 list-disc space-y-1 pl-5;
+  }
+  .release-notes-markdown [data-streamdown="ordered-list"] {
+    @apply my-2 ml-0 list-decimal space-y-1 pl-5;
+  }
+  .release-notes-markdown [data-streamdown="list-item"] {
+    @apply pl-1 text-xs leading-relaxed text-muted-foreground;
+  }
+  .release-notes-markdown [data-streamdown="blockquote"] {
+    @apply my-2 border-l-2 border-border/70 pl-3 text-xs not-italic text-muted-foreground;
+  }
+  .release-notes-markdown [data-streamdown="inline-code"] {
+    @apply rounded border border-border/50 bg-muted/60 px-1 py-0.5 font-mono text-[11px] text-foreground/90;
+  }
+
   /* Smooth entrance for chat bubbles */
   .chat-bubble-enter {
     animation: chatBubbleIn 0.3s cubic-bezier(0.16, 1, 0.3, 1);

--- a/crates/agent-gui/src/pages/settings/AboutSection.tsx
+++ b/crates/agent-gui/src/pages/settings/AboutSection.tsx
@@ -12,6 +12,7 @@ import {
   Shield,
   Sparkles,
 } from "../../components/icons";
+import { Markdown } from "../../components/Markdown";
 import { Button } from "../../components/ui/button";
 import { useLocale } from "../../i18n";
 import { updateUpdateSettings } from "../../lib/settings";
@@ -53,6 +54,36 @@ function formatReleaseDate(value?: string | null) {
 function releaseTitle(result?: AppUpdateCheckResult) {
   if (!result) return "";
   return result.releaseName?.trim() || result.releaseTag?.trim() || result.version || "";
+}
+
+function normalizeTitle(value: string) {
+  return value
+    .replace(/^#+\s*/, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function releaseNotesBody(result?: AppUpdateCheckResult) {
+  const body = result?.body?.replace(/^\s*(?:<!--[\s\S]*?-->\s*)+/, "").trim();
+  if (!body) return "";
+
+  const title = normalizeTitle(releaseTitle(result));
+  if (!title) return body;
+
+  const lines = body.split(/\r?\n/);
+  const firstContentIndex = lines.findIndex((line) => line.trim());
+  if (firstContentIndex < 0) return "";
+
+  const firstContentLine = lines[firstContentIndex].trim();
+  if (/^#\s+/.test(firstContentLine) && normalizeTitle(firstContentLine) === title) {
+    return lines
+      .slice(firstContentIndex + 1)
+      .join("\n")
+      .trim();
+  }
+
+  return body;
 }
 
 export function AboutSection(props: SettingsSectionProps) {
@@ -122,6 +153,7 @@ export function AboutSection(props: SettingsSectionProps) {
   }
 
   const latestResult = "result" in checkState ? checkState.result : undefined;
+  const latestReleaseNotes = releaseNotesBody(latestResult);
   const channelLabel =
     latestResult?.channel === "prerelease"
       ? t("settings.aboutChannelPrerelease")
@@ -288,11 +320,14 @@ export function AboutSection(props: SettingsSectionProps) {
             </div>
           </div>
 
-          {latestResult?.body ? (
+          {latestReleaseNotes ? (
             <div className="space-y-2 rounded-xl border border-border/60 bg-background/70 p-4">
               <div className="text-sm font-semibold">{releaseTitle(latestResult)}</div>
-              <div className="max-h-48 overflow-auto whitespace-pre-wrap text-xs leading-relaxed text-muted-foreground">
-                {latestResult.body}
+              <div className="max-h-48 overflow-auto pr-2">
+                <Markdown
+                  content={latestReleaseNotes}
+                  className="release-notes-markdown text-xs leading-relaxed text-muted-foreground"
+                />
               </div>
             </div>
           ) : null}


### PR DESCRIPTION
## Summary
- render update release notes through the existing Markdown component
- strip leading release body comments and duplicate title headings before display
- add compact markdown styling for release notes content

## Testing
- PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm -C crates/agent-gui exec biome check src/pages/settings/AboutSection.tsx
- PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm -C crates/agent-gui lint (fails on existing repo-wide Biome diagnostics outside this change)
- PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm -C crates/agent-gui exec biome check src/pages/settings/AboutSection.tsx src/index.css (CSS parse blocked by current Biome config not enabling Tailwind directives)