### PR TITLE
Improve provider model fetch, ccswitch import UX, and settings grouping

### DIFF
--- a/crates/agent-gateway/internal/handler/provider_models.go
+++ b/crates/agent-gateway/internal/handler/provider_models.go
@@ -7,10 +7,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 )
 
 const maxProviderModelsResponseBytes = 2 << 20
+
+const anthropicAPIVersion = "2023-06-01"
 
 type HTTPStatusError struct {
 	Status  int
@@ -35,6 +38,16 @@ var codexModelsSuffixes = []string{
 	"/response",
 }
 
+type providerModelsAttempt struct {
+	url     string
+	headers map[string]string
+}
+
+type providerModelsAttemptFailure struct {
+	upstreamStatus int
+	err            error
+}
+
 func FetchProviderModels(
 	ctx context.Context,
 	req ProviderModelsRequestBody,
@@ -57,7 +70,7 @@ func fetchProviderModelsWithClient(
 		}
 	}
 
-	modelsURL, err := buildProviderModelsURL(providerType, baseURL)
+	attempts, err := buildProviderModelsAttempts(providerType, baseURL, apiKey)
 	if err != nil {
 		return nil, &HTTPStatusError{
 			Status:  http.StatusBadRequest,
@@ -65,57 +78,89 @@ func fetchProviderModelsWithClient(
 		}
 	}
 
-	upstreamReq, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	var failures []providerModelsAttemptFailure
+	var emptyResult *ProviderModelsResult
+
+	for _, attempt := range attempts {
+		result, failure, err := runProviderModelsAttempt(ctx, client, attempt)
+		if err != nil {
+			return nil, err
+		}
+		if failure != nil {
+			failures = append(failures, *failure)
+			continue
+		}
+		if providerModelsBodyHasEntries(result.Body) {
+			return result, nil
+		}
+		emptyResult = result
+	}
+
+	if emptyResult != nil {
+		return emptyResult, nil
+	}
+
+	return nil, pickProviderModelsFailure(failures)
+}
+
+// runProviderModelsAttempt performs a single upstream request. A non-nil
+// error aborts the whole fetch (policy block); a non-nil failure lets the
+// caller fall back to the next attempt.
+func runProviderModelsAttempt(
+	ctx context.Context,
+	client outboundHTTPClient,
+	attempt providerModelsAttempt,
+) (*ProviderModelsResult, *providerModelsAttemptFailure, error) {
+	upstreamReq, err := http.NewRequestWithContext(ctx, http.MethodGet, attempt.url, nil)
 	if err != nil {
-		return nil, &HTTPStatusError{
+		return nil, nil, &HTTPStatusError{
 			Status:  http.StatusBadRequest,
 			Message: "invalid provider models URL",
 		}
 	}
-
-	upstreamReq.Header.Set("Content-Type", "application/json")
-	if providerType == "gemini" {
-		upstreamReq.Header.Set("x-goog-api-key", apiKey)
-	} else {
-		upstreamReq.Header.Set("Authorization", "Bearer "+apiKey)
-		upstreamReq.Header.Set("x-api-key", apiKey)
-	}
-	if providerType == "claude_code" {
-		upstreamReq.Header.Set("anthropic-version", "2023-06-01")
+	for key, value := range attempt.headers {
+		upstreamReq.Header.Set(key, value)
 	}
 
 	resp, err := client.Do(upstreamReq)
 	if err != nil {
 		if isSafeOutboundBlockedError(err) {
-			return nil, &HTTPStatusError{
+			return nil, nil, &HTTPStatusError{
 				Status:  http.StatusBadRequest,
 				Message: "provider models URL is not allowed",
 			}
 		}
-		return nil, err
+		return nil, &providerModelsAttemptFailure{err: err}, nil
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxProviderModelsResponseBytes))
 	if err != nil {
-		return nil, &HTTPStatusError{
-			Status:  http.StatusBadGateway,
-			Message: "failed to read provider model response",
-		}
+		return nil, &providerModelsAttemptFailure{
+			err: &HTTPStatusError{
+				Status:  http.StatusBadGateway,
+				Message: "failed to read provider model response",
+			},
+		}, nil
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, &HTTPStatusError{
-			Status:  mapUpstreamProviderStatus(resp.StatusCode),
-			Message: extractUpstreamErrorMessage(body, resp.Status),
-		}
+		return nil, &providerModelsAttemptFailure{
+			upstreamStatus: resp.StatusCode,
+			err: &HTTPStatusError{
+				Status:  mapUpstreamProviderStatus(resp.StatusCode),
+				Message: extractUpstreamErrorMessage(body, resp.Status),
+			},
+		}, nil
 	}
 
 	if !json.Valid(body) {
-		return nil, &HTTPStatusError{
-			Status:  http.StatusBadGateway,
-			Message: "provider model response is not valid JSON",
-		}
+		return nil, &providerModelsAttemptFailure{
+			err: &HTTPStatusError{
+				Status:  http.StatusBadGateway,
+				Message: "provider model response is not valid JSON",
+			},
+		}, nil
 	}
 
 	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
@@ -126,10 +171,129 @@ func fetchProviderModelsWithClient(
 	return &ProviderModelsResult{
 		ContentType: contentType,
 		Body:        body,
-	}, nil
+	}, nil, nil
 }
 
-func buildProviderModelsURL(providerType string, baseURL string) (string, error) {
+func buildProviderModelsAttempts(
+	providerType string,
+	baseURL string,
+	apiKey string,
+) ([]providerModelsAttempt, error) {
+	defaultURL, err := buildProviderModelsURL(providerType, baseURL, false)
+	if err != nil {
+		return nil, err
+	}
+	officialURL, err := buildProviderModelsURL(providerType, baseURL, true)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := []providerModelsAttempt{
+		{url: defaultURL, headers: buildProviderModelsHeaders(providerType, apiKey, false)},
+		{url: officialURL, headers: buildProviderModelsHeaders(providerType, apiKey, true)},
+	}
+
+	attempts := make([]providerModelsAttempt, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		signature := providerModelsAttemptSignature(candidate)
+		if _, ok := seen[signature]; ok {
+			continue
+		}
+		seen[signature] = struct{}{}
+		attempts = append(attempts, candidate)
+	}
+	return attempts, nil
+}
+
+func providerModelsAttemptSignature(attempt providerModelsAttempt) string {
+	keys := make([]string, 0, len(attempt.headers))
+	for key := range attempt.headers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var builder strings.Builder
+	builder.WriteString(attempt.url)
+	for _, key := range keys {
+		builder.WriteString("||")
+		builder.WriteString(key)
+		builder.WriteString("=")
+		builder.WriteString(attempt.headers[key])
+	}
+	return builder.String()
+}
+
+func buildProviderModelsHeaders(
+	providerType string,
+	apiKey string,
+	official bool,
+) map[string]string {
+	headers := map[string]string{"Content-Type": "application/json"}
+	switch providerType {
+	case "gemini":
+		headers["x-goog-api-key"] = apiKey
+		if !official {
+			headers["Authorization"] = "Bearer " + apiKey
+		}
+	case "claude_code":
+		headers["x-api-key"] = apiKey
+		headers["anthropic-version"] = anthropicAPIVersion
+		if !official {
+			headers["Authorization"] = "Bearer " + apiKey
+		}
+	default:
+		headers["Authorization"] = "Bearer " + apiKey
+		if !official {
+			headers["x-api-key"] = apiKey
+		}
+	}
+	return headers
+}
+
+func providerModelsBodyHasEntries(body []byte) bool {
+	var payload any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+
+	switch typed := payload.(type) {
+	case []any:
+		return len(typed) > 0
+	case map[string]any:
+		if items, ok := typed["data"].([]any); ok && len(items) > 0 {
+			return true
+		}
+		if items, ok := typed["models"].([]any); ok && len(items) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func isMissingEndpointStatus(status int) bool {
+	return status == http.StatusNotFound || status == http.StatusMethodNotAllowed
+}
+
+// pickProviderModelsFailure prefers the most informative failure: the last
+// one that is not a bare "endpoint missing" upstream status, falling back to
+// the last failure overall.
+func pickProviderModelsFailure(failures []providerModelsAttemptFailure) error {
+	for index := len(failures) - 1; index >= 0; index-- {
+		if !isMissingEndpointStatus(failures[index].upstreamStatus) {
+			return failures[index].err
+		}
+	}
+	if len(failures) > 0 {
+		return failures[len(failures)-1].err
+	}
+	return &HTTPStatusError{
+		Status:  http.StatusBadGateway,
+		Message: "failed to fetch provider models",
+	}
+}
+
+func buildProviderModelsURL(providerType string, baseURL string, official bool) (string, error) {
 	normalizedBaseURL := strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	if normalizedBaseURL == "" {
 		return "", errors.New("base_url is required")
@@ -178,13 +342,17 @@ func buildProviderModelsURL(providerType string, baseURL string) (string, error)
 	}
 
 	if providerType == "gemini" {
+		versionPath := "/v1"
+		if official {
+			versionPath = "/v1beta"
+		}
 		normalizedPath := strings.TrimRight(parsed.Path, "/")
 		if strings.HasSuffix(strings.ToLower(normalizedPath), "/models") {
 			parsed.Path = normalizedPath
 		} else if isGeminiVersionPath(normalizedPath) {
 			parsed.Path = normalizedPath + "/models"
 		} else {
-			parsed.Path = normalizedPath + "/v1beta/models"
+			parsed.Path = normalizedPath + versionPath + "/models"
 		}
 		return parsed.String(), nil
 	}

--- a/crates/agent-gateway/internal/handler/provider_models_test.go
+++ b/crates/agent-gateway/internal/handler/provider_models_test.go
@@ -1,8 +1,10 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -10,7 +12,7 @@ import (
 func TestBuildProviderModelsURLForGemini(t *testing.T) {
 	t.Parallel()
 
-	cases := map[string]string{
+	officialCases := map[string]string{
 		"https://generativelanguage.googleapis.com":                                                    "https://generativelanguage.googleapis.com/v1beta/models",
 		"https://generativelanguage.googleapis.com/v1beta":                                             "https://generativelanguage.googleapis.com/v1beta/models",
 		"https://generativelanguage.googleapis.com/v1beta/models":                                      "https://generativelanguage.googleapis.com/v1beta/models",
@@ -18,21 +20,92 @@ func TestBuildProviderModelsURLForGemini(t *testing.T) {
 		"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent": "https://generativelanguage.googleapis.com/v1beta/models",
 	}
 
-	for input, want := range cases {
-		got, err := buildProviderModelsURL("gemini", input)
+	for input, want := range officialCases {
+		got, err := buildProviderModelsURL("gemini", input, true)
 		if err != nil {
-			t.Fatalf("buildProviderModelsURL(%q) error = %v", input, err)
+			t.Fatalf("buildProviderModelsURL(%q, official) error = %v", input, err)
 		}
 		if got != want {
-			t.Fatalf("buildProviderModelsURL(%q) = %q, want %q", input, got, want)
+			t.Fatalf("buildProviderModelsURL(%q, official) = %q, want %q", input, got, want)
 		}
+	}
+
+	defaultCases := map[string]string{
+		"https://generativelanguage.googleapis.com":        "https://generativelanguage.googleapis.com/v1/models",
+		"https://generativelanguage.googleapis.com/v1beta": "https://generativelanguage.googleapis.com/v1beta/models",
+		"https://relay.example.com":                        "https://relay.example.com/v1/models",
+	}
+
+	for input, want := range defaultCases {
+		got, err := buildProviderModelsURL("gemini", input, false)
+		if err != nil {
+			t.Fatalf("buildProviderModelsURL(%q, default) error = %v", input, err)
+		}
+		if got != want {
+			t.Fatalf("buildProviderModelsURL(%q, default) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestBuildProviderModelsAttempts(t *testing.T) {
+	t.Parallel()
+
+	geminiAttempts, err := buildProviderModelsAttempts("gemini", "https://relay.example.com", "test-key")
+	if err != nil {
+		t.Fatalf("buildProviderModelsAttempts(gemini) error = %v", err)
+	}
+	if len(geminiAttempts) != 2 {
+		t.Fatalf("gemini attempts = %d, want 2", len(geminiAttempts))
+	}
+	if geminiAttempts[0].url != "https://relay.example.com/v1/models" {
+		t.Fatalf("gemini default attempt URL = %q", geminiAttempts[0].url)
+	}
+	if geminiAttempts[1].url != "https://relay.example.com/v1beta/models" {
+		t.Fatalf("gemini official attempt URL = %q", geminiAttempts[1].url)
+	}
+	if geminiAttempts[0].headers["Authorization"] == "" {
+		t.Fatal("gemini default attempt should include Authorization header")
+	}
+	if geminiAttempts[1].headers["Authorization"] != "" {
+		t.Fatal("gemini official attempt should not include Authorization header")
+	}
+	if geminiAttempts[1].headers["x-goog-api-key"] != "test-key" {
+		t.Fatal("gemini official attempt should authenticate with x-goog-api-key")
+	}
+
+	claudeAttempts, err := buildProviderModelsAttempts("claude_code", "https://relay.example.com", "test-key")
+	if err != nil {
+		t.Fatalf("buildProviderModelsAttempts(claude_code) error = %v", err)
+	}
+	if len(claudeAttempts) != 2 {
+		t.Fatalf("claude_code attempts = %d, want 2", len(claudeAttempts))
+	}
+	if claudeAttempts[0].url != claudeAttempts[1].url {
+		t.Fatal("claude_code attempts should share the /v1/models URL")
+	}
+	if claudeAttempts[1].headers["Authorization"] != "" {
+		t.Fatal("claude_code official attempt should drop the Authorization header")
+	}
+	if claudeAttempts[1].headers["anthropic-version"] == "" {
+		t.Fatal("claude_code official attempt should keep anthropic-version")
+	}
+
+	codexAttempts, err := buildProviderModelsAttempts("codex", "https://relay.example.com/v1", "test-key")
+	if err != nil {
+		t.Fatalf("buildProviderModelsAttempts(codex) error = %v", err)
+	}
+	if len(codexAttempts) != 2 {
+		t.Fatalf("codex attempts = %d, want 2", len(codexAttempts))
+	}
+	if codexAttempts[0].url != "https://relay.example.com/v1/models" {
+		t.Fatalf("codex default attempt URL = %q", codexAttempts[0].url)
 	}
 }
 
 func TestBuildProviderModelsURLRejectsLoopback(t *testing.T) {
 	t.Parallel()
 
-	if _, err := buildProviderModelsURL("codex", "http://127.0.0.1:11434"); err == nil {
+	if _, err := buildProviderModelsURL("codex", "http://127.0.0.1:11434", false); err == nil {
 		t.Fatal("buildProviderModelsURL() error = nil, want loopback rejection")
 	}
 }
@@ -40,7 +113,7 @@ func TestBuildProviderModelsURLRejectsLoopback(t *testing.T) {
 func TestBuildProviderModelsURLRejectsIPv4MappedLoopback(t *testing.T) {
 	t.Parallel()
 
-	if _, err := buildProviderModelsURL("codex", "http://[::ffff:127.0.0.1]:11434"); err == nil {
+	if _, err := buildProviderModelsURL("codex", "http://[::ffff:127.0.0.1]:11434", false); err == nil {
 		t.Fatal("buildProviderModelsURL() error = nil, want IPv4-mapped loopback rejection")
 	}
 }
@@ -62,5 +135,140 @@ func TestFetchProviderModelsRejectsUnsafeURL(t *testing.T) {
 	}
 	if statusErr.Status != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", statusErr.Status, http.StatusBadRequest)
+	}
+}
+
+type stubOutboundHTTPClient struct {
+	requests []*http.Request
+	respond  func(req *http.Request) (*http.Response, error)
+}
+
+func (c *stubOutboundHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.requests = append(c.requests, req)
+	return c.respond(req)
+}
+
+func stubJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+	}
+}
+
+func TestFetchProviderModelsFallsBackToOfficialEndpoint(t *testing.T) {
+	t.Parallel()
+
+	client := &stubOutboundHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path == "/v1/models" {
+				return stubJSONResponse(http.StatusNotFound, `{"error":"not found"}`), nil
+			}
+			return stubJSONResponse(http.StatusOK, `{"models":[{"name":"models/gemini-2.5-pro"}]}`), nil
+		},
+	}
+
+	result, err := fetchProviderModelsWithClient(context.Background(), ProviderModelsRequestBody{
+		Type:    "gemini",
+		BaseURL: "https://relay.example.com",
+		APIKey:  "test-key",
+	}, client)
+	if err != nil {
+		t.Fatalf("fetchProviderModelsWithClient() error = %v", err)
+	}
+	if len(client.requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(client.requests))
+	}
+	if client.requests[0].URL.Path != "/v1/models" {
+		t.Fatalf("first request path = %q, want /v1/models", client.requests[0].URL.Path)
+	}
+	if client.requests[1].URL.Path != "/v1beta/models" {
+		t.Fatalf("second request path = %q, want /v1beta/models", client.requests[1].URL.Path)
+	}
+	if !bytes.Contains(result.Body, []byte("gemini-2.5-pro")) {
+		t.Fatalf("result body = %s, want fetched models", result.Body)
+	}
+}
+
+func TestFetchProviderModelsFallsBackWhenDefaultListIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	client := &stubOutboundHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path == "/v1/models" {
+				return stubJSONResponse(http.StatusOK, `{"data":[]}`), nil
+			}
+			return stubJSONResponse(http.StatusOK, `{"models":[{"name":"models/gemini-2.5-flash"}]}`), nil
+		},
+	}
+
+	result, err := fetchProviderModelsWithClient(context.Background(), ProviderModelsRequestBody{
+		Type:    "gemini",
+		BaseURL: "https://relay.example.com",
+		APIKey:  "test-key",
+	}, client)
+	if err != nil {
+		t.Fatalf("fetchProviderModelsWithClient() error = %v", err)
+	}
+	if !bytes.Contains(result.Body, []byte("gemini-2.5-flash")) {
+		t.Fatalf("result body = %s, want official models", result.Body)
+	}
+}
+
+func TestFetchProviderModelsStopsAtFirstSuccess(t *testing.T) {
+	t.Parallel()
+
+	client := &stubOutboundHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			return stubJSONResponse(http.StatusOK, `{"data":[{"id":"gpt-5"}]}`), nil
+		},
+	}
+
+	result, err := fetchProviderModelsWithClient(context.Background(), ProviderModelsRequestBody{
+		Type:    "codex",
+		BaseURL: "https://relay.example.com",
+		APIKey:  "test-key",
+	}, client)
+	if err != nil {
+		t.Fatalf("fetchProviderModelsWithClient() error = %v", err)
+	}
+	if len(client.requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(client.requests))
+	}
+	if !bytes.Contains(result.Body, []byte("gpt-5")) {
+		t.Fatalf("result body = %s, want default models", result.Body)
+	}
+}
+
+func TestFetchProviderModelsPrefersInformativeFailure(t *testing.T) {
+	t.Parallel()
+
+	client := &stubOutboundHTTPClient{
+		respond: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path == "/v1/models" {
+				return stubJSONResponse(http.StatusUnauthorized, `{"error":"invalid api key"}`), nil
+			}
+			return stubJSONResponse(http.StatusNotFound, `{"error":"not found"}`), nil
+		},
+	}
+
+	_, err := fetchProviderModelsWithClient(context.Background(), ProviderModelsRequestBody{
+		Type:    "gemini",
+		BaseURL: "https://relay.example.com",
+		APIKey:  "test-key",
+	}, client)
+	if err == nil {
+		t.Fatal("fetchProviderModelsWithClient() error = nil, want failure")
+	}
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("error = %T, want *HTTPStatusError", err)
+	}
+	if statusErr.Status != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", statusErr.Status, http.StatusUnauthorized)
+	}
+	if statusErr.Message != "invalid api key" {
+		t.Fatalf("message = %q, want %q", statusErr.Message, "invalid api key")
 	}
 }

--- a/crates/agent-gateway/web/src/i18n/config.ts
+++ b/crates/agent-gateway/web/src/i18n/config.ts
@@ -1812,9 +1812,9 @@ export const translations: Record<Locale, Record<string, string>> = {
     "chat.runtime.settingsSyncTitle": "Syncing desktop settings",
     "chat.runtime.reasoning": "Thinking effort",
     "chat.emptyRound": "(No reply)",
-    "chat.inputHint": "Type a message, @ to mention files, Enter to send, Shift+Enter for newline",
+    "chat.inputHint": "Type a message, @ to reference files, prompts can be queued...",
     "chat.inputHintWithSkills":
-      "Type a message, @ to mention files, $ to reference Skills, Enter to send, Shift+Enter for newline",
+      "Type a message, @ to reference files, $ to reference Skills, prompts can be queued...",
     "chat.compactingContext": "Compressing context",
     "chat.compactingContextWait": "Compressing context, please wait...",
     "chat.editMessage": "Edit Message",

--- a/crates/agent-gateway/web/src/pages/SettingsPage.tsx
+++ b/crates/agent-gateway/web/src/pages/SettingsPage.tsx
@@ -93,14 +93,16 @@ const NAV_GROUPS: NavGroup[] = [
     labelKey: "settings.groupGeneral",
     items: [
       { id: "system", icon: <Settings2 className="h-4 w-4" /> },
-      { id: "systemTools", icon: <Wrench className="h-4 w-4" /> },
       { id: "providers", icon: <Cpu className="h-4 w-4" /> },
       { id: "agents", icon: <BookOpen className="h-4 w-4" /> },
     ],
   },
   {
     labelKey: "settings.groupIntelligence",
-    items: [{ id: "memory", icon: <Brain className="h-4 w-4" /> }],
+    items: [
+      { id: "memory", icon: <Brain className="h-4 w-4" /> },
+      { id: "systemTools", icon: <Wrench className="h-4 w-4" /> },
+    ],
   },
   {
     labelKey: "settings.groupAutomation",

--- a/crates/agent-gateway/web/src/pages/settings/providerUtils.ts
+++ b/crates/agent-gateway/web/src/pages/settings/providerUtils.ts
@@ -12,6 +12,7 @@ const GATEWAY_WEBUI_MARKER = "gateway";
 const GATEWAY_TOKEN_STORAGE_KEY = "liveagent.gateway.token";
 const CODEX_MODELS_SUFFIXES = ["/chat/completions", "/responses", "/response"];
 const GEMINI_GENERATE_SUFFIXES = [":streamGenerateContent", ":generateContent"];
+const ANTHROPIC_API_VERSION = "2023-06-01";
 
 export function isGatewayWebuiRuntime() {
   return (
@@ -55,15 +56,123 @@ function normalizeModelBaseUrl(type: ProviderId, baseUrl: string) {
   return normalizeBaseUrl(normalizedUrl);
 }
 
-function buildModelsUrl(type: ProviderId, baseUrl: string) {
+export type ProviderModelsAttemptKind = "default" | "official";
+
+export type ProviderModelsAttempt = {
+  kind: ProviderModelsAttemptKind;
+  headers: Record<string, string>;
+};
+
+export type ProviderModelsFailure = {
+  status: number | null;
+  message: string;
+};
+
+function buildGeminiModelsUrl(baseUrl: string, versionPath: string) {
+  const normalizedUrl = normalizeBaseUrl(baseUrl);
+  if (normalizedUrl.toLowerCase().endsWith("/models")) return normalizedUrl;
+  if (/\/v\d+(?:beta)?$/i.test(normalizedUrl)) return `${normalizedUrl}/models`;
+  return `${normalizedUrl}/${versionPath}/models`;
+}
+
+export function buildProviderModelsUrl(
+  type: ProviderId,
+  baseUrl: string,
+  kind: ProviderModelsAttemptKind,
+) {
   if (type === "gemini") {
-    const normalizedUrl = normalizeBaseUrl(baseUrl);
-    if (normalizedUrl.toLowerCase().endsWith("/models")) return normalizedUrl;
-    if (/\/v\d+(?:beta)?$/i.test(normalizedUrl)) return `${normalizedUrl}/models`;
-    return `${normalizedUrl}/v1beta/models`;
+    return buildGeminiModelsUrl(baseUrl, kind === "official" ? "v1beta" : "v1");
   }
 
   return baseUrl.endsWith("/v1") ? `${baseUrl}/models` : `${baseUrl}/v1/models`;
+}
+
+function buildDefaultModelsHeaders(type: ProviderId, apiKey: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+  if (type === "gemini") {
+    headers["x-goog-api-key"] = apiKey;
+    return headers;
+  }
+  headers["x-api-key"] = apiKey;
+  if (type === "claude_code") {
+    headers["anthropic-version"] = ANTHROPIC_API_VERSION;
+  }
+  return headers;
+}
+
+function buildOfficialModelsHeaders(type: ProviderId, apiKey: string): Record<string, string> {
+  if (type === "gemini") {
+    return {
+      "Content-Type": "application/json",
+      "x-goog-api-key": apiKey,
+    };
+  }
+  if (type === "claude_code") {
+    return {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": ANTHROPIC_API_VERSION,
+    };
+  }
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+}
+
+function providerModelsAttemptSignature(
+  type: ProviderId,
+  baseUrl: string,
+  attempt: ProviderModelsAttempt,
+) {
+  const url = buildProviderModelsUrl(type, baseUrl, attempt.kind);
+  const headers = Object.entries(attempt.headers).sort(([a], [b]) => a.localeCompare(b));
+  return `${url}||${JSON.stringify(headers)}`;
+}
+
+export function buildProviderModelsAttempts(
+  type: ProviderId,
+  baseUrl: string,
+  apiKey: string,
+): ProviderModelsAttempt[] {
+  const candidates: ProviderModelsAttempt[] = [
+    { kind: "default", headers: buildDefaultModelsHeaders(type, apiKey) },
+    { kind: "official", headers: buildOfficialModelsHeaders(type, apiKey) },
+  ];
+
+  const attempts: ProviderModelsAttempt[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    const signature = providerModelsAttemptSignature(type, baseUrl, candidate);
+    if (seen.has(signature)) continue;
+    seen.add(signature);
+    attempts.push(candidate);
+  }
+  return attempts;
+}
+
+function isMissingEndpointStatus(status: number | null) {
+  return status === 404 || status === 405;
+}
+
+export function pickProviderModelsFailure(
+  failures: ProviderModelsFailure[],
+): ProviderModelsFailure | null {
+  for (let index = failures.length - 1; index >= 0; index -= 1) {
+    if (!isMissingEndpointStatus(failures[index].status)) return failures[index];
+  }
+  return failures.length > 0 ? failures[failures.length - 1] : null;
+}
+
+function extractModelListItems(data: unknown): unknown[] | null {
+  if (Array.isArray(data)) return data;
+  const payload = data as { data?: unknown; models?: unknown } | null;
+  if (Array.isArray(payload?.data)) return payload.data;
+  if (Array.isArray(payload?.models)) return payload.models;
+  return null;
 }
 
 async function readFetchError(response: Response, fallback: string) {
@@ -105,14 +214,9 @@ async function fetchModelsThroughGateway(
     api_key: apiKey,
   } as any);
 
-  if (Array.isArray((data as { data?: unknown[] } | null)?.data)) {
-    return normalizeFetchedModels((data as { data: unknown[] }).data, type);
-  }
-  if (Array.isArray((data as { models?: unknown[] } | null)?.models)) {
-    return normalizeFetchedModels((data as { models: unknown[] }).models, type);
-  }
-  if (Array.isArray(data)) {
-    return normalizeFetchedModels(data, type);
+  const items = extractModelListItems(data);
+  if (items !== null) {
+    return normalizeFetchedModels(items, type);
   }
 
   const maybeError =
@@ -234,39 +338,53 @@ export async function fetchModelsFromApi(
     return fetchModelsThroughGateway(type, normalizedUrl, normalizedApiKey);
   }
 
-  const headers: Record<string, string> =
-    type === "gemini"
-      ? {
-          "Content-Type": "application/json",
-          "x-goog-api-key": normalizedApiKey,
-        }
-      : {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${normalizedApiKey}`,
-          "x-api-key": normalizedApiKey,
-        };
+  const attempts = buildProviderModelsAttempts(type, normalizedUrl, normalizedApiKey);
+  const failures: ProviderModelsFailure[] = [];
+  let emptyResult: ProviderModelConfig[] | null = null;
 
-  if (type === "claude_code") {
-    headers["anthropic-version"] = "2023-06-01";
+  for (const attempt of attempts) {
+    const proxyRequest = await prepareProxyRequest(type, normalizedUrl, attempt.headers);
+    const modelsUrl = buildProviderModelsUrl(type, proxyRequest.baseUrl, attempt.kind);
+
+    let response: Response;
+    try {
+      response = await fetch(modelsUrl, { headers: proxyRequest.headers });
+    } catch (error) {
+      failures.push({
+        status: null,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    if (!response.ok) {
+      failures.push({
+        status: response.status,
+        message: await readFetchError(response, `HTTP ${response.status} ${response.statusText}`),
+      });
+      continue;
+    }
+
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      failures.push({ status: null, message: "Model list response is not valid JSON" });
+      continue;
+    }
+
+    const items = extractModelListItems(data);
+    if (items === null) {
+      emptyResult ??= [];
+      continue;
+    }
+    const models = normalizeFetchedModels(items, type);
+    if (models.length > 0) return models;
+    emptyResult = models;
   }
 
-  const proxyRequest = await prepareProxyRequest(type, normalizedUrl, headers);
-  const proxyUrl = buildModelsUrl(type, proxyRequest.baseUrl);
+  if (emptyResult !== null) return emptyResult;
 
-  const res = await fetch(proxyUrl, { headers: proxyRequest.headers });
-  if (!res.ok) {
-    throw new Error(await readFetchError(res, `HTTP ${res.status} ${res.statusText}`));
-  }
-  const data = await res.json();
-
-  if (Array.isArray(data.data)) {
-    return normalizeFetchedModels(data.data, type);
-  }
-  if (Array.isArray(data.models)) {
-    return normalizeFetchedModels(data.models, type);
-  }
-  if (Array.isArray(data)) {
-    return normalizeFetchedModels(data, type);
-  }
-  return [];
+  const failure = pickProviderModelsFailure(failures);
+  throw new Error(failure?.message ?? "Failed to fetch model list");
 }

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/ccs_import.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/ccs_import.rs
@@ -22,10 +22,19 @@ pub struct CcsProvidersResponse {
 #[tauri::command]
 pub async fn settings_list_ccswitch_providers() -> Result<CcsProvidersResponse, String> {
     tauri::async_runtime::spawn_blocking(|| {
-        let path = default_ccswitch_db_path();
-        let providers = list_ccswitch_liveagent_providers_from_db(&path)?;
+        let candidates = ccswitch_db_candidates();
+        let path = candidates.iter().find(|path| path.exists());
+        let providers = match path {
+            Some(path) => list_ccswitch_liveagent_providers_from_db(path)?,
+            None => Vec::new(),
+        };
         let message = if providers.is_empty() {
-            format!("未发现 ccswitch LiveAgent 供应商：{}", path.display())
+            let checked = candidates
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join("；");
+            format!("未发现 ccswitch LiveAgent 供应商，已检查：{checked}")
         } else {
             format!("发现 {} 个 ccswitch LiveAgent 供应商", providers.len())
         };
@@ -39,11 +48,46 @@ pub async fn settings_list_ccswitch_providers() -> Result<CcsProvidersResponse, 
     .map_err(|e| format!("settings_list_ccswitch_providers join 失败：{e}"))?
 }
 
-fn default_ccswitch_db_path() -> PathBuf {
+/// ccswitch (Tauri 应用 id `com.ccswitch.desktop`) 允许用户把数据目录整体迁移到
+/// 自定义路径（例如同步到 OneDrive），迁移后真正使用的数据库不再位于默认的
+/// `~/.cc-switch/` 下，而是记录在其自身配置目录的 `app_paths.json` 里
+/// （`app_config_dir_override` 字段）。这里优先用该 override 目录，找不到再回退默认目录。
+fn ccswitch_db_candidates() -> Vec<PathBuf> {
+    let filename = format!("{}-{}.db", "cc", "switch");
+    let mut candidates = Vec::new();
+    if let Some(override_dir) = ccswitch_override_config_dir() {
+        candidates.push(override_dir.join(&filename));
+    }
+    candidates.push(ccswitch_legacy_config_dir().join(&filename));
+    candidates
+}
+
+fn ccswitch_legacy_config_dir() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(format!(".{}-{}", "cc", "switch"))
-        .join(format!("{}-{}.db", "cc", "switch"))
+}
+
+fn ccswitch_override_config_dir() -> Option<PathBuf> {
+    let app_paths_file = dirs::config_dir()?
+        .join("com.ccswitch.desktop")
+        .join("app_paths.json");
+    let content = fs::read_to_string(app_paths_file).ok()?;
+    let value: Value = serde_json::from_str(&content).ok()?;
+    let override_dir = value.get("app_config_dir_override")?.as_str()?.trim();
+    if override_dir.is_empty() {
+        return None;
+    }
+    Some(expand_home_prefix(override_dir))
+}
+
+fn expand_home_prefix(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(path)
 }
 
 fn list_ccswitch_liveagent_providers_from_db(

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -1889,9 +1889,9 @@ export const translations: Record<Locale, Record<string, string>> = {
     "chat.runtime.tunnelSettingsSyncing": "Syncing desktop settings",
     "chat.runtime.reasoning": "Thinking effort",
     "chat.emptyRound": "(No reply)",
-    "chat.inputHint": "Type a message, @ to mention files, Enter to send, Shift+Enter for newline",
+    "chat.inputHint": "Type a message, @ to reference files, prompts can be queued...",
     "chat.inputHintWithSkills":
-      "Type a message, @ to mention files, $ to reference Skills, Enter to send, Shift+Enter for newline",
+      "Type a message, @ to reference files, $ to reference Skills, prompts can be queued...",
     "chat.compactingContext": "Compressing context",
     "chat.compactingContextWait": "Compressing context, please wait...",
     "chat.editMessage": "Edit Message",

--- a/crates/agent-gui/src/pages/SettingsPage.tsx
+++ b/crates/agent-gui/src/pages/SettingsPage.tsx
@@ -94,14 +94,16 @@ const NAV_GROUPS: NavGroup[] = [
     labelKey: "settings.groupGeneral",
     items: [
       { id: "system", icon: <Settings2 className="h-3.5 w-3.5" /> },
-      { id: "systemTools", icon: <Wrench className="h-3.5 w-3.5" /> },
       { id: "providers", icon: <Cpu className="h-3.5 w-3.5" /> },
       { id: "agents", icon: <BookOpen className="h-3.5 w-3.5" /> },
     ],
   },
   {
     labelKey: "settings.groupIntelligence",
-    items: [{ id: "memory", icon: <Brain className="h-3.5 w-3.5" /> }],
+    items: [
+      { id: "memory", icon: <Brain className="h-3.5 w-3.5" /> },
+      { id: "systemTools", icon: <Wrench className="h-3.5 w-3.5" /> },
+    ],
   },
   {
     labelKey: "settings.groupAutomation",

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -1125,7 +1125,7 @@ function ProviderList(props: {
       : ccsAll.length
         ? `发现 ${ccsBreakdown
             .map((entry) => `${getProviderLabel(entry.type)} ${entry.count}`)
-            .join(" · ")}，点击选择导入`
+            .join(" · ")}`
         : scanned
           ? ccsMessage || "未发现可导入的供应商"
           : "点击扫描本地配置";

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -838,9 +838,7 @@ function CcsImportModal(props: {
       .filter((group) => group.rows.length > 0);
   }, [rows, initialType]);
 
-  const [selected, setSelected] = useState<Set<string>>(
-    () => new Set(rows.filter((row) => row.selectable).map((row) => row.key)),
-  );
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
   const [result, setResult] = useState<string | null>(null);
   const [activeType, setActiveType] = useState<ProviderId>(initialType);
 
@@ -984,7 +982,6 @@ function CcsImportModal(props: {
 
                 <div className="min-h-0 flex-1 divide-y overflow-y-auto">
                   {activeRows.map(({ item, key, exists, transferable, selectable }) => {
-                    const modelCount = item.models?.length ?? 0;
                     return (
                       <label
                         key={key}
@@ -1017,14 +1014,11 @@ function CcsImportModal(props: {
                             {item.baseUrl || "未配置 Base URL"}
                           </div>
                         </div>
-                        <div className="flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
-                          {item.apiKey.trim() ? (
-                            <span title="已包含 API Key">
-                              <Key className="h-3 w-3" />
-                            </span>
-                          ) : null}
-                          {modelCount > 0 ? <span>{modelCount} 模型</span> : null}
-                        </div>
+                        {item.apiKey.trim() ? (
+                          <span className="shrink-0 text-muted-foreground" title="已包含 API Key">
+                            <Key className="h-3 w-3" />
+                          </span>
+                        ) : null}
                       </label>
                     );
                   })}

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -2,11 +2,15 @@ import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
+  CheckCircle2,
+  ChevronDown,
   ClaudeIcon,
   Download,
   Eye,
   EyeOff,
   GeminiIcon,
+  Key,
+  Loader2,
   OpenaiChatgptIcon,
   Pencil,
   Plus,
@@ -18,6 +22,14 @@ import {
 } from "../../components/icons";
 
 import { Button } from "../../components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../../components/ui/dropdown-menu";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import {
@@ -39,6 +51,7 @@ import {
   updateCustomProviders,
   updateCustomSettings,
 } from "../../lib/settings";
+import { cn } from "../../lib/shared/utils";
 import {
   createDraftModelConfig,
   fetchModelsFromApi,
@@ -766,8 +779,303 @@ function ccsProviderIsTransferable(item: CcsProviderImportItem) {
   return ccsProviderCanSyncModels(item) || (item.models?.length ?? 0) > 0;
 }
 
+// sourceId alone can collide across ccswitch app_type buckets that map to the
+// same provider tab (e.g. "claude" and "claude-code"), so key rows on both.
+function ccsItemKey(item: CcsProviderImportItem) {
+  return `${item.appType}:${item.sourceId}`;
+}
+
+function CcsSourceLogo({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 select-none items-center justify-center rounded-lg bg-gradient-to-br from-sky-500 to-indigo-500 font-bold text-white shadow-sm",
+        className,
+      )}
+    >
+      CC
+    </span>
+  );
+}
+
+function CcsImportModal(props: {
+  initialType: ProviderId;
+  items: CcsProviderImportItem[];
+  existingProviders: CustomProvider[];
+  importing: boolean;
+  onImport: (items: CcsProviderImportItem[]) => Promise<string>;
+  onClose: () => void;
+}) {
+  const { initialType, items, existingProviders, importing, onImport, onClose } = props;
+  const { t } = useLocale();
+
+  const existingIdentity = useMemo(
+    () => new Set(existingProviders.map(ccsImportIdentity)),
+    [existingProviders],
+  );
+  const rows = useMemo(
+    () =>
+      items.map((item) => {
+        const exists = existingIdentity.has(
+          ccsImportIdentity({ type: item.providerType, name: item.name, baseUrl: item.baseUrl }),
+        );
+        const transferable = ccsProviderIsTransferable(item);
+        return {
+          item,
+          key: ccsItemKey(item),
+          exists,
+          transferable,
+          selectable: transferable && !exists,
+        };
+      }),
+    [items, existingIdentity],
+  );
+  // All provider types in one modal, the tab the user came from leading.
+  const groups = useMemo(() => {
+    const order = [initialType, ...PROVIDER_TABS.filter((tab) => tab !== initialType)];
+    return order
+      .map((type) => ({ type, rows: rows.filter((row) => row.item.providerType === type) }))
+      .filter((group) => group.rows.length > 0);
+  }, [rows, initialType]);
+
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(rows.filter((row) => row.selectable).map((row) => row.key)),
+  );
+  const [result, setResult] = useState<string | null>(null);
+  const [activeType, setActiveType] = useState<ProviderId>(initialType);
+
+  const selectableKeys = rows.filter((row) => row.selectable).map((row) => row.key);
+  const selectedCount = selectableKeys.filter((key) => selected.has(key)).length;
+
+  // The initial tab may have no discovered configs — fall back to the first
+  // group that does.
+  const activeGroup = groups.find((group) => group.type === activeType) ?? groups[0];
+  const activeRows = activeGroup?.rows ?? [];
+  const activeSelectableKeys = activeRows.filter((row) => row.selectable).map((row) => row.key);
+  const activeSelectedCount = activeSelectableKeys.filter((key) => selected.has(key)).length;
+  const activeAllSelected =
+    activeSelectableKeys.length > 0 && activeSelectedCount === activeSelectableKeys.length;
+
+  function toggleRow(key: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  function toggleAllActive() {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const key of activeSelectableKeys) {
+        if (activeAllSelected) next.delete(key);
+        else next.add(key);
+      }
+      return next;
+    });
+  }
+
+  async function handleImport() {
+    const chosen = rows
+      .filter((row) => row.selectable && selected.has(row.key))
+      .map((row) => row.item);
+    if (!chosen.length || importing) return;
+    setResult(null);
+    try {
+      const summary = await onImport(chosen);
+      setResult(summary);
+      setSelected(new Set());
+    } catch (err) {
+      setResult(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={importing ? undefined : onClose}
+      />
+
+      <div className="relative z-10 flex h-[min(35rem,85vh)] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border bg-background shadow-2xl">
+        <div className="flex items-center gap-3 border-b px-6 py-4">
+          <CcsSourceLogo className="h-9 w-9 text-[12px]" />
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-semibold">从 CC Switch 导入</div>
+            <div className="mt-0.5 text-xs text-muted-foreground">
+              左侧选择供应商类型，右侧勾选要导入的配置，导入后自动获取并激活模型
+            </div>
+          </div>
+          <button
+            type="button"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+            onClick={onClose}
+            disabled={importing}
+            title={t("settings.cancel")}
+            aria-label={t("settings.cancel")}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        <div className="flex min-h-0 flex-1">
+          {groups.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center px-6 py-10 text-sm text-muted-foreground">
+              未发现可导入的供应商
+            </div>
+          ) : (
+            <>
+              <div className="flex w-44 shrink-0 flex-col gap-1 overflow-y-auto border-r bg-muted/30 p-2">
+                {groups.map((group) => {
+                  const groupSelectable = group.rows.filter((row) => row.selectable);
+                  const groupSelected = groupSelectable.filter((row) =>
+                    selected.has(row.key),
+                  ).length;
+                  const active = group.type === activeGroup?.type;
+                  return (
+                    <button
+                      key={group.type}
+                      type="button"
+                      onClick={() => setActiveType(group.type)}
+                      className={cn(
+                        "flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left transition-colors",
+                        active
+                          ? "bg-background text-foreground shadow-sm"
+                          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                      )}
+                    >
+                      <span className="flex w-5 shrink-0 items-center justify-center text-base">
+                        <ProviderBrandIcon type={group.type} />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium">
+                          {getProviderLabel(group.type)}
+                        </span>
+                        <span className="block text-[11px] text-muted-foreground">
+                          {group.rows.length} 项配置
+                        </span>
+                      </span>
+                      {groupSelected > 0 ? (
+                        <span className="shrink-0 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+                          {groupSelected}
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="flex min-w-0 flex-1 flex-col">
+                <div className="flex items-center justify-between gap-2 border-b bg-muted/20 px-5 py-2">
+                  <div className="text-xs text-muted-foreground">
+                    已选 {activeSelectedCount} / {activeSelectableKeys.length} 个可导入
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2 text-xs"
+                    onClick={toggleAllActive}
+                    disabled={!activeSelectableKeys.length || importing}
+                  >
+                    {activeAllSelected ? t("settings.deselectAll") : t("settings.selectAll")}
+                  </Button>
+                </div>
+
+                <div className="min-h-0 flex-1 divide-y overflow-y-auto">
+                  {activeRows.map(({ item, key, exists, transferable, selectable }) => {
+                    const modelCount = item.models?.length ?? 0;
+                    return (
+                      <label
+                        key={key}
+                        className={cn(
+                          "flex items-center gap-3 px-5 py-3 transition-colors",
+                          selectable ? "cursor-pointer hover:bg-accent/40" : "opacity-55",
+                        )}
+                      >
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4 shrink-0 accent-primary"
+                          checked={selectable && selected.has(key)}
+                          disabled={!selectable || importing}
+                          onChange={() => toggleRow(key)}
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="truncate text-sm font-medium">{item.name}</span>
+                            {exists ? (
+                              <span className="shrink-0 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+                                已导入
+                              </span>
+                            ) : !transferable ? (
+                              <span className="shrink-0 rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">
+                                无 API 配置
+                              </span>
+                            ) : null}
+                          </div>
+                          <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                            {item.baseUrl || "未配置 Base URL"}
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
+                          {item.apiKey.trim() ? (
+                            <span title="已包含 API Key">
+                              <Key className="h-3 w-3" />
+                            </span>
+                          ) : null}
+                          {modelCount > 0 ? <span>{modelCount} 模型</span> : null}
+                        </div>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {result ? (
+          <div className="border-t px-6 py-3">
+            <div className="flex items-start gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-700 dark:text-emerald-300">
+              <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{result}</span>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="flex items-center justify-between gap-2 border-t px-6 py-4">
+          <div className="text-xs text-muted-foreground">
+            共已选 {selectedCount} / {selectableKeys.length} 个可导入
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={onClose} disabled={importing}>
+              {result ? "关闭" : t("settings.cancel")}
+            </Button>
+            <Button
+              className="gap-1.5"
+              onClick={() => void handleImport()}
+              disabled={importing || selectedCount === 0}
+            >
+              {importing ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  正在导入…
+                </>
+              ) : (
+                `导入 ${selectedCount} 个供应商`
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
 function ProviderList(props: {
   type: ProviderId;
+  isActive: boolean;
   providers: CustomProvider[];
   onAdd: () => void;
   onEdit: (provider: CustomProvider) => void;
@@ -776,14 +1084,14 @@ function ProviderList(props: {
   ccsLoading: boolean;
   ccsImporting: boolean;
   ccsMessage: string | null;
-  thirdPartyImportOpen: boolean;
-  onToggleThirdPartyImport: () => void;
-  onImportCcsProviders: () => void;
+  onEnsureCcsScan: () => void;
   onRefreshCcsProviders: () => void;
+  onOpenCcsImport: () => void;
 }) {
   const { t } = useLocale();
   const {
     type,
+    isActive,
     providers,
     onAdd,
     onEdit,
@@ -792,14 +1100,41 @@ function ProviderList(props: {
     ccsLoading,
     ccsImporting,
     ccsMessage,
-    thirdPartyImportOpen,
-    onToggleThirdPartyImport,
-    onImportCcsProviders,
+    onEnsureCcsScan,
     onRefreshCcsProviders,
+    onOpenCcsImport,
   } = props;
+  const [syncMenuOpen, setSyncMenuOpen] = useState(false);
   const filtered = providers.filter((provider) => provider.type === type);
-  const ccsProvidersForType =
-    ccsProviders?.providers.filter((provider) => provider.providerType === type) ?? [];
+  const ccsAll = ccsProviders?.providers ?? [];
+  const ccsBreakdown = PROVIDER_TABS.map((tab) => ({
+    type: tab,
+    count: ccsAll.filter((provider) => provider.providerType === tab).length,
+  })).filter((entry) => entry.count > 0);
+
+  // The menu popup is portaled, so it would outlive its trigger when the tab
+  // pane is slid away and marked inert — close it as the pane deactivates.
+  useEffect(() => {
+    if (!isActive) setSyncMenuOpen(false);
+  }, [isActive]);
+
+  function handleSyncMenuOpenChange(open: boolean) {
+    setSyncMenuOpen(open);
+    if (open) onEnsureCcsScan();
+  }
+
+  const scanned = ccsProviders !== null;
+  const ccsSubtitle = ccsImporting
+    ? "正在导入供应商、获取并激活模型…"
+    : ccsLoading
+      ? "正在扫描本地配置…"
+      : ccsAll.length
+        ? `发现 ${ccsBreakdown
+            .map((entry) => `${getProviderLabel(entry.type)} ${entry.count}`)
+            .join(" · ")}，点击选择导入`
+        : scanned
+          ? ccsMessage || "未发现可导入的供应商"
+          : "点击扫描本地配置";
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
@@ -809,55 +1144,80 @@ function ProviderList(props: {
             ? t("settings.noProviders")
             : `${filtered.length} ${t("settings.navProviders")}`}
         </div>
-        <div className="relative flex items-center gap-2">
+        <div className="flex items-center gap-2">
           <Button variant="outline" size="sm" className="gap-1.5" onClick={onAdd}>
             <Plus className="h-3.5 w-3.5" />
             {t("settings.addProvider")}
           </Button>
-          <div className="relative">
-            <Button
-              variant="outline"
-              size="sm"
-              className="gap-1.5"
-              onClick={onToggleThirdPartyImport}
-              disabled={ccsImporting}
+          <DropdownMenu open={syncMenuOpen} onOpenChange={handleSyncMenuOpenChange}>
+            <DropdownMenuTrigger
+              render={<Button variant="outline" size="sm" className="gap-1.5" />}
             >
-              <Download className="h-3.5 w-3.5" />
+              {ccsImporting ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Download className="h-3.5 w-3.5" />
+              )}
               从第三方同步
-            </Button>
-            {thirdPartyImportOpen ? (
-              <div className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-72 overflow-hidden rounded-xl border bg-popover p-2 text-popover-foreground shadow-xl">
-                <button
-                  type="button"
-                  className="flex w-full flex-col items-start rounded-lg px-3 py-2 text-left hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
-                  disabled={ccsLoading || ccsImporting || !ccsProvidersForType.length}
-                  onClick={onImportCcsProviders}
+              <ChevronDown
+                className={cn(
+                  "h-3.5 w-3.5 text-muted-foreground transition-transform duration-200 ease-out",
+                  syncMenuOpen && "rotate-180",
+                )}
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              sideOffset={8}
+              collisionPadding={8}
+              className="model-selector-dropdown w-80 overflow-hidden rounded-xl border-border/40 bg-popover/70 p-0 shadow-[0_12px_40px_-12px_rgba(0,0,0,0.25)] ring-1 ring-white/10 backdrop-blur-2xl backdrop-saturate-150 supports-[backdrop-filter]:bg-popover/55"
+            >
+              <DropdownMenuLabel className="px-3 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">
+                导入来源
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator className="my-0 bg-border/40" />
+              <div className="p-1.5">
+                <DropdownMenuItem
+                  className="model-selector-item cursor-pointer items-start gap-3 rounded-lg px-2.5 py-2.5"
+                  disabled={ccsLoading || ccsImporting || !ccsAll.length}
+                  onSelect={onOpenCcsImport}
                 >
-                  <strong className="text-sm">ccswitch</strong>
-                  <span className="mt-0.5 text-xs text-muted-foreground">
-                    {ccsImporting
-                      ? "正在导入供应商、获取并激活全部模型…"
-                      : ccsLoading
-                        ? "正在扫描…"
-                        : ccsProvidersForType.length
-                          ? `发现 ${ccsProvidersForType.length} 个 ${getProviderLabel(type)} 供应商`
-                          : ccsMessage || `未发现 ${getProviderLabel(type)} 供应商`}
+                  <CcsSourceLogo className="h-9 w-9 text-[11px]" />
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="flex items-center gap-1.5 text-sm font-medium">
+                      CC Switch
+                      {ccsAll.length > 0 ? (
+                        <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+                          {ccsAll.length}
+                        </span>
+                      ) : null}
+                    </span>
+                    <span
+                      className="line-clamp-2 text-xs text-muted-foreground"
+                      title={ccsSubtitle}
+                    >
+                      {ccsSubtitle}
+                    </span>
                   </span>
-                </button>
-                <button
-                  type="button"
-                  className="mt-1 flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm hover:bg-accent"
-                  onClick={onRefreshCcsProviders}
-                  disabled={ccsLoading || ccsImporting}
-                >
-                  <RefreshCw
-                    className={`h-4 w-4 ${ccsLoading || ccsImporting ? "animate-spin" : ""}`}
-                  />
-                  刷新列表
-                </button>
+                  {ccsLoading || ccsImporting ? (
+                    <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+                  ) : null}
+                </DropdownMenuItem>
               </div>
-            ) : null}
-          </div>
+              <DropdownMenuSeparator className="my-0 bg-border/40" />
+              <div className="p-1.5">
+                <DropdownMenuItem
+                  closeOnClick={false}
+                  className="model-selector-item cursor-pointer gap-2 rounded-lg px-2.5 py-2 text-xs text-muted-foreground"
+                  disabled={ccsLoading || ccsImporting}
+                  onSelect={onRefreshCcsProviders}
+                >
+                  <RefreshCw className={cn("h-3.5 w-3.5", ccsLoading && "animate-spin")} />
+                  重新扫描本地配置
+                </DropdownMenuItem>
+              </div>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 
@@ -931,10 +1291,10 @@ export function ProvidersSection(props: SettingsSectionProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [customSettingsOpen, setCustomSettingsOpen] = useState(false);
   const [editingProvider, setEditingProvider] = useState<CustomProvider | null>(null);
-  const [thirdPartyImportTab, setThirdPartyImportTab] = useState<ProviderId | null>(null);
+  const [ccsImportType, setCcsImportType] = useState<ProviderId | null>(null);
   const [ccsProviders, setCcsProviders] = useState<CcsProvidersResponse | null>(null);
   const [ccsLoading, setCcsLoading] = useState(false);
-  const [ccsImportingType, setCcsImportingType] = useState<ProviderId | null>(null);
+  const [ccsImporting, setCcsImporting] = useState(false);
   const [ccsMessage, setCcsMessage] = useState<string | null>(null);
 
   async function refreshCcsProviders() {
@@ -951,27 +1311,20 @@ export function ProvidersSection(props: SettingsSectionProps) {
     }
   }
 
-  function toggleThirdPartyImport(type: ProviderId) {
-    setThirdPartyImportTab((openTab) => {
-      const next = openTab === type ? null : type;
-      if (next && !ccsProviders && !ccsLoading) void refreshCcsProviders();
-      return next;
-    });
+  function ensureCcsScan() {
+    if (!ccsProviders && !ccsLoading) void refreshCcsProviders();
   }
 
   function buildCcsImportedProviders(
     existingProviders: CustomProvider[],
-    providerType: ProviderId,
+    items: CcsProviderImportItem[],
   ) {
-    const imports =
-      ccsProviders?.providers.filter(
-        (provider) => provider.providerType === providerType && ccsProviderIsTransferable(provider),
-      ) ?? [];
     const existingIds = new Set(existingProviders.map((provider) => provider.id));
     const existingIdentity = new Set(existingProviders.map(ccsImportIdentity));
     const imported: CustomProvider[] = [];
 
-    for (const item of imports) {
+    for (const item of items) {
+      if (!ccsProviderIsTransferable(item)) continue;
       const identity = ccsImportIdentity({
         type: item.providerType,
         name: item.name,
@@ -985,24 +1338,20 @@ export function ProvidersSection(props: SettingsSectionProps) {
     return imported;
   }
 
-  async function importCcsProviders(providerType: ProviderId) {
-    const imports =
-      ccsProviders?.providers.filter((provider) => provider.providerType === providerType) ?? [];
-    if (!imports.length) return;
-
-    const transferable = imports.filter(ccsProviderIsTransferable);
-    const skippedCount = imports.length - transferable.length;
+  async function importCcsProviders(items: CcsProviderImportItem[]): Promise<string> {
+    const transferable = items.filter(ccsProviderIsTransferable);
     if (!transferable.length) {
-      setCcsMessage(`ccswitch 中的 ${getProviderLabel(providerType)} 供应商没有可导入的 API 配置`);
-      return;
+      const message = "所选供应商没有可导入的 API 配置";
+      setCcsMessage(message);
+      return message;
     }
 
-    setCcsImportingType(providerType);
+    setCcsImporting(true);
     setCcsMessage("正在导入供应商、获取并激活全部模型…");
 
     try {
       setSettings((prev) => {
-        const nextImported = buildCcsImportedProviders(prev.customProviders, providerType);
+        const nextImported = buildCcsImportedProviders(prev.customProviders, transferable);
         if (!nextImported.length) return prev;
         return updateCustomProviders(prev, [...prev.customProviders, ...nextImported]);
       });
@@ -1054,16 +1403,22 @@ export function ProvidersSection(props: SettingsSectionProps) {
       const fetchedCount = modelResults.filter((result) => result.fetched).length;
       const failedCount = modelResults.filter((result) => result.failed).length;
       const totalModels = modelResults.reduce((total, result) => total + result.models.length, 0);
+      const importedByType = PROVIDER_TABS.map((tab) => ({
+        type: tab,
+        count: transferable.filter((item) => item.providerType === tab).length,
+      })).filter((entry) => entry.count > 0);
       const details = [
-        `已同步 ${transferable.length} 个 ${getProviderLabel(providerType)} 供应商`,
+        `已导入 ${importedByType
+          .map((entry) => `${entry.count} 个 ${getProviderLabel(entry.type)}`)
+          .join("、")} 供应商`,
         fetchedCount > 0 ? `获取并激活 ${totalModels} 个模型` : "已激活供应商内的全部模型",
         failedCount > 0 ? `${failedCount} 个供应商模型获取失败` : "",
-        skippedCount > 0 ? `${skippedCount} 个无 API 配置已跳过` : "",
       ].filter(Boolean);
-      setCcsMessage(details.join("，"));
-      setThirdPartyImportTab(null);
+      const summary = details.join("，");
+      setCcsMessage(summary);
+      return summary;
     } finally {
-      setCcsImportingType(null);
+      setCcsImporting(false);
     }
   }
 
@@ -1119,10 +1474,7 @@ export function ProvidersSection(props: SettingsSectionProps) {
             <button
               key={tab}
               type="button"
-              onClick={() => {
-                setActiveTab(tab);
-                setThirdPartyImportTab(null);
-              }}
+              onClick={() => setActiveTab(tab)}
               className={`inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all ${
                 activeTab === tab
                   ? "bg-background text-foreground shadow"
@@ -1161,18 +1513,18 @@ export function ProvidersSection(props: SettingsSectionProps) {
             >
               <ProviderList
                 type={tab}
+                isActive={activeTab === tab}
                 providers={settings.customProviders}
                 onAdd={openAdd}
                 onEdit={openEdit}
                 onDelete={handleDelete}
                 ccsProviders={ccsProviders}
                 ccsLoading={ccsLoading}
-                ccsImporting={ccsImportingType === tab}
+                ccsImporting={ccsImporting}
                 ccsMessage={ccsMessage}
-                thirdPartyImportOpen={thirdPartyImportTab === tab}
-                onToggleThirdPartyImport={() => toggleThirdPartyImport(tab)}
-                onImportCcsProviders={() => void importCcsProviders(tab)}
+                onEnsureCcsScan={ensureCcsScan}
                 onRefreshCcsProviders={() => void refreshCcsProviders()}
+                onOpenCcsImport={() => setCcsImportType(tab)}
               />
             </div>
           ))}
@@ -1185,6 +1537,16 @@ export function ProvidersSection(props: SettingsSectionProps) {
           initialData={editingProvider ?? undefined}
           onSave={handleSave}
           onClose={closeModal}
+        />
+      ) : null}
+      {ccsImportType ? (
+        <CcsImportModal
+          initialType={ccsImportType}
+          items={ccsProviders?.providers ?? []}
+          existingProviders={settings.customProviders}
+          importing={ccsImporting}
+          onImport={importCcsProviders}
+          onClose={() => setCcsImportType(null)}
         />
       ) : null}
       {customSettingsOpen ? (

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -1166,9 +1166,21 @@ function ProviderList(props: {
               collisionPadding={8}
               className="model-selector-dropdown w-80 overflow-hidden rounded-xl border-border/40 bg-popover/70 p-0 shadow-[0_12px_40px_-12px_rgba(0,0,0,0.25)] ring-1 ring-white/10 backdrop-blur-2xl backdrop-saturate-150 supports-[backdrop-filter]:bg-popover/55"
             >
-              <DropdownMenuLabel className="px-3 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">
-                导入来源
-              </DropdownMenuLabel>
+              <div className="flex items-center justify-between gap-2 px-3 py-1.5">
+                <DropdownMenuLabel className="p-0 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">
+                  导入来源
+                </DropdownMenuLabel>
+                <DropdownMenuItem
+                  closeOnClick={false}
+                  className="h-7 w-7 cursor-pointer justify-center rounded-md p-0 text-muted-foreground"
+                  disabled={ccsLoading || ccsImporting}
+                  onSelect={onRefreshCcsProviders}
+                  aria-label="重新扫描本地配置"
+                  title="重新扫描本地配置"
+                >
+                  <RefreshCw className={cn("h-3.5 w-3.5", ccsLoading && "animate-spin")} />
+                </DropdownMenuItem>
+              </div>
               <DropdownMenuSeparator className="my-0 bg-border/40" />
               <div className="p-1.5">
                 <DropdownMenuItem
@@ -1196,18 +1208,6 @@ function ProviderList(props: {
                   {ccsLoading || ccsImporting ? (
                     <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
                   ) : null}
-                </DropdownMenuItem>
-              </div>
-              <DropdownMenuSeparator className="my-0 bg-border/40" />
-              <div className="p-1.5">
-                <DropdownMenuItem
-                  closeOnClick={false}
-                  className="model-selector-item cursor-pointer gap-2 rounded-lg px-2.5 py-2 text-xs text-muted-foreground"
-                  disabled={ccsLoading || ccsImporting}
-                  onSelect={onRefreshCcsProviders}
-                >
-                  <RefreshCw className={cn("h-3.5 w-3.5", ccsLoading && "animate-spin")} />
-                  重新扫描本地配置
                 </DropdownMenuItem>
               </div>
             </DropdownMenuContent>

--- a/crates/agent-gui/src/pages/settings/providerUtils.ts
+++ b/crates/agent-gui/src/pages/settings/providerUtils.ts
@@ -12,6 +12,7 @@ const GATEWAY_WEBUI_MARKER = "gateway";
 const GATEWAY_TOKEN_STORAGE_KEY = "liveagent.gateway.token";
 const CODEX_MODELS_SUFFIXES = ["/chat/completions", "/responses", "/response"];
 const GEMINI_GENERATE_SUFFIXES = [":streamGenerateContent", ":generateContent"];
+const ANTHROPIC_API_VERSION = "2023-06-01";
 
 export function isGatewayWebuiRuntime() {
   return (
@@ -55,15 +56,123 @@ function normalizeModelBaseUrl(type: ProviderId, baseUrl: string) {
   return normalizeBaseUrl(normalizedUrl);
 }
 
-function buildModelsUrl(type: ProviderId, baseUrl: string) {
+export type ProviderModelsAttemptKind = "default" | "official";
+
+export type ProviderModelsAttempt = {
+  kind: ProviderModelsAttemptKind;
+  headers: Record<string, string>;
+};
+
+export type ProviderModelsFailure = {
+  status: number | null;
+  message: string;
+};
+
+function buildGeminiModelsUrl(baseUrl: string, versionPath: string) {
+  const normalizedUrl = normalizeBaseUrl(baseUrl);
+  if (normalizedUrl.toLowerCase().endsWith("/models")) return normalizedUrl;
+  if (/\/v\d+(?:beta)?$/i.test(normalizedUrl)) return `${normalizedUrl}/models`;
+  return `${normalizedUrl}/${versionPath}/models`;
+}
+
+export function buildProviderModelsUrl(
+  type: ProviderId,
+  baseUrl: string,
+  kind: ProviderModelsAttemptKind,
+) {
   if (type === "gemini") {
-    const normalizedUrl = normalizeBaseUrl(baseUrl);
-    if (normalizedUrl.toLowerCase().endsWith("/models")) return normalizedUrl;
-    if (/\/v\d+(?:beta)?$/i.test(normalizedUrl)) return `${normalizedUrl}/models`;
-    return `${normalizedUrl}/v1beta/models`;
+    return buildGeminiModelsUrl(baseUrl, kind === "official" ? "v1beta" : "v1");
   }
 
   return baseUrl.endsWith("/v1") ? `${baseUrl}/models` : `${baseUrl}/v1/models`;
+}
+
+function buildDefaultModelsHeaders(type: ProviderId, apiKey: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+  if (type === "gemini") {
+    headers["x-goog-api-key"] = apiKey;
+    return headers;
+  }
+  headers["x-api-key"] = apiKey;
+  if (type === "claude_code") {
+    headers["anthropic-version"] = ANTHROPIC_API_VERSION;
+  }
+  return headers;
+}
+
+function buildOfficialModelsHeaders(type: ProviderId, apiKey: string): Record<string, string> {
+  if (type === "gemini") {
+    return {
+      "Content-Type": "application/json",
+      "x-goog-api-key": apiKey,
+    };
+  }
+  if (type === "claude_code") {
+    return {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": ANTHROPIC_API_VERSION,
+    };
+  }
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+}
+
+function providerModelsAttemptSignature(
+  type: ProviderId,
+  baseUrl: string,
+  attempt: ProviderModelsAttempt,
+) {
+  const url = buildProviderModelsUrl(type, baseUrl, attempt.kind);
+  const headers = Object.entries(attempt.headers).sort(([a], [b]) => a.localeCompare(b));
+  return `${url}||${JSON.stringify(headers)}`;
+}
+
+export function buildProviderModelsAttempts(
+  type: ProviderId,
+  baseUrl: string,
+  apiKey: string,
+): ProviderModelsAttempt[] {
+  const candidates: ProviderModelsAttempt[] = [
+    { kind: "default", headers: buildDefaultModelsHeaders(type, apiKey) },
+    { kind: "official", headers: buildOfficialModelsHeaders(type, apiKey) },
+  ];
+
+  const attempts: ProviderModelsAttempt[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    const signature = providerModelsAttemptSignature(type, baseUrl, candidate);
+    if (seen.has(signature)) continue;
+    seen.add(signature);
+    attempts.push(candidate);
+  }
+  return attempts;
+}
+
+function isMissingEndpointStatus(status: number | null) {
+  return status === 404 || status === 405;
+}
+
+export function pickProviderModelsFailure(
+  failures: ProviderModelsFailure[],
+): ProviderModelsFailure | null {
+  for (let index = failures.length - 1; index >= 0; index -= 1) {
+    if (!isMissingEndpointStatus(failures[index].status)) return failures[index];
+  }
+  return failures.length > 0 ? failures[failures.length - 1] : null;
+}
+
+function extractModelListItems(data: unknown): unknown[] | null {
+  if (Array.isArray(data)) return data;
+  const payload = data as { data?: unknown; models?: unknown } | null;
+  if (Array.isArray(payload?.data)) return payload.data;
+  if (Array.isArray(payload?.models)) return payload.models;
+  return null;
 }
 
 async function readFetchError(response: Response, fallback: string) {
@@ -105,14 +214,9 @@ async function fetchModelsThroughGateway(
     api_key: apiKey,
   } as any);
 
-  if (Array.isArray((data as { data?: unknown[] } | null)?.data)) {
-    return normalizeFetchedModels((data as { data: unknown[] }).data, type);
-  }
-  if (Array.isArray((data as { models?: unknown[] } | null)?.models)) {
-    return normalizeFetchedModels((data as { models: unknown[] }).models, type);
-  }
-  if (Array.isArray(data)) {
-    return normalizeFetchedModels(data, type);
+  const items = extractModelListItems(data);
+  if (items !== null) {
+    return normalizeFetchedModels(items, type);
   }
 
   const maybeError =
@@ -234,39 +338,53 @@ export async function fetchModelsFromApi(
     return fetchModelsThroughGateway(type, normalizedUrl, normalizedApiKey);
   }
 
-  const headers: Record<string, string> =
-    type === "gemini"
-      ? {
-          "Content-Type": "application/json",
-          "x-goog-api-key": normalizedApiKey,
-        }
-      : {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${normalizedApiKey}`,
-          "x-api-key": normalizedApiKey,
-        };
+  const attempts = buildProviderModelsAttempts(type, normalizedUrl, normalizedApiKey);
+  const failures: ProviderModelsFailure[] = [];
+  let emptyResult: ProviderModelConfig[] | null = null;
 
-  if (type === "claude_code") {
-    headers["anthropic-version"] = "2023-06-01";
+  for (const attempt of attempts) {
+    const proxyRequest = await prepareProxyRequest(type, normalizedUrl, attempt.headers);
+    const modelsUrl = buildProviderModelsUrl(type, proxyRequest.baseUrl, attempt.kind);
+
+    let response: Response;
+    try {
+      response = await fetch(modelsUrl, { headers: proxyRequest.headers });
+    } catch (error) {
+      failures.push({
+        status: null,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    if (!response.ok) {
+      failures.push({
+        status: response.status,
+        message: await readFetchError(response, `HTTP ${response.status} ${response.statusText}`),
+      });
+      continue;
+    }
+
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      failures.push({ status: null, message: "Model list response is not valid JSON" });
+      continue;
+    }
+
+    const items = extractModelListItems(data);
+    if (items === null) {
+      emptyResult ??= [];
+      continue;
+    }
+    const models = normalizeFetchedModels(items, type);
+    if (models.length > 0) return models;
+    emptyResult = models;
   }
 
-  const proxyRequest = await prepareProxyRequest(type, normalizedUrl, headers);
-  const proxyUrl = buildModelsUrl(type, proxyRequest.baseUrl);
+  if (emptyResult !== null) return emptyResult;
 
-  const res = await fetch(proxyUrl, { headers: proxyRequest.headers });
-  if (!res.ok) {
-    throw new Error(await readFetchError(res, `HTTP ${res.status} ${res.statusText}`));
-  }
-  const data = await res.json();
-
-  if (Array.isArray(data.data)) {
-    return normalizeFetchedModels(data.data, type);
-  }
-  if (Array.isArray(data.models)) {
-    return normalizeFetchedModels(data.models, type);
-  }
-  if (Array.isArray(data)) {
-    return normalizeFetchedModels(data, type);
-  }
-  return [];
+  const failure = pickProviderModelsFailure(failures);
+  throw new Error(failure?.message ?? "Failed to fetch model list");
 }

--- a/crates/agent-gui/test/settings/provider-models-fetch.test.mjs
+++ b/crates/agent-gui/test/settings/provider-models-fetch.test.mjs
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader({
+  mocks: {
+    "@tauri-apps/api/core": {
+      invoke(command) {
+        if (command === "proxy_get_server_info") {
+          return Promise.resolve({ baseUrl: "http://proxy.local:9999", token: "proxy-token" });
+        }
+        throw new Error(`unexpected invoke(${command})`);
+      },
+    },
+  },
+});
+const providerUtils = loader.loadModule("src/pages/settings/providerUtils.ts");
+
+function jsonResponse(status, payload) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: String(status),
+    json: () => Promise.resolve(payload),
+    text: () => Promise.resolve(JSON.stringify(payload)),
+  };
+}
+
+function withFetchStub(responder, run) {
+  const calls = [];
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = (url, options) => {
+    calls.push({ url: String(url), options });
+    return Promise.resolve(responder(String(url), calls.length));
+  };
+  return Promise.resolve()
+    .then(() => run(calls))
+    .finally(() => {
+      if (previousFetch === undefined) delete globalThis.fetch;
+      else globalThis.fetch = previousFetch;
+    });
+}
+
+test("buildProviderModelsUrl defaults to /v1/models and falls back to official endpoints", () => {
+  assert.equal(
+    providerUtils.buildProviderModelsUrl("gemini", "https://relay.example.com", "default"),
+    "https://relay.example.com/v1/models",
+  );
+  assert.equal(
+    providerUtils.buildProviderModelsUrl("gemini", "https://relay.example.com", "official"),
+    "https://relay.example.com/v1beta/models",
+  );
+  assert.equal(
+    providerUtils.buildProviderModelsUrl(
+      "gemini",
+      "https://generativelanguage.googleapis.com/v1beta",
+      "default",
+    ),
+    "https://generativelanguage.googleapis.com/v1beta/models",
+  );
+  assert.equal(
+    providerUtils.buildProviderModelsUrl("claude_code", "https://relay.example.com", "default"),
+    "https://relay.example.com/v1/models",
+  );
+  assert.equal(
+    providerUtils.buildProviderModelsUrl("claude_code", "https://relay.example.com", "official"),
+    "https://relay.example.com/v1/models",
+  );
+  assert.equal(
+    providerUtils.buildProviderModelsUrl("codex", "https://relay.example.com/v1", "default"),
+    "https://relay.example.com/v1/models",
+  );
+});
+
+test("buildProviderModelsAttempts orders default before official with provider headers", () => {
+  const gemini = providerUtils.buildProviderModelsAttempts(
+    "gemini",
+    "https://relay.example.com",
+    "test-key",
+  );
+  assert.equal(gemini.length, 2);
+  assert.deepEqual(
+    gemini.map((attempt) => attempt.kind),
+    ["default", "official"],
+  );
+  assert.equal(gemini[0].headers.Authorization, "Bearer test-key");
+  assert.equal(gemini[0].headers["x-goog-api-key"], "test-key");
+  assert.equal(gemini[1].headers.Authorization, undefined);
+  assert.equal(gemini[1].headers["x-goog-api-key"], "test-key");
+
+  const claude = providerUtils.buildProviderModelsAttempts(
+    "claude_code",
+    "https://relay.example.com",
+    "test-key",
+  );
+  assert.equal(claude.length, 2);
+  assert.equal(claude[0].headers.Authorization, "Bearer test-key");
+  assert.equal(claude[0].headers["anthropic-version"], "2023-06-01");
+  assert.equal(claude[1].headers.Authorization, undefined);
+  assert.equal(claude[1].headers["x-api-key"], "test-key");
+  assert.equal(claude[1].headers["anthropic-version"], "2023-06-01");
+
+  const codex = providerUtils.buildProviderModelsAttempts(
+    "codex",
+    "https://relay.example.com",
+    "test-key",
+  );
+  assert.equal(codex.length, 2);
+  assert.equal(codex[0].headers["x-api-key"], "test-key");
+  assert.equal(codex[1].headers["x-api-key"], undefined);
+  assert.equal(codex[1].headers.Authorization, "Bearer test-key");
+});
+
+test("pickProviderModelsFailure prefers informative errors over missing-endpoint noise", () => {
+  assert.deepEqual(
+    providerUtils.pickProviderModelsFailure([
+      { status: 401, message: "invalid api key" },
+      { status: 404, message: "not found" },
+    ]),
+    { status: 401, message: "invalid api key" },
+  );
+  assert.deepEqual(
+    providerUtils.pickProviderModelsFailure([
+      { status: 404, message: "not found" },
+      { status: 400, message: "api key invalid" },
+    ]),
+    { status: 400, message: "api key invalid" },
+  );
+  assert.deepEqual(
+    providerUtils.pickProviderModelsFailure([
+      { status: 404, message: "first" },
+      { status: 404, message: "second" },
+    ]),
+    { status: 404, message: "second" },
+  );
+  assert.equal(providerUtils.pickProviderModelsFailure([]), null);
+});
+
+test("fetchModelsFromApi falls back to the official gemini endpoint on 404", async () => {
+  await withFetchStub(
+    (url) =>
+      url.includes("/v1/models")
+        ? jsonResponse(404, { error: "not found" })
+        : jsonResponse(200, { models: [{ name: "models/gemini-2.5-pro" }] }),
+    async (calls) => {
+      const models = await providerUtils.fetchModelsFromApi(
+        "gemini",
+        "https://relay.example.com",
+        "test-key",
+      );
+      assert.equal(calls.length, 2);
+      assert.ok(calls[0].url.endsWith("/proxy/gemini/v1/models"));
+      assert.ok(calls[1].url.endsWith("/proxy/gemini/v1beta/models"));
+      assert.deepEqual(
+        models.map((model) => model.id),
+        ["gemini-2.5-pro"],
+      );
+    },
+  );
+});
+
+test("fetchModelsFromApi returns the default /v1/models result without falling back", async () => {
+  await withFetchStub(
+    () => jsonResponse(200, { data: [{ id: "gpt-5" }] }),
+    async (calls) => {
+      const models = await providerUtils.fetchModelsFromApi(
+        "codex",
+        "https://relay.example.com",
+        "test-key",
+      );
+      assert.equal(calls.length, 1);
+      assert.ok(calls[0].url.endsWith("/proxy/codex/v1/models"));
+      assert.deepEqual(
+        models.map((model) => model.id),
+        ["gpt-5"],
+      );
+    },
+  );
+});
+
+test("fetchModelsFromApi falls back to official when the default list is empty", async () => {
+  await withFetchStub(
+    (url) =>
+      url.includes("/v1/models")
+        ? jsonResponse(200, { data: [] })
+        : jsonResponse(200, { models: [{ name: "models/gemini-2.5-flash" }] }),
+    async (calls) => {
+      const models = await providerUtils.fetchModelsFromApi(
+        "gemini",
+        "https://relay.example.com",
+        "test-key",
+      );
+      assert.equal(calls.length, 2);
+      assert.deepEqual(
+        models.map((model) => model.id),
+        ["gemini-2.5-flash"],
+      );
+    },
+  );
+});
+
+test("fetchModelsFromApi surfaces the informative failure when every attempt fails", async () => {
+  await withFetchStub(
+    (url) =>
+      url.includes("/v1/models")
+        ? jsonResponse(401, { error: "invalid api key" })
+        : jsonResponse(404, { error: "not found" }),
+    async (calls) => {
+      await assert.rejects(
+        providerUtils.fetchModelsFromApi("gemini", "https://relay.example.com", "test-key"),
+        /invalid api key/,
+      );
+      assert.equal(calls.length, 2);
+    },
+  );
+});
+
+test("fetchModelsFromApi retries claude_code with official anthropic headers", async () => {
+  await withFetchStub(
+    (_url, callIndex) =>
+      callIndex === 1
+        ? jsonResponse(401, { error: "authorization header rejected" })
+        : jsonResponse(200, { data: [{ id: "claude-opus-4-8" }] }),
+    async (calls) => {
+      const models = await providerUtils.fetchModelsFromApi(
+        "claude_code",
+        "https://relay.example.com",
+        "test-key",
+      );
+      assert.equal(calls.length, 2);
+      assert.equal(calls[0].options.headers.Authorization, "Bearer test-key");
+      assert.equal(calls[1].options.headers.Authorization, undefined);
+      assert.equal(calls[1].options.headers["x-api-key"], "test-key");
+      assert.deepEqual(
+        models.map((model) => model.id),
+        ["claude-opus-4-8"],
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Provider model listing now tries the OpenAI-style `{base}/v1/models` endpoint first (with a unioned auth header) before falling back to each provider's official API (gemini `/v1beta/models`, claude_code `/v1/models` with `x-api-key`, codex Bearer) — implemented in both the GUI direct-fetch path and the gateway Go handler, mirrored byte-for-byte between GUI/web `providerUtils.ts`
- Reworked ccswitch provider import: resolves the real cc-switch database via `app_paths.json` with fallback to `~/.cc-switch`, replaces the old sync popup with a dropdown menu, and adds a two-pane import modal (provider-type nav + checkable config list) that imports all selected configs in one batch
- Simplified the ccswitch refresh action and import selection flow, removed a redundant import instruction
- Grouped system tools under "Intelligence" in settings
- Synced composer placeholder copy across i18n locales

## Test plan
- [x] `provider_models_test.go` covers the new fallback handler logic
- [x] `provider-models-fetch.test.mjs` covers the GUI/web fetch fallback path
- [ ] Manual smoke test of ccswitch import modal and provider model refresh in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)