### PR TITLE
feat(gui): import ccswitch providers

### DIFF
--- a/crates/agent-gui/src-tauri/src/commands/config/settings/ccs_import.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/ccs_import.rs
@@ -1,0 +1,296 @@
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CcsProviderImportItem {
+    pub source_id: String,
+    pub app_type: String,
+    pub provider_type: String,
+    pub name: String,
+    pub base_url: String,
+    pub api_key: String,
+    pub request_format: String,
+    pub models: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CcsProvidersResponse {
+    pub status: String,
+    pub message: String,
+    pub providers: Vec<CcsProviderImportItem>,
+}
+
+#[tauri::command]
+pub async fn settings_list_ccswitch_providers() -> Result<CcsProvidersResponse, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        let path = default_ccswitch_db_path();
+        let providers = list_ccswitch_liveagent_providers_from_db(&path)?;
+        let message = if providers.is_empty() {
+            format!("未发现 ccswitch LiveAgent 供应商：{}", path.display())
+        } else {
+            format!("发现 {} 个 ccswitch LiveAgent 供应商", providers.len())
+        };
+        Ok(CcsProvidersResponse {
+            status: "success".to_string(),
+            message,
+            providers,
+        })
+    })
+    .await
+    .map_err(|e| format!("settings_list_ccswitch_providers join 失败：{e}"))?
+}
+
+fn default_ccswitch_db_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(format!(".{}-{}", "cc", "switch"))
+        .join(format!("{}-{}.db", "cc", "switch"))
+}
+
+fn list_ccswitch_liveagent_providers_from_db(
+    path: &std::path::Path,
+) -> Result<Vec<CcsProviderImportItem>, String> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let conn = Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("打开 ccswitch 数据库失败 {}：{e}", path.display()))?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, app_type, name, settings_config
+             FROM providers
+             WHERE app_type IN ('codex', 'claude', 'claude-code', 'claude_code', 'gemini')
+             ORDER BY
+               CASE app_type
+                 WHEN 'claude' THEN 0
+                 WHEN 'claude-code' THEN 0
+                 WHEN 'claude_code' THEN 0
+                 WHEN 'codex' THEN 1
+                 WHEN 'gemini' THEN 2
+                 ELSE 3
+               END,
+               COALESCE(sort_index, 999999), created_at ASC, id ASC",
+        )
+        .map_err(|e| format!("读取 ccswitch providers 表失败：{e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .map_err(|e| format!("查询 ccswitch providers 失败：{e}"))?;
+
+    let mut providers = Vec::new();
+    for row in rows {
+        let (source_id, app_type, name, settings_config) =
+            row.map_err(|e| format!("读取 ccswitch provider 行失败：{e}"))?;
+        let Ok(config) = serde_json::from_str::<Value>(&settings_config) else {
+            continue;
+        };
+        if let Some(provider) = ccs_provider_from_value(&source_id, &app_type, &name, &config) {
+            providers.push(provider);
+        }
+    }
+    Ok(providers)
+}
+
+fn ccs_provider_from_value(
+    source_id: &str,
+    app_type: &str,
+    name: &str,
+    config: &Value,
+) -> Option<CcsProviderImportItem> {
+    let provider_type = ccs_provider_type_from_app_type(app_type)?;
+    let base_url = ccs_extract_base_url(provider_type, config).unwrap_or_default();
+    let api_key = ccs_extract_api_key(provider_type, config).unwrap_or_default();
+    Some(CcsProviderImportItem {
+        source_id: source_id.to_string(),
+        app_type: app_type.to_string(),
+        provider_type: provider_type.to_string(),
+        name: strip_ccswitch_suffix(name).to_string(),
+        base_url,
+        api_key,
+        request_format: if provider_type == "codex" && ccs_is_chat_protocol(config) {
+            "openai-completions".to_string()
+        } else {
+            "openai-responses".to_string()
+        },
+        models: ccs_extract_models(provider_type, config),
+    })
+}
+
+fn ccs_provider_type_from_app_type(app_type: &str) -> Option<&'static str> {
+    match app_type.trim().to_ascii_lowercase().as_str() {
+        "codex" => Some("codex"),
+        "claude" | "claude-code" | "claude_code" => Some("claude_code"),
+        "gemini" => Some("gemini"),
+        _ => None,
+    }
+}
+
+fn ccs_extract_models(provider_type: &str, config: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut push_model = |value: String| {
+        let model = value.trim().to_string();
+        if !model.is_empty() && !out.iter().any(|item| item == &model) {
+            out.push(model);
+        }
+    };
+
+    match provider_type {
+        "claude_code" => {
+            for key in [
+                "ANTHROPIC_MODEL",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                "ANTHROPIC_DEFAULT_OPUS_MODEL",
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            ] {
+                if let Some(model) = ccs_string_at_path(config, &["env", key]) {
+                    push_model(model);
+                }
+            }
+        }
+        "gemini" => {
+            for key in ["GEMINI_MODEL", "GOOGLE_GEMINI_MODEL", "GOOGLE_MODEL"] {
+                if let Some(model) = ccs_string_at_path(config, &["env", key]) {
+                    push_model(model);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    for key in ["model", "default_model", "defaultModel"] {
+        if let Some(model) = ccs_string_at(config, &[key]) {
+            push_model(model);
+        }
+        if let Some(model) = config
+            .get("config")
+            .and_then(|value| ccs_string_at(value, &[key]))
+        {
+            push_model(model);
+        }
+    }
+    if let Some(config_text) = config.get("config").and_then(Value::as_str) {
+        if let Some(model) = ccs_extract_toml_string_value(config_text, "model") {
+            push_model(model);
+        }
+    }
+    out
+}
+
+fn ccs_extract_base_url(provider_type: &str, config: &Value) -> Option<String> {
+    match provider_type {
+        "claude_code" => ccs_string_at_path(config, &["env", "ANTHROPIC_BASE_URL"])
+            .or_else(|| ccs_string_at_path(config, &["config", "ANTHROPIC_BASE_URL"])),
+        "gemini" => ccs_string_at_path(config, &["env", "GEMINI_BASE_URL"])
+            .or_else(|| ccs_string_at_path(config, &["env", "GOOGLE_GEMINI_BASE_URL"]))
+            .or_else(|| ccs_string_at_path(config, &["config", "base_url"])),
+        _ => ccs_string_at(config, &["base_url", "baseURL"])
+            .or_else(|| {
+                config
+                    .get("config")
+                    .and_then(|value| ccs_string_at(value, &["base_url", "baseURL"]))
+            })
+            .or_else(|| {
+                config
+                    .get("config")
+                    .and_then(Value::as_str)
+                    .and_then(|text| ccs_extract_toml_string_value(text, "base_url"))
+            }),
+    }
+    .map(|value| value.trim().trim_end_matches('/').to_string())
+}
+
+fn ccs_extract_api_key(provider_type: &str, config: &Value) -> Option<String> {
+    match provider_type {
+        "claude_code" => ccs_string_at_path(config, &["env", "ANTHROPIC_AUTH_TOKEN"])
+            .or_else(|| ccs_string_at_path(config, &["env", "ANTHROPIC_API_KEY"])),
+        "gemini" => ccs_string_at_path(config, &["env", "GEMINI_API_KEY"])
+            .or_else(|| ccs_string_at_path(config, &["env", "GOOGLE_API_KEY"])),
+        _ => config
+            .pointer("/env/OPENAI_API_KEY")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .or_else(|| {
+                config
+                    .pointer("/auth/OPENAI_API_KEY")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .or_else(|| ccs_string_at(config, &["apiKey", "api_key"]))
+            .or_else(|| {
+                config
+                    .get("config")
+                    .and_then(|value| ccs_string_at(value, &["apiKey", "api_key"]))
+            }),
+    }
+}
+
+fn ccs_is_chat_protocol(config: &Value) -> bool {
+    ccs_string_at(config, &["api_format", "apiFormat"])
+        .map(|value| ccs_matches_chat_protocol(&value))
+        .unwrap_or(false)
+        || config
+            .get("config")
+            .and_then(Value::as_str)
+            .and_then(|text| ccs_extract_toml_string_value(text, "wire_api"))
+            .map(|value| ccs_matches_chat_protocol(&value))
+            .unwrap_or(false)
+        || ccs_extract_base_url("codex", config)
+            .map(|value| value.to_ascii_lowercase().ends_with("/chat/completions"))
+            .unwrap_or(false)
+}
+
+fn ccs_matches_chat_protocol(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "chat" | "chat_completions" | "chat-completions" | "openai_chat" | "openai-chat"
+    )
+}
+
+fn ccs_string_at(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+fn ccs_string_at_path(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    current.as_str().map(str::to_string)
+}
+
+fn ccs_extract_toml_string_value(text: &str, key: &str) -> Option<String> {
+    for line in text.lines() {
+        let trimmed = line.trim();
+        let Some(rest) = trimmed.strip_prefix(key) else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let quote = rest.chars().next()?;
+        if quote != '"' && quote != '\'' {
+            continue;
+        }
+        let rest = &rest[quote.len_utf8()..];
+        let end = rest.find(quote)?;
+        return Some(rest[..end].to_string());
+    }
+    None
+}
+
+fn strip_ccswitch_suffix(name: &str) -> &str {
+    name.trim()
+        .strip_suffix("（ccswitch）")
+        .or_else(|| name.trim().strip_suffix("(ccswitch)"))
+        .unwrap_or_else(|| name.trim())
+}

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/mod.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/mod.rs
@@ -146,6 +146,7 @@ include!("remote.rs");
 include!("db.rs");
 include!("json.rs");
 include!("providers.rs");
+include!("ccs_import.rs");
 include!("agents.rs");
 include!("system.rs");
 include!("mcp.rs");

--- a/crates/agent-gui/src-tauri/src/lib.rs
+++ b/crates/agent-gui/src-tauri/src/lib.rs
@@ -113,6 +113,7 @@ macro_rules! app_invoke_handler {
             // Settings
             commands::settings::settings_load_all,
             commands::settings::settings_save_providers,
+            commands::settings::settings_list_ccswitch_providers,
             commands::settings::settings_save_system,
             commands::settings::settings_save_mcp,
             commands::settings::settings_save_agents,

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -1,7 +1,9 @@
+import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   ClaudeIcon,
+  Download,
   Eye,
   EyeOff,
   GeminiIcon,
@@ -59,6 +61,23 @@ type ModelSettingsModalProps = {
   model: ProviderModelConfig;
   onClose: () => void;
   onSave: (model: ProviderModelConfig) => void;
+};
+
+type CcsProviderImportItem = {
+  sourceId: string;
+  appType: string;
+  providerType: ProviderId;
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+  requestFormat: CodexRequestFormat;
+  models?: string[];
+};
+
+type CcsProvidersResponse = {
+  status: string;
+  message: string;
+  providers: CcsProviderImportItem[];
 };
 
 const PROVIDER_TABS: ProviderId[] = ["claude_code", "codex", "gemini"];
@@ -697,16 +716,90 @@ function CustomSettingsDrawer(props: SettingsSectionProps & { onClose: () => voi
   );
 }
 
+function ccsImportIdentity(provider: Pick<CustomProvider, "type" | "name" | "baseUrl">) {
+  const name = provider.name
+    .replace(/[（(]ccswitch[）)]/i, "")
+    .trim()
+    .toLowerCase();
+  const baseUrl = provider.baseUrl.trim().replace(/\/+$/, "").toLowerCase();
+  return `${provider.type}\n${name}\n${baseUrl}`;
+}
+
+function providerFromCcs(item: CcsProviderImportItem, existingIds: Set<string>): CustomProvider {
+  const baseId =
+    `ccswitch-${item.sourceId}`
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "ccswitch-provider";
+  let id = baseId;
+  for (let index = 2; existingIds.has(id); index += 1) id = `${baseId}-${index}`;
+  existingIds.add(id);
+
+  const providerType = item.providerType;
+  const models = (item.models ?? []).map((model) => createDraftModelConfig(providerType, model));
+  return {
+    id,
+    name: `${item.name.replace(/[（(]ccswitch[）)]/i, "").trim()}（ccswitch）`,
+    type: providerType,
+    baseUrl: item.baseUrl,
+    apiKey: item.apiKey,
+    apiKeyConfigured: item.apiKey.trim().length > 0,
+    models,
+    activeModels: models.map((model) => model.id),
+    requestFormat:
+      providerType === "codex"
+        ? item.requestFormat === "openai-completions"
+          ? "openai-completions"
+          : "openai-responses"
+        : undefined,
+    reasoning: "off",
+    promptCachingEnabled: providerType === "claude_code",
+    nativeWebSearchEnabled: true,
+  };
+}
+
+function ccsProviderCanSyncModels(item: CcsProviderImportItem) {
+  return item.baseUrl.trim().length > 0 && item.apiKey.trim().length > 0;
+}
+
+function ccsProviderIsTransferable(item: CcsProviderImportItem) {
+  return ccsProviderCanSyncModels(item) || (item.models?.length ?? 0) > 0;
+}
+
 function ProviderList(props: {
   type: ProviderId;
   providers: CustomProvider[];
   onAdd: () => void;
   onEdit: (provider: CustomProvider) => void;
   onDelete: (id: string) => void;
+  ccsProviders: CcsProvidersResponse | null;
+  ccsLoading: boolean;
+  ccsImporting: boolean;
+  ccsMessage: string | null;
+  thirdPartyImportOpen: boolean;
+  onToggleThirdPartyImport: () => void;
+  onImportCcsProviders: () => void;
+  onRefreshCcsProviders: () => void;
 }) {
   const { t } = useLocale();
-  const { type, providers, onAdd, onEdit, onDelete } = props;
+  const {
+    type,
+    providers,
+    onAdd,
+    onEdit,
+    onDelete,
+    ccsProviders,
+    ccsLoading,
+    ccsImporting,
+    ccsMessage,
+    thirdPartyImportOpen,
+    onToggleThirdPartyImport,
+    onImportCcsProviders,
+    onRefreshCcsProviders,
+  } = props;
   const filtered = providers.filter((provider) => provider.type === type);
+  const ccsProvidersForType =
+    ccsProviders?.providers.filter((provider) => provider.providerType === type) ?? [];
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
@@ -716,10 +809,56 @@ function ProviderList(props: {
             ? t("settings.noProviders")
             : `${filtered.length} ${t("settings.navProviders")}`}
         </div>
-        <Button variant="outline" size="sm" className="gap-1.5" onClick={onAdd}>
-          <Plus className="h-3.5 w-3.5" />
-          {t("settings.addProvider")}
-        </Button>
+        <div className="relative flex items-center gap-2">
+          <Button variant="outline" size="sm" className="gap-1.5" onClick={onAdd}>
+            <Plus className="h-3.5 w-3.5" />
+            {t("settings.addProvider")}
+          </Button>
+          <div className="relative">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={onToggleThirdPartyImport}
+              disabled={ccsImporting}
+            >
+              <Download className="h-3.5 w-3.5" />
+              从第三方同步
+            </Button>
+            {thirdPartyImportOpen ? (
+              <div className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-72 overflow-hidden rounded-xl border bg-popover p-2 text-popover-foreground shadow-xl">
+                <button
+                  type="button"
+                  className="flex w-full flex-col items-start rounded-lg px-3 py-2 text-left hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={ccsLoading || ccsImporting || !ccsProvidersForType.length}
+                  onClick={onImportCcsProviders}
+                >
+                  <strong className="text-sm">ccswitch</strong>
+                  <span className="mt-0.5 text-xs text-muted-foreground">
+                    {ccsImporting
+                      ? "正在导入供应商、获取并激活全部模型…"
+                      : ccsLoading
+                        ? "正在扫描…"
+                        : ccsProvidersForType.length
+                          ? `发现 ${ccsProvidersForType.length} 个 ${getProviderLabel(type)} 供应商`
+                          : ccsMessage || `未发现 ${getProviderLabel(type)} 供应商`}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="mt-1 flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm hover:bg-accent"
+                  onClick={onRefreshCcsProviders}
+                  disabled={ccsLoading || ccsImporting}
+                >
+                  <RefreshCw
+                    className={`h-4 w-4 ${ccsLoading || ccsImporting ? "animate-spin" : ""}`}
+                  />
+                  刷新列表
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </div>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto pr-1">
@@ -792,6 +931,141 @@ export function ProvidersSection(props: SettingsSectionProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [customSettingsOpen, setCustomSettingsOpen] = useState(false);
   const [editingProvider, setEditingProvider] = useState<CustomProvider | null>(null);
+  const [thirdPartyImportTab, setThirdPartyImportTab] = useState<ProviderId | null>(null);
+  const [ccsProviders, setCcsProviders] = useState<CcsProvidersResponse | null>(null);
+  const [ccsLoading, setCcsLoading] = useState(false);
+  const [ccsImportingType, setCcsImportingType] = useState<ProviderId | null>(null);
+  const [ccsMessage, setCcsMessage] = useState<string | null>(null);
+
+  async function refreshCcsProviders() {
+    setCcsLoading(true);
+    try {
+      const result = await invoke<CcsProvidersResponse>("settings_list_ccswitch_providers");
+      setCcsProviders(result);
+      setCcsMessage(result.message);
+    } catch (err) {
+      setCcsMessage(err instanceof Error ? err.message : String(err));
+      setCcsProviders(null);
+    } finally {
+      setCcsLoading(false);
+    }
+  }
+
+  function toggleThirdPartyImport(type: ProviderId) {
+    setThirdPartyImportTab((openTab) => {
+      const next = openTab === type ? null : type;
+      if (next && !ccsProviders && !ccsLoading) void refreshCcsProviders();
+      return next;
+    });
+  }
+
+  function buildCcsImportedProviders(
+    existingProviders: CustomProvider[],
+    providerType: ProviderId,
+  ) {
+    const imports =
+      ccsProviders?.providers.filter(
+        (provider) => provider.providerType === providerType && ccsProviderIsTransferable(provider),
+      ) ?? [];
+    const existingIds = new Set(existingProviders.map((provider) => provider.id));
+    const existingIdentity = new Set(existingProviders.map(ccsImportIdentity));
+    const imported: CustomProvider[] = [];
+
+    for (const item of imports) {
+      const identity = ccsImportIdentity({
+        type: item.providerType,
+        name: item.name,
+        baseUrl: item.baseUrl,
+      });
+      if (existingIdentity.has(identity)) continue;
+      existingIdentity.add(identity);
+      imported.push(providerFromCcs(item, existingIds));
+    }
+
+    return imported;
+  }
+
+  async function importCcsProviders(providerType: ProviderId) {
+    const imports =
+      ccsProviders?.providers.filter((provider) => provider.providerType === providerType) ?? [];
+    if (!imports.length) return;
+
+    const transferable = imports.filter(ccsProviderIsTransferable);
+    const skippedCount = imports.length - transferable.length;
+    if (!transferable.length) {
+      setCcsMessage(`ccswitch 中的 ${getProviderLabel(providerType)} 供应商没有可导入的 API 配置`);
+      return;
+    }
+
+    setCcsImportingType(providerType);
+    setCcsMessage("正在导入供应商、获取并激活全部模型…");
+
+    try {
+      setSettings((prev) => {
+        const nextImported = buildCcsImportedProviders(prev.customProviders, providerType);
+        if (!nextImported.length) return prev;
+        return updateCustomProviders(prev, [...prev.customProviders, ...nextImported]);
+      });
+
+      const modelResults = await Promise.all(
+        transferable.map(async (item) => {
+          const identity = ccsImportIdentity({
+            type: item.providerType,
+            name: item.name,
+            baseUrl: item.baseUrl,
+          });
+          if (!ccsProviderCanSyncModels(item)) {
+            return { identity, models: [] as ProviderModelConfig[], fetched: false, failed: false };
+          }
+          try {
+            const models = await fetchModelsFromApi(item.providerType, item.baseUrl, item.apiKey);
+            return { identity, models, fetched: true, failed: false };
+          } catch {
+            return { identity, models: [] as ProviderModelConfig[], fetched: false, failed: true };
+          }
+        }),
+      );
+
+      const resultsByIdentity = new Map(
+        modelResults.map((result) => [result.identity, result] as const),
+      );
+      setSettings((prev) => {
+        let changed = false;
+        const providers = prev.customProviders.map((provider) => {
+          const result = resultsByIdentity.get(ccsImportIdentity(provider));
+          if (!result) return provider;
+          const models = result.fetched
+            ? mergeFetchedModels(result.models, provider.models)
+            : provider.models;
+          const activeModels = models.map((model) => model.id);
+          if (
+            models === provider.models &&
+            activeModels.length === provider.activeModels.length &&
+            activeModels.every((model, index) => model === provider.activeModels[index])
+          ) {
+            return provider;
+          }
+          changed = true;
+          return { ...provider, models, activeModels };
+        });
+        return changed ? updateCustomProviders(prev, providers) : prev;
+      });
+
+      const fetchedCount = modelResults.filter((result) => result.fetched).length;
+      const failedCount = modelResults.filter((result) => result.failed).length;
+      const totalModels = modelResults.reduce((total, result) => total + result.models.length, 0);
+      const details = [
+        `已同步 ${transferable.length} 个 ${getProviderLabel(providerType)} 供应商`,
+        fetchedCount > 0 ? `获取并激活 ${totalModels} 个模型` : "已激活供应商内的全部模型",
+        failedCount > 0 ? `${failedCount} 个供应商模型获取失败` : "",
+        skippedCount > 0 ? `${skippedCount} 个无 API 配置已跳过` : "",
+      ].filter(Boolean);
+      setCcsMessage(details.join("，"));
+      setThirdPartyImportTab(null);
+    } finally {
+      setCcsImportingType(null);
+    }
+  }
 
   function openAdd() {
     setEditingProvider(null);
@@ -845,7 +1119,10 @@ export function ProvidersSection(props: SettingsSectionProps) {
             <button
               key={tab}
               type="button"
-              onClick={() => setActiveTab(tab)}
+              onClick={() => {
+                setActiveTab(tab);
+                setThirdPartyImportTab(null);
+              }}
               className={`inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all ${
                 activeTab === tab
                   ? "bg-background text-foreground shadow"
@@ -888,6 +1165,14 @@ export function ProvidersSection(props: SettingsSectionProps) {
                 onAdd={openAdd}
                 onEdit={openEdit}
                 onDelete={handleDelete}
+                ccsProviders={ccsProviders}
+                ccsLoading={ccsLoading}
+                ccsImporting={ccsImportingType === tab}
+                ccsMessage={ccsMessage}
+                thirdPartyImportOpen={thirdPartyImportTab === tab}
+                onToggleThirdPartyImport={() => toggleThirdPartyImport(tab)}
+                onImportCcsProviders={() => void importCcsProviders(tab)}
+                onRefreshCcsProviders={() => void refreshCcsProviders()}
               />
             </div>
           ))}


### PR DESCRIPTION
## Summary

- add a Tauri command that reads transferable Claude Code, Codex, and Gemini providers from `~/.cc-switch/cc-switch.db`
- add per-provider-tab **Sync from third party** UI for ccswitch imports
- map ccswitch providers to LiveAgent's Anthropic, OpenAI, and Gemini provider types, with identity-based deduplication and settings persistence
- automatically fetch each imported provider's model list and activate all discovered models
- allow repeated syncs to repair existing imports with zero active models, while isolating per-provider fetch failures and skipping entries without transferable API configuration

## Validation

- `pnpm -C crates/agent-gui exec tsc --noEmit`
- `cargo check --manifest-path crates/agent-gui/src-tauri/Cargo.toml`
- `pnpm -C crates/agent-gui tauri build --bundles app`
- manually verified model discovery and persisted active-model counts for Anthropic, OpenAI, and Gemini ccswitch providers
