### PR TITLE
Fix some known issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,6 +3261,7 @@ dependencies = [
  "uuid",
  "wait-timeout",
  "walkdir",
+ "windows-sys 0.61.2",
  "zip 0.6.6",
 ]
 

--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -297,6 +297,11 @@ export default function GatewayApp() {
   // Per-conversation runtime workdir (drafts have no persisted summary yet).
   const conversationWorkdirsRef = useRef<Map<string, string>>(new Map());
   const displayedConversationWorkdirRef = useRef("");
+  const pendingUploadContextRef = useRef<{
+    conversationId: string;
+    workdir: string;
+    executionMode: string;
+  } | null>(null);
   const displayedConversationBusyRef = useRef(false);
   const historyLoadSequenceRef = useRef(0);
   const visibleConversationRevisionRef = useRef(0);
@@ -3070,6 +3075,34 @@ export default function GatewayApp() {
     currentConversationRuntimeWorkdir ||
     (isAgentMode ? activeWorkspaceProjectPath || settings.system.workdir.trim() : "");
   displayedConversationWorkdirRef.current = displayedConversationWorkdir;
+  // Pending uploads live under their conversation's workdir uploads/ tree.
+  // Switching conversations keeps every conversation's uploads, but a workdir
+  // change within the same conversation (a draft switching projects) makes its
+  // relative paths stale, and a mode flip away from tools invalidates all of
+  // them — mirroring the GUI-side rule in usePendingUploads.
+  useEffect(() => {
+    const executionMode = settings.system.executionMode;
+    const previous = pendingUploadContextRef.current;
+    pendingUploadContextRef.current = {
+      conversationId: displayedConversationId,
+      workdir: displayedConversationWorkdir,
+      executionMode,
+    };
+    if (!previous) return;
+    if (previous.executionMode !== executionMode) {
+      clearPendingUploads();
+      return;
+    }
+    if (previous.conversationId !== displayedConversationId) return;
+    if (previous.workdir === displayedConversationWorkdir) return;
+    setPendingUploadsForConversation(displayedConversationId, []);
+  }, [
+    clearPendingUploads,
+    displayedConversationId,
+    displayedConversationWorkdir,
+    settings.system.executionMode,
+    setPendingUploadsForConversation,
+  ]);
   useEffect(() => {
     if (!api || !displayedConversationId) {
       queuedChatTurnsRef.current = [];
@@ -3517,6 +3550,7 @@ export default function GatewayApp() {
           ref={fileInputRef}
           type="file"
           multiple
+          aria-label={translate("chat.upload.selectFiles", settings.locale)}
           className="gateway-hidden-file-input"
           onChange={(event) => {
             const files = Array.from(event.currentTarget.files ?? []);

--- a/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
+++ b/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
@@ -1373,10 +1373,6 @@ export function GatewayTranscript({
     return (
       <div className="gateway-transcript-shell">
         <div className="gateway-chat-column gateway-empty-state">
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center overflow-hidden">
-            <div className="hero-glow-pulse h-[360px] w-[360px] rounded-full bg-[radial-gradient(closest-side,hsl(var(--foreground)/0.08),transparent_70%)] blur-3xl" />
-          </div>
-
           <div className="relative flex flex-col items-center">
             <div className="hero-entrance hero-icon-float mb-5 flex h-24 w-24 items-center justify-center">
               <img

--- a/crates/agent-gateway/web/src/index.css
+++ b/crates/agent-gateway/web/src/index.css
@@ -892,34 +892,6 @@
     }
   }
 
-  /* Glow pulse animation */
-  .hero-glow-pulse {
-    animation:
-      heroGlowPulse 5s ease-in-out infinite,
-      heroFadeIn 1.2s ease-out both;
-  }
-
-  @keyframes heroGlowPulse {
-    0%,
-    100% {
-      opacity: 0.7;
-      transform: scale(1);
-    }
-    50% {
-      opacity: 1;
-      transform: scale(1.12);
-    }
-  }
-
-  @keyframes heroFadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 0.7;
-    }
-  }
-
   /* Mention composer placeholder */
   .mention-composer.is-empty::before {
     content: attr(data-placeholder);

--- a/crates/agent-gateway/web/src/pages/chat/ChatComposerBar.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/ChatComposerBar.tsx
@@ -498,140 +498,143 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
         {queuedTurns.length > 0 ? (
           <div
             ref={queuePanelRef}
-            className={cn(
-              "relative z-30 mx-auto mb-[-1px] w-[calc(100%-1.5rem)] max-w-[720px] overflow-visible rounded-t-lg rounded-b-none border border-b-0 border-black/[0.055] bg-white/70 p-1 shadow-[0_8px_24px_-18px_rgba(15,23,42,0.24),inset_0_1px_0_rgba(255,255,255,0.72)] backdrop-blur-2xl backdrop-saturate-[165%] transition-[padding] duration-200 ease-out dark:border-white/[0.10] dark:bg-white/[0.06] dark:shadow-[0_8px_24px_-18px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.08)]",
-              queueCollapsed && "px-1 py-0.5",
-            )}
+            className="relative z-30 mx-auto mb-[-1px] w-[calc(100%-1.5rem)] max-w-[720px]"
           >
-            <div className="relative flex h-2 items-center justify-center">
-              <span className="pointer-events-none absolute inset-x-1 top-1/2 h-px -translate-y-1/2 rounded-full bg-black/10 dark:bg-white/15" />
-              <button
-                type="button"
-                onClick={toggleQueueCollapsed}
-                aria-label={toggleQueueTooltip}
-                aria-expanded={!queueCollapsed}
-                className="relative z-10 inline-flex h-4 w-7 items-center justify-center rounded-full border border-black/[0.06] bg-white/80 text-muted-foreground shadow-[0_1px_4px_-2px_rgba(15,23,42,0.35)] transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring dark:border-white/10 dark:bg-zinc-900/80"
-              >
-                {queueCollapsed ? (
-                  <ChevronDown className="h-3 w-3" />
-                ) : (
-                  <ChevronUp className="h-3 w-3" />
-                )}
-              </button>
-            </div>
             <div
               aria-hidden={queueCollapsed}
               className={cn(
-                "grid transition-[grid-template-rows,margin-top,opacity] duration-200 ease-out",
-                queueCollapsed
-                  ? "mt-0 grid-rows-[0fr] opacity-0"
-                  : "mt-1 grid-rows-[1fr] opacity-100",
+                "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+                queueCollapsed ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100",
               )}
             >
-              <div className="relative min-h-0 overflow-hidden">
-                <ul
-                  ref={queueListRef}
-                  data-scrollable={queuedTurns.length > 2 ? "true" : "false"}
-                  className={cn(
-                    "chat-queue-scroll flex min-w-0 flex-col gap-1 overflow-x-hidden",
-                    queuedTurns.length > 2
-                      ? "h-[76px] overflow-y-scroll pr-3"
-                      : "max-h-[76px] overflow-y-hidden pr-1",
-                  )}
-                >
-                  {queuedTurns.map((item, index) => (
-                    <li
-                      key={item.id}
-                      className="relative grid h-9 min-h-9 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 rounded-md border border-black/[0.035] bg-white/42 px-2 text-xs shadow-[inset_0_1px_0_rgba(255,255,255,0.56)] backdrop-blur-xl backdrop-saturate-[150%] transition-[border-color,background-color] dark:border-white/[0.06] dark:bg-white/[0.04] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+              <div className="min-h-0 overflow-hidden">
+                <div className="rounded-t-lg border border-b-0 border-black/[0.055] bg-white/70 px-1 pb-1 pt-2 shadow-[0_8px_24px_-18px_rgba(15,23,42,0.24),inset_0_1px_0_rgba(255,255,255,0.72)] backdrop-blur-2xl backdrop-saturate-[165%] dark:border-white/[0.10] dark:bg-white/[0.06] dark:shadow-[0_8px_24px_-18px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.08)]">
+                  <div className="relative min-h-0">
+                    <ul
+                      ref={queueListRef}
+                      data-scrollable={queuedTurns.length > 2 ? "true" : "false"}
+                      className={cn(
+                        "chat-queue-scroll flex min-w-0 flex-col gap-1 overflow-x-hidden",
+                        queuedTurns.length > 2
+                          ? "h-[76px] overflow-y-scroll pr-3"
+                          : "max-h-[76px] overflow-y-hidden pr-1",
+                      )}
                     >
-                      <div className="flex shrink-0 items-center gap-0.5">
-                        {index > 0 ? (
-                          <button
-                            type="button"
-                            disabled={queueCollapsed}
-                            onClick={() => onMoveQueuedTurnUp(item.id)}
-                            aria-label={t("chat.queue.moveUp")}
-                            className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-35"
-                          >
-                            <ChevronUp className="h-3 w-3" />
-                          </button>
-                        ) : (
-                          <span aria-hidden className="h-6 w-6" />
-                        )}
-                        <Clock3 className="h-3 w-3 shrink-0 text-muted-foreground/65" />
+                      {queuedTurns.map((item, index) => (
+                        <li
+                          key={item.id}
+                          className="relative grid h-9 min-h-9 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 rounded-md border border-black/[0.035] bg-white/42 px-2 text-xs shadow-[inset_0_1px_0_rgba(255,255,255,0.56)] backdrop-blur-xl backdrop-saturate-[150%] transition-[border-color,background-color] dark:border-white/[0.06] dark:bg-white/[0.04] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+                        >
+                          <div className="flex shrink-0 items-center gap-0.5">
+                            {index > 0 ? (
+                              <button
+                                type="button"
+                                disabled={queueCollapsed}
+                                onClick={() => onMoveQueuedTurnUp(item.id)}
+                                aria-label={t("chat.queue.moveUp")}
+                                className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-35"
+                              >
+                                <ChevronUp className="h-3 w-3" />
+                              </button>
+                            ) : (
+                              <span aria-hidden className="h-6 w-6" />
+                            )}
+                            <Clock3 className="h-3 w-3 shrink-0 text-muted-foreground/65" />
+                          </div>
+                          <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
+                            <span className="block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px] leading-4 text-foreground/88">
+                              {item.previewText || t("chat.queue.emptyMessage")}
+                            </span>
+                            {item.fileCount > 0 ? (
+                              <span className="max-w-[4.5rem] shrink-0 overflow-hidden text-ellipsis whitespace-nowrap text-[9px] leading-4 text-muted-foreground">
+                                {t("chat.queue.fileCount").replace(
+                                  "{count}",
+                                  String(item.fileCount),
+                                )}
+                              </span>
+                            ) : null}
+                          </div>
+                          <div className="flex shrink-0 items-center gap-0.5">
+                            <RuntimeControlTooltip label={t("chat.queue.edit")}>
+                              <button
+                                type="button"
+                                disabled={queueCollapsed}
+                                onClick={() => onEditQueuedTurn(item.id)}
+                                title={t("chat.queue.edit")}
+                                aria-label={t("chat.queue.edit")}
+                                className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground"
+                              >
+                                <SquarePen className="h-3 w-3" />
+                              </button>
+                            </RuntimeControlTooltip>
+                            <RuntimeControlTooltip label={t("chat.queue.runNow")}>
+                              <button
+                                type="button"
+                                disabled={queueCollapsed}
+                                onClick={() => onRunQueuedTurnNow(item.id)}
+                                title={t("chat.queue.runNow")}
+                                aria-label={t("chat.queue.runNow")}
+                                className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground"
+                              >
+                                <Play className="h-3 w-3" />
+                              </button>
+                            </RuntimeControlTooltip>
+                            <RuntimeControlTooltip label={t("chat.queue.delete")}>
+                              <button
+                                type="button"
+                                disabled={queueCollapsed}
+                                onClick={() => onRemoveQueuedTurn(item.id)}
+                                title={t("chat.queue.delete")}
+                                aria-label={t("chat.queue.delete")}
+                                className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                              >
+                                <Trash2 className="h-3 w-3" />
+                              </button>
+                            </RuntimeControlTooltip>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                    {shouldShowQueueScrollbar ? (
+                      <div
+                        ref={queueScrollbarTrackRef}
+                        aria-hidden
+                        className="chat-queue-scrollbar"
+                        onPointerCancel={handleQueueScrollbarPointerUp}
+                        onPointerDown={handleQueueScrollbarPointerDown}
+                        onPointerMove={handleQueueScrollbarPointerMove}
+                        onPointerUp={handleQueueScrollbarPointerUp}
+                      >
+                        <div
+                          className="chat-queue-scrollbar-thumb"
+                          style={{
+                            height: `${queueScrollbar.thumbHeight}px`,
+                            transform: `translateY(${queueScrollbar.thumbTop}px)`,
+                          }}
+                        />
                       </div>
-                      <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
-                        <span className="block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px] leading-4 text-foreground/88">
-                          {item.previewText || t("chat.queue.emptyMessage")}
-                        </span>
-                        {item.fileCount > 0 ? (
-                          <span className="max-w-[4.5rem] shrink-0 overflow-hidden text-ellipsis whitespace-nowrap text-[9px] leading-4 text-muted-foreground">
-                            {t("chat.queue.fileCount").replace("{count}", String(item.fileCount))}
-                          </span>
-                        ) : null}
-                      </div>
-                      <div className="flex shrink-0 items-center gap-0.5">
-                        <RuntimeControlTooltip label={t("chat.queue.edit")}>
-                          <button
-                            type="button"
-                            disabled={queueCollapsed}
-                            onClick={() => onEditQueuedTurn(item.id)}
-                            title={t("chat.queue.edit")}
-                            aria-label={t("chat.queue.edit")}
-                            className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground"
-                          >
-                            <SquarePen className="h-3 w-3" />
-                          </button>
-                        </RuntimeControlTooltip>
-                        <RuntimeControlTooltip label={t("chat.queue.runNow")}>
-                          <button
-                            type="button"
-                            disabled={queueCollapsed}
-                            onClick={() => onRunQueuedTurnNow(item.id)}
-                            title={t("chat.queue.runNow")}
-                            aria-label={t("chat.queue.runNow")}
-                            className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground"
-                          >
-                            <Play className="h-3 w-3" />
-                          </button>
-                        </RuntimeControlTooltip>
-                        <RuntimeControlTooltip label={t("chat.queue.delete")}>
-                          <button
-                            type="button"
-                            disabled={queueCollapsed}
-                            onClick={() => onRemoveQueuedTurn(item.id)}
-                            title={t("chat.queue.delete")}
-                            aria-label={t("chat.queue.delete")}
-                            className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                          >
-                            <Trash2 className="h-3 w-3" />
-                          </button>
-                        </RuntimeControlTooltip>
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-                {shouldShowQueueScrollbar ? (
-                  <div
-                    ref={queueScrollbarTrackRef}
-                    aria-hidden
-                    className="chat-queue-scrollbar"
-                    onPointerCancel={handleQueueScrollbarPointerUp}
-                    onPointerDown={handleQueueScrollbarPointerDown}
-                    onPointerMove={handleQueueScrollbarPointerMove}
-                    onPointerUp={handleQueueScrollbarPointerUp}
-                  >
-                    <div
-                      className="chat-queue-scrollbar-thumb"
-                      style={{
-                        height: `${queueScrollbar.thumbHeight}px`,
-                        transform: `translateY(${queueScrollbar.thumbTop}px)`,
-                      }}
-                    />
+                    ) : null}
                   </div>
-                ) : null}
+                </div>
               </div>
             </div>
+            <button
+              type="button"
+              onClick={toggleQueueCollapsed}
+              title={toggleQueueTooltip}
+              aria-label={toggleQueueTooltip}
+              aria-expanded={!queueCollapsed}
+              className="absolute left-1/2 top-0 z-40 inline-flex h-[18px] -translate-x-1/2 -translate-y-1/2 items-center gap-1 rounded-full border border-black/[0.07] bg-white/90 pl-1.5 pr-2 text-muted-foreground shadow-[0_2px_10px_-4px_rgba(15,23,42,0.45),inset_0_1px_0_rgba(255,255,255,0.85)] backdrop-blur-xl backdrop-saturate-150 transition-[background-color,color,scale] hover:bg-white hover:text-foreground active:scale-95 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring dark:border-white/[0.12] dark:bg-zinc-900/90 dark:shadow-[0_2px_10px_-4px_rgba(0,0,0,0.8),inset_0_1px_0_rgba(255,255,255,0.10)] dark:hover:bg-zinc-900"
+            >
+              {queueCollapsed ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronUp className="h-3 w-3" />
+              )}
+              <span className="text-[10px] font-medium leading-none tabular-nums">
+                {queuedTurns.length}
+              </span>
+            </button>
           </div>
         ) : null}
 

--- a/crates/agent-gui/src-tauri/Cargo.toml
+++ b/crates/agent-gui/src-tauri/Cargo.toml
@@ -61,3 +61,6 @@ russh-sftp = "2.3.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSButton", "NSControl", "NSView", "NSWindow"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }

--- a/crates/agent-gui/src-tauri/src/commands/workspace/fs.rs
+++ b/crates/agent-gui/src-tauri/src/commands/workspace/fs.rs
@@ -233,12 +233,33 @@ fn file_identity(meta: &fs::Metadata, _canon: &Path) -> String {
 }
 
 #[cfg(windows)]
-fn file_identity(meta: &fs::Metadata, canon: &Path) -> String {
-    use std::os::windows::fs::MetadataExt;
-    match (meta.volume_serial_number(), meta.file_index()) {
-        (Some(volume), Some(index)) => format!("{volume}:{index}"),
-        _ => format!("path:{}", display_path(canon).to_lowercase()),
+fn file_identity(_meta: &fs::Metadata, canon: &Path) -> String {
+    // std's volume_serial_number()/file_index() are unstable (windows_by_handle,
+    // rust-lang/rust#63010); query GetFileInformationByHandle directly instead.
+    fn identity_by_handle(path: &Path) -> Option<String> {
+        use std::os::windows::fs::OpenOptionsExt;
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Storage::FileSystem::{
+            GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION, FILE_FLAG_BACKUP_SEMANTICS,
+        };
+
+        // access_mode(0): metadata-only handle, no read permission required.
+        // FILE_FLAG_BACKUP_SEMANTICS is required to open directories.
+        let file = fs::OpenOptions::new()
+            .access_mode(0)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+            .open(path)
+            .ok()?;
+        let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+        if unsafe { GetFileInformationByHandle(file.as_raw_handle() as _, &mut info) } == 0 {
+            return None;
+        }
+        let volume = info.dwVolumeSerialNumber;
+        let index = (u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow);
+        Some(format!("{volume}:{index}"))
     }
+    identity_by_handle(canon)
+        .unwrap_or_else(|| format!("path:{}", display_path(canon).to_lowercase()))
 }
 
 fn levenshtein_at_most(a: &str, b: &str, max: usize) -> bool {

--- a/crates/agent-gui/src/index.css
+++ b/crates/agent-gui/src/index.css
@@ -1093,34 +1093,6 @@
     }
   }
 
-  /* Glow pulse animation */
-  .hero-glow-pulse {
-    animation:
-      heroGlowPulse 5s ease-in-out infinite,
-      heroFadeIn 1.2s ease-out both;
-  }
-
-  @keyframes heroGlowPulse {
-    0%,
-    100% {
-      opacity: 0.7;
-      transform: scale(1);
-    }
-    50% {
-      opacity: 1;
-      transform: scale(1.12);
-    }
-  }
-
-  @keyframes heroFadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 0.7;
-    }
-  }
-
   /* Mention composer placeholder */
   .mention-composer.is-empty::before {
     content: attr(data-placeholder);

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -1723,6 +1723,7 @@ export function ChatPage(props: ChatPageProps) {
   } = usePendingUploads({
     isAgentMode,
     workdir: displayedConversationWorkdir,
+    conversationId: currentConversationId,
     currentConversationIdRef,
     composerRef,
     setErrorMessage,
@@ -3314,9 +3315,8 @@ export function ChatPage(props: ChatPageProps) {
 
   useEffect(() => {
     currentConversationIdRef.current = currentConversationId;
-    setPendingUploadedFiles(
-      pendingUploadsByConversationRef.current.get(currentConversationId) ?? [],
-    );
+    // Per-conversation pending uploads are restored inside usePendingUploads
+    // when its conversationId param changes.
   }, [currentConversationId]);
 
   useEffect(() => {

--- a/crates/agent-gui/src/pages/chat/components/ChatComposerBar.tsx
+++ b/crates/agent-gui/src/pages/chat/components/ChatComposerBar.tsx
@@ -499,142 +499,145 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
         {queuedTurns.length > 0 ? (
           <div
             ref={queuePanelRef}
-            className={cn(
-              "relative z-30 mx-auto mb-[-1px] w-[calc(100%-1.5rem)] max-w-[720px] overflow-visible rounded-t-lg rounded-b-none border border-b-0 border-black/[0.055] bg-white/70 p-1 shadow-[0_8px_24px_-18px_rgba(15,23,42,0.24),inset_0_1px_0_rgba(255,255,255,0.72)] backdrop-blur-2xl backdrop-saturate-[165%] transition-[padding] duration-200 ease-out dark:border-white/[0.10] dark:bg-white/[0.06] dark:shadow-[0_8px_24px_-18px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.08)]",
-              queueCollapsed && "px-1 py-0.5",
-            )}
+            className="relative z-30 mx-auto mb-[-1px] w-[calc(100%-1.5rem)] max-w-[720px]"
           >
-            <div className="relative flex h-2 items-center justify-center">
-              <span className="pointer-events-none absolute inset-x-1 top-1/2 h-px -translate-y-1/2 rounded-full bg-black/10 dark:bg-white/15" />
-              <button
-                type="button"
-                onClick={toggleQueueCollapsed}
-                aria-label={toggleQueueTooltip}
-                aria-expanded={!queueCollapsed}
-                className="relative z-10 inline-flex h-4 w-7 items-center justify-center rounded-full border border-black/[0.06] bg-white/80 text-muted-foreground shadow-[0_1px_4px_-2px_rgba(15,23,42,0.35)] transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring dark:border-white/10 dark:bg-zinc-900/80"
-              >
-                {queueCollapsed ? (
-                  <ChevronDown className="h-3 w-3" />
-                ) : (
-                  <ChevronUp className="h-3 w-3" />
-                )}
-              </button>
-            </div>
             <div
               aria-hidden={queueCollapsed}
               className={cn(
-                "grid transition-[grid-template-rows,margin-top,opacity] duration-200 ease-out",
-                queueCollapsed
-                  ? "mt-0 grid-rows-[0fr] opacity-0"
-                  : "mt-1 grid-rows-[1fr] opacity-100",
+                "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+                queueCollapsed ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100",
               )}
             >
-              <div className="relative min-h-0 overflow-hidden">
-                <ul
-                  ref={queueListRef}
-                  data-scrollable={queuedTurns.length > 2 ? "true" : "false"}
-                  className={cn(
-                    "chat-queue-scroll flex min-w-0 flex-col gap-1 overflow-x-hidden",
-                    queuedTurns.length > 2
-                      ? "h-[76px] overflow-y-scroll pr-3"
-                      : "max-h-[76px] overflow-y-hidden pr-1",
-                  )}
-                >
-                  {queuedTurns.map((item, index) => {
-                    return (
-                      <li
-                        key={item.id}
-                        className="relative grid h-9 min-h-9 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 rounded-md border border-black/[0.035] bg-white/42 px-2 text-xs shadow-[inset_0_1px_0_rgba(255,255,255,0.56)] backdrop-blur-xl backdrop-saturate-[150%] transition-[border-color,background-color] dark:border-white/[0.06] dark:bg-white/[0.04] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+              <div className="min-h-0 overflow-hidden">
+                <div className="rounded-t-lg border border-b-0 border-black/[0.055] bg-white/70 px-1 pb-1 pt-2 shadow-[0_8px_24px_-18px_rgba(15,23,42,0.24),inset_0_1px_0_rgba(255,255,255,0.72)] backdrop-blur-2xl backdrop-saturate-[165%] dark:border-white/[0.10] dark:bg-white/[0.06] dark:shadow-[0_8px_24px_-18px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.08)]">
+                  <div className="relative min-h-0">
+                    <ul
+                      ref={queueListRef}
+                      data-scrollable={queuedTurns.length > 2 ? "true" : "false"}
+                      className={cn(
+                        "chat-queue-scroll flex min-w-0 flex-col gap-1 overflow-x-hidden",
+                        queuedTurns.length > 2
+                          ? "h-[76px] overflow-y-scroll pr-3"
+                          : "max-h-[76px] overflow-y-hidden pr-1",
+                      )}
+                    >
+                      {queuedTurns.map((item, index) => {
+                        return (
+                          <li
+                            key={item.id}
+                            className="relative grid h-9 min-h-9 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 rounded-md border border-black/[0.035] bg-white/42 px-2 text-xs shadow-[inset_0_1px_0_rgba(255,255,255,0.56)] backdrop-blur-xl backdrop-saturate-[150%] transition-[border-color,background-color] dark:border-white/[0.06] dark:bg-white/[0.04] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+                          >
+                            <div className="flex shrink-0 items-center gap-0.5">
+                              {index > 0 ? (
+                                <button
+                                  type="button"
+                                  disabled={queueCollapsed}
+                                  onClick={() => onMoveQueuedTurnUp(item.id)}
+                                  aria-label={t("chat.queue.moveUp")}
+                                  className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-35"
+                                >
+                                  <ChevronUp className="h-3 w-3" />
+                                </button>
+                              ) : (
+                                <span aria-hidden className="h-6 w-6" />
+                              )}
+                              <Clock3 className="h-3 w-3 shrink-0 text-muted-foreground/65" />
+                            </div>
+                            <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
+                              <span className="block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px] leading-4 text-foreground/88">
+                                {item.previewText || t("chat.queue.emptyMessage")}
+                              </span>
+                              {item.fileCount > 0 ? (
+                                <span className="max-w-[4.5rem] shrink-0 overflow-hidden text-ellipsis whitespace-nowrap text-[9px] leading-4 text-muted-foreground">
+                                  {t("chat.queue.fileCount").replace(
+                                    "{count}",
+                                    String(item.fileCount),
+                                  )}
+                                </span>
+                              ) : null}
+                            </div>
+                            <div className="flex shrink-0 items-center gap-0.5">
+                              <RuntimeControlTooltip label={t("chat.queue.edit")}>
+                                <button
+                                  type="button"
+                                  disabled={queueCollapsed}
+                                  onClick={() => onEditQueuedTurn(item.id)}
+                                  title={t("chat.queue.edit")}
+                                  aria-label={t("chat.queue.edit")}
+                                  className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground"
+                                >
+                                  <SquarePen className="h-3 w-3" />
+                                </button>
+                              </RuntimeControlTooltip>
+                              <RuntimeControlTooltip label={t("chat.queue.runNow")}>
+                                <button
+                                  type="button"
+                                  disabled={queueCollapsed}
+                                  onClick={() => onRunQueuedTurnNow(item.id)}
+                                  title={t("chat.queue.runNow")}
+                                  aria-label={t("chat.queue.runNow")}
+                                  className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground"
+                                >
+                                  <Play className="h-3 w-3" />
+                                </button>
+                              </RuntimeControlTooltip>
+                              <RuntimeControlTooltip label={t("chat.queue.delete")}>
+                                <button
+                                  type="button"
+                                  disabled={queueCollapsed}
+                                  onClick={() => onRemoveQueuedTurn(item.id)}
+                                  title={t("chat.queue.delete")}
+                                  aria-label={t("chat.queue.delete")}
+                                  className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                                >
+                                  <Trash2 className="h-3 w-3" />
+                                </button>
+                              </RuntimeControlTooltip>
+                            </div>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                    {shouldShowQueueScrollbar ? (
+                      <div
+                        ref={queueScrollbarTrackRef}
+                        aria-hidden
+                        className="chat-queue-scrollbar"
+                        onPointerCancel={handleQueueScrollbarPointerUp}
+                        onPointerDown={handleQueueScrollbarPointerDown}
+                        onPointerMove={handleQueueScrollbarPointerMove}
+                        onPointerUp={handleQueueScrollbarPointerUp}
                       >
-                        <div className="flex shrink-0 items-center gap-0.5">
-                          {index > 0 ? (
-                            <button
-                              type="button"
-                              disabled={queueCollapsed}
-                              onClick={() => onMoveQueuedTurnUp(item.id)}
-                              aria-label={t("chat.queue.moveUp")}
-                              className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-35"
-                            >
-                              <ChevronUp className="h-3 w-3" />
-                            </button>
-                          ) : (
-                            <span aria-hidden className="h-6 w-6" />
-                          )}
-                          <Clock3 className="h-3 w-3 shrink-0 text-muted-foreground/65" />
-                        </div>
-                        <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
-                          <span className="block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11px] leading-4 text-foreground/88">
-                            {item.previewText || t("chat.queue.emptyMessage")}
-                          </span>
-                          {item.fileCount > 0 ? (
-                            <span className="max-w-[4.5rem] shrink-0 overflow-hidden text-ellipsis whitespace-nowrap text-[9px] leading-4 text-muted-foreground">
-                              {t("chat.queue.fileCount").replace("{count}", String(item.fileCount))}
-                            </span>
-                          ) : null}
-                        </div>
-                        <div className="flex shrink-0 items-center gap-0.5">
-                          <RuntimeControlTooltip label={t("chat.queue.edit")}>
-                            <button
-                              type="button"
-                              disabled={queueCollapsed}
-                              onClick={() => onEditQueuedTurn(item.id)}
-                              title={t("chat.queue.edit")}
-                              aria-label={t("chat.queue.edit")}
-                              className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground"
-                            >
-                              <SquarePen className="h-3 w-3" />
-                            </button>
-                          </RuntimeControlTooltip>
-                          <RuntimeControlTooltip label={t("chat.queue.runNow")}>
-                            <button
-                              type="button"
-                              disabled={queueCollapsed}
-                              onClick={() => onRunQueuedTurnNow(item.id)}
-                              title={t("chat.queue.runNow")}
-                              aria-label={t("chat.queue.runNow")}
-                              className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground"
-                            >
-                              <Play className="h-3 w-3" />
-                            </button>
-                          </RuntimeControlTooltip>
-                          <RuntimeControlTooltip label={t("chat.queue.delete")}>
-                            <button
-                              type="button"
-                              disabled={queueCollapsed}
-                              onClick={() => onRemoveQueuedTurn(item.id)}
-                              title={t("chat.queue.delete")}
-                              aria-label={t("chat.queue.delete")}
-                              className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                            >
-                              <Trash2 className="h-3 w-3" />
-                            </button>
-                          </RuntimeControlTooltip>
-                        </div>
-                      </li>
-                    );
-                  })}
-                </ul>
-                {shouldShowQueueScrollbar ? (
-                  <div
-                    ref={queueScrollbarTrackRef}
-                    aria-hidden
-                    className="chat-queue-scrollbar"
-                    onPointerCancel={handleQueueScrollbarPointerUp}
-                    onPointerDown={handleQueueScrollbarPointerDown}
-                    onPointerMove={handleQueueScrollbarPointerMove}
-                    onPointerUp={handleQueueScrollbarPointerUp}
-                  >
-                    <div
-                      className="chat-queue-scrollbar-thumb"
-                      style={{
-                        height: `${queueScrollbar.thumbHeight}px`,
-                        transform: `translateY(${queueScrollbar.thumbTop}px)`,
-                      }}
-                    />
+                        <div
+                          className="chat-queue-scrollbar-thumb"
+                          style={{
+                            height: `${queueScrollbar.thumbHeight}px`,
+                            transform: `translateY(${queueScrollbar.thumbTop}px)`,
+                          }}
+                        />
+                      </div>
+                    ) : null}
                   </div>
-                ) : null}
+                </div>
               </div>
             </div>
+            <button
+              type="button"
+              onClick={toggleQueueCollapsed}
+              title={toggleQueueTooltip}
+              aria-label={toggleQueueTooltip}
+              aria-expanded={!queueCollapsed}
+              className="absolute left-1/2 top-0 z-40 inline-flex h-[18px] -translate-x-1/2 -translate-y-1/2 items-center gap-1 rounded-full border border-black/[0.07] bg-white/90 pl-1.5 pr-2 text-muted-foreground shadow-[0_2px_10px_-4px_rgba(15,23,42,0.45),inset_0_1px_0_rgba(255,255,255,0.85)] backdrop-blur-xl backdrop-saturate-150 transition-[background-color,color,scale] hover:bg-white hover:text-foreground active:scale-95 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring dark:border-white/[0.12] dark:bg-zinc-900/90 dark:shadow-[0_2px_10px_-4px_rgba(0,0,0,0.8),inset_0_1px_0_rgba(255,255,255,0.10)] dark:hover:bg-zinc-900"
+            >
+              {queueCollapsed ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronUp className="h-3 w-3" />
+              )}
+              <span className="text-[10px] font-medium leading-none tabular-nums">
+                {queuedTurns.length}
+              </span>
+            </button>
           </div>
         ) : null}
 

--- a/crates/agent-gui/src/pages/chat/hooks/usePendingUploads.ts
+++ b/crates/agent-gui/src/pages/chat/hooks/usePendingUploads.ts
@@ -22,6 +22,7 @@ type SystemUploadedReadableFileInput = {
 type UsePendingUploadsParams = {
   isAgentMode: boolean;
   workdir: string;
+  conversationId: string;
   currentConversationIdRef: MutableRefObject<string>;
   composerRef: MutableRefObject<MentionComposerHandle | null>;
   setErrorMessage: (message: string | null) => void;
@@ -53,6 +54,7 @@ export function usePendingUploads(params: UsePendingUploadsParams) {
   const {
     isAgentMode,
     workdir,
+    conversationId,
     currentConversationIdRef,
     composerRef,
     setErrorMessage,
@@ -61,7 +63,11 @@ export function usePendingUploads(params: UsePendingUploadsParams) {
   const [pendingUploadedFiles, setPendingUploadedFiles] = useState<PendingUploadedFile[]>([]);
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
   const activeUploadTasksRef = useRef(0);
-  const uploadContextRef = useRef<{ isAgentMode: boolean; workdir: string } | null>(null);
+  const uploadContextRef = useRef<{
+    isAgentMode: boolean;
+    workdir: string;
+    conversationId: string;
+  } | null>(null);
   const pendingUploadsByConversationRef = useRef(new Map<string, PendingUploadedFile[]>());
   const pendingUploadedFilesRef = useRef(pendingUploadedFiles);
 
@@ -79,16 +85,6 @@ export function usePendingUploads(params: UsePendingUploadsParams) {
       }
     };
   }, []);
-
-  useEffect(() => {
-    const previous = uploadContextRef.current;
-    uploadContextRef.current = { isAgentMode, workdir };
-    if (!previous) return;
-    if (previous.isAgentMode === isAgentMode && previous.workdir === workdir) return;
-    pendingUploadsByConversationRef.current.clear();
-    pendingUploadedFilesRef.current = [];
-    setPendingUploadedFiles([]);
-  }, [isAgentMode, workdir]);
 
   const getPendingUploadsForConversation = useCallback(
     (conversationId: string) => {
@@ -125,6 +121,36 @@ export function usePendingUploads(params: UsePendingUploadsParams) {
     },
     [currentConversationIdRef],
   );
+
+  useEffect(() => {
+    const targetConversationId = conversationId.trim();
+    const nextFiles = targetConversationId
+      ? (pendingUploadsByConversationRef.current.get(targetConversationId) ?? [])
+      : [];
+    pendingUploadedFilesRef.current = nextFiles;
+    setPendingUploadedFiles(nextFiles);
+  }, [conversationId]);
+
+  useEffect(() => {
+    const previous = uploadContextRef.current;
+    uploadContextRef.current = { isAgentMode, workdir, conversationId };
+    if (!previous) return;
+    if (previous.isAgentMode !== isAgentMode) {
+      // Attachments are only usable in tools mode; a mode flip invalidates
+      // every conversation's pending uploads.
+      pendingUploadsByConversationRef.current.clear();
+      pendingUploadedFilesRef.current = [];
+      setPendingUploadedFiles([]);
+      return;
+    }
+    // Switching conversations must not invalidate any conversation's
+    // uploads — each entry is relative to its own workdir. Only a workdir
+    // change within the same conversation (a draft switching projects)
+    // makes that conversation's relative paths stale.
+    if (previous.conversationId !== conversationId) return;
+    if (previous.workdir === workdir) return;
+    setPendingUploadsForConversation(conversationId, []);
+  }, [isAgentMode, workdir, conversationId, setPendingUploadsForConversation]);
 
   const captureUploadTarget = useCallback(() => {
     const targetConversationId = currentConversationIdRef.current.trim();

--- a/crates/agent-gui/src/pages/chat/transcript/ChatTranscript.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/ChatTranscript.tsx
@@ -157,10 +157,6 @@ export const ChatTranscript = memo(function ChatTranscript(props: ChatTranscript
         <div className="mx-auto w-full max-w-[768px] px-5 py-4">
           {showNoModelsState ? (
             <div className="flex min-h-[calc(100vh-220px)] flex-col items-center justify-center">
-              <div className="pointer-events-none absolute inset-0 flex items-center justify-center overflow-hidden">
-                <div className="hero-glow-pulse h-[360px] w-[360px] rounded-full bg-[radial-gradient(closest-side,hsl(var(--foreground)/0.08),transparent_70%)] blur-3xl" />
-              </div>
-
               <div className="relative flex flex-col items-center">
                 <div className="hero-entrance hero-icon-float mb-5 flex h-24 w-24 items-center justify-center">
                   <img
@@ -192,10 +188,6 @@ export const ChatTranscript = memo(function ChatTranscript(props: ChatTranscript
             </div>
           ) : showStartChatState ? (
             <div className="flex min-h-[calc(100vh-220px)] flex-col items-center justify-center">
-              <div className="pointer-events-none absolute inset-0 flex items-center justify-center overflow-hidden">
-                <div className="hero-glow-pulse h-[360px] w-[360px] rounded-full bg-[radial-gradient(closest-side,hsl(var(--foreground)/0.08),transparent_70%)] blur-3xl" />
-              </div>
-
               <div className="relative flex flex-col items-center">
                 <div className="hero-entrance hero-icon-float mb-5 flex h-24 w-24 items-center justify-center">
                   <img


### PR DESCRIPTION
## Summary
- Pin the queue collapse toggle to the panel border as a clasp (chevron + queued-turn count), mirrored across agent-gui and gateway web
- Replace unstable `windows_by_handle` APIs with `windows-sys` so the GUI builds on stable Rust toolchains
- Fix pending-upload invalidation to be scoped per-conversation instead of clearing all drafts on any workdir change
- Remove the empty-state hero glow behind the logo on both frontends

## Test plan
- [x] Verify queue panel clasp collapses/expands correctly in agent-gui and gateway web
- [x] Build agent-gui on Windows (stable toolchain) and confirm file identity/fileId still resolves correctly
- [x] Switch between conversations across projects and confirm pending upload attachments are preserved/cleared correctly
- [x] Visually confirm empty-state logo has no glow in light/dark mode on both frontends

🤖 Generated with [Claude Code](https://claude.com/claude-code)