### PR TITLE
fix(thinking-levels): keep thinking available for non-catalog custom models

### DIFF
--- a/crates/agent-gateway/test/webui/web-settings.test.mjs
+++ b/crates/agent-gateway/test/webui/web-settings.test.mjs
@@ -176,6 +176,30 @@ test("web chat runtime controls default and follow model-aware reasoning support
     }),
     ["minimal", "low", "medium", "high"],
   );
+  // 目录之外的自定义模型（deepseek/glm 等）按可推理处理，与桌面端一致：
+  // 标准四档；deepseek 走 codex 时镜像桌面端适配层的 xhigh 档。
+  assert.deepEqual(
+    settings.getChatRuntimeReasoningLevelsForProvider({
+      providerId: "codex",
+      requestFormat: "openai-completions",
+      modelId: "glm-4.7",
+    }),
+    ["minimal", "low", "medium", "high"],
+  );
+  assert.deepEqual(
+    settings.getChatRuntimeReasoningLevelsForProvider({
+      providerId: "claude_code",
+      modelId: "deepseek-reasoner",
+    }),
+    ["minimal", "low", "medium", "high"],
+  );
+  assert.deepEqual(
+    settings.getChatRuntimeReasoningLevelsForProvider({
+      providerId: "codex",
+      modelId: "deepseek-chat",
+    }),
+    ["minimal", "low", "medium", "high", "xhigh"],
+  );
 
   assert.equal(settings.isThinkingAlwaysOnForModel("claude_code", "claude-fable-5"), true);
   assert.equal(settings.isThinkingAlwaysOnForModel("claude_code", "claude-opus-4-8"), false);

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -933,9 +933,21 @@ export function getKnownModelThinkingLevels(
   providerId: ProviderId,
   modelId: string | undefined,
 ): ReasoningLevel[] {
-  const known = findKnownModel(providerId, modelId);
-  if (!known) return [];
-  return getSupportedThinkingLevels(known).filter((level) => level !== "off");
+  const trimmedId = modelId?.trim();
+  if (!trimmedId) return [];
+  const known = findKnownModel(providerId, trimmedId);
+  // 目录之外的自定义模型（deepseek/glm 等三方聚合）无法从 id 判断推理能力，
+  // 与桌面端 modelFactory 自定义分支一致按可推理处理：标准档位，xhigh/max
+  // 仍需目录 opt-in；deepseek 走 codex 时镜像桌面端 DeepSeek 适配层的 xhigh 档。
+  const model =
+    known ??
+    ({
+      reasoning: true,
+      ...(providerId === "codex" && trimmedId.toLowerCase().includes("deepseek")
+        ? { thinkingLevelMap: { xhigh: "max" } }
+        : {}),
+    } as Parameters<typeof getSupportedThinkingLevels>[0]);
+  return getSupportedThinkingLevels(model).filter((level) => level !== "off");
 }
 
 export function isThinkingAlwaysOnForModel(

--- a/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
@@ -77,29 +77,6 @@ function maybeAppendCodexApiVersion(baseUrl: string) {
   }
 }
 
-function supportsCodexReasoningModel(modelId: string) {
-  const normalizedModelId = modelId.trim().toLowerCase();
-  return (
-    normalizedModelId.startsWith("gpt-5") ||
-    normalizedModelId.includes("codex") ||
-    normalizedModelId.startsWith("o1") ||
-    normalizedModelId.startsWith("o3") ||
-    normalizedModelId.startsWith("o4")
-  );
-}
-
-function supportsOpenAICompletionsReasoningModel(modelId: string) {
-  const normalizedModelId = modelId.trim().toLowerCase();
-  return (
-    supportsCodexReasoningModel(normalizedModelId) ||
-    normalizedModelId.includes("deepseek") ||
-    normalizedModelId.includes("gpt-oss") ||
-    normalizedModelId.includes("qwen") ||
-    normalizedModelId.includes("reason") ||
-    normalizedModelId.includes("think")
-  );
-}
-
 function supportsOpenAICompletionsImageInputModel(modelId: string) {
   const normalizedModelId = modelId.trim().toLowerCase();
   if (normalizedModelId.includes("search-preview")) return false;
@@ -292,10 +269,10 @@ export function createModelFromConfig(
       api,
       provider: "openai",
       baseUrl: normalizedBaseUrl,
-      reasoning:
-        api === "openai-completions"
-          ? supportsOpenAICompletionsReasoningModel(modelId)
-          : supportsCodexReasoningModel(modelId),
+      // 目录之外的自定义模型无法从 id 可靠判断推理能力，与 anthropic/gemini
+      // 自定义分支一致按可推理处理（标准档位，xhigh/max 仍需目录 opt-in），
+      // 是否真的下发思考由用户的开关决定。
+      reasoning: true,
       input: resolveCodexModelInput(api, modelId),
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow,

--- a/crates/agent-gui/test/settings/normalization.test.mjs
+++ b/crates/agent-gui/test/settings/normalization.test.mjs
@@ -325,6 +325,34 @@ test("chat runtime controls default and follow provider model reasoning support"
     }),
     ["low", "high"],
   );
+  // 目录之外的自定义模型（glm/kimi 等三方聚合）按可推理处理：标准四档，
+  // 不因 id 猜不中而禁用思考。
+  assert.deepEqual(
+    settings.getChatRuntimeReasoningLevelsForProvider({
+      providerId: "codex",
+      requestFormat: "openai-completions",
+      modelId: "glm-4.7",
+      baseUrl: "https://api.z.ai/api/coding/paas/v4",
+    }),
+    ["minimal", "low", "medium", "high"],
+  );
+  assert.deepEqual(
+    settings.getChatRuntimeReasoningLevelsForProvider({
+      providerId: "claude_code",
+      modelId: "glm-4.7",
+      baseUrl: "https://api.z.ai/api/anthropic",
+    }),
+    ["minimal", "low", "medium", "high"],
+  );
+  // DeepSeek 走 codex：适配层 thinkingLevelMap 额外开出 xhigh。
+  assert.deepEqual(
+    settings.getChatRuntimeReasoningLevelsForProvider({
+      providerId: "codex",
+      modelId: "deepseek-chat",
+      baseUrl: "https://api.deepseek.com",
+    }),
+    ["minimal", "low", "medium", "high", "xhigh"],
+  );
 
   assert.deepEqual(
     settings.normalizeChatRuntimeControlsForProvider(


### PR DESCRIPTION
## Problem

The catalog-driven thinking-level rewrite (merged in #80) disabled the thinking toggle entirely for models that pi-ai's catalog doesn't know:

- **Desktop GUI**: under codex providers, reasoning support for non-catalog models was guessed from id keywords — the list was missing `glm`/`kimi`/`minimax`, and the openai-responses list only recognized gpt-5/codex/o1–o4. A wrong guess produced an empty level list, which disabled the thinking toggle and dropdown.
- **Web UI**: `getKnownModelThinkingLevels` hard-coded `reasoning: false` for any catalog miss, so DeepSeek/GLM configured under **any** provider (anthropic or codex) could not enable thinking at all.

## Fix

Custom model ids can't be reliably classified, so both frontends now treat non-catalog models as reasoning-capable with the standard levels (`minimal/low/medium/high`; `xhigh`/`max` remain catalog-opt-in), matching the existing custom anthropic/gemini branches. Whether thinking is actually sent stays under the user's toggle.

- GUI: delete the `supportsCodexReasoningModel` / `supportsOpenAICompletionsReasoningModel` id heuristics; custom codex models default `reasoning: true`.
- Web: catalog-miss fallback becomes reasoning-capable, and mirrors the desktop DeepSeek adapter's `xhigh` tier so a desktop-selected `xhigh` isn't clamped away by the web normalizer after sync.
- Tests: added glm/deepseek coverage under codex and anthropic providers on both ends.

Catalog models (gpt-5.x, claude-sonnet-5, gemini, …) are unaffected.

## Verification

- `tsc --noEmit` clean in both `crates/agent-gui` and `crates/agent-gateway/web`
- agent-gui: 763/763 tests pass
- agent-gateway JS (`test/webui` + `web/test`): 274/274 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)