### PR TITLE
feat(providers): import Cherry Studio configurations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,6 +2776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
+
+[[package]]
 name = "internal-russh-num-bigint"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3073,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leveldb-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad243539ed0c8177fda730a6654e6e2e1b5542102c6d69e9aae733881a631e2"
+dependencies = [
+ "crc32c",
+ "integer-encoding",
+ "snap",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3159,6 +3185,7 @@ dependencies = [
  "futures-util",
  "globset",
  "ignore",
+ "leveldb-core",
  "lopdf",
  "notify",
  "objc2-app-kit 0.3.2",
@@ -5808,6 +5835,12 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"

--- a/crates/agent-gui/src-tauri/Cargo.toml
+++ b/crates/agent-gui/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ tauri-plugin-mcp-bridge = "0.12.0"
 dirs = "6.0.0"
 ignore = "0.4.27"
 rusqlite = { version = "0.40.1", features = ["bundled"] }
+leveldb-core = "0.1.0"
 chrono = "0.4.45"
 tokio-cron-scheduler = "0.15.1"
 tonic = { version = "0.14.6", features = ["transport", "tls-ring", "tls-webpki-roots"] }

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/cherry_import.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/cherry_import.rs
@@ -1,0 +1,845 @@
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CherryProviderImportItem {
+    pub source_id: String,
+    pub source_version: String,
+    pub source_provider_type: String,
+    pub provider_type: String,
+    pub name: String,
+    pub base_url: String,
+    pub api_key: String,
+    pub api_key_count: usize,
+    pub request_format: String,
+    pub enabled: bool,
+    pub importable: bool,
+    pub reason: String,
+    pub warning: String,
+    pub excluded_model_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CherryProvidersResponse {
+    pub status: String,
+    pub message: String,
+    pub version: String,
+    pub data_path: String,
+    pub total_provider_count: usize,
+    pub enabled_provider_count: usize,
+    pub providers: Vec<CherryProviderImportItem>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum CherryImportProtocol {
+    Claude,
+    CodexCompletions,
+    CodexResponses,
+    Gemini,
+}
+
+impl CherryImportProtocol {
+    fn provider_type(self) -> &'static str {
+        match self {
+            Self::Claude => "claude_code",
+            Self::CodexCompletions | Self::CodexResponses => "codex",
+            Self::Gemini => "gemini",
+        }
+    }
+
+    fn request_format(self) -> &'static str {
+        match self {
+            Self::CodexCompletions => "openai-completions",
+            _ => "openai-responses",
+        }
+    }
+
+    fn variant(self) -> &'static str {
+        match self {
+            Self::Claude => "anthropic",
+            Self::CodexCompletions => "openai-chat",
+            Self::CodexResponses => "openai-responses",
+            Self::Gemini => "gemini",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CherryImportGroup {
+    protocol: CherryImportProtocol,
+    base_url: String,
+    models: Vec<String>,
+}
+
+#[derive(Debug)]
+struct CherryImportScan {
+    version: String,
+    data_path: PathBuf,
+    total_provider_count: usize,
+    enabled_provider_count: usize,
+    providers: Vec<CherryProviderImportItem>,
+}
+
+#[tauri::command]
+pub async fn settings_list_cherry_studio_providers() -> Result<CherryProvidersResponse, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        let candidates = cherry_user_data_candidates();
+        let mut read_errors = Vec::new();
+
+        for data_path in &candidates {
+            let sqlite_path = data_path.join("cherrystudio.sqlite");
+            if !sqlite_path.is_file() {
+                continue;
+            }
+            match cherry_read_v2(&sqlite_path, data_path) {
+                Ok(scan) => return Ok(cherry_scan_response(scan)),
+                Err(error) => read_errors.push(error),
+            }
+        }
+
+        for data_path in &candidates {
+            let leveldb_path = data_path.join("Local Storage").join("leveldb");
+            if !leveldb_path.is_dir() {
+                continue;
+            }
+            match cherry_read_v1(&leveldb_path, data_path) {
+                Ok(scan) => return Ok(cherry_scan_response(scan)),
+                Err(error) => read_errors.push(error),
+            }
+        }
+
+        if !read_errors.is_empty() {
+            return Err(read_errors.join("；"));
+        }
+
+        Ok(CherryProvidersResponse {
+            status: "success".to_string(),
+            message: "未发现 Cherry Studio 供应商数据".to_string(),
+            version: String::new(),
+            data_path: candidates
+                .first()
+                .map(|path| path.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+            total_provider_count: 0,
+            enabled_provider_count: 0,
+            providers: Vec::new(),
+        })
+    })
+    .await
+    .map_err(|error| format!("settings_list_cherry_studio_providers join 失败：{error}"))?
+}
+
+fn cherry_scan_response(scan: CherryImportScan) -> CherryProvidersResponse {
+    let ready_count = scan.providers.iter().filter(|item| item.importable).count();
+    CherryProvidersResponse {
+        status: "success".to_string(),
+        message: format!(
+            "Cherry Studio {}：发现 {} 个供应商，{} 个可同步配置",
+            scan.version, scan.total_provider_count, ready_count
+        ),
+        version: scan.version,
+        data_path: scan.data_path.to_string_lossy().into_owned(),
+        total_provider_count: scan.total_provider_count,
+        enabled_provider_count: scan.enabled_provider_count,
+        providers: scan.providers,
+    }
+}
+
+fn cherry_user_data_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    let Some(home) = dirs::home_dir() else {
+        return candidates;
+    };
+    let cherry_home = home.join(".cherrystudio");
+
+    cherry_collect_boot_config_paths(&cherry_home.join("boot-config.json"), &mut candidates);
+    cherry_collect_legacy_config_paths(
+        &cherry_home.join("config").join("config.json"),
+        &mut candidates,
+    );
+
+    #[cfg(target_os = "macos")]
+    cherry_push_unique_path(
+        &mut candidates,
+        home.join("Library")
+            .join("Application Support")
+            .join("CherryStudio"),
+    );
+    #[cfg(target_os = "windows")]
+    if let Some(config_dir) = dirs::config_dir() {
+        cherry_push_unique_path(&mut candidates, config_dir.join("CherryStudio"));
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        let config_dir = std::env::var_os("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".config"));
+        cherry_push_unique_path(&mut candidates, config_dir.join("CherryStudio"));
+    }
+    candidates
+}
+
+fn cherry_collect_boot_config_paths(path: &std::path::Path, out: &mut Vec<PathBuf>) {
+    let Ok(text) = fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(config) = serde_json::from_str::<Value>(&text) else {
+        return;
+    };
+    let Some(paths) = config.get("app.user_data_path").and_then(Value::as_object) else {
+        return;
+    };
+    for value in paths.values().filter_map(Value::as_str) {
+        cherry_push_unique_path(out, PathBuf::from(value));
+    }
+}
+
+fn cherry_collect_legacy_config_paths(path: &std::path::Path, out: &mut Vec<PathBuf>) {
+    let Ok(text) = fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(config) = serde_json::from_str::<Value>(&text) else {
+        return;
+    };
+    let Some(value) = config.get("appDataPath") else {
+        return;
+    };
+    if let Some(path) = value.as_str() {
+        cherry_push_unique_path(out, PathBuf::from(path));
+        return;
+    }
+    if let Some(items) = value.as_array() {
+        for path in items
+            .iter()
+            .filter_map(|item| item.get("dataPath"))
+            .filter_map(Value::as_str)
+        {
+            cherry_push_unique_path(out, PathBuf::from(path));
+        }
+    }
+}
+
+fn cherry_push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.iter().any(|existing| existing == &path) {
+        paths.push(path);
+    }
+}
+
+fn cherry_read_v1(
+    leveldb_path: &std::path::Path,
+    data_path: &std::path::Path,
+) -> Result<CherryImportScan, String> {
+    let key = b"persist:cherry-studio";
+    let records = leveldb_core::read_dir(leveldb_path)
+        .map_err(|error| format!("读取 Cherry Studio LevelDB 失败：{error}"))?;
+    let latest = records
+        .iter()
+        .filter(|record| record.key.windows(key.len()).any(|window| window == key))
+        .max_by_key(|record| record.seq)
+        .ok_or_else(|| "Cherry Studio LevelDB 中没有 persist:cherry-studio".to_string())?;
+    if latest.deleted {
+        return Err("Cherry Studio 供应商数据已被删除".to_string());
+    }
+    let persisted_text = cherry_decode_chromium_string(&latest.value)?;
+    let persisted = serde_json::from_str::<Value>(&persisted_text)
+        .map_err(|error| format!("解析 Cherry Studio Redux 根数据失败：{error}"))?;
+    let llm = match persisted.get("llm") {
+        Some(Value::String(text)) => serde_json::from_str::<Value>(text)
+            .map_err(|error| format!("解析 Cherry Studio llm 数据失败：{error}"))?,
+        Some(value) => value.clone(),
+        None => return Err("Cherry Studio Redux 数据缺少 llm".to_string()),
+    };
+    let source_providers = llm
+        .get("providers")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "Cherry Studio llm.providers 格式无效".to_string())?;
+    let version = cherry_read_version(data_path).unwrap_or_else(|| "1.x".to_string());
+    let enabled_provider_count = source_providers
+        .iter()
+        .filter(|provider| {
+            provider
+                .get("enabled")
+                .and_then(Value::as_bool)
+                .unwrap_or(true)
+        })
+        .count();
+    let mut providers = Vec::new();
+    for provider in source_providers {
+        cherry_append_v1_provider(provider, &version, &mut providers);
+    }
+    Ok(CherryImportScan {
+        version,
+        data_path: data_path.to_path_buf(),
+        total_provider_count: source_providers.len(),
+        enabled_provider_count,
+        providers,
+    })
+}
+
+fn cherry_decode_chromium_string(bytes: &[u8]) -> Result<String, String> {
+    match bytes.first().copied() {
+        Some(0) => {
+            let payload = &bytes[1..];
+            if payload.len() % 2 != 0 {
+                return Err("Cherry Studio Local Storage UTF-16 数据长度无效".to_string());
+            }
+            let utf16 = payload
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .collect::<Vec<_>>();
+            String::from_utf16(&utf16)
+                .map_err(|error| format!("解码 Cherry Studio Local Storage 失败：{error}"))
+        }
+        Some(1) => Ok(bytes[1..].iter().map(|byte| char::from(*byte)).collect()),
+        _ => Err("未知的 Cherry Studio Local Storage 字符串编码".to_string()),
+    }
+}
+
+fn cherry_append_v1_provider(
+    provider: &Value,
+    version: &str,
+    out: &mut Vec<CherryProviderImportItem>,
+) {
+    let source_id = cherry_value_string(provider, "id");
+    let name = cherry_value_string(provider, "name");
+    let source_provider_type = cherry_value_string(provider, "type");
+    if source_id.is_empty() || name.is_empty() {
+        return;
+    }
+    let enabled = provider
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    let api_keys = cherry_split_v1_api_keys(&cherry_value_string(provider, "apiKey"));
+    let api_key = api_keys.first().cloned().unwrap_or_default();
+    let auth_type = cherry_value_string(provider, "authType");
+    let source_models = provider
+        .get("models")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let mut groups = Vec::<CherryImportGroup>::new();
+    let mut excluded_model_count = 0usize;
+
+    for model in &source_models {
+        let model_id = cherry_value_string(model, "id");
+        let explicit_endpoint = cherry_value_string(model, "endpoint_type");
+        let protocol = if explicit_endpoint.is_empty() {
+            cherry_v1_default_protocol(&source_provider_type)
+        } else {
+            cherry_protocol_from_endpoint(&explicit_endpoint)
+        };
+        let Some(protocol) = protocol else {
+            excluded_model_count += 1;
+            continue;
+        };
+        if model_id.is_empty() || !cherry_model_is_chat_compatible(model, &model_id) {
+            excluded_model_count += 1;
+            continue;
+        }
+        let base_url = cherry_v1_base_url(provider, &source_provider_type, protocol);
+        cherry_group_add_model(&mut groups, protocol, base_url, model_id);
+    }
+
+    if groups.is_empty() {
+        let Some(protocol) = cherry_v1_default_protocol(&source_provider_type) else {
+            return;
+        };
+        let base_url = cherry_v1_base_url(provider, &source_provider_type, protocol);
+        groups.push(CherryImportGroup {
+            protocol,
+            base_url,
+            models: Vec::new(),
+        });
+    }
+
+    let warning = if provider
+        .get("extra_headers")
+        .and_then(Value::as_object)
+        .is_some_and(|headers| !headers.is_empty())
+    {
+        "Cherry Studio 的自定义请求头不会同步".to_string()
+    } else if api_keys.len() > 1 {
+        format!("检测到 {} 个 API Key，将使用第一个", api_keys.len())
+    } else {
+        String::new()
+    };
+
+    for group in groups {
+        let models_only_unsupported = !source_models.is_empty() && group.models.is_empty();
+        let reason = if auth_type == "oauth" {
+            "OAuth 登录凭据不支持迁移".to_string()
+        } else if api_key.is_empty() {
+            "未配置可迁移的 API Key".to_string()
+        } else if group.base_url.is_empty() {
+            "未配置 Base URL".to_string()
+        } else if models_only_unsupported {
+            "仅包含 LiveAgent 不支持的非聊天模型".to_string()
+        } else {
+            String::new()
+        };
+        out.push(CherryProviderImportItem {
+            source_id: format!("{}::{}", source_id, group.protocol.variant()),
+            source_version: version.to_string(),
+            source_provider_type: source_provider_type.clone(),
+            provider_type: group.protocol.provider_type().to_string(),
+            name: name.clone(),
+            base_url: group.base_url,
+            api_key: api_key.clone(),
+            api_key_count: api_keys.len(),
+            request_format: group.protocol.request_format().to_string(),
+            enabled,
+            importable: reason.is_empty(),
+            reason,
+            warning: warning.clone(),
+            excluded_model_count,
+        });
+    }
+}
+
+fn cherry_read_v2(
+    sqlite_path: &std::path::Path,
+    data_path: &std::path::Path,
+) -> Result<CherryImportScan, String> {
+    let conn = Connection::open_with_flags(sqlite_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|error| format!("打开 Cherry Studio SQLite 失败：{error}"))?;
+    conn.busy_timeout(Duration::from_secs(3))
+        .map_err(|error| format!("设置 Cherry Studio SQLite 超时失败：{error}"))?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT provider_id, name, endpoint_configs, default_chat_endpoint,
+                    api_keys, auth_config, provider_settings, is_enabled
+             FROM user_provider
+             ORDER BY order_key ASC, provider_id ASC",
+        )
+        .map_err(|error| format!("读取 Cherry Studio user_provider 失败：{error}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, bool>(7)?,
+            ))
+        })
+        .map_err(|error| format!("查询 Cherry Studio user_provider 失败：{error}"))?;
+    let mut source_rows = Vec::new();
+    for row in rows {
+        source_rows
+            .push(row.map_err(|error| format!("读取 Cherry Studio provider 行失败：{error}"))?);
+    }
+    let total_provider_count = source_rows.len();
+    let enabled_provider_count = source_rows.iter().filter(|row| row.7).count();
+    let version = cherry_read_version(data_path).unwrap_or_else(|| "2.x".to_string());
+    let mut providers = Vec::new();
+
+    for (
+        source_id,
+        name,
+        endpoint_configs_text,
+        default_endpoint,
+        api_keys_text,
+        auth_config_text,
+        provider_settings_text,
+        enabled,
+    ) in source_rows
+    {
+        let endpoint_configs = cherry_parse_optional_json(endpoint_configs_text.as_deref());
+        let api_keys = cherry_v2_api_keys(api_keys_text.as_deref());
+        let api_key = api_keys.first().cloned().unwrap_or_default();
+        let auth_config = cherry_parse_optional_json(auth_config_text.as_deref());
+        let auth_type = auth_config
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("api-key");
+        let mut model_stmt = conn
+            .prepare(
+                "SELECT model_id, endpoint_types, capabilities, output_modalities,
+                        is_enabled, is_hidden
+                 FROM user_model
+                 WHERE provider_id = ?1
+                 ORDER BY order_key ASC, model_id ASC",
+            )
+            .map_err(|error| format!("读取 Cherry Studio user_model 失败：{error}"))?;
+        let model_rows = model_stmt
+            .query_map([&source_id], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, bool>(4)?,
+                    row.get::<_, bool>(5)?,
+                ))
+            })
+            .map_err(|error| format!("查询 Cherry Studio user_model 失败：{error}"))?;
+        let mut groups = Vec::<CherryImportGroup>::new();
+        let mut source_model_count = 0usize;
+        let mut excluded_model_count = 0usize;
+        for row in model_rows {
+            let (model_id, endpoints_text, capabilities_text, output_text, model_enabled, hidden) =
+                row.map_err(|error| format!("读取 Cherry Studio model 行失败：{error}"))?;
+            if !model_enabled || hidden {
+                continue;
+            }
+            source_model_count += 1;
+            let endpoints = cherry_parse_optional_json(endpoints_text.as_deref());
+            let endpoint = endpoints
+                .as_array()
+                .and_then(|values| values.first())
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .or_else(|| default_endpoint.clone())
+                .unwrap_or_default();
+            let Some(protocol) = cherry_protocol_from_endpoint(&endpoint) else {
+                excluded_model_count += 1;
+                continue;
+            };
+            let capabilities = cherry_parse_optional_json(capabilities_text.as_deref());
+            let output_modalities = cherry_parse_optional_json(output_text.as_deref());
+            if !cherry_v2_model_is_chat_compatible(&model_id, &capabilities, &output_modalities) {
+                excluded_model_count += 1;
+                continue;
+            }
+            let base_url = cherry_v2_endpoint_base_url(&endpoint_configs, &endpoint);
+            cherry_group_add_model(&mut groups, protocol, base_url, model_id);
+        }
+
+        if groups.is_empty() {
+            let Some(protocol) = default_endpoint
+                .as_deref()
+                .and_then(cherry_protocol_from_endpoint)
+            else {
+                continue;
+            };
+            let base_url = cherry_v2_endpoint_base_url(
+                &endpoint_configs,
+                default_endpoint.as_deref().unwrap_or_default(),
+            );
+            groups.push(CherryImportGroup {
+                protocol,
+                base_url,
+                models: Vec::new(),
+            });
+        }
+
+        let settings = cherry_parse_optional_json(provider_settings_text.as_deref());
+        let warning = if settings
+            .get("extraHeaders")
+            .and_then(Value::as_object)
+            .is_some_and(|headers| !headers.is_empty())
+        {
+            "Cherry Studio 的自定义请求头不会同步".to_string()
+        } else if api_keys.len() > 1 {
+            format!("检测到 {} 个启用 API Key，将使用第一个", api_keys.len())
+        } else {
+            String::new()
+        };
+
+        for group in groups {
+            let models_only_unsupported = source_model_count > 0 && group.models.is_empty();
+            let reason = if auth_type != "api-key" {
+                format!("{auth_type} 登录凭据不支持迁移")
+            } else if api_key.is_empty() {
+                "未配置启用的 API Key".to_string()
+            } else if group.base_url.is_empty() {
+                "未配置当前协议的 Base URL".to_string()
+            } else if models_only_unsupported {
+                "仅包含 LiveAgent 不支持的非聊天模型".to_string()
+            } else {
+                String::new()
+            };
+            providers.push(CherryProviderImportItem {
+                source_id: format!("{}::{}", source_id, group.protocol.variant()),
+                source_version: version.clone(),
+                source_provider_type: default_endpoint.clone().unwrap_or_default(),
+                provider_type: group.protocol.provider_type().to_string(),
+                name: name.clone(),
+                base_url: group.base_url,
+                api_key: api_key.clone(),
+                api_key_count: api_keys.len(),
+                request_format: group.protocol.request_format().to_string(),
+                enabled,
+                importable: reason.is_empty(),
+                reason,
+                warning: warning.clone(),
+                excluded_model_count,
+            });
+        }
+    }
+
+    Ok(CherryImportScan {
+        version,
+        data_path: data_path.to_path_buf(),
+        total_provider_count,
+        enabled_provider_count,
+        providers,
+    })
+}
+
+fn cherry_v1_default_protocol(provider_type: &str) -> Option<CherryImportProtocol> {
+    match provider_type.trim().to_ascii_lowercase().as_str() {
+        "anthropic" | "vertex-anthropic" => Some(CherryImportProtocol::Claude),
+        "gemini" | "vertexai" => Some(CherryImportProtocol::Gemini),
+        "openai-response" => Some(CherryImportProtocol::CodexResponses),
+        "openai" | "new-api" | "gateway" | "ollama" => Some(CherryImportProtocol::CodexCompletions),
+        _ => None,
+    }
+}
+
+fn cherry_protocol_from_endpoint(endpoint: &str) -> Option<CherryImportProtocol> {
+    match endpoint.trim().to_ascii_lowercase().as_str() {
+        "anthropic" | "anthropic-messages" | "messages" => Some(CherryImportProtocol::Claude),
+        "gemini" | "google-generate-content" | "generatecontent" | "streamgeneratecontent" => {
+            Some(CherryImportProtocol::Gemini)
+        }
+        "openai-response" | "openai-responses" | "responses" | "response" => {
+            Some(CherryImportProtocol::CodexResponses)
+        }
+        "openai" | "openai-chat-completions" | "chat/completions" | "ollama-chat" => {
+            Some(CherryImportProtocol::CodexCompletions)
+        }
+        _ => None,
+    }
+}
+
+fn cherry_v1_base_url(
+    provider: &Value,
+    provider_type: &str,
+    protocol: CherryImportProtocol,
+) -> String {
+    let raw = if protocol == CherryImportProtocol::Claude && provider_type != "new-api" {
+        let anthropic = cherry_value_string(provider, "anthropicApiHost");
+        if anthropic.is_empty() {
+            cherry_value_string(provider, "apiHost")
+        } else {
+            anthropic
+        }
+    } else {
+        cherry_value_string(provider, "apiHost")
+    };
+    cherry_normalize_routed_base_url(&raw)
+}
+
+fn cherry_normalize_routed_base_url(value: &str) -> String {
+    let trimmed = value.trim();
+    if !trimmed.ends_with('#') {
+        return trimmed.trim_end_matches('/').to_string();
+    }
+    let mut base = trimmed
+        .trim_end_matches('#')
+        .trim_end_matches('/')
+        .to_string();
+    let lower = base.to_ascii_lowercase();
+    for suffix in [
+        "/chat/completions",
+        "/responses",
+        "/response",
+        "/messages",
+        ":streamgeneratecontent",
+        ":generatecontent",
+        "/streamgeneratecontent",
+        "/generatecontent",
+    ] {
+        if lower.ends_with(suffix) {
+            base.truncate(base.len() - suffix.len());
+            break;
+        }
+    }
+    base.trim_end_matches(['/', ':']).to_string()
+}
+
+fn cherry_group_add_model(
+    groups: &mut Vec<CherryImportGroup>,
+    protocol: CherryImportProtocol,
+    base_url: String,
+    model_id: String,
+) {
+    if let Some(group) = groups
+        .iter_mut()
+        .find(|group| group.protocol == protocol && group.base_url == base_url)
+    {
+        if !group.models.iter().any(|model| model == &model_id) {
+            group.models.push(model_id);
+        }
+        return;
+    }
+    groups.push(CherryImportGroup {
+        protocol,
+        base_url,
+        models: vec![model_id],
+    });
+}
+
+fn cherry_model_is_chat_compatible(model: &Value, model_id: &str) -> bool {
+    if cherry_model_id_looks_non_chat(model_id) {
+        return false;
+    }
+    let types = model
+        .get("type")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>();
+    if !types.is_empty()
+        && !types.iter().any(|kind| {
+            matches!(
+                kind.to_ascii_lowercase().as_str(),
+                "text" | "vision" | "reasoning" | "function_calling" | "web_search"
+            )
+        })
+    {
+        return false;
+    }
+    true
+}
+
+fn cherry_v2_model_is_chat_compatible(
+    model_id: &str,
+    capabilities: &Value,
+    output_modalities: &Value,
+) -> bool {
+    if cherry_model_id_looks_non_chat(model_id) {
+        return false;
+    }
+    if let Some(outputs) = output_modalities.as_array() {
+        let values = outputs
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_ascii_lowercase)
+            .collect::<Vec<_>>();
+        if !values.is_empty() && !values.iter().any(|value| value == "text") {
+            return false;
+        }
+    }
+    if let Some(values) = capabilities.as_array() {
+        let only_non_chat = !values.is_empty()
+            && values.iter().filter_map(Value::as_str).all(|value| {
+                matches!(
+                    value.to_ascii_lowercase().as_str(),
+                    "embedding"
+                        | "rerank"
+                        | "image-generation"
+                        | "audio-generation"
+                        | "audio-transcript"
+                        | "video-generation"
+                )
+            });
+        if only_non_chat {
+            return false;
+        }
+    }
+    true
+}
+
+fn cherry_model_id_looks_non_chat(model_id: &str) -> bool {
+    let lower = model_id.to_ascii_lowercase();
+    [
+        "embedding",
+        "rerank",
+        "whisper",
+        "realtime",
+        "audio-preview",
+        "audio-realtime",
+        "image",
+        "video",
+        "banana",
+        "dall-e",
+        "imagen",
+        "sora-",
+        "veo-",
+        "tts-",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+fn cherry_split_v1_api_keys(value: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let mut current = String::new();
+    let mut escaped = false;
+    for character in value.chars() {
+        if escaped {
+            if character == ',' {
+                current.push(',');
+            } else {
+                current.push('\\');
+                current.push(character);
+            }
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        } else if character == ',' {
+            let key = current.trim();
+            if !key.is_empty() {
+                keys.push(key.to_string());
+            }
+            current.clear();
+        } else {
+            current.push(character);
+        }
+    }
+    if escaped {
+        current.push('\\');
+    }
+    let key = current.trim();
+    if !key.is_empty() {
+        keys.push(key.to_string());
+    }
+    keys
+}
+
+fn cherry_v2_api_keys(text: Option<&str>) -> Vec<String> {
+    cherry_parse_optional_json(text)
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|entry| {
+            entry
+                .get("isEnabled")
+                .and_then(Value::as_bool)
+                .unwrap_or(true)
+        })
+        .filter_map(|entry| entry.get("key").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn cherry_v2_endpoint_base_url(endpoint_configs: &Value, endpoint: &str) -> String {
+    endpoint_configs
+        .get(endpoint)
+        .and_then(|config| config.get("baseUrl"))
+        .and_then(Value::as_str)
+        .map(cherry_normalize_routed_base_url)
+        .unwrap_or_default()
+}
+
+fn cherry_parse_optional_json(text: Option<&str>) -> Value {
+    text.and_then(|value| serde_json::from_str::<Value>(value).ok())
+        .unwrap_or(Value::Null)
+}
+
+fn cherry_value_string(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn cherry_read_version(data_path: &std::path::Path) -> Option<String> {
+    let text = fs::read_to_string(data_path.join("version.log")).ok()?;
+    text.lines()
+        .rev()
+        .find_map(|line| line.split('|').next())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/cherry_import.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/cherry_import.rs
@@ -82,50 +82,114 @@ struct CherryImportScan {
 #[tauri::command]
 pub async fn settings_list_cherry_studio_providers() -> Result<CherryProvidersResponse, String> {
     tauri::async_runtime::spawn_blocking(|| {
-        let candidates = cherry_user_data_candidates();
-        let mut read_errors = Vec::new();
-
-        for data_path in &candidates {
-            let sqlite_path = data_path.join("cherrystudio.sqlite");
-            if !sqlite_path.is_file() {
-                continue;
-            }
-            match cherry_read_v2(&sqlite_path, data_path) {
-                Ok(scan) => return Ok(cherry_scan_response(scan)),
-                Err(error) => read_errors.push(error),
-            }
-        }
-
-        for data_path in &candidates {
-            let leveldb_path = data_path.join("Local Storage").join("leveldb");
-            if !leveldb_path.is_dir() {
-                continue;
-            }
-            match cherry_read_v1(&leveldb_path, data_path) {
-                Ok(scan) => return Ok(cherry_scan_response(scan)),
-                Err(error) => read_errors.push(error),
-            }
-        }
-
-        if !read_errors.is_empty() {
-            return Err(read_errors.join("；"));
-        }
-
-        Ok(CherryProvidersResponse {
-            status: "success".to_string(),
-            message: "未发现 Cherry Studio 供应商数据".to_string(),
-            version: String::new(),
-            data_path: candidates
-                .first()
-                .map(|path| path.to_string_lossy().into_owned())
-                .unwrap_or_default(),
-            total_provider_count: 0,
-            enabled_provider_count: 0,
-            providers: Vec::new(),
-        })
+        cherry_scan_candidates(&cherry_user_data_candidates(), false)
     })
     .await
     .map_err(|error| format!("settings_list_cherry_studio_providers join 失败：{error}"))?
+}
+
+#[tauri::command]
+pub async fn settings_list_cherry_studio_providers_from_path(
+    data_path: String,
+) -> Result<CherryProvidersResponse, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let selected = PathBuf::from(data_path.trim());
+        if selected.as_os_str().is_empty() {
+            return Err("未选择 Cherry Studio 数据目录".to_string());
+        }
+        cherry_scan_candidates(&cherry_manual_data_candidates(&selected), true)
+    })
+    .await
+    .map_err(|error| {
+        format!("settings_list_cherry_studio_providers_from_path join 失败：{error}")
+    })?
+}
+
+fn cherry_scan_candidates(
+    candidates: &[PathBuf],
+    require_data: bool,
+) -> Result<CherryProvidersResponse, String> {
+    let mut read_errors = Vec::new();
+
+    for data_path in candidates {
+        let sqlite_path = data_path.join("cherrystudio.sqlite");
+        if !sqlite_path.is_file() {
+            continue;
+        }
+        match cherry_read_v2(&sqlite_path, data_path) {
+            Ok(scan) => return Ok(cherry_scan_response(scan)),
+            Err(error) => read_errors.push(format!("{}：{error}", data_path.display())),
+        }
+    }
+
+    for data_path in candidates {
+        let leveldb_path = data_path.join("Local Storage").join("leveldb");
+        if !leveldb_path.is_dir() {
+            continue;
+        }
+        match cherry_read_v1(&leveldb_path, data_path) {
+            Ok(scan) => return Ok(cherry_scan_response(scan)),
+            Err(error) => read_errors.push(format!("{}：{error}", data_path.display())),
+        }
+    }
+
+    if require_data {
+        if !read_errors.is_empty() {
+            return Err(format!(
+                "选择的目录不是有效的 Cherry Studio 数据目录：{}",
+                read_errors.join("；")
+            ));
+        }
+        return Err(format!(
+            "选择的目录中未发现 Cherry Studio 数据，请检查以下位置：{}",
+            candidates
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join("、")
+        ));
+    }
+
+    if !read_errors.is_empty() {
+        return Err(read_errors.join("；"));
+    }
+    Ok(CherryProvidersResponse {
+        status: "success".to_string(),
+        message: "未发现 Cherry Studio 供应商数据".to_string(),
+        version: String::new(),
+        data_path: candidates
+            .first()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        total_provider_count: 0,
+        enabled_provider_count: 0,
+        providers: Vec::new(),
+    })
+}
+
+fn cherry_manual_data_candidates(selected: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    cherry_push_unique_path(&mut candidates, selected.to_path_buf());
+    cherry_push_unique_path(&mut candidates, selected.join("data"));
+    cherry_push_unique_path(&mut candidates, selected.join("CherryStudio"));
+    cherry_push_unique_path(&mut candidates, selected.join("Cherry Studio"));
+
+    if selected.file_name().is_some_and(|name| name == "leveldb")
+        && selected.parent().and_then(Path::file_name)
+            == Some(std::ffi::OsStr::new("Local Storage"))
+    {
+        if let Some(user_data) = selected.parent().and_then(Path::parent) {
+            cherry_push_unique_path(&mut candidates, user_data.to_path_buf());
+        }
+    } else if selected
+        .file_name()
+        .is_some_and(|name| name == "Local Storage")
+    {
+        if let Some(user_data) = selected.parent() {
+            cherry_push_unique_path(&mut candidates, user_data.to_path_buf());
+        }
+    }
+    candidates
 }
 
 fn cherry_scan_response(scan: CherryImportScan) -> CherryProvidersResponse {

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/mod.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/mod.rs
@@ -147,6 +147,7 @@ include!("db.rs");
 include!("json.rs");
 include!("providers.rs");
 include!("ccs_import.rs");
+include!("cherry_import.rs");
 include!("agents.rs");
 include!("system.rs");
 include!("mcp.rs");

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/mod.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/mod.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Map, Number, Value};
 use std::{
     collections::{HashMap, HashSet},
     fs,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
@@ -1077,4 +1077,60 @@ mod tests {
         );
     }
 
+    #[test]
+    fn cherry_split_v1_api_keys_handles_escaped_commas() {
+        assert_eq!(
+            cherry_split_v1_api_keys(r"first\,part, second, ,third"),
+            vec!["first,part", "second", "third"]
+        );
+    }
+
+    #[test]
+    fn cherry_normalize_routed_base_url_removes_endpoint_marker() {
+        assert_eq!(
+            cherry_normalize_routed_base_url("https://example.test/v1/chat/completions#"),
+            "https://example.test/v1"
+        );
+        assert_eq!(
+            cherry_normalize_routed_base_url(
+                "https://generativelanguage.googleapis.com/v1beta/models/demo:generateContent#"
+            ),
+            "https://generativelanguage.googleapis.com/v1beta/models/demo"
+        );
+    }
+
+    #[test]
+    fn cherry_v1_new_api_splits_chat_protocols_and_filters_non_chat_models() {
+        let provider = json!({
+            "id": "mixed-provider",
+            "name": "Mixed API",
+            "type": "new-api",
+            "apiKey": "secret",
+            "apiHost": "https://example.test/v1",
+            "enabled": true,
+            "models": [
+                { "id": "gpt-chat", "endpoint_type": "openai-chat-completions", "type": ["text"] },
+                { "id": "claude-chat", "endpoint_type": "anthropic-messages", "type": ["text"] },
+                { "id": "text-embedding-3-small", "endpoint_type": "openai-chat-completions", "type": ["embedding"] }
+            ]
+        });
+        let mut imported = Vec::new();
+
+        cherry_append_v1_provider(&provider, "1.9.9", &mut imported);
+
+        assert_eq!(imported.len(), 2);
+        assert!(imported.iter().all(|item| item.importable));
+        assert!(imported.iter().all(|item| item.api_key == "secret"));
+        assert!(imported.iter().all(|item| item.excluded_model_count == 1));
+        assert!(!cherry_model_is_chat_compatible(
+            &json!({"type": ["image_generation"]}),
+            "nano-banana"
+        ));
+        assert!(imported.iter().any(|item| {
+            item.provider_type == "codex" && item.request_format == "openai-completions"
+        }));
+        assert!(imported
+            .iter()
+            .any(|item| item.provider_type == "claude_code"));
+    }
 }

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
@@ -1086,6 +1086,25 @@ mod tests {
     }
 
     #[test]
+    fn cherry_manual_data_candidates_support_portable_and_nested_directories() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let portable = root.path().join("CherryStudioPortable");
+        let data = portable.join("data");
+        let local_storage = data.join("Local Storage");
+        let leveldb = local_storage.join("leveldb");
+
+        let portable_candidates = cherry_manual_data_candidates(&portable);
+        assert!(portable_candidates.contains(&portable));
+        assert!(portable_candidates.contains(&data));
+
+        let local_storage_candidates = cherry_manual_data_candidates(&local_storage);
+        assert!(local_storage_candidates.contains(&data));
+
+        let leveldb_candidates = cherry_manual_data_candidates(&leveldb);
+        assert!(leveldb_candidates.contains(&data));
+    }
+
+    #[test]
     fn cherry_normalize_routed_base_url_removes_endpoint_marker() {
         assert_eq!(
             cherry_normalize_routed_base_url("https://example.test/v1/chat/completions#"),

--- a/crates/agent-gui/src-tauri/src/lib.rs
+++ b/crates/agent-gui/src-tauri/src/lib.rs
@@ -115,6 +115,7 @@ macro_rules! app_invoke_handler {
             commands::settings::settings_save_providers,
             commands::settings::settings_list_ccswitch_providers,
             commands::settings::settings_list_cherry_studio_providers,
+            commands::settings::settings_list_cherry_studio_providers_from_path,
             commands::settings::settings_save_system,
             commands::settings::settings_save_mcp,
             commands::settings::settings_save_agents,

--- a/crates/agent-gui/src-tauri/src/lib.rs
+++ b/crates/agent-gui/src-tauri/src/lib.rs
@@ -114,6 +114,7 @@ macro_rules! app_invoke_handler {
             commands::settings::settings_load_all,
             commands::settings::settings_save_providers,
             commands::settings::settings_list_ccswitch_providers,
+            commands::settings::settings_list_cherry_studio_providers,
             commands::settings::settings_save_system,
             commands::settings::settings_save_mcp,
             commands::settings::settings_save_agents,

--- a/crates/agent-gui/src/pages/settings/CherryStudioImportModal.tsx
+++ b/crates/agent-gui/src/pages/settings/CherryStudioImportModal.tsx
@@ -1,0 +1,259 @@
+import { useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { Check, RefreshCw, X } from "../../components/icons";
+import { Button } from "../../components/ui/button";
+import type { CodexRequestFormat, ProviderId } from "../../lib/settings";
+
+export type CherryProviderImportItem = {
+  sourceId: string;
+  sourceVersion: string;
+  sourceProviderType: string;
+  providerType: ProviderId;
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+  apiKeyCount: number;
+  requestFormat: CodexRequestFormat;
+  enabled: boolean;
+  importable: boolean;
+  reason: string;
+  warning: string;
+  excludedModelCount: number;
+};
+
+export type CherryProvidersResponse = {
+  status: string;
+  message: string;
+  version: string;
+  dataPath: string;
+  totalProviderCount: number;
+  enabledProviderCount: number;
+  providers: CherryProviderImportItem[];
+};
+
+type CherryStudioImportModalProps = {
+  providerType: ProviderId;
+  response: CherryProvidersResponse;
+  importing: boolean;
+  isExisting: (item: CherryProviderImportItem) => boolean;
+  onClose: () => void;
+  onConfirm: (items: CherryProviderImportItem[]) => void;
+};
+
+const PROVIDER_LABELS: Record<ProviderId, string> = {
+  claude_code: "Anthropic",
+  codex: "OpenAI",
+  gemini: "Gemini",
+};
+
+function itemKey(item: CherryProviderImportItem) {
+  return `${item.sourceId}\n${item.baseUrl}\n${item.requestFormat}`;
+}
+
+function itemProtocolLabel(item: CherryProviderImportItem) {
+  if (item.providerType === "claude_code") return "Anthropic Messages";
+  if (item.providerType === "gemini") return "Gemini Generate Content";
+  return item.requestFormat === "openai-responses" ? "Responses API" : "Chat Completions";
+}
+
+export function CherryStudioImportModal(props: CherryStudioImportModalProps) {
+  const { providerType, response, importing, isExisting, onClose, onConfirm } = props;
+  const candidates = useMemo(
+    () => response.providers.filter((item) => item.providerType === providerType),
+    [providerType, response.providers],
+  );
+  const defaultSelected = useMemo(
+    () => candidates.filter((item) => item.enabled && item.importable).map(itemKey),
+    [candidates],
+  );
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(defaultSelected));
+  const [showAll, setShowAll] = useState(defaultSelected.length === 0);
+
+  const visibleItems = showAll
+    ? candidates
+    : candidates.filter((item) => item.enabled && item.importable);
+  const selectedItems = candidates.filter((item) => selected.has(itemKey(item)) && item.importable);
+
+  function toggleItem(item: CherryProviderImportItem) {
+    if (!item.importable || importing) return;
+    setSelected((current) => {
+      const next = new Set(current);
+      const key = itemKey(item);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  function selectVisible() {
+    setSelected((current) => {
+      const next = new Set(current);
+      for (const item of visibleItems) {
+        if (item.importable) next.add(itemKey(item));
+      }
+      return next;
+    });
+  }
+
+  function clearVisible() {
+    setSelected((current) => {
+      const next = new Set(current);
+      for (const item of visibleItems) next.delete(itemKey(item));
+      return next;
+    });
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-[70] flex items-center justify-center p-4">
+      <button
+        type="button"
+        aria-label="关闭 Cherry Studio 同步"
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={importing ? undefined : onClose}
+      />
+      <div className="relative z-10 flex max-h-[88vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border bg-background shadow-2xl">
+        <div className="flex shrink-0 items-start justify-between gap-4 border-b px-6 py-4">
+          <div>
+            <div className="text-base font-semibold">从 Cherry Studio 同步</div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              仅同步 Base URL 和 API Key，模型由 LiveAgent 获取并激活；当前显示{" "}
+              {PROVIDER_LABELS[providerType]} 配置
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={onClose}
+            disabled={importing}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b bg-muted/20 px-6 py-3">
+          <label className="flex cursor-pointer items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={showAll}
+              onChange={(event) => setShowAll(event.currentTarget.checked)}
+              disabled={importing}
+            />
+            显示禁用或不兼容配置
+          </label>
+          <div className="flex items-center gap-2 text-xs">
+            <button type="button" className="text-primary hover:underline" onClick={selectVisible}>
+              全选可用项
+            </button>
+            <span className="text-muted-foreground">/</span>
+            <button type="button" className="text-primary hover:underline" onClick={clearVisible}>
+              清空
+            </button>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
+          {visibleItems.length === 0 ? (
+            <div className="rounded-xl border border-dashed py-10 text-center text-sm text-muted-foreground">
+              当前标签下没有可同步的 Cherry Studio 聊天供应商
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {visibleItems.map((item) => {
+                const checked = selected.has(itemKey(item));
+                const existing = isExisting(item);
+                return (
+                  <button
+                    key={itemKey(item)}
+                    type="button"
+                    className={`flex w-full items-start gap-3 rounded-xl border px-4 py-3 text-left transition-colors ${
+                      item.importable
+                        ? checked
+                          ? "border-primary/45 bg-primary/[0.06]"
+                          : "hover:bg-accent/40"
+                        : "cursor-not-allowed bg-muted/25 opacity-65"
+                    }`}
+                    onClick={() => toggleItem(item)}
+                    disabled={!item.importable || importing}
+                  >
+                    <span
+                      className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border ${
+                        checked && item.importable
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-muted-foreground/40"
+                      }`}
+                    >
+                      {checked && item.importable ? <Check className="h-3 w-3" /> : null}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="flex flex-wrap items-center gap-2">
+                        <strong className="text-sm font-medium">{item.name}</strong>
+                        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                          {itemProtocolLabel(item)}
+                        </span>
+                        {existing ? (
+                          <span className="rounded bg-blue-500/10 px-1.5 py-0.5 text-[10px] text-blue-600 dark:text-blue-300">
+                            将更新
+                          </span>
+                        ) : null}
+                        {!item.enabled ? (
+                          <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-700 dark:text-amber-300">
+                            Cherry 中已禁用
+                          </span>
+                        ) : null}
+                      </span>
+                      <span className="mt-1 block truncate text-xs text-muted-foreground">
+                        {item.baseUrl || "未配置 Base URL"}
+                      </span>
+                      <span className="mt-1 block text-xs text-muted-foreground">
+                        {item.apiKeyCount > 0 ? "密钥已配置" : "无可迁移密钥"} · 模型由 LiveAgent 从
+                        API 获取
+                        {item.excludedModelCount > 0
+                          ? ` · Cherry 中识别到 ${item.excludedModelCount} 个非聊天模型`
+                          : ""}
+                      </span>
+                      {item.reason ? (
+                        <span className="mt-1.5 block text-xs text-destructive">{item.reason}</span>
+                      ) : item.warning ? (
+                        <span className="mt-1.5 block text-xs text-amber-700 dark:text-amber-300">
+                          {item.warning}
+                        </span>
+                      ) : null}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="shrink-0 space-y-3 border-t bg-background px-6 py-4">
+          <div className="rounded-lg border bg-muted/25 px-3 py-2 text-xs text-muted-foreground">
+            同步后 LiveAgent 会使用自己的模型获取功能请求供应商
+            API，并自动激活获取到的全部聊天模型。
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-xs text-muted-foreground">
+              已选择 {selectedItems.length} 个供应商配置
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" onClick={onClose} disabled={importing}>
+                取消
+              </Button>
+              <Button
+                className="min-w-32 gap-2"
+                onClick={() => onConfirm(selectedItems)}
+                disabled={importing || selectedItems.length === 0}
+              >
+                {importing ? <RefreshCw className="h-4 w-4 animate-spin" /> : null}
+                {importing ? "正在同步…" : `同步 ${selectedItems.length} 个`}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -1525,7 +1525,7 @@ export function ProvidersSection(props: SettingsSectionProps) {
 
   async function chooseCherryDataDirectory() {
     const selected = await invoke<string | null>("system_pick_folder", {
-      initialWorkdir: cherryDataPath ?? cherryProviders?.dataPath ?? undefined,
+      initial_workdir: cherryDataPath ?? cherryProviders?.dataPath ?? undefined,
     });
     if (!selected) return;
 

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -53,6 +53,11 @@ import {
 } from "../../lib/settings";
 import { cn } from "../../lib/shared/utils";
 import {
+  type CherryProviderImportItem,
+  type CherryProvidersResponse,
+  CherryStudioImportModal,
+} from "./CherryStudioImportModal";
+import {
   createDraftModelConfig,
   fetchModelsFromApi,
   isGatewayWebuiRuntime,
@@ -779,6 +784,76 @@ function ccsProviderIsTransferable(item: CcsProviderImportItem) {
   return ccsProviderCanSyncModels(item) || (item.models?.length ?? 0) > 0;
 }
 
+function cherryProviderId(item: CherryProviderImportItem) {
+  const baseId = `cherry-studio-${item.sourceId}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return baseId || "cherry-studio-provider";
+}
+
+function cherryProviderName(item: CherryProviderImportItem, allItems: CherryProviderImportItem[]) {
+  const duplicateCount = allItems.filter(
+    (candidate) =>
+      candidate.name.trim().toLowerCase() === item.name.trim().toLowerCase() &&
+      candidate.providerType === item.providerType &&
+      candidate.baseUrl.trim().replace(/\/+$/, "").toLowerCase() ===
+        item.baseUrl.trim().replace(/\/+$/, "").toLowerCase(),
+  ).length;
+  if (duplicateCount <= 1) return `${item.name.trim()}（Cherry Studio）`;
+  const sourceId = item.sourceId.split("::", 1)[0].slice(0, 8);
+  return `${item.name.trim()}（Cherry Studio · ${sourceId}）`;
+}
+
+function providerFromCherry(
+  item: CherryProviderImportItem,
+  allItems: CherryProviderImportItem[],
+  existing?: CustomProvider,
+): CustomProvider {
+  const providerType = item.providerType;
+  const models = existing?.models ?? [];
+  return {
+    ...(existing ?? {}),
+    id: cherryProviderId(item),
+    name: existing?.name ?? cherryProviderName(item, allItems),
+    type: providerType,
+    baseUrl: item.baseUrl,
+    apiKey: item.apiKey,
+    apiKeyConfigured: item.apiKey.trim().length > 0,
+    models,
+    activeModels: existing?.activeModels ?? [],
+    requestFormat:
+      providerType === "codex"
+        ? item.requestFormat === "openai-completions"
+          ? "openai-completions"
+          : "openai-responses"
+        : undefined,
+    reasoning: existing?.reasoning ?? "off",
+    promptCachingEnabled: existing?.promptCachingEnabled ?? providerType === "claude_code",
+    nativeWebSearchEnabled: existing?.nativeWebSearchEnabled ?? true,
+  };
+}
+
+function isLikelyCherryChatModel(modelId: string) {
+  const lower = modelId.toLowerCase();
+  return ![
+    "embedding",
+    "rerank",
+    "whisper",
+    "realtime",
+    "audio-preview",
+    "audio-realtime",
+    "image",
+    "video",
+    "banana",
+    "dall-e",
+    "imagen",
+    "sora-",
+    "veo-",
+    "tts-",
+  ].some((needle) => lower.includes(needle));
+}
+
 // sourceId alone can collide across ccswitch app_type buckets that map to the
 // same provider tab (e.g. "claude" and "claude-code"), so key rows on both.
 function ccsItemKey(item: CcsProviderImportItem) {
@@ -794,6 +869,19 @@ function CcsSourceLogo({ className }: { className?: string }) {
       )}
     >
       CC
+    </span>
+  );
+}
+
+function CherrySourceLogo({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 select-none items-center justify-center rounded-lg bg-gradient-to-br from-rose-500 to-orange-500 font-bold text-white shadow-sm",
+        className,
+      )}
+    >
+      CS
     </span>
   );
 }
@@ -1078,9 +1166,14 @@ function ProviderList(props: {
   ccsLoading: boolean;
   ccsImporting: boolean;
   ccsMessage: string | null;
-  onEnsureCcsScan: () => void;
-  onRefreshCcsProviders: () => void;
+  cherryProviders: CherryProvidersResponse | null;
+  cherryLoading: boolean;
+  cherryImporting: boolean;
+  cherryMessage: string | null;
+  onEnsureThirdPartyScan: () => void;
+  onRefreshThirdPartyProviders: () => void;
   onOpenCcsImport: () => void;
+  onOpenCherryImport: () => void;
 }) {
   const { t } = useLocale();
   const {
@@ -1094,13 +1187,19 @@ function ProviderList(props: {
     ccsLoading,
     ccsImporting,
     ccsMessage,
-    onEnsureCcsScan,
-    onRefreshCcsProviders,
+    cherryProviders,
+    cherryLoading,
+    cherryImporting,
+    cherryMessage,
+    onEnsureThirdPartyScan,
+    onRefreshThirdPartyProviders,
     onOpenCcsImport,
+    onOpenCherryImport,
   } = props;
   const [syncMenuOpen, setSyncMenuOpen] = useState(false);
   const filtered = providers.filter((provider) => provider.type === type);
   const ccsAll = ccsProviders?.providers ?? [];
+  const cherryAll = cherryProviders?.providers ?? [];
   const ccsBreakdown = PROVIDER_TABS.map((tab) => ({
     type: tab,
     count: ccsAll.filter((provider) => provider.providerType === tab).length,
@@ -1114,7 +1213,7 @@ function ProviderList(props: {
 
   function handleSyncMenuOpenChange(open: boolean) {
     setSyncMenuOpen(open);
-    if (open) onEnsureCcsScan();
+    if (open) onEnsureThirdPartyScan();
   }
 
   const scanned = ccsProviders !== null;
@@ -1129,6 +1228,18 @@ function ProviderList(props: {
         : scanned
           ? ccsMessage || "未发现可导入的供应商"
           : "点击扫描本地配置";
+  const cherryReady = cherryAll.filter(
+    (provider) => provider.providerType === type && provider.importable,
+  ).length;
+  const cherrySubtitle = cherryImporting
+    ? "正在同步供应商、获取并激活模型…"
+    : cherryLoading
+      ? "正在扫描本地配置…"
+      : cherryProviders
+        ? cherryMessage || `发现 ${cherryReady} 个可同步配置`
+        : cherryMessage || "点击扫描本地配置";
+  const thirdPartyLoading = ccsLoading || cherryLoading;
+  const thirdPartyImporting = ccsImporting || cherryImporting;
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
@@ -1145,9 +1256,16 @@ function ProviderList(props: {
           </Button>
           <DropdownMenu open={syncMenuOpen} onOpenChange={handleSyncMenuOpenChange}>
             <DropdownMenuTrigger
-              render={<Button variant="outline" size="sm" className="gap-1.5" />}
+              render={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  disabled={thirdPartyImporting}
+                />
+              }
             >
-              {ccsImporting ? (
+              {thirdPartyImporting ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
               ) : (
                 <Download className="h-3.5 w-3.5" />
@@ -1173,12 +1291,12 @@ function ProviderList(props: {
                 <DropdownMenuItem
                   closeOnClick={false}
                   className="h-7 w-7 cursor-pointer justify-center rounded-md p-0 text-muted-foreground"
-                  disabled={ccsLoading || ccsImporting}
-                  onSelect={onRefreshCcsProviders}
+                  disabled={thirdPartyLoading || thirdPartyImporting}
+                  onSelect={onRefreshThirdPartyProviders}
                   aria-label="重新扫描本地配置"
                   title="重新扫描本地配置"
                 >
-                  <RefreshCw className={cn("h-3.5 w-3.5", ccsLoading && "animate-spin")} />
+                  <RefreshCw className={cn("h-3.5 w-3.5", thirdPartyLoading && "animate-spin")} />
                 </DropdownMenuItem>
               </div>
               <DropdownMenuSeparator className="my-0 bg-border/40" />
@@ -1206,6 +1324,32 @@ function ProviderList(props: {
                     </span>
                   </span>
                   {ccsLoading || ccsImporting ? (
+                    <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+                  ) : null}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="model-selector-item cursor-pointer items-start gap-3 rounded-lg px-2.5 py-2.5"
+                  disabled={cherryLoading || cherryImporting || !cherryAll.length}
+                  onSelect={onOpenCherryImport}
+                >
+                  <CherrySourceLogo className="h-9 w-9 text-[11px]" />
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="flex items-center gap-1.5 text-sm font-medium">
+                      Cherry Studio
+                      {cherryReady > 0 ? (
+                        <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+                          {cherryReady}
+                        </span>
+                      ) : null}
+                    </span>
+                    <span
+                      className="line-clamp-2 text-xs text-muted-foreground"
+                      title={cherrySubtitle}
+                    >
+                      {cherrySubtitle}
+                    </span>
+                  </span>
+                  {cherryLoading || cherryImporting ? (
                     <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
                   ) : null}
                 </DropdownMenuItem>
@@ -1286,27 +1430,51 @@ export function ProvidersSection(props: SettingsSectionProps) {
   const [customSettingsOpen, setCustomSettingsOpen] = useState(false);
   const [editingProvider, setEditingProvider] = useState<CustomProvider | null>(null);
   const [ccsImportType, setCcsImportType] = useState<ProviderId | null>(null);
+  const [cherryImportType, setCherryImportType] = useState<ProviderId | null>(null);
   const [ccsProviders, setCcsProviders] = useState<CcsProvidersResponse | null>(null);
   const [ccsLoading, setCcsLoading] = useState(false);
   const [ccsImporting, setCcsImporting] = useState(false);
   const [ccsMessage, setCcsMessage] = useState<string | null>(null);
+  const [cherryProviders, setCherryProviders] = useState<CherryProvidersResponse | null>(null);
+  const [cherryLoading, setCherryLoading] = useState(false);
+  const [cherryImporting, setCherryImporting] = useState(false);
+  const [cherryMessage, setCherryMessage] = useState<string | null>(null);
 
-  async function refreshCcsProviders() {
+  async function refreshThirdPartyProviders() {
     setCcsLoading(true);
-    try {
-      const result = await invoke<CcsProvidersResponse>("settings_list_ccswitch_providers");
-      setCcsProviders(result);
-      setCcsMessage(result.message);
-    } catch (err) {
-      setCcsMessage(err instanceof Error ? err.message : String(err));
+    setCherryLoading(true);
+    const [ccsResult, cherryResult] = await Promise.allSettled([
+      invoke<CcsProvidersResponse>("settings_list_ccswitch_providers"),
+      invoke<CherryProvidersResponse>("settings_list_cherry_studio_providers"),
+    ]);
+    if (ccsResult.status === "fulfilled") {
+      setCcsProviders(ccsResult.value);
+      setCcsMessage(ccsResult.value.message);
+    } else {
       setCcsProviders(null);
-    } finally {
-      setCcsLoading(false);
+      setCcsMessage(
+        ccsResult.reason instanceof Error ? ccsResult.reason.message : String(ccsResult.reason),
+      );
     }
+    if (cherryResult.status === "fulfilled") {
+      setCherryProviders(cherryResult.value);
+      setCherryMessage(cherryResult.value.message);
+    } else {
+      setCherryProviders(null);
+      setCherryMessage(
+        cherryResult.reason instanceof Error
+          ? cherryResult.reason.message
+          : String(cherryResult.reason),
+      );
+    }
+    setCcsLoading(false);
+    setCherryLoading(false);
   }
 
-  function ensureCcsScan() {
-    if (!ccsProviders && !ccsLoading) void refreshCcsProviders();
+  function ensureThirdPartyScan() {
+    if ((!ccsProviders || !cherryProviders) && !ccsLoading && !cherryLoading) {
+      void refreshThirdPartyProviders();
+    }
   }
 
   function buildCcsImportedProviders(
@@ -1416,6 +1584,114 @@ export function ProvidersSection(props: SettingsSectionProps) {
     }
   }
 
+  async function importCherryProviders(items: CherryProviderImportItem[]) {
+    const importable = items.filter((item) => item.importable);
+    if (!importable.length) {
+      const message = "所选 Cherry Studio 配置没有可导入的 API 配置";
+      setCherryMessage(message);
+      return;
+    }
+
+    setCherryImporting(true);
+    setCherryMessage("正在同步供应商、获取并激活全部模型…");
+
+    const allItems = cherryProviders?.providers ?? importable;
+
+    try {
+      setSettings((prev) => {
+        let changed = false;
+        const providers = [...prev.customProviders];
+
+        for (const item of importable) {
+          const id = cherryProviderId(item);
+          const existingIndex = providers.findIndex((provider) => provider.id === id);
+          const nextProvider = providerFromCherry(
+            item,
+            allItems,
+            existingIndex >= 0 ? providers[existingIndex] : undefined,
+          );
+
+          if (existingIndex >= 0) providers[existingIndex] = nextProvider;
+          else providers.push(nextProvider);
+          changed = true;
+        }
+
+        return changed ? updateCustomProviders(prev, providers) : prev;
+      });
+
+      const modelResults = await Promise.all(
+        importable.map(async (item) => {
+          const identity = cherryProviderId(item);
+          try {
+            const fetchedModels = await fetchModelsFromApi(
+              item.providerType,
+              item.baseUrl,
+              item.apiKey,
+            );
+            const models = fetchedModels.filter((model) => isLikelyCherryChatModel(model.id));
+            return { identity, models, fetched: true, failed: false };
+          } catch {
+            return {
+              identity,
+              models: [] as ProviderModelConfig[],
+              fetched: false,
+              failed: true,
+            };
+          }
+        }),
+      );
+
+      const resultsByIdentity = new Map(
+        modelResults.map((result) => [result.identity, result] as const),
+      );
+      setSettings((prev) => {
+        let changed = false;
+        const providers = prev.customProviders.map((provider) => {
+          const result = resultsByIdentity.get(provider.id);
+          if (!result?.fetched) return provider;
+
+          const models = mergeFetchedModels(result.models, provider.models);
+          const activeModels = models.map((model) => model.id);
+          if (
+            models.length === provider.models.length &&
+            models.every((model, index) => model.id === provider.models[index]?.id) &&
+            activeModels.length === provider.activeModels.length &&
+            activeModels.every((model, index) => model === provider.activeModels[index])
+          ) {
+            return provider;
+          }
+          changed = true;
+          return { ...provider, models, activeModels };
+        });
+        return changed ? updateCustomProviders(prev, providers) : prev;
+      });
+
+      const fetchedCount = modelResults.filter((result) => result.fetched).length;
+      const failedCount = modelResults.filter((result) => result.failed).length;
+      const refreshedModelCount = modelResults.reduce(
+        (total, result) => total + result.models.length,
+        0,
+      );
+      const importedByType = PROVIDER_TABS.map((type) => ({
+        type,
+        count: importable.filter((item) => item.providerType === type).length,
+      })).filter((entry) => entry.count > 0);
+      const details = [
+        `已同步 ${importedByType
+          .map((entry) => `${entry.count} 个 ${getProviderLabel(entry.type)}`)
+          .join("、")} 供应商`,
+        fetchedCount > 0 && refreshedModelCount > 0
+          ? `LiveAgent 获取并激活 ${refreshedModelCount} 个模型`
+          : "LiveAgent API 未返回可用模型",
+        failedCount > 0 ? `${failedCount} 个供应商模型获取失败` : "",
+      ].filter(Boolean);
+      setCherryMessage(details.join("，"));
+      setCherryImportType(null);
+    } finally {
+      setCherryImporting(false);
+    }
+  }
+
   function openAdd() {
     setEditingProvider(null);
     setModalOpen(true);
@@ -1516,9 +1792,14 @@ export function ProvidersSection(props: SettingsSectionProps) {
                 ccsLoading={ccsLoading}
                 ccsImporting={ccsImporting}
                 ccsMessage={ccsMessage}
-                onEnsureCcsScan={ensureCcsScan}
-                onRefreshCcsProviders={() => void refreshCcsProviders()}
+                cherryProviders={cherryProviders}
+                cherryLoading={cherryLoading}
+                cherryImporting={cherryImporting}
+                cherryMessage={cherryMessage}
+                onEnsureThirdPartyScan={ensureThirdPartyScan}
+                onRefreshThirdPartyProviders={() => void refreshThirdPartyProviders()}
                 onOpenCcsImport={() => setCcsImportType(tab)}
+                onOpenCherryImport={() => setCherryImportType(tab)}
               />
             </div>
           ))}
@@ -1541,6 +1822,18 @@ export function ProvidersSection(props: SettingsSectionProps) {
           importing={ccsImporting}
           onImport={importCcsProviders}
           onClose={() => setCcsImportType(null)}
+        />
+      ) : null}
+      {cherryImportType && cherryProviders ? (
+        <CherryStudioImportModal
+          providerType={cherryImportType}
+          response={cherryProviders}
+          importing={cherryImporting}
+          isExisting={(item) =>
+            settings.customProviders.some((provider) => provider.id === cherryProviderId(item))
+          }
+          onConfirm={(items) => void importCherryProviders(items)}
+          onClose={() => setCherryImportType(null)}
         />
       ) : null}
       {customSettingsOpen ? (

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -8,6 +8,7 @@ import {
   Download,
   Eye,
   EyeOff,
+  FolderOpen,
   GeminiIcon,
   Key,
   Loader2,
@@ -117,6 +118,19 @@ function ProviderBrandIcon({ type }: { type: ProviderId }) {
 }
 
 const REDACTED_API_KEY_DISPLAY = "API Key";
+const CHERRY_DATA_PATH_STORAGE_KEY = "liveagent.cherryStudioDataPath";
+
+function readCherryDataPath() {
+  try {
+    return localStorage.getItem(CHERRY_DATA_PATH_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function cherryDataPathLabel(path: string) {
+  return path.split(/[\\/]/).filter(Boolean).at(-1) || path;
+}
 
 function normalizeModelDomId(modelId: string) {
   return modelId.replace(/[^a-zA-Z0-9_-]+/g, "-");
@@ -1170,10 +1184,13 @@ function ProviderList(props: {
   cherryLoading: boolean;
   cherryImporting: boolean;
   cherryMessage: string | null;
+  cherryDataPath: string | null;
   onEnsureThirdPartyScan: () => void;
   onRefreshThirdPartyProviders: () => void;
   onOpenCcsImport: () => void;
   onOpenCherryImport: () => void;
+  onChooseCherryDataDirectory: () => void;
+  onResetCherryDataDirectory: () => void;
 }) {
   const { t } = useLocale();
   const {
@@ -1191,10 +1208,13 @@ function ProviderList(props: {
     cherryLoading,
     cherryImporting,
     cherryMessage,
+    cherryDataPath,
     onEnsureThirdPartyScan,
     onRefreshThirdPartyProviders,
     onOpenCcsImport,
     onOpenCherryImport,
+    onChooseCherryDataDirectory,
+    onResetCherryDataDirectory,
   } = props;
   const [syncMenuOpen, setSyncMenuOpen] = useState(false);
   const filtered = providers.filter((provider) => provider.type === type);
@@ -1353,6 +1373,33 @@ function ProviderList(props: {
                     <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
                   ) : null}
                 </DropdownMenuItem>
+                <DropdownMenuSeparator className="my-1 bg-border/40" />
+                <DropdownMenuItem
+                  className="model-selector-item cursor-pointer items-start gap-3 rounded-lg px-2.5 py-2.5"
+                  disabled={cherryLoading || cherryImporting}
+                  onSelect={onChooseCherryDataDirectory}
+                >
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                    <FolderOpen className="h-4 w-4" />
+                  </span>
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="text-sm font-medium">选择 Cherry Studio 数据目录…</span>
+                    <span className="line-clamp-2 text-xs text-muted-foreground">
+                      {cherryDataPath
+                        ? `当前：${cherryDataPathLabel(cherryDataPath)}`
+                        : "支持 Windows 便携版和自定义位置"}
+                    </span>
+                  </span>
+                </DropdownMenuItem>
+                {cherryDataPath ? (
+                  <DropdownMenuItem
+                    className="model-selector-item cursor-pointer rounded-lg px-2.5 py-2 text-xs text-muted-foreground"
+                    disabled={cherryLoading || cherryImporting}
+                    onSelect={onResetCherryDataDirectory}
+                  >
+                    恢复自动检测
+                  </DropdownMenuItem>
+                ) : null}
               </div>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -1439,13 +1486,18 @@ export function ProvidersSection(props: SettingsSectionProps) {
   const [cherryLoading, setCherryLoading] = useState(false);
   const [cherryImporting, setCherryImporting] = useState(false);
   const [cherryMessage, setCherryMessage] = useState<string | null>(null);
+  const [cherryDataPath, setCherryDataPath] = useState<string | null>(readCherryDataPath);
 
   async function refreshThirdPartyProviders() {
     setCcsLoading(true);
     setCherryLoading(true);
     const [ccsResult, cherryResult] = await Promise.allSettled([
       invoke<CcsProvidersResponse>("settings_list_ccswitch_providers"),
-      invoke<CherryProvidersResponse>("settings_list_cherry_studio_providers"),
+      cherryDataPath
+        ? invoke<CherryProvidersResponse>("settings_list_cherry_studio_providers_from_path", {
+            dataPath: cherryDataPath,
+          })
+        : invoke<CherryProvidersResponse>("settings_list_cherry_studio_providers"),
     ]);
     if (ccsResult.status === "fulfilled") {
       setCcsProviders(ccsResult.value);
@@ -1469,6 +1521,48 @@ export function ProvidersSection(props: SettingsSectionProps) {
     }
     setCcsLoading(false);
     setCherryLoading(false);
+  }
+
+  async function chooseCherryDataDirectory() {
+    const selected = await invoke<string | null>("system_pick_folder", {
+      initialWorkdir: cherryDataPath ?? cherryProviders?.dataPath ?? undefined,
+    });
+    if (!selected) return;
+
+    setCherryLoading(true);
+    setCherryMessage("正在扫描选择的 Cherry Studio 数据目录…");
+    try {
+      const response = await invoke<CherryProvidersResponse>(
+        "settings_list_cherry_studio_providers_from_path",
+        { dataPath: selected },
+      );
+      const resolvedPath = response.dataPath || selected;
+      localStorage.setItem(CHERRY_DATA_PATH_STORAGE_KEY, resolvedPath);
+      setCherryDataPath(resolvedPath);
+      setCherryProviders(response);
+      setCherryMessage(response.message);
+    } catch (error) {
+      setCherryMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setCherryLoading(false);
+    }
+  }
+
+  function resetCherryDataDirectory() {
+    localStorage.removeItem(CHERRY_DATA_PATH_STORAGE_KEY);
+    setCherryDataPath(null);
+    setCherryProviders(null);
+    setCherryMessage("已恢复自动检测，正在重新扫描…");
+    setCherryLoading(true);
+    void invoke<CherryProvidersResponse>("settings_list_cherry_studio_providers")
+      .then((response) => {
+        setCherryProviders(response);
+        setCherryMessage(response.message);
+      })
+      .catch((error) => {
+        setCherryMessage(error instanceof Error ? error.message : String(error));
+      })
+      .finally(() => setCherryLoading(false));
   }
 
   function ensureThirdPartyScan() {
@@ -1796,10 +1890,13 @@ export function ProvidersSection(props: SettingsSectionProps) {
                 cherryLoading={cherryLoading}
                 cherryImporting={cherryImporting}
                 cherryMessage={cherryMessage}
+                cherryDataPath={cherryDataPath}
                 onEnsureThirdPartyScan={ensureThirdPartyScan}
                 onRefreshThirdPartyProviders={() => void refreshThirdPartyProviders()}
                 onOpenCcsImport={() => setCcsImportType(tab)}
                 onOpenCherryImport={() => setCherryImportType(tab)}
+                onChooseCherryDataDirectory={() => void chooseCherryDataDirectory()}
+                onResetCherryDataDirectory={resetCherryDataDirectory}
               />
             </div>
           ))}

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -1,3 +1,4 @@
+import { Popover } from "@base-ui/react";
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -12,6 +13,7 @@ import {
   GeminiIcon,
   Key,
   Loader2,
+  MoreHorizontal,
   OpenaiChatgptIcon,
   Pencil,
   Plus,
@@ -126,10 +128,6 @@ function readCherryDataPath() {
   } catch {
     return null;
   }
-}
-
-function cherryDataPathLabel(path: string) {
-  return path.split(/[\\/]/).filter(Boolean).at(-1) || path;
 }
 
 function normalizeModelDomId(modelId: string) {
@@ -1260,6 +1258,7 @@ function ProviderList(props: {
         : cherryMessage || "点击扫描本地配置";
   const thirdPartyLoading = ccsLoading || cherryLoading;
   const thirdPartyImporting = ccsImporting || cherryImporting;
+  const cherryResolvedDataPath = cherryDataPath ?? cherryProviders?.dataPath ?? "";
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
@@ -1347,59 +1346,108 @@ function ProviderList(props: {
                     <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
                   ) : null}
                 </DropdownMenuItem>
-                <DropdownMenuItem
-                  className="model-selector-item cursor-pointer items-start gap-3 rounded-lg px-2.5 py-2.5"
-                  disabled={cherryLoading || cherryImporting || !cherryAll.length}
-                  onSelect={onOpenCherryImport}
-                >
-                  <CherrySourceLogo className="h-9 w-9 text-[11px]" />
-                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span className="flex items-center gap-1.5 text-sm font-medium">
-                      Cherry Studio
-                      {cherryReady > 0 ? (
-                        <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
-                          {cherryReady}
-                        </span>
-                      ) : null}
-                    </span>
-                    <span
-                      className="line-clamp-2 text-xs text-muted-foreground"
-                      title={cherrySubtitle}
-                    >
-                      {cherrySubtitle}
-                    </span>
-                  </span>
-                  {cherryLoading || cherryImporting ? (
-                    <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
-                  ) : null}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator className="my-1 bg-border/40" />
-                <DropdownMenuItem
-                  className="model-selector-item cursor-pointer items-start gap-3 rounded-lg px-2.5 py-2.5"
-                  disabled={cherryLoading || cherryImporting}
-                  onSelect={onChooseCherryDataDirectory}
-                >
-                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-                    <FolderOpen className="h-4 w-4" />
-                  </span>
-                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span className="text-sm font-medium">选择 Cherry Studio 数据目录…</span>
-                    <span className="line-clamp-2 text-xs text-muted-foreground">
-                      {cherryDataPath
-                        ? `当前：${cherryDataPathLabel(cherryDataPath)}`
-                        : "支持 Windows 便携版和自定义位置"}
-                    </span>
-                  </span>
-                </DropdownMenuItem>
-                {cherryDataPath ? (
+                <div className="flex items-stretch gap-1">
                   <DropdownMenuItem
-                    className="model-selector-item cursor-pointer rounded-lg px-2.5 py-2 text-xs text-muted-foreground"
-                    disabled={cherryLoading || cherryImporting}
-                    onSelect={onResetCherryDataDirectory}
+                    className="model-selector-item min-w-0 flex-1 cursor-pointer items-start gap-3 rounded-lg px-2.5 py-2.5"
+                    disabled={cherryLoading || cherryImporting || !cherryAll.length}
+                    onSelect={onOpenCherryImport}
                   >
-                    恢复自动检测
+                    <CherrySourceLogo className="h-9 w-9 text-[11px]" />
+                    <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span className="flex items-center gap-1.5 text-sm font-medium">
+                        Cherry Studio
+                        {cherryReady > 0 ? (
+                          <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+                            {cherryReady}
+                          </span>
+                        ) : null}
+                      </span>
+                      <span
+                        className="line-clamp-2 text-xs text-muted-foreground"
+                        title={cherrySubtitle}
+                      >
+                        {cherrySubtitle}
+                      </span>
+                    </span>
+                    {cherryLoading || cherryImporting ? (
+                      <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+                    ) : null}
                   </DropdownMenuItem>
-                ) : null}
+                  <Popover.Root>
+                    <Popover.Trigger
+                      render={
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-auto w-8 shrink-0 rounded-lg text-muted-foreground"
+                          disabled={cherryLoading || cherryImporting}
+                          aria-label="Cherry Studio 数据目录设置"
+                          title="Cherry Studio 数据目录设置"
+                        />
+                      }
+                    >
+                      <MoreHorizontal className="h-4 w-4" />
+                    </Popover.Trigger>
+                    <Popover.Portal>
+                      <Popover.Positioner
+                        side="bottom"
+                        align="end"
+                        sideOffset={6}
+                        collisionPadding={8}
+                        className="z-[10000]"
+                      >
+                        <Popover.Popup className="w-80 rounded-xl border border-border bg-popover p-3 text-popover-foreground shadow-xl outline-none">
+                          <div className="space-y-3">
+                            <div>
+                              <div className="text-sm font-medium">Cherry Studio 数据目录</div>
+                              <div className="mt-0.5 text-xs text-muted-foreground">
+                                {cherryDataPath
+                                  ? "正在使用手动指定的目录"
+                                  : "LiveAgent 会自动读取 Cherry Studio 的数据目录设置"}
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <Input
+                                readOnly
+                                value={cherryResolvedDataPath}
+                                placeholder={cherryLoading ? "正在检测…" : "未检测到数据目录"}
+                                className="h-9 min-w-0 flex-1 text-xs"
+                                title={cherryResolvedDataPath}
+                              />
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="icon"
+                                className="h-9 w-9 shrink-0"
+                                disabled={cherryLoading || cherryImporting}
+                                onClick={onChooseCherryDataDirectory}
+                                title="选择数据目录"
+                                aria-label="选择 Cherry Studio 数据目录"
+                              >
+                                <FolderOpen className="h-4 w-4" />
+                              </Button>
+                            </div>
+                            <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+                              <span>{cherryDataPath ? "手动指定" : "自动检测"}</span>
+                              {cherryDataPath ? (
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-7 px-2 text-xs"
+                                  onClick={onResetCherryDataDirectory}
+                                >
+                                  恢复自动检测
+                                </Button>
+                              ) : null}
+                            </div>
+                          </div>
+                        </Popover.Popup>
+                      </Popover.Positioner>
+                    </Popover.Portal>
+                  </Popover.Root>
+                </div>
               </div>
             </DropdownMenuContent>
           </DropdownMenu>


### PR DESCRIPTION
## Summary

- add Cherry Studio to the third-party provider sync menu
- discover Cherry Studio 1.x LevelDB and 2.x SQLite data, including custom data directories
- preview supported Anthropic, OpenAI-compatible, and Gemini configurations without exposing API key values
- import only provider protocol, Base URL, and API key; let LiveAgent fetch and activate models through its existing model discovery flow
- update repeated imports by deterministic Cherry Studio source IDs and filter non-chat model providers

Provider tabs are selected by API protocol rather than model family. For example, Claude models served through `/v1/chat/completions` remain OpenAI-compatible providers.

## Verification

- `pnpm -C crates/agent-gui exec tsc --noEmit`
- `pnpm -C crates/agent-gui exec biome check src/pages/settings/ProvidersSection.tsx src/pages/settings/CherryStudioImportModal.tsx`
- `cargo check --manifest-path crates/agent-gui/src-tauri/Cargo.toml`
- `cargo test --manifest-path crates/agent-gui/src-tauri/Cargo.toml cherry_ --lib`
- `pnpm -C crates/agent-gui test:frontend` (820 passed)
- macOS application bundle built and verified against Cherry Studio 1.9.9 data