### PR TITLE
feat(ui): macOS overlay titlebar with sidebar toggle and settings sho…

### DIFF
--- a/crates/agent-gui/src-tauri/tauri.conf.json
+++ b/crates/agent-gui/src-tauri/tauri.conf.json
@@ -13,12 +13,13 @@
     "withGlobalTauri": true,
     "windows": [
       {
-        "title": "LiveAgent",
+        "title": "",
         "width": 1400,
         "height": 800,
         "minWidth": 1200,
         "minHeight": 720,
-        "backgroundThrottling": "disabled"
+        "backgroundThrottling": "disabled",
+        "titleBarStyle": "Overlay"
       }
     ],
     "security": {

--- a/crates/agent-gui/src/components/MacOsTitleBarSpacer.tsx
+++ b/crates/agent-gui/src/components/MacOsTitleBarSpacer.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { cn } from "../lib/shared/utils";
+import { PanelLeft, PanelLeftClose, Settings } from "./icons";
+
+type TauriWindow = Window & { __TAURI_INTERNALS__?: unknown };
+
+export function isMacOsTauri(): boolean {
+  if (typeof window === "undefined") return false;
+  const hasTauri = !!(window as TauriWindow).__TAURI_INTERNALS__;
+  return hasTauri && /Mac/i.test(navigator.platform);
+}
+
+/** Vertical spacer at the top of a sidebar column — clears the macOS traffic lights. */
+export function MacOsTitleBarSpacer({ className }: { className?: string }) {
+  const [show] = useState(isMacOsTauri);
+  if (!show) return null;
+  return (
+    <div
+      data-tauri-drag-region
+      className={cn("h-[38px] shrink-0", className)}
+    />
+  );
+}
+
+/**
+ * Fixed-position sidebar toggle for macOS overlay titlebar.
+ * Always appears at the same x position (right of traffic lights), regardless of sidebar state.
+ */
+export function MacOsTitleBarToggle({
+  sidebarOpen,
+  onToggle,
+  onOpenSettings,
+}: {
+  sidebarOpen: boolean;
+  onToggle: () => void;
+  onOpenSettings?: () => void;
+}) {
+  const [show] = useState(isMacOsTauri);
+  if (!show) return null;
+  return (
+    <div className="fixed left-[76px] top-0 z-49 flex h-[32px] items-center gap-0.5">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex cursor-pointer size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+      >
+        {sidebarOpen ? (
+          <PanelLeftClose className="h-3.5 w-3.5" />
+        ) : (
+          <PanelLeft className="h-3.5 w-3.5" />
+        )}
+      </button>
+      {onOpenSettings && (
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          className="flex cursor-pointer size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+        >
+          <Settings className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Horizontal spacer on the left of a header row — used in ChatHeader when sidebar is
+ * closed on macOS to clear the traffic lights + fixed toggle button zone.
+ */
+export function MacOsTitleBarLeadingInset({ className }: { className?: string }) {
+  const [show] = useState(isMacOsTauri);
+  if (!show) return null;
+  return (
+    <div
+      data-tauri-drag-region
+      className={cn("w-[88px] shrink-0", className)}
+    />
+  );
+}

--- a/crates/agent-gui/src/components/chat/ChatHistorySidebar.tsx
+++ b/crates/agent-gui/src/components/chat/ChatHistorySidebar.tsx
@@ -1,6 +1,7 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import iconSimpleUrl from "../../../src-tauri/icons/icon-simple.png";
+import { MacOsTitleBarSpacer, isMacOsTauri } from "../MacOsTitleBarSpacer";
 import { useLocale } from "../../i18n";
 import type { ChatHistorySummary } from "../../lib/chat/history/chatHistory";
 import {
@@ -922,6 +923,7 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
       )}
     >
       <div className="chat-history-sidebar-inner flex w-[272px] min-w-[272px] min-h-0 flex-1 flex-col">
+        <MacOsTitleBarSpacer className="bg-[hsl(var(--sidebar-bg))]" />
         <div className="shrink-0 border-b border-border/50 px-3 pb-3 pt-3">
           <div className="flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-2.5">
@@ -937,16 +939,18 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
               </div>
             </div>
 
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={onCloseSidebar}
-              title={t("sidebar.closeSidebar")}
-              className="h-9 w-9 shrink-0 rounded-2xl text-muted-foreground hover:text-foreground"
-            >
-              <PanelLeftClose className="h-4 w-4" />
-            </Button>
+            {!isMacOsTauri() && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={onCloseSidebar}
+                title={t("sidebar.closeSidebar")}
+                className="h-9 w-9 shrink-0 rounded-2xl text-muted-foreground hover:text-foreground"
+              >
+                <PanelLeftClose className="h-4 w-4" />
+              </Button>
+            )}
           </div>
 
           <div className="mt-3 flex flex-col gap-1">

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { MacOsTitleBarSpacer, MacOsTitleBarToggle } from "../components/MacOsTitleBarSpacer";
 import { ChatHistorySidebar } from "../components/chat/ChatHistorySidebar";
 import { HistoryShareModal } from "../components/chat/HistoryShareModal";
 import type {
@@ -3245,6 +3246,10 @@ export function ChatPage(props: ChatPageProps) {
     setSidebarOpen(false);
   }, []);
 
+  const handleToggleSidebar = useCallback(() => {
+    setSidebarOpen((prev) => !prev);
+  }, []);
+
   const handleNewConversation = useCallback(() => {
     setHistorySwitchOverlay(null);
     clearCachedComposerDraft();
@@ -3800,6 +3805,7 @@ export function ChatPage(props: ChatPageProps) {
 
   return (
     <div className="flex h-full min-h-0">
+      <MacOsTitleBarToggle sidebarOpen={sidebarOpen} onToggle={handleToggleSidebar} onOpenSettings={() => onOpenSettings()} />
       {/* ---- Sidebar ---- */}
       <ChatHistorySidebar
         items={historyItems}
@@ -3922,6 +3928,7 @@ export function ChatPage(props: ChatPageProps) {
           />
         ) : (
           <>
+            <MacOsTitleBarSpacer />
             <div className="relative z-20">
               <ChatHeader
                 settings={settings}

--- a/crates/agent-gui/src/pages/SettingsPage.tsx
+++ b/crates/agent-gui/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { isMacOsTauri } from "../components/MacOsTitleBarSpacer";
 import {
   ArrowLeft,
   BookOpen,
@@ -59,24 +60,14 @@ function NavItem({ icon, label, active, onClick }: NavItemProps) {
     <button
       type="button"
       onClick={onClick}
-      className={`group w-full rounded-xl px-3 py-2.5 text-left transition-all ${
+      className={`flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors ${
         active
-          ? "bg-primary text-primary-foreground shadow-xs"
-          : "text-foreground hover:bg-accent/60"
+          ? "bg-accent font-medium text-foreground"
+          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
       }`}
     >
-      <div className="flex items-center gap-3">
-        <div
-          className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
-            active
-              ? "bg-primary-foreground/20 text-primary-foreground"
-              : "bg-accent text-muted-foreground group-hover:bg-accent/80"
-          }`}
-        >
-          {icon}
-        </div>
-        <div className="min-w-0 text-sm font-medium leading-none">{label}</div>
-      </div>
+      <span className="shrink-0 opacity-70">{icon}</span>
+      <span className="leading-none">{label}</span>
     </button>
   );
 }
@@ -84,35 +75,35 @@ function NavItem({ icon, label, active, onClick }: NavItemProps) {
 const NAV_ITEMS_STATIC: Array<{ id: SectionId; icon: ReactNode }> = [
   {
     id: "system",
-    icon: <Settings2 className="h-4 w-4" />,
+    icon: <Settings2 className="h-3.5 w-3.5" />,
   },
   {
     id: "providers",
-    icon: <Cpu className="h-4 w-4" />,
+    icon: <Cpu className="h-3.5 w-3.5" />,
   },
   {
     id: "agents",
-    icon: <BookOpen className="h-4 w-4" />,
+    icon: <BookOpen className="h-3.5 w-3.5" />,
   },
   {
     id: "memory",
-    icon: <Brain className="h-4 w-4" />,
+    icon: <Brain className="h-3.5 w-3.5" />,
   },
   {
     id: "hooks",
-    icon: <Zap className="h-4 w-4" />,
+    icon: <Zap className="h-3.5 w-3.5" />,
   },
   {
     id: "cron",
-    icon: <Clock3 className="h-4 w-4" />,
+    icon: <Clock3 className="h-3.5 w-3.5" />,
   },
   {
     id: "remote",
-    icon: <Cloud className="h-4 w-4" />,
+    icon: <Cloud className="h-3.5 w-3.5" />,
   },
   {
     id: "about",
-    icon: <Info className="h-4 w-4" />,
+    icon: <Info className="h-3.5 w-3.5" />,
   },
 ];
 
@@ -192,78 +183,90 @@ export function SettingsPage(props: SettingsPageProps) {
     }
   })();
 
+  const onMac = isMacOsTauri();
+
   return (
-    <div className="flex h-full bg-background">
-      <aside className="flex w-60 shrink-0 flex-col border-r bg-muted/30">
-        <div className="flex items-center gap-2.5 border-b px-4 py-4">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-            <Settings2 className="h-4 w-4 text-primary" />
-          </div>
-          <div>
-            <div className="text-sm font-semibold">{t("settings.title")}</div>
-            <div className="text-[11px] text-muted-foreground">LiveAgent</div>
-          </div>
-        </div>
-
-        <nav className="flex-1 space-y-1 px-3 py-3">
-          {navItems.map((item) => (
-            <NavItem
-              key={item.id}
-              icon={item.icon}
-              label={item.label}
-              active={section === item.id}
-              onClick={() => setSection(item.id)}
-            />
-          ))}
-        </nav>
-
-        <div className="border-t px-3 py-3">
+    <div className="flex h-full flex-col bg-background">
+      {onMac && (
+        <div data-tauri-drag-region className="flex h-[38px] shrink-0 items-center">
+          <div data-tauri-drag-region className="w-[76px] shrink-0" />
           <button
             type="button"
             onClick={onBack}
-            className="flex w-full items-center gap-2 rounded-xl px-3 py-2.5 text-sm text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+            className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
           >
-            <ArrowLeft className="h-4 w-4" />
+            <ArrowLeft className="h-3.5 w-3.5 shrink-0" />
             <span>{t("settings.backToChat")}</span>
           </button>
+          <div data-tauri-drag-region className="flex-1" />
         </div>
-      </aside>
+      )}
 
-      <main className="flex min-w-0 flex-1 flex-col">
-        <header className="flex items-center justify-between border-b px-6 py-4">
-          <div className="overflow-hidden">
+      <div className="flex min-h-0 flex-1">
+        <aside className="flex w-52 shrink-0 flex-col border-r bg-muted/20">
+          {!onMac && (
+            <div className="px-3 pb-1 pt-3">
+              <button
+                type="button"
+                onClick={onBack}
+                className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+              >
+                <ArrowLeft className="h-4 w-4 shrink-0" />
+                <span>{t("settings.backToChat")}</span>
+              </button>
+            </div>
+          )}
+
+          <nav className="flex-1 space-y-0.5 px-3 py-2">
+            {navItems.map((item) => (
+              <NavItem
+                key={item.id}
+                icon={item.icon}
+                label={item.label}
+                active={section === item.id}
+                onClick={() => setSection(item.id)}
+              />
+            ))}
+          </nav>
+
+          <div className="border-t px-4 py-2.5">
+            <div
+              className="flex items-center gap-1.5 text-xs text-muted-foreground"
+              title={saveIndicator.title}
+            >
+              <div className={`h-1.5 w-1.5 rounded-full ${saveIndicator.dotClass}`} />
+              {saveIndicator.text}
+            </div>
+          </div>
+        </aside>
+
+        <main className="flex min-w-0 flex-1 flex-col">
+          <div className="border-b px-6 py-3.5">
             <div key={section} className="settings-section-title-enter text-base font-semibold">
               {sectionLabels[section]}
             </div>
           </div>
-          <div
-            className="flex items-center gap-1.5 text-xs text-muted-foreground"
-            title={saveIndicator.title}
-          >
-            <div className={`h-1.5 w-1.5 rounded-full ${saveIndicator.dotClass}`} />
-            {saveIndicator.text}
-          </div>
-        </header>
 
-        <div
-          key={section}
-          className={`settings-section-enter flex-1 px-6 py-5 ${
-            section === "hooks" || section === "providers" || section === "memory"
-              ? "flex min-h-0 flex-col overflow-hidden"
-              : "overflow-auto"
-          }`}
-        >
           <div
-            className={`settings-section-shell ${
+            key={section}
+            className={`settings-section-enter flex-1 px-6 py-5 ${
               section === "hooks" || section === "providers" || section === "memory"
-                ? "flex min-h-0 flex-1 flex-col"
-                : "min-h-full"
+                ? "flex min-h-0 flex-col overflow-hidden"
+                : "overflow-auto"
             }`}
           >
-            {sectionContent}
+            <div
+              className={`settings-section-shell ${
+                section === "hooks" || section === "providers" || section === "memory"
+                  ? "flex min-h-0 flex-1 flex-col"
+                  : "min-h-full"
+              }`}
+            >
+              {sectionContent}
+            </div>
           </div>
-        </div>
-      </main>
+        </main>
+      </div>
     </div>
   );
 }

--- a/crates/agent-gui/src/pages/chat/ChatHeader.tsx
+++ b/crates/agent-gui/src/pages/chat/ChatHeader.tsx
@@ -12,6 +12,7 @@ import {
   Sun,
 } from "../../components/icons";
 
+import { isMacOsTauri } from "../../components/MacOsTitleBarSpacer";
 import { Button } from "../../components/ui/button";
 import {
   DropdownMenu,
@@ -99,9 +100,9 @@ export const ChatHeader = memo(function ChatHeader(props: {
   const selectedOption = modelOptions.find((o) => o.value === selectedValue);
 
   return (
-    <header className="flex items-center justify-between gap-2 px-4 py-2.5">
+    <header data-tauri-drag-region className="flex items-center justify-between gap-2 px-4 py-2.5">
       <div className="flex min-w-0 items-center gap-1.5">
-        {!sidebarOpen ? (
+        {!sidebarOpen && !isMacOsTauri() ? (
           <Button
             variant="ghost"
             size="icon"
@@ -120,7 +121,7 @@ export const ChatHeader = memo(function ChatHeader(props: {
                 variant="ghost"
                 disabled={!hasModels}
                 className={cn(
-                  "model-selector-trigger h-9 max-w-[min(20rem,calc(100vw-8.5rem))] justify-between gap-1.5 overflow-hidden rounded-lg px-3 text-base font-semibold text-foreground transition-all duration-200 ease-out hover:bg-muted/60 dark:text-white",
+                  "model-selector-trigger h-9 max-w-[min(20rem,calc(100vw-8.5rem))] justify-between gap-1.5 overflow-hidden rounded-lg px-3 cursor-pointer text-xs font-normal text-foreground transition-all duration-200 ease-out hover:bg-muted/60 dark:text-white",
                   isModelMenuOpen && "bg-muted/70 shadow-sm",
                 )}
               />
@@ -251,15 +252,17 @@ export const ChatHeader = memo(function ChatHeader(props: {
             <Moon className="h-4.5 w-4.5" />
           )}
         </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => onOpenSettings()}
-          title={t("tooltip.settings")}
-          className="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground"
-        >
-          <Settings className="h-4.5 w-4.5" />
-        </Button>
+        {!isMacOsTauri() && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => onOpenSettings()}
+            title={t("tooltip.settings")}
+            className="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground"
+          >
+            <Settings className="h-4.5 w-4.5" />
+          </Button>
+        )}
         {trailingActions}
       </div>
     </header>


### PR DESCRIPTION
…rtcut

- Remove native window title bar (titleBarStyle: Overlay), set title to ""
- Add MacOsTitleBarSpacer / MacOsTitleBarToggle / MacOsTitleBarLeadingInset components for traffic-light clearance and drag regions
- Fix sidebar close button and spacer for macOS traffic-light zone
- Place sidebar toggle + settings button at fixed position in title bar row
- Push ChatHeader content below title bar zone via MacOsTitleBarSpacer
- Move settings page back button into macOS title bar row (Claude.ai style)
- Model selector trigger: text-xs, font-normal, cursor-pointer