### PR TITLE
fix(providers): preserve edited API keys and merge duplicate Cherry import results

### DIFF
--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -817,6 +817,12 @@ function cherryProviderName(item: CherryProviderImportItem, allItems: CherryProv
   return `${item.name.trim()}（Cherry Studio · ${sourceId}）`;
 }
 
+// Re-syncing an existing provider must not silently revert an API key the
+// user already configured in LiveAgent; like `name`, the existing key wins.
+function cherryEffectiveApiKey(item: CherryProviderImportItem, existing?: CustomProvider) {
+  return existing?.apiKey?.trim() ? existing.apiKey : item.apiKey;
+}
+
 function providerFromCherry(
   item: CherryProviderImportItem,
   allItems: CherryProviderImportItem[],
@@ -824,14 +830,15 @@ function providerFromCherry(
 ): CustomProvider {
   const providerType = item.providerType;
   const models = existing?.models ?? [];
+  const apiKey = cherryEffectiveApiKey(item, existing);
   return {
     ...(existing ?? {}),
     id: cherryProviderId(item),
     name: existing?.name ?? cherryProviderName(item, allItems),
     type: providerType,
     baseUrl: item.baseUrl,
-    apiKey: item.apiKey,
-    apiKeyConfigured: item.apiKey.trim().length > 0,
+    apiKey,
+    apiKeyConfigured: apiKey.trim().length > 0,
     models,
     activeModels: existing?.activeModels ?? [],
     requestFormat:
@@ -1738,6 +1745,9 @@ export function ProvidersSection(props: SettingsSectionProps) {
     setCherryMessage("正在同步供应商、获取并激活全部模型…");
 
     const allItems = cherryProviders?.providers ?? importable;
+    const existingById = new Map(
+      settings.customProviders.map((provider) => [provider.id, provider] as const),
+    );
 
     try {
       setSettings((prev) => {
@@ -1768,7 +1778,7 @@ export function ProvidersSection(props: SettingsSectionProps) {
             const fetchedModels = await fetchModelsFromApi(
               item.providerType,
               item.baseUrl,
-              item.apiKey,
+              cherryEffectiveApiKey(item, existingById.get(identity)),
             );
             const models = fetchedModels.filter((model) => isLikelyCherryChatModel(model.id));
             return { identity, models, fetched: true, failed: false };
@@ -1783,9 +1793,22 @@ export function ProvidersSection(props: SettingsSectionProps) {
         }),
       );
 
-      const resultsByIdentity = new Map(
-        modelResults.map((result) => [result.identity, result] as const),
-      );
+      // Two selected items can normalize to the same provider id; merge their
+      // results instead of letting the last one win.
+      const resultsByIdentity = new Map<string, (typeof modelResults)[number]>();
+      for (const result of modelResults) {
+        const merged = resultsByIdentity.get(result.identity);
+        if (!merged) {
+          resultsByIdentity.set(result.identity, result);
+          continue;
+        }
+        resultsByIdentity.set(result.identity, {
+          identity: result.identity,
+          models: mergeFetchedModels(result.models, merged.models),
+          fetched: merged.fetched || result.fetched,
+          failed: merged.failed || result.failed,
+        });
+      }
       setSettings((prev) => {
         let changed = false;
         const providers = prev.customProviders.map((provider) => {


### PR DESCRIPTION
## Summary

Follow-up to #89 (branched from its head, so this PR includes #89's commits; it collapses to the two fixes below once #89 merges).

- **Re-sync no longer reverts a user-edited API key.** `providerFromCherry` unconditionally overwrote `apiKey` with the Cherry Studio value, so re-importing a provider marked "将更新" silently discarded a key the user had changed in LiveAgent (while `name` was preserved — asymmetric). A new `cherryEffectiveApiKey` helper makes the existing non-empty key win, both when writing settings and when calling `fetchModelsFromApi` (the fetch previously used the stale Cherry key too, so model refresh could fail even though the provider had a working key).
- **Duplicate provider ids no longer drop model results.** `cherryProviderId` normalizes `sourceId`, so two selected items can collapse to the same id; `resultsByIdentity` was built with `new Map(...)`, letting the last result overwrite the first. Results for the same identity are now merged: model lists via `mergeFetchedModels` (union, deduped), `fetched`/`failed` flags OR-ed, so the summary message and activated models stay accurate.

## Verification

- `pnpm -C crates/agent-gui exec tsc --noEmit`
- `pnpm -C crates/agent-gui exec biome check src/pages/settings/ProvidersSection.tsx` (7 warnings, identical to pre-change baseline)
- `pnpm -C crates/agent-gui test:frontend` (820 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)