### PR TITLE
feat(ui): inset window chrome into a rounded card

### DIFF
--- a/crates/agent-gui/src-tauri/tauri.conf.json
+++ b/crates/agent-gui/src-tauri/tauri.conf.json
@@ -19,7 +19,8 @@
         "minWidth": 1200,
         "minHeight": 720,
         "backgroundThrottling": "disabled",
-        "titleBarStyle": "Overlay"
+        "titleBarStyle": "Overlay",
+        "trafficLightPosition": { "x": 18, "y": 18 }
       }
     ],
     "security": {

--- a/crates/agent-gui/src/App.tsx
+++ b/crates/agent-gui/src/App.tsx
@@ -42,9 +42,13 @@ const GATEWAY_SETTINGS_SYNC_EVENT = "gateway:settings-sync";
 
 function AppChrome(props: { children: ReactNode }) {
   return (
-    <div className="relative flex h-full w-full flex-col overflow-hidden">
+    <div className="relative flex h-full w-full flex-col overflow-hidden bg-[hsl(220_13%_91%)] dark:bg-[hsl(224_22%_5%)]">
       <WindowsTitleBar />
-      <div className="relative min-h-0 flex-1">{props.children}</div>
+      <div className="relative min-h-0 flex-1 p-1.5">
+        <div className="relative h-full w-full overflow-hidden rounded-xl bg-background shadow-[0_0_0_0.5px_hsl(var(--border)/0.6)]">
+          {props.children}
+        </div>
+      </div>
     </div>
   );
 }

--- a/crates/agent-gui/src/components/MacOsTitleBarSpacer.tsx
+++ b/crates/agent-gui/src/components/MacOsTitleBarSpacer.tsx
@@ -38,7 +38,7 @@ export function MacOsTitleBarToggle({
   const [show] = useState(isMacOsTauri);
   if (!show) return null;
   return (
-    <div className="fixed left-[76px] top-0 z-49 flex h-[32px] items-center gap-0.5">
+    <div className="fixed left-[82px] top-[4px] z-49 flex h-[32px] items-center gap-0.5">
       <button
         type="button"
         onClick={onToggle}

--- a/crates/agent-gui/src/pages/SettingsPage.tsx
+++ b/crates/agent-gui/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
-import { isMacOsTauri } from "../components/MacOsTitleBarSpacer";
+import { isMacOsTauri, MacOsTitleBarSpacer } from "../components/MacOsTitleBarSpacer";
 import {
   ArrowLeft,
   BookOpen,
@@ -187,35 +187,21 @@ export function SettingsPage(props: SettingsPageProps) {
 
   return (
     <div className="flex h-full flex-col bg-background">
-      {onMac && (
-        <div data-tauri-drag-region className="flex h-[38px] shrink-0 items-center">
-          <div data-tauri-drag-region className="w-[76px] shrink-0" />
-          <button
-            type="button"
-            onClick={onBack}
-            className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
-          >
-            <ArrowLeft className="h-3.5 w-3.5 shrink-0" />
-            <span>{t("settings.backToChat")}</span>
-          </button>
-          <div data-tauri-drag-region className="flex-1" />
-        </div>
-      )}
-
       <div className="flex min-h-0 flex-1">
         <aside className="flex w-52 shrink-0 flex-col border-r bg-muted/20">
-          {!onMac && (
-            <div className="px-3 pb-1 pt-3">
-              <button
-                type="button"
-                onClick={onBack}
-                className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
-              >
-                <ArrowLeft className="h-4 w-4 shrink-0" />
-                <span>{t("settings.backToChat")}</span>
-              </button>
-            </div>
+          {onMac && (
+            <div data-tauri-drag-region className="h-[38px] shrink-0" />
           )}
+          <div className="px-3 pb-1 pt-3">
+            <button
+              type="button"
+              onClick={onBack}
+              className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4 shrink-0" />
+              <span>{t("settings.backToChat")}</span>
+            </button>
+          </div>
 
           <nav className="flex-1 space-y-0.5 px-3 py-2">
             {navItems.map((item) => (
@@ -241,6 +227,7 @@ export function SettingsPage(props: SettingsPageProps) {
         </aside>
 
         <main className="flex min-w-0 flex-1 flex-col">
+          <MacOsTitleBarSpacer />
           <div className="border-b px-6 py-3.5">
             <div key={section} className="settings-section-title-enter text-base font-semibold">
               {sectionLabels[section]}


### PR DESCRIPTION
Wrap the app content in a rounded card with a subtle outer frame so the window has visual breathing room on all sides, then push the macOS traffic lights and the custom sidebar/settings buttons inward to align with the new inset. Move the SettingsPage "back to chat" control into the sidebar column so it shares the layout with the nav items.