### PR TITLE
feat(providers): ccswitch import improvements, TodoWrite tool & Windows adaptation

### DIFF
--- a/crates/agent-gui/src-tauri/src/commands/config/settings/ccs_import.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/ccs_import.rs
@@ -59,6 +59,21 @@ fn ccswitch_db_candidates() -> Vec<PathBuf> {
         candidates.push(override_dir.join(&filename));
     }
     candidates.push(ccswitch_legacy_config_dir().join(&filename));
+    // Windows 上 `HOME` 可能被 Git/MSYS 等注入且不等于真实用户目录，ccswitch
+    // v3.10.3 曾据此把数据库写到 `%HOME%\.cc-switch\`，上游至今保留该位置作读取
+    // 兜底（见其 config.rs get_app_config_dir），这里同样纳入候选。
+    #[cfg(windows)]
+    if let Ok(home_env) = std::env::var("HOME") {
+        let trimmed = home_env.trim();
+        if !trimmed.is_empty() {
+            let legacy = PathBuf::from(trimmed)
+                .join(format!(".{}-{}", "cc", "switch"))
+                .join(&filename);
+            if !candidates.contains(&legacy) {
+                candidates.push(legacy);
+            }
+        }
+    }
     candidates
 }
 
@@ -81,8 +96,14 @@ fn ccswitch_override_config_dir() -> Option<PathBuf> {
     Some(expand_home_prefix(override_dir))
 }
 
+/// 与上游 ccswitch 的 `resolve_path` 对齐：支持 `~`、`~/`、`~\` 三种写法
+/// （Windows 用户习惯用反斜杠书写迁移路径，ccswitch 自身能解析这些形式）。
 fn expand_home_prefix(path: &str) -> PathBuf {
-    if let Some(rest) = path.strip_prefix("~/") {
+    if path == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    } else if let Some(rest) = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\")) {
         if let Some(home) = dirs::home_dir() {
             return home.join(rest);
         }

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
@@ -1077,4 +1077,58 @@ mod tests {
         );
     }
 
+    #[test]
+    fn expand_home_prefix_supports_bare_tilde() {
+        let home = dirs::home_dir().expect("home dir available in tests");
+        assert_eq!(expand_home_prefix("~"), home);
+    }
+
+    #[test]
+    fn expand_home_prefix_supports_forward_slash() {
+        let home = dirs::home_dir().expect("home dir available in tests");
+        assert_eq!(
+            expand_home_prefix("~/OneDrive/ccswitch"),
+            home.join("OneDrive/ccswitch")
+        );
+    }
+
+    #[test]
+    fn expand_home_prefix_supports_windows_backslash() {
+        let home = dirs::home_dir().expect("home dir available in tests");
+        assert_eq!(
+            expand_home_prefix("~\\OneDrive\\ccswitch"),
+            home.join("OneDrive\\ccswitch")
+        );
+    }
+
+    #[test]
+    fn expand_home_prefix_passes_through_absolute_paths() {
+        assert_eq!(
+            expand_home_prefix("/data/ccswitch"),
+            PathBuf::from("/data/ccswitch")
+        );
+        assert_eq!(
+            expand_home_prefix("C:\\Users\\Alice\\ccswitch"),
+            PathBuf::from("C:\\Users\\Alice\\ccswitch")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn ccswitch_db_candidates_include_home_env_fallback_on_windows() {
+        // 候选列表必须覆盖 ccswitch v3.10.3 在 `%HOME%\.cc-switch\` 的遗留库位置。
+        let previous = std::env::var("HOME").ok();
+        std::env::set_var("HOME", "C:\\legacy-home");
+        let candidates = ccswitch_db_candidates();
+        match previous {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+
+        let expected = PathBuf::from("C:\\legacy-home")
+            .join(".cc-switch")
+            .join("cc-switch.db");
+        assert!(candidates.contains(&expected));
+    }
+
 }


### PR DESCRIPTION
## Summary

This PR batches 9 commits from `features`, centered on the ccswitch provider import flow plus a new built-in TodoWrite tool:

### ccswitch provider import (设置 → 供应商 → 从第三方同步)
- Improve import UX: all provider types in one modal, clearer selection semantics, dedup against existing providers (`aed41ae`, `b394b17`, `2d84eb4`, `e050d9b`)
- **Windows adaptation** (`28a68dc`): mirror upstream cc-switch path resolution — expand `~` / `~\` prefixes in `app_config_dir_override` (previously only `~/`), and add the v3.10.3 legacy `%HOME%\.cc-switch\` database location as a Windows-only candidate (Git/MSYS-injected `HOME`)

### Other changes
- feat(tools): add TodoWrite built-in tool for in-chat task tracking (`29adde3`)
- feat(providers): default model fetch to `/v1/models` with official-API fallback (`d40e746`)
- fix(settings): group system tools under intelligence (`94e5214`)
- fix(i18n): sync composer placeholder copy across locales (`66022c9`)

## Test plan
- `cargo test -p liveagent settings` — 29 passed, including 5 new unit tests covering `~`/`~/`/`~\` home-prefix expansion, absolute-path passthrough, and the Windows `HOME` fallback candidate
- TodoWrite tool covered by `crates/agent-gui/test/tools/todo-tools.test.mjs`
- Manual verification of the ccswitch import modal flow in the GUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)