### PR TITLE
feat(providers): add unified stream retry and structural hosted-search parsing

### DIFF
--- a/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
+++ b/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
@@ -298,118 +298,6 @@ export function startHostedSearchFetchProbe(params: {
   };
 }
 
-function normalizedType(value: unknown) {
-  return readString(value).replace(/-/g, "_").toLowerCase();
-}
-
-function hasRecordMatching(
-  value: unknown,
-  matches: (record: Record<string, unknown>) => boolean,
-): boolean {
-  if (Array.isArray(value)) return value.some((item) => hasRecordMatching(item, matches));
-  if (!isRecord(value)) return false;
-  if (matches(value)) return true;
-  return Object.values(value).some((child) => hasRecordMatching(child, matches));
-}
-
-function isOpenAIWebSearchRecord(record: Record<string, unknown>) {
-  const type = normalizedType(record.type);
-  return type === "web_search_call" || type.startsWith("web_search_call_");
-}
-
-function isOpenAIUrlCitationRecord(record: Record<string, unknown>) {
-  return normalizedType(record.type) === "url_citation";
-}
-
-function hasOpenAISearchSignal(value: unknown) {
-  if (!isRecord(value)) return false;
-  const eventType = normalizedType(value.type);
-  if (eventType.includes("web_search_call")) return true;
-  if (eventType.includes("output_text.annotation")) {
-    const annotation = isRecord(value.annotation) ? value.annotation : {};
-    return isOpenAIUrlCitationRecord(annotation);
-  }
-  const item = isRecord(value.item) ? value.item : {};
-  if (isOpenAIWebSearchRecord(item)) return true;
-  return hasRecordMatching(
-    value,
-    (record) => isOpenAIWebSearchRecord(record) || isOpenAIUrlCitationRecord(record),
-  );
-}
-
-function isAnthropicWebSearchRecord(record: Record<string, unknown>) {
-  const type = normalizedType(record.type);
-  const name = readString(record.name).toLowerCase();
-  return (
-    (type === "server_tool_use" && name === "web_search") ||
-    type === "web_search_tool_result" ||
-    type === "web_search_result" ||
-    type === "webpage_location" ||
-    (name === "web_search" && type.includes("tool"))
-  );
-}
-
-function hasAnthropicSearchSignal(value: unknown) {
-  if (!isRecord(value)) return false;
-  const eventType = normalizedType(value.type);
-  if (eventType.includes("web_search")) return true;
-  const contentBlock = isRecord(value.content_block) ? value.content_block : {};
-  if (isAnthropicWebSearchRecord(contentBlock)) return true;
-  return hasRecordMatching(value, isAnthropicWebSearchRecord);
-}
-
-function hasGeminiGroundingSignal(value: unknown) {
-  return hasRecordMatching(value, (record) => {
-    if (isRecord(record.groundingMetadata)) return true;
-    if (Array.isArray(record.groundingChunks)) return true;
-    if (Array.isArray(record.webSearchQueries)) return true;
-    return false;
-  });
-}
-
-function hasSearchSignal(providerId: ProviderId, value: unknown): boolean {
-  if (providerId === "codex") return hasOpenAISearchSignal(value);
-  if (providerId === "claude_code") return hasAnthropicSearchSignal(value);
-  if (providerId === "gemini") return hasGeminiGroundingSignal(value);
-  return false;
-}
-
-function collectQueries(value: unknown, out: string[] = [], keyHint = ""): string[] {
-  if (typeof value === "string") {
-    const normalizedHint = keyHint.toLowerCase();
-    if (
-      normalizedHint === "query" ||
-      normalizedHint === "search_query" ||
-      normalizedHint === "searchquery" ||
-      normalizedHint === "websearchqueries"
-    ) {
-      const text = value.replace(/\s+/g, " ").trim();
-      if (text && text.length <= 500 && !out.includes(text)) out.push(text);
-    }
-    return out;
-  }
-
-  if (Array.isArray(value)) {
-    value.forEach((item) => {
-      collectQueries(item, out, keyHint);
-    });
-    return out;
-  }
-
-  if (!isRecord(value)) return out;
-  for (const [key, child] of Object.entries(value)) {
-    const normalizedKey = key.replace(/[-_]/g, "").toLowerCase();
-    if (Array.isArray(child) && normalizedKey === "websearchqueries") {
-      child.forEach((item) => {
-        collectQueries(item, out, "webSearchQueries");
-      });
-      continue;
-    }
-    collectQueries(child, out, key);
-  }
-  return out;
-}
-
 function isHttpUrl(value: string) {
   try {
     const url = new URL(value);
@@ -419,129 +307,284 @@ function isHttpUrl(value: string) {
   }
 }
 
-function collectSources(value: unknown, out = new Map<string, HostedSearchSource>()) {
-  if (Array.isArray(value)) {
-    value.forEach((item) => {
-      collectSources(item, out);
-    });
-    return out;
-  }
-  if (!isRecord(value)) return out;
-
-  const directUrl = readString(value.url ?? value.uri);
-  if (directUrl && isHttpUrl(directUrl)) {
-    const existing = out.get(directUrl);
-    const type = readString(value.type);
-    const sourceType =
-      type === "url_citation" ||
-      value.cited_text ||
-      value.citedText ||
-      existing?.sourceType === "citation"
-        ? "citation"
-        : "source";
-    const title = readString(value.title ?? value.name) || existing?.title;
-    const snippet = readString(value.snippet ?? value.description) || existing?.snippet;
-    const citedText = readString(value.cited_text ?? value.citedText) || existing?.citedText;
-    out.set(directUrl, {
-      url: directUrl,
-      ...(title ? { title } : {}),
-      ...(snippet ? { snippet } : {}),
-      ...(citedText ? { citedText } : {}),
-      sourceType,
-    });
-  }
-
-  for (const child of Object.values(value)) {
-    collectSources(child, out);
-  }
-  return out;
+/** Raw (untrimmed) string read, for accumulating JSON text fragments where whitespace is significant. */
+function readRawString(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }
 
-function findFirstSearchRecordId(
-  value: unknown,
-  matches: (record: Record<string, unknown>) => boolean,
-): string {
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      const id = findFirstSearchRecordId(item, matches);
-      if (id) return id;
+type SearchEventParser = {
+  parse: (raw: unknown) => HostedSearchUpdate[];
+};
+
+// ---------------------------------------------------------------------------
+// OpenAI Responses: web_search_call lifecycle events + url_citation annotations.
+// Every event carries a complete, self-contained payload — no cross-event state.
+// ---------------------------------------------------------------------------
+
+function mapOpenAIWebSearchCallStatus(rawStatus: string, isDoneEvent: boolean): HostedSearchStatus {
+  const normalized = rawStatus.toLowerCase();
+  if (/fail|error|cancel/.test(normalized)) return "failed";
+  if (/complete|completed|done|succeeded|finished/.test(normalized)) return "completed";
+  return isDoneEvent ? "completed" : "searching";
+}
+
+function parseOpenAIResponsesSearchEvent(raw: unknown): HostedSearchUpdate[] {
+  if (!isRecord(raw)) return [];
+  const type = readString(raw.type);
+
+  if (type === "response.output_item.added" || type === "response.output_item.done") {
+    const item = isRecord(raw.item) ? raw.item : {};
+    if (readString(item.type) !== "web_search_call") return [];
+    const action = isRecord(item.action) ? item.action : {};
+    const query = readString(action.query);
+    const id = readString(item.id) || readString(item.call_id);
+    return [
+      {
+        ...(id ? { id } : {}),
+        provider: "codex",
+        status: mapOpenAIWebSearchCallStatus(readString(item.status), type.endsWith(".done")),
+        queries: query ? [query] : [],
+        sources: [],
+      },
+    ];
+  }
+
+  // Defensive coverage for the dedicated response.web_search_call.* lifecycle
+  // events (in_progress/searching/completed) some OpenAI-compatible gateways
+  // emit alongside (or instead of) output_item add/done.
+  if (type.startsWith("response.web_search_call.")) {
+    const suffix = type.slice("response.web_search_call.".length).toLowerCase();
+    const id = readString(raw.item_id) || readString(raw.output_item_id);
+    return [
+      {
+        ...(id ? { id } : {}),
+        provider: "codex",
+        status: /fail|error|cancel/.test(suffix)
+          ? "failed"
+          : /complete|completed|done/.test(suffix)
+            ? "completed"
+            : "searching",
+        queries: [],
+        sources: [],
+      },
+    ];
+  }
+
+  if (type === "response.output_text.annotation.added") {
+    const annotation = isRecord(raw.annotation) ? raw.annotation : {};
+    if (readString(annotation.type) !== "url_citation") return [];
+    const url = readString(annotation.url ?? annotation.uri);
+    if (!url || !isHttpUrl(url)) return [];
+    const title = readString(annotation.title);
+    return [
+      {
+        provider: "codex",
+        status: "completed",
+        queries: [],
+        sources: [{ url, ...(title ? { title } : {}), sourceType: "citation" }],
+      },
+    ];
+  }
+
+  return [];
+}
+
+function createOpenAIResponsesSearchEventParser(): SearchEventParser {
+  return { parse: parseOpenAIResponsesSearchEvent };
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic Messages: server_tool_use (web_search) content blocks are stateful —
+// the query is either given whole on content_block_start, or streamed in as
+// input_json_delta.partial_json fragments keyed by content_block.index that
+// only become valid JSON once fully accumulated. Web search results arrive
+// whole on content_block_start; citations arrive via citations_delta on text
+// blocks and are associated with the most recently active search by the
+// aggregator's own last-id fallback (they carry no search id of their own).
+// ---------------------------------------------------------------------------
+
+type AnthropicSearchBlockState = {
+  toolId: string;
+  jsonBuffer: string;
+  lastQuery: string;
+};
+
+function tryExtractAnthropicQuery(jsonBuffer: string): string {
+  const parsed = maybeParseJson(jsonBuffer);
+  return isRecord(parsed) ? readString(parsed.query) : "";
+}
+
+function extractAnthropicResultSources(content: unknown): HostedSearchSource[] {
+  if (!Array.isArray(content)) return [];
+  const sources: HostedSearchSource[] = [];
+  for (const item of content) {
+    if (!isRecord(item)) continue;
+    const url = readString(item.url);
+    if (!url || !isHttpUrl(url)) continue;
+    const title = readString(item.title);
+    sources.push({ url, ...(title ? { title } : {}), sourceType: "source" });
+  }
+  return sources;
+}
+
+function createAnthropicSearchEventParser(): SearchEventParser {
+  const searchBlocksByIndex = new Map<number, AnthropicSearchBlockState>();
+
+  function parseContentBlockStart(raw: Record<string, unknown>): HostedSearchUpdate[] {
+    const index = typeof raw.index === "number" ? raw.index : -1;
+    const block = isRecord(raw.content_block) ? raw.content_block : {};
+    const blockType = readString(block.type);
+    const name = readString(block.name).toLowerCase();
+
+    if (blockType === "server_tool_use" && name === "web_search") {
+      const toolId = readString(block.id);
+      const state: AnthropicSearchBlockState = { toolId, jsonBuffer: "", lastQuery: "" };
+      searchBlocksByIndex.set(index, state);
+
+      const query = isRecord(block.input) ? readString(block.input.query) : "";
+      if (!query) return [];
+      state.lastQuery = query;
+      return [
+        {
+          ...(toolId ? { id: toolId } : {}),
+          provider: "claude_code",
+          status: "searching",
+          queries: [query],
+          sources: [],
+        },
+      ];
     }
-    return "";
-  }
-  if (!isRecord(value)) return "";
-  if (matches(value)) {
-    const id = readString(value.id) || readString(value.call_id) || readString(value.tool_use_id);
-    if (id) return id;
-  }
-  for (const child of Object.values(value)) {
-    const id = findFirstSearchRecordId(child, matches);
-    if (id) return id;
-  }
-  return "";
-}
 
-function readExplicitSearchId(providerId: ProviderId, raw: unknown) {
-  if (!isRecord(raw)) return "";
-
-  if (providerId === "codex") {
-    const eventType = normalizedType(raw.type);
-    if (eventType.includes("output_text.annotation")) return "";
-    if (eventType.includes("web_search_call")) {
-      return readString(raw.item_id) || readString(raw.output_item_id);
+    if (blockType === "web_search_tool_result" || blockType === "web_search_tool_result_error") {
+      const toolUseId = readString(block.tool_use_id);
+      return [
+        {
+          ...(toolUseId ? { id: toolUseId } : {}),
+          provider: "claude_code",
+          status: blockType === "web_search_tool_result_error" ? "failed" : "completed",
+          queries: [],
+          sources: extractAnthropicResultSources(block.content),
+        },
+      ];
     }
-    return findFirstSearchRecordId(raw, isOpenAIWebSearchRecord);
+
+    return [];
   }
 
-  if (providerId === "claude_code") {
-    return findFirstSearchRecordId(raw, isAnthropicWebSearchRecord);
+  function parseContentBlockDelta(raw: Record<string, unknown>): HostedSearchUpdate[] {
+    const index = typeof raw.index === "number" ? raw.index : -1;
+    const delta = isRecord(raw.delta) ? raw.delta : {};
+    const deltaType = readString(delta.type);
+
+    if (deltaType === "input_json_delta") {
+      const state = searchBlocksByIndex.get(index);
+      if (!state) return [];
+      state.jsonBuffer += readRawString(delta.partial_json);
+      const query = tryExtractAnthropicQuery(state.jsonBuffer);
+      if (!query || query === state.lastQuery) return [];
+      state.lastQuery = query;
+      return [
+        {
+          ...(state.toolId ? { id: state.toolId } : {}),
+          provider: "claude_code",
+          status: "searching",
+          queries: [query],
+          sources: [],
+        },
+      ];
+    }
+
+    if (deltaType === "citations_delta") {
+      const citation = isRecord(delta.citation) ? delta.citation : {};
+      const url = readString(citation.url);
+      if (!url || !isHttpUrl(url)) return [];
+      const title = readString(citation.title);
+      return [
+        {
+          provider: "claude_code",
+          status: "completed",
+          queries: [],
+          sources: [{ url, ...(title ? { title } : {}), sourceType: "citation" }],
+        },
+      ];
+    }
+
+    return [];
   }
 
-  const item = isRecord(raw.item) ? raw.item : {};
-  const contentBlock = isRecord(raw.content_block) ? raw.content_block : {};
-  return (
-    readString(raw.item_id) ||
-    readString(raw.tool_use_id) ||
-    readString(item.id) ||
-    readString(item.call_id) ||
-    readString(contentBlock.id) ||
-    readString(contentBlock.tool_use_id)
-  );
+  function parse(raw: unknown): HostedSearchUpdate[] {
+    if (!isRecord(raw)) return [];
+    const type = readString(raw.type);
+
+    if (type === "content_block_start") return parseContentBlockStart(raw);
+    if (type === "content_block_delta") return parseContentBlockDelta(raw);
+    if (type === "content_block_stop") {
+      const index = typeof raw.index === "number" ? raw.index : -1;
+      searchBlocksByIndex.delete(index);
+      return [];
+    }
+
+    return [];
+  }
+
+  return { parse };
 }
 
-function readRawStatus(raw: unknown, sources: HostedSearchSource[]): HostedSearchStatus {
-  const record = isRecord(raw) ? raw : {};
-  const item = isRecord(record.item) ? record.item : {};
-  const statusText = [readString(record.type), readString(record.status), readString(item.status)]
-    .join(" ")
-    .toLowerCase();
+// ---------------------------------------------------------------------------
+// Gemini: grounding metadata arrives whole on each candidate — no lifecycle
+// events, no search id. A chunk means results are in; a query alone means the
+// search is still running.
+// ---------------------------------------------------------------------------
 
-  if (/fail|error|cancel/.test(statusText)) return "failed";
-  if (/complete|completed|done|succeeded|finished/.test(statusText)) return "completed";
-  if (/searching|in_progress|started|added/.test(statusText)) return "searching";
-  return sources.length > 0 ? "completed" : "searching";
-}
+function parseGeminiSearchEvent(raw: unknown): HostedSearchUpdate[] {
+  if (!isRecord(raw)) return [];
+  const candidates = Array.isArray(raw.candidates) ? raw.candidates : [];
+  const queries: string[] = [];
+  const sources: HostedSearchSource[] = [];
 
-function normalizeRawHostedSearchUpdate(
-  providerId: ProviderId,
-  raw: unknown,
-): HostedSearchUpdate | null {
-  if (!hasSearchSignal(providerId, raw)) return null;
-  const queries = collectQueries(raw);
-  const sources = [...collectSources(raw).values()];
-  const status = readRawStatus(raw, sources);
-  const id = readExplicitSearchId(providerId, raw);
+  for (const candidate of candidates) {
+    if (!isRecord(candidate)) continue;
+    const grounding = isRecord(candidate.groundingMetadata) ? candidate.groundingMetadata : {};
 
-  if (!id && queries.length === 0 && sources.length === 0 && status === "searching") {
-    return null;
+    if (Array.isArray(grounding.webSearchQueries)) {
+      for (const query of grounding.webSearchQueries) {
+        const text = readString(query);
+        if (text && !queries.includes(text)) queries.push(text);
+      }
+    }
+
+    if (Array.isArray(grounding.groundingChunks)) {
+      for (const chunk of grounding.groundingChunks) {
+        if (!isRecord(chunk)) continue;
+        const web = isRecord(chunk.web) ? chunk.web : {};
+        const url = readString(web.uri ?? web.url);
+        if (!url || !isHttpUrl(url)) continue;
+        const title = readString(web.title);
+        sources.push({ url, ...(title ? { title } : {}), sourceType: "source" });
+      }
+    }
   }
 
-  return {
-    ...(id ? { id } : {}),
-    provider: providerId,
-    status,
-    queries,
-    sources,
-  };
+  if (queries.length === 0 && sources.length === 0) return [];
+  return [
+    {
+      provider: "gemini",
+      status: sources.length > 0 ? "completed" : "searching",
+      queries,
+      sources,
+    },
+  ];
+}
+
+function createGeminiSearchEventParser(): SearchEventParser {
+  return { parse: parseGeminiSearchEvent };
+}
+
+function createHostedSearchEventParser(providerId: ProviderId): SearchEventParser {
+  if (providerId === "codex") return createOpenAIResponsesSearchEventParser();
+  if (providerId === "claude_code") return createAnthropicSearchEventParser();
+  if (providerId === "gemini") return createGeminiSearchEventParser();
+  return { parse: () => [] };
 }
 
 export function createHostedSearchEventAggregator(params: {
@@ -552,6 +595,7 @@ export function createHostedSearchEventAggregator(params: {
   const signaturesById = new Map<string, string>();
   const fallbackId = `hosted-search-${params.providerId}`;
   let lastId = fallbackId;
+  const parser = createHostedSearchEventParser(params.providerId);
 
   const blockSignature = (block: HostedSearchBlock) =>
     safeStringify({
@@ -611,9 +655,7 @@ export function createHostedSearchEventAggregator(params: {
 
   return {
     accept(rawEvent) {
-      const update = normalizeRawHostedSearchUpdate(params.providerId, rawEvent);
-      if (!update) return;
-      emit(update);
+      for (const update of parser.parse(rawEvent)) emit(update);
     },
     complete() {
       return finalize("completed", true);

--- a/crates/agent-gui/src/lib/providers/nativeWebSearch.ts
+++ b/crates/agent-gui/src/lib/providers/nativeWebSearch.ts
@@ -1,6 +1,8 @@
-import type { ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
+import type { Model, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
 import type { HostedSearchBlock } from "../chat/messages/hostedSearch";
 import type { ProviderId } from "../settings";
+import { isRecord } from "./runtime/common";
+import { supportsAdaptiveAnthropicThinking } from "./runtime/thinkingLevels";
 
 export const HIDDEN_PROVIDER_NATIVE_WEB_SEARCH_TOOL_NAMES = [
   "WebSearch",
@@ -8,6 +10,7 @@ export const HIDDEN_PROVIDER_NATIVE_WEB_SEARCH_TOOL_NAMES = [
   "builtin_web_search",
   "web_search_20250305",
   "web_search_20260209",
+  "web_search_20260318",
   "web_search_preview",
 ] as const;
 
@@ -19,9 +22,69 @@ export function isProviderNativeWebSearchToolName(toolName: string | undefined) 
     normalized === "web_search" ||
     normalized === "web_search_20250305" ||
     normalized === "web_search_20260209" ||
+    normalized === "web_search_20260318" ||
     normalized === "web_search_preview" ||
     normalized.startsWith("web_search_call")
   );
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic web search tool version: model-aware adaptive upgrade.
+// `dynamicFiltering` (20260318) is a superset of the 20260209 dynamic-filtering
+// capability plus `response_inclusion` control, and is the version the official
+// docs currently document/exemplify. Eligibility mirrors adaptive-thinking
+// support (`compat.forceAdaptiveThinking`) since both track the same "modern
+// Anthropic model" catalog boundary.
+// ---------------------------------------------------------------------------
+
+export const ANTHROPIC_WEB_SEARCH_TOOL_TYPES = {
+  legacy: "web_search_20250305",
+  dynamicFiltering: "web_search_20260318",
+} as const;
+
+export function supportsAnthropicDynamicFilteringWebSearch(model: Model<any>): boolean {
+  return supportsAdaptiveAnthropicThinking(model);
+}
+
+export function resolveAnthropicWebSearchToolType(
+  model: Model<any>,
+): (typeof ANTHROPIC_WEB_SEARCH_TOOL_TYPES)[keyof typeof ANTHROPIC_WEB_SEARCH_TOOL_TYPES] {
+  return supportsAnthropicDynamicFilteringWebSearch(model)
+    ? ANTHROPIC_WEB_SEARCH_TOOL_TYPES.dynamicFiltering
+    : ANTHROPIC_WEB_SEARCH_TOOL_TYPES.legacy;
+}
+
+// ---------------------------------------------------------------------------
+// Request-payload tool detectors (single catalog source; consumed by
+// runtime/nativeSearchPayload.ts to avoid a second drifting copy).
+// ---------------------------------------------------------------------------
+
+export function hasAnthropicWebSearchTool(tool: unknown) {
+  if (!isRecord(tool)) return false;
+  const type = tool.type;
+  const name = tool.name;
+  return (
+    name === "web_search" ||
+    type === ANTHROPIC_WEB_SEARCH_TOOL_TYPES.legacy ||
+    type === "web_search_20260209" ||
+    type === ANTHROPIC_WEB_SEARCH_TOOL_TYPES.dynamicFiltering
+  );
+}
+
+export function hasOpenAIResponsesWebSearchTool(tool: unknown) {
+  if (!isRecord(tool)) return false;
+  const type = tool.type;
+  return (
+    type === "web_search" ||
+    type === "web_search_2025_08_26" ||
+    type === "web_search_preview" ||
+    type === "web_search_preview_2025_03_11"
+  );
+}
+
+export function hasGeminiGoogleSearchTool(tool: unknown) {
+  if (!isRecord(tool)) return false;
+  return Boolean(tool.googleSearch || tool.google_search || tool.googleSearchRetrieval);
 }
 
 function readToolCallStringArgument(toolCall: ToolCall, name: string) {

--- a/crates/agent-gui/src/lib/providers/runtime/nativeSearchPayload.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/nativeSearchPayload.ts
@@ -1,6 +1,12 @@
 import type { Model } from "@earendil-works/pi-ai";
 import type { ProviderId } from "../../settings";
-import { providerSupportsNativeWebSearch } from "../nativeWebSearch";
+import {
+  hasAnthropicWebSearchTool,
+  hasGeminiGoogleSearchTool,
+  hasOpenAIResponsesWebSearchTool,
+  providerSupportsNativeWebSearch,
+  resolveAnthropicWebSearchToolType,
+} from "../nativeWebSearch";
 import { isRecord } from "./common";
 import type { StreamOptionsEx } from "./types";
 
@@ -14,31 +20,8 @@ function isOfficialOpenAIBaseUrl(baseUrl: string | undefined) {
   }
 }
 
-function hasOpenAIResponsesWebSearchTool(tool: unknown) {
-  if (!isRecord(tool)) return false;
-  const type = tool.type;
-  return (
-    type === "web_search" ||
-    type === "web_search_2025_08_26" ||
-    type === "web_search_preview" ||
-    type === "web_search_preview_2025_03_11"
-  );
-}
-
 function hasOpenAIChatCompletionsWebSearchOptions(payload: Record<string, unknown>) {
   return isRecord(payload.web_search_options);
-}
-
-function hasAnthropicWebSearchTool(tool: unknown) {
-  if (!isRecord(tool)) return false;
-  const type = tool.type;
-  const name = tool.name;
-  return name === "web_search" || type === "web_search_20260209" || type === "web_search_20250305";
-}
-
-function hasGeminiGoogleSearchTool(tool: unknown) {
-  if (!isRecord(tool)) return false;
-  return Boolean(tool.googleSearch || tool.google_search || tool.googleSearchRetrieval);
 }
 
 function appendUniqueTool(
@@ -214,7 +197,7 @@ export function attachProviderNativeWebSearch(
       if (providerId === "claude_code") {
         return appendUniqueTool(
           nextPayload,
-          { type: "web_search_20250305", name: "web_search" },
+          { type: resolveAnthropicWebSearchToolType(model), name: "web_search" },
           hasAnthropicWebSearchTool,
         );
       }

--- a/crates/agent-gui/src/lib/providers/runtime/streamByApi.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/streamByApi.ts
@@ -20,6 +20,7 @@ import {
   mapDeepSeekReasoningEffort,
 } from "../deepSeekProviderAdapter";
 import { resolveMaxTokens } from "./common";
+import { withStreamRetry } from "./streamRetry";
 import { normalizeStructuredToolCallHistoryForDeepSeek } from "./textModeToolRecovery";
 import {
   type AnthropicEffort,
@@ -106,27 +107,32 @@ export function streamSimpleByApi(model: Model<any>, context: Context, options: 
       const anthropicContext = isDeepSeekAnthropic
         ? normalizeStructuredToolCallHistoryForDeepSeek(context)
         : context;
-      const stream = streamAnthropic(model as any, anthropicContext, {
-        temperature: anthropicOptions.temperature,
-        maxTokens: anthropicThinking.maxTokens,
-        signal: anthropicOptions.signal,
-        apiKey: anthropicOptions.apiKey,
-        cacheRetention: anthropicOptions.cacheRetention,
-        sessionId: anthropicOptions.sessionId,
-        headers: anthropicOptions.headers,
-        onPayload: anthropicOptions.onPayload,
-        maxRetryDelayMs: anthropicOptions.maxRetryDelayMs,
-        metadata: anthropicOptions.metadata,
-        thinkingEnabled: anthropicThinking.thinkingEnabled,
-        ...(anthropicThinking.effort ? { effort: anthropicThinking.effort } : {}),
-        ...(anthropicThinking.thinkingBudgetTokens !== undefined
-          ? { thinkingBudgetTokens: anthropicThinking.thinkingBudgetTokens }
-          : {}),
-        toolChoice: anthropicOptions.toolChoice ?? "none",
-      });
-      return isDeepSeekAnthropic || anthropicOptions.deepSeekDsmlToolCallRepair
-        ? wrapDeepSeekDsmlToolCallStream(stream)
-        : stream;
+      return withStreamRetry(
+        () => {
+          const stream = streamAnthropic(model as any, anthropicContext, {
+            temperature: anthropicOptions.temperature,
+            maxTokens: anthropicThinking.maxTokens,
+            signal: anthropicOptions.signal,
+            apiKey: anthropicOptions.apiKey,
+            cacheRetention: anthropicOptions.cacheRetention,
+            sessionId: anthropicOptions.sessionId,
+            headers: anthropicOptions.headers,
+            onPayload: anthropicOptions.onPayload,
+            maxRetryDelayMs: anthropicOptions.maxRetryDelayMs,
+            metadata: anthropicOptions.metadata,
+            thinkingEnabled: anthropicThinking.thinkingEnabled,
+            ...(anthropicThinking.effort ? { effort: anthropicThinking.effort } : {}),
+            ...(anthropicThinking.thinkingBudgetTokens !== undefined
+              ? { thinkingBudgetTokens: anthropicThinking.thinkingBudgetTokens }
+              : {}),
+            toolChoice: anthropicOptions.toolChoice ?? "none",
+          });
+          return isDeepSeekAnthropic || anthropicOptions.deepSeekDsmlToolCallRepair
+            ? wrapDeepSeekDsmlToolCallStream(stream)
+            : stream;
+        },
+        { signal: anthropicOptions.signal, ...anthropicOptions.streamRetry },
+      );
     }
     case "openai-completions": {
       const openAICompletionsOptions = isDeepSeekTarget({
@@ -147,14 +153,20 @@ export function streamSimpleByApi(model: Model<any>, context: Context, options: 
         reasoningEffort: clampOpenAIReasoningEffort(model, openAICompletionsOptions.reasoning),
         toolChoice: mapToolChoiceToOpenAI(openAICompletionsOptions.toolChoice),
       };
-      return streamOpenAICompletions(model as any, openAICompletionsContext, openAIOptions);
+      return withStreamRetry(
+        () => streamOpenAICompletions(model as any, openAICompletionsContext, openAIOptions),
+        { signal: openAICompletionsOptions.signal, ...openAICompletionsOptions.streamRetry },
+      );
     }
     case "openai-responses": {
       const openAIOptions: OpenAIResponsesOptions = {
         ...buildOpenAIBaseOptions(model, options),
         reasoningEffort: clampOpenAIReasoningEffort(model, options.reasoning),
       };
-      return streamOpenAIResponses(model as any, context, openAIOptions);
+      return withStreamRetry(() => streamOpenAIResponses(model as any, context, openAIOptions), {
+        signal: options.signal,
+        ...options.streamRetry,
+      });
     }
     case "google-generative-ai": {
       const googleOptions: GoogleOptions = {
@@ -169,7 +181,10 @@ export function streamSimpleByApi(model: Model<any>, context: Context, options: 
         thinking: resolveGeminiThinkingRuntime(model, options.reasoning),
         toolChoice: mapToolChoiceToGoogle(options.toolChoice) ?? "none",
       };
-      return streamGoogle(model as any, context, googleOptions);
+      return withStreamRetry(() => streamGoogle(model as any, context, googleOptions), {
+        signal: options.signal,
+        ...options.streamRetry,
+      });
     }
     default:
       throw new Error(`Unsupported model API: ${model.api}`);

--- a/crates/agent-gui/src/lib/providers/runtime/streamRetry.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/streamRetry.ts
@@ -1,0 +1,139 @@
+import {
+  createAssistantMessageEventStream,
+  isRetryableAssistantError,
+  type AssistantMessageEvent,
+  type AssistantMessageEventStream,
+} from "@earendil-works/pi-ai";
+
+export const DEFAULT_STREAM_RETRY_MAX_ATTEMPTS = 3;
+
+const STREAM_RETRY_BASE_DELAY_MS = 500;
+const STREAM_RETRY_MAX_DELAY_MS = 8_000;
+
+export type StreamRetryConfig = {
+  maxAttempts?: number;
+  disabled?: boolean;
+};
+
+export type StreamRetryOptions = StreamRetryConfig & {
+  signal?: AbortSignal;
+};
+
+type TerminalEvent = Extract<AssistantMessageEvent, { type: "done" | "error" }>;
+
+const COMMITTING_EVENT_TYPES = new Set<AssistantMessageEvent["type"]>([
+  "text_delta",
+  "thinking_delta",
+  "toolcall_start",
+]);
+
+function isTerminalEvent(event: AssistantMessageEvent): event is TerminalEvent {
+  return event.type === "done" || event.type === "error";
+}
+
+function terminalMessage(event: TerminalEvent) {
+  return event.type === "done" ? event.message : event.error;
+}
+
+/** Full-jitter exponential backoff (AWS-style): uniform(0, min(cap, base * 2^(attempt-1))). */
+export function computeStreamRetryBackoffMs(attempt: number): number {
+  const cap = Math.min(STREAM_RETRY_MAX_DELAY_MS, STREAM_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+  return Math.random() * cap;
+}
+
+function sleepWithAbort(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  if (signal?.aborted) return Promise.reject(signal.reason ?? new Error("Aborted"));
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error("Aborted"));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Wraps a fresh-stream factory with attempt-scoped retry for transient
+ * provider/transport failures.
+ *
+ * Events are buffered per attempt until the first content-bearing event
+ * ("committed": text_delta / thinking_delta / toolcall_start) is observed. An
+ * attempt that ends in error before committing, classified retryable by
+ * pi-ai's `isRetryableAssistantError`, is discarded wholesale and replaced by
+ * a fresh `factory()` call after a full-jitter backoff — the caller never
+ * sees the failed attempt's events. Once committed, or once retries are
+ * exhausted/disabled, events pass straight through untouched.
+ *
+ * The pump below runs eagerly (not gated on the returned stream being
+ * iterated) because pi-ai's own stream factories start their network work as
+ * soon as they're called, independent of consumer iteration — some callers
+ * only await `.result()` without ever iterating events, and that pattern must
+ * keep working through this wrapper.
+ */
+export function withStreamRetry(
+  factory: () => AssistantMessageEventStream,
+  options?: StreamRetryOptions,
+): AssistantMessageEventStream {
+  const maxAttempts = Math.max(1, options?.maxAttempts ?? DEFAULT_STREAM_RETRY_MAX_ATTEMPTS);
+  const disabled = options?.disabled ?? false;
+  const signal = options?.signal;
+
+  const output = createAssistantMessageEventStream();
+  const firstSource = factory();
+
+  void (async () => {
+    let attempt = 1;
+    let source = firstSource;
+
+    while (true) {
+      let committed = false;
+      const buffered: AssistantMessageEvent[] = [];
+      let terminal: TerminalEvent | undefined;
+
+      for await (const event of source) {
+        if (!committed && COMMITTING_EVENT_TYPES.has(event.type)) {
+          committed = true;
+          for (const bufferedEvent of buffered.splice(0)) output.push(bufferedEvent);
+        }
+        if (committed) {
+          output.push(event);
+        } else {
+          buffered.push(event);
+        }
+        if (isTerminalEvent(event)) terminal = event;
+      }
+
+      if (terminal?.type === "error" && !committed && !disabled && attempt < maxAttempts) {
+        if (isRetryableAssistantError(terminalMessage(terminal))) {
+          attempt += 1;
+          try {
+            await sleepWithAbort(computeStreamRetryBackoffMs(attempt - 1), signal);
+            source = factory();
+            continue;
+          } catch {
+            // Aborted mid-backoff, or the next attempt failed to start —
+            // surface the prior attempt's real failure below instead of
+            // hanging the consumer on a retry that will never happen.
+          }
+        }
+      }
+
+      if (!committed) {
+        for (const bufferedEvent of buffered) output.push(bufferedEvent);
+      }
+      // Some streams (notably minimal test doubles) never yield a terminal
+      // done/error event through iteration and only expose the final message
+      // via result(). output.end() is idempotent once a terminal event has
+      // already been pushed above, so this also safety-nets that case.
+      output.end(await source.result());
+      return;
+    }
+  })();
+
+  return output;
+}

--- a/crates/agent-gui/src/lib/providers/runtime/streamRetry.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/streamRetry.ts
@@ -1,8 +1,8 @@
 import {
-  createAssistantMessageEventStream,
-  isRetryableAssistantError,
   type AssistantMessageEvent,
   type AssistantMessageEventStream,
+  createAssistantMessageEventStream,
+  isRetryableAssistantError,
 } from "@earendil-works/pi-ai";
 
 export const DEFAULT_STREAM_RETRY_MAX_ATTEMPTS = 3;

--- a/crates/agent-gui/src/lib/providers/runtime/types.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/types.ts
@@ -5,6 +5,7 @@ import type {
   ProviderModelConfig,
   ReasoningLevel,
 } from "../../settings";
+import type { StreamRetryConfig } from "./streamRetry";
 
 export type ModelOption = {
   value: string; // encodes customProviderId::model
@@ -46,4 +47,6 @@ export type StreamOptionsEx = SimpleStreamOptions & {
   deepSeekDsmlToolCallRepair?: boolean;
   deepSeekProviderAdapter?: boolean;
   deepSeekAnthropicPayloadToolBlockFlattening?: boolean;
+  /** Escape hatch for the unified provider stream retry in streamByApi.ts. */
+  streamRetry?: StreamRetryConfig;
 };

--- a/crates/agent-gui/test/helpers/load-ts-module.mjs
+++ b/crates/agent-gui/test/helpers/load-ts-module.mjs
@@ -31,6 +31,9 @@ const piAiEventStream = await import(
     import.meta.url,
   ).href
 );
+const piAiRetry = await import(
+  new URL("../../node_modules/@earendil-works/pi-ai/dist/utils/retry.js", import.meta.url).href
+);
 const piAiProvidersAll = await import(
   new URL(
     "../../node_modules/@earendil-works/pi-ai/dist/providers/all.js",
@@ -106,6 +109,8 @@ function createDefaultMocks() {
       repairJson: piAiJsonParse.repairJson,
       getSupportedThinkingLevels: piAiModels.getSupportedThinkingLevels,
       clampThinkingLevel: piAiModels.clampThinkingLevel,
+      isRetryableAssistantError: piAiRetry.isRetryableAssistantError,
+      createAssistantMessageEventStream: piAiEventStream.createAssistantMessageEventStream,
       EventStream: class EventStream {
         constructor() {
           throw new Error("EventStream mock was not expected to be constructed");
@@ -209,10 +214,25 @@ export function createTsModuleLoader(options = {}) {
     : path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
   const requireFromRoot = createRequire(path.join(rootDir, "package.json"));
   const cache = new Map();
-  const mocks = new Map([
-    ...Object.entries(createDefaultMocks()),
-    ...Object.entries(options.mocks ?? {}),
-  ]);
+  const defaultMocks = createDefaultMocks();
+  const mocks = new Map(Object.entries(defaultMocks));
+  // Tests conventionally override a mocked module by supplying only the
+  // handful of exports they care about (e.g. { getModel() {...} } for
+  // "@earendil-works/pi-ai"), expecting every other default export — like
+  // the real isRetryableAssistantError/createAssistantMessageEventStream —
+  // to keep working underneath. Shallow-merge instead of replacing so those
+  // partial overrides don't silently drop unrelated default exports.
+  for (const [specifier, override] of Object.entries(options.mocks ?? {})) {
+    const base = defaultMocks[specifier];
+    const isPlainMerge =
+      base &&
+      typeof base === "object" &&
+      !Array.isArray(base) &&
+      override &&
+      typeof override === "object" &&
+      !Array.isArray(override);
+    mocks.set(specifier, isPlainMerge ? { ...base, ...override } : override);
+  }
 
   function resolveLocal(specifier, parentDir = rootDir) {
     const candidate = path.isAbsolute(specifier)

--- a/crates/agent-gui/test/providers/hosted-search-events.test.mjs
+++ b/crates/agent-gui/test/providers/hosted-search-events.test.mjs
@@ -250,3 +250,133 @@ test("hosted search aggregation extracts structural Anthropic and Gemini search 
     "https://example.com/gemini",
   ]);
 });
+
+test("hosted search aggregation accumulates an Anthropic query streamed as partial_json fragments", () => {
+  const anthropic = hostedSearchEvents.createHostedSearchEventAggregator({
+    providerId: "claude_code",
+  });
+
+  // The real Anthropic wire format streams the tool-call JSON input across
+  // several content_block_delta events; no single fragment is valid JSON on
+  // its own, so the query can only be read once every fragment has arrived.
+  anthropic.accept({
+    type: "content_block_start",
+    index: 0,
+    content_block: { type: "server_tool_use", id: "toolu_incremental", name: "web_search" },
+  });
+  anthropic.accept({
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "input_json_delta", partial_json: '{"que' },
+  });
+  assert.deepEqual(anthropic.getBlocks(), []);
+
+  anthropic.accept({
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "input_json_delta", partial_json: 'ry": "LiveAg' },
+  });
+  assert.deepEqual(anthropic.getBlocks(), []);
+
+  anthropic.accept({
+    type: "content_block_delta",
+    index: 0,
+    delta: { type: "input_json_delta", partial_json: 'ent incremental search"}' },
+  });
+
+  assert.deepEqual(anthropic.getBlocks()[0].queries, ["LiveAgent incremental search"]);
+  assert.equal(anthropic.getBlocks()[0].status, "searching");
+
+  anthropic.accept({ type: "content_block_stop", index: 0 });
+});
+
+test("hosted search aggregation extracts Anthropic citations_delta into the active search block", () => {
+  const anthropic = hostedSearchEvents.createHostedSearchEventAggregator({
+    providerId: "claude_code",
+  });
+
+  anthropic.accept({
+    type: "content_block_start",
+    content_block: {
+      type: "server_tool_use",
+      id: "toolu_cited",
+      name: "web_search",
+      input: { query: "LiveAgent citation search" },
+    },
+  });
+  anthropic.accept({
+    type: "content_block_delta",
+    index: 1,
+    delta: {
+      type: "citations_delta",
+      citation: { url: "https://example.com/cited", title: "Cited Result" },
+    },
+  });
+
+  const block = anthropic.getBlocks()[0];
+  assert.deepEqual(block.queries, ["LiveAgent citation search"]);
+  assert.deepEqual(
+    block.sources.map((source) => ({ url: source.url, sourceType: source.sourceType })),
+    [{ url: "https://example.com/cited", sourceType: "citation" }],
+  );
+});
+
+test("hosted search aggregation marks Anthropic web_search_tool_result_error as failed", () => {
+  const anthropic = hostedSearchEvents.createHostedSearchEventAggregator({
+    providerId: "claude_code",
+  });
+
+  anthropic.accept({
+    type: "content_block_start",
+    content_block: {
+      type: "server_tool_use",
+      id: "toolu_failed",
+      name: "web_search",
+      input: { query: "LiveAgent failing search" },
+    },
+  });
+  anthropic.accept({
+    type: "content_block_start",
+    content_block: { type: "web_search_tool_result_error", tool_use_id: "toolu_failed" },
+  });
+
+  assert.equal(anthropic.getBlocks()[0].status, "failed");
+});
+
+test("hosted search aggregation extracts OpenAI url_citation annotations and marks call completion", () => {
+  const emitted = [];
+  const openai = hostedSearchEvents.createHostedSearchEventAggregator({
+    providerId: "codex",
+    onHostedSearch: (block) => emitted.push(block),
+  });
+
+  openai.accept({
+    type: "response.output_item.added",
+    item: {
+      type: "web_search_call",
+      id: "search-annotated",
+      status: "in_progress",
+      action: { query: "LiveAgent OpenAI search" },
+    },
+  });
+  openai.accept({
+    type: "response.output_item.done",
+    item: { type: "web_search_call", id: "search-annotated", status: "completed" },
+  });
+  openai.accept({
+    type: "response.output_text.annotation.added",
+    annotation: {
+      type: "url_citation",
+      url: "https://example.com/openai",
+      title: "OpenAI Result",
+    },
+  });
+
+  const block = openai.getBlocks()[0];
+  assert.equal(block.status, "completed");
+  assert.deepEqual(block.queries, ["LiveAgent OpenAI search"]);
+  assert.deepEqual(
+    block.sources.map((source) => ({ url: source.url, sourceType: source.sourceType })),
+    [{ url: "https://example.com/openai", sourceType: "citation" }],
+  );
+});

--- a/crates/agent-gui/test/providers/native-web-search.test.mjs
+++ b/crates/agent-gui/test/providers/native-web-search.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const {
+  ANTHROPIC_WEB_SEARCH_TOOL_TYPES,
+  resolveAnthropicWebSearchToolType,
+  supportsAnthropicDynamicFilteringWebSearch,
+  hasAnthropicWebSearchTool,
+  hasOpenAIResponsesWebSearchTool,
+  hasGeminiGoogleSearchTool,
+  isProviderNativeWebSearchToolName,
+  HIDDEN_PROVIDER_NATIVE_WEB_SEARCH_TOOL_NAMES,
+} = loader.loadModule("src/lib/providers/nativeWebSearch.ts");
+
+function createAnthropicModel(id, overrides = {}) {
+  return {
+    id,
+    name: id,
+    api: "anthropic-messages",
+    provider: "anthropic",
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 64_000,
+    ...overrides,
+  };
+}
+
+test("resolveAnthropicWebSearchToolType returns the dynamic-filtering version for adaptive-thinking models", () => {
+  const model = createAnthropicModel("claude-fable-5", { compat: { forceAdaptiveThinking: true } });
+  assert.equal(supportsAnthropicDynamicFilteringWebSearch(model), true);
+  assert.equal(resolveAnthropicWebSearchToolType(model), ANTHROPIC_WEB_SEARCH_TOOL_TYPES.dynamicFiltering);
+  assert.equal(resolveAnthropicWebSearchToolType(model), "web_search_20260318");
+});
+
+test("resolveAnthropicWebSearchToolType returns the legacy version for non-adaptive-thinking models", () => {
+  const model = createAnthropicModel("claude-opus-4-6", { compat: { forceAdaptiveThinking: false } });
+  assert.equal(supportsAnthropicDynamicFilteringWebSearch(model), false);
+  assert.equal(resolveAnthropicWebSearchToolType(model), ANTHROPIC_WEB_SEARCH_TOOL_TYPES.legacy);
+  assert.equal(resolveAnthropicWebSearchToolType(model), "web_search_20250305");
+});
+
+test("resolveAnthropicWebSearchToolType defaults to legacy when compat is absent", () => {
+  const model = createAnthropicModel("claude-custom-x");
+  assert.equal(resolveAnthropicWebSearchToolType(model), ANTHROPIC_WEB_SEARCH_TOOL_TYPES.legacy);
+});
+
+test("hasAnthropicWebSearchTool recognizes every live tool-type version plus the bare name", () => {
+  assert.equal(hasAnthropicWebSearchTool({ type: "web_search_20250305", name: "web_search" }), true);
+  assert.equal(hasAnthropicWebSearchTool({ type: "web_search_20260209", name: "web_search" }), true);
+  assert.equal(hasAnthropicWebSearchTool({ type: "web_search_20260318", name: "web_search" }), true);
+  assert.equal(hasAnthropicWebSearchTool({ type: "something_else", name: "web_search" }), true);
+  assert.equal(hasAnthropicWebSearchTool({ type: "function", name: "unrelated" }), false);
+  assert.equal(hasAnthropicWebSearchTool(null), false);
+  assert.equal(hasAnthropicWebSearchTool("web_search"), false);
+});
+
+test("hasOpenAIResponsesWebSearchTool recognizes current and legacy preview tool types", () => {
+  assert.equal(hasOpenAIResponsesWebSearchTool({ type: "web_search" }), true);
+  assert.equal(hasOpenAIResponsesWebSearchTool({ type: "web_search_2025_08_26" }), true);
+  assert.equal(hasOpenAIResponsesWebSearchTool({ type: "web_search_preview" }), true);
+  assert.equal(hasOpenAIResponsesWebSearchTool({ type: "web_search_preview_2025_03_11" }), true);
+  assert.equal(hasOpenAIResponsesWebSearchTool({ type: "function" }), false);
+});
+
+test("hasGeminiGoogleSearchTool recognizes camelCase and snake_case tool shapes", () => {
+  assert.equal(hasGeminiGoogleSearchTool({ googleSearch: {} }), true);
+  assert.equal(hasGeminiGoogleSearchTool({ google_search: {} }), true);
+  assert.equal(hasGeminiGoogleSearchTool({ googleSearchRetrieval: {} }), true);
+  assert.equal(hasGeminiGoogleSearchTool({ functionDeclarations: [] }), false);
+});
+
+test("isProviderNativeWebSearchToolName matches every hidden tool name, case-insensitively", () => {
+  for (const name of HIDDEN_PROVIDER_NATIVE_WEB_SEARCH_TOOL_NAMES) {
+    assert.equal(isProviderNativeWebSearchToolName(name), true);
+    assert.equal(isProviderNativeWebSearchToolName(name.toUpperCase()), true);
+  }
+  assert.equal(isProviderNativeWebSearchToolName("web_search_call_12345"), true);
+  assert.equal(isProviderNativeWebSearchToolName("unrelated_tool"), false);
+  assert.equal(isProviderNativeWebSearchToolName(undefined), false);
+});

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -333,14 +333,14 @@ test("official OpenAI Chat Completions models behind proxy keep native compat", 
   assert.equal(model.compat, undefined);
 });
 
-test("Codex Chat Completions streams forward reasoning effort", () => {
+test("Codex Chat Completions streams forward reasoning effort", async () => {
   let captured;
   const localLoader = createTsModuleLoader({
     mocks: {
       "@earendil-works/pi-ai/api/openai-completions": {
         stream(model, context, options) {
           captured = { model, context, options };
-          return { mocked: true };
+          return createMockAssistantStream();
         },
       },
     },
@@ -359,7 +359,8 @@ test("Codex Chat Completions streams forward reasoning effort", () => {
     { reasoning: "high", toolChoice: "auto" },
   );
 
-  assert.deepEqual(result, { mocked: true });
+  assert.equal(typeof result.result, "function");
+  await result.result();
   assert.equal(captured.options.reasoningEffort, "high");
   assert.equal(captured.options.toolChoice, "auto");
 });
@@ -389,7 +390,7 @@ test("DeepSeek OpenAI payload adapter injects thinking and reasoning_content", a
       "@earendil-works/pi-ai/api/openai-completions": {
         stream(model, context, options) {
           captured = { model, context, options };
-          return { mocked: true };
+          return createMockAssistantStream();
         },
       },
     },
@@ -407,7 +408,7 @@ test("DeepSeek OpenAI payload adapter injects thinking and reasoning_content", a
     { messages: [] },
     { reasoning: "minimal", toolChoice: "auto" },
   );
-  assert.deepEqual(result, { mocked: true });
+  assert.equal(typeof result.result, "function");
   assert.equal(typeof captured.options.onPayload, "function");
 
   const adapted = await captured.options.onPayload(

--- a/crates/agent-gui/test/providers/stream-retry.test.mjs
+++ b/crates/agent-gui/test/providers/stream-retry.test.mjs
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const { withStreamRetry, computeStreamRetryBackoffMs, DEFAULT_STREAM_RETRY_MAX_ATTEMPTS } =
+  loader.loadModule("src/lib/providers/runtime/streamRetry.ts");
+
+function createUsage() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function createAssistant(text, stopReason, extra = {}) {
+  return {
+    role: "assistant",
+    content: text ? [{ type: "text", text }] : [],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "test-model",
+    usage: createUsage(),
+    stopReason,
+    timestamp: Date.now(),
+    ...extra,
+  };
+}
+
+function createErrorStream(errorMessage) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "error", error: createAssistant(undefined, "error", { errorMessage }) };
+    },
+    async result() {
+      return createAssistant(undefined, "error", { errorMessage });
+    },
+  };
+}
+
+function createSuccessStream(text) {
+  const assistant = createAssistant(text, "stop");
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "start", partial: { ...assistant, content: [] } };
+      yield {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: text,
+        partial: { ...assistant, content: [{ type: "text", text }] },
+      };
+      yield { type: "done", message: assistant };
+    },
+    async result() {
+      return assistant;
+    },
+  };
+}
+
+function createErrorAfterContentStream(text, errorMessage) {
+  const partial = createAssistant(text, "error", { errorMessage });
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "start", partial: { ...partial, content: [] } };
+      yield {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: text,
+        partial: { ...partial, content: [{ type: "text", text }] },
+      };
+      yield { type: "error", error: partial };
+    },
+    async result() {
+      return partial;
+    },
+  };
+}
+
+function createAbortedDoneStream() {
+  const assistant = createAssistant(undefined, "aborted");
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "done", message: assistant };
+    },
+    async result() {
+      return assistant;
+    },
+  };
+}
+
+async function collectEvents(eventStream) {
+  const events = [];
+  for await (const event of eventStream) events.push(event);
+  return events;
+}
+
+test("withStreamRetry succeeds after N retryable errors without leaking failed-attempt events", async () => {
+  let calls = 0;
+  const wrapped = withStreamRetry(
+    () => {
+      calls += 1;
+      if (calls < 3) return createErrorStream("503 service unavailable");
+      return createSuccessStream("final answer");
+    },
+    { maxAttempts: 5 },
+  );
+
+  const events = await collectEvents(wrapped);
+  assert.equal(calls, 3);
+  assert.deepEqual(
+    events.map((event) => event.type),
+    ["start", "text_delta", "done"],
+  );
+  const final = await wrapped.result();
+  assert.equal(final.stopReason, "stop");
+  assert.equal(final.content[0].text, "final answer");
+});
+
+test("withStreamRetry does not retry once content has been committed", async () => {
+  let calls = 0;
+  const wrapped = withStreamRetry(() => {
+    calls += 1;
+    return createErrorAfterContentStream("partial", "503 service unavailable");
+  });
+
+  const events = await collectEvents(wrapped);
+  assert.equal(calls, 1);
+  assert.deepEqual(
+    events.map((event) => event.type),
+    ["start", "text_delta", "error"],
+  );
+  const final = await wrapped.result();
+  assert.equal(final.stopReason, "error");
+});
+
+test("withStreamRetry never retries an aborted stream", async () => {
+  let calls = 0;
+  const wrapped = withStreamRetry(() => {
+    calls += 1;
+    return createAbortedDoneStream();
+  });
+
+  const events = await collectEvents(wrapped);
+  assert.equal(calls, 1);
+  assert.deepEqual(
+    events.map((event) => event.type),
+    ["done"],
+  );
+  const final = await wrapped.result();
+  assert.equal(final.stopReason, "aborted");
+});
+
+test("withStreamRetry respects maxAttempts and surfaces the last failure", async () => {
+  let calls = 0;
+  const wrapped = withStreamRetry(
+    () => {
+      calls += 1;
+      return createErrorStream(`rate limit exceeded (attempt ${calls})`);
+    },
+    { maxAttempts: 3 },
+  );
+
+  const events = await collectEvents(wrapped);
+  assert.equal(calls, 3);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, "error");
+  const final = await wrapped.result();
+  assert.equal(final.stopReason, "error");
+  assert.match(final.errorMessage, /attempt 3/);
+});
+
+test("withStreamRetry does not retry non-retryable errors", async () => {
+  let calls = 0;
+  const wrapped = withStreamRetry(
+    () => {
+      calls += 1;
+      return createErrorStream("insufficient_quota: billing required");
+    },
+    { maxAttempts: 5 },
+  );
+
+  const events = await collectEvents(wrapped);
+  assert.equal(calls, 1);
+  assert.equal(events[0].type, "error");
+});
+
+test("withStreamRetry backoff aborted before it can fire prevents any further attempt", async () => {
+  // Pre-abort so the retry loop's sleepWithAbort() rejects synchronously on
+  // its aborted-check, instead of racing a real timer against a real abort
+  // (which would make this test's timing non-deterministic).
+  let calls = 0;
+  const controller = new AbortController();
+  controller.abort(new Error("cancelled"));
+  const wrapped = withStreamRetry(
+    () => {
+      calls += 1;
+      return createErrorStream("503 service unavailable");
+    },
+    { maxAttempts: 5, signal: controller.signal },
+  );
+
+  const events = await collectEvents(wrapped);
+  assert.equal(calls, 1);
+  assert.equal(events[0].type, "error");
+  assert.match(events[0].error.errorMessage, /503/);
+});
+
+test("withStreamRetry with disabled:true never retries", async () => {
+  let calls = 0;
+  const wrapped = withStreamRetry(
+    () => {
+      calls += 1;
+      return createErrorStream("503 service unavailable");
+    },
+    { maxAttempts: 5, disabled: true },
+  );
+
+  await collectEvents(wrapped);
+  assert.equal(calls, 1);
+});
+
+test("computeStreamRetryBackoffMs stays within the full-jitter cap and grows with attempt", () => {
+  for (let attempt = 1; attempt <= 6; attempt += 1) {
+    const delay = computeStreamRetryBackoffMs(attempt);
+    assert.ok(delay >= 0);
+    assert.ok(delay <= 8000);
+  }
+});
+
+test("DEFAULT_STREAM_RETRY_MAX_ATTEMPTS is a sane positive default", () => {
+  assert.ok(DEFAULT_STREAM_RETRY_MAX_ATTEMPTS >= 1);
+});


### PR DESCRIPTION
## Summary
- Add `withStreamRetry` wrapping all four provider stream APIs (Anthropic, OpenAI completions/responses, Gemini) so transient assistant-stream errors are retried instead of surfacing immediately
- Replace the heuristic recursive hosted-search-event matching with per-provider stateful parsers that follow each provider's actual wire protocol (Anthropic `partial_json` accumulation and `citations_delta`, OpenAI `output_item`/annotation lifecycle, Gemini grounding metadata)
- Add Anthropic's `web_search_20260318` dynamic-filtering tool version, selected adaptively per model

## Test plan
- [x] `stream-retry.test.mjs`, `hosted-search-events.test.mjs`, `native-web-search.test.mjs`, `request-options.test.mjs` cover the new retry and parsing logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)