### PR TITLE
fix: Gemini relay tool payload gating + surface tool errors instead of {}

### DIFF
--- a/crates/agent-gateway/web/src/pages/chat/assistant-bubble/ToolCallItem.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/assistant-bubble/ToolCallItem.tsx
@@ -226,6 +226,16 @@ function ToolCallItem({
                 );
               }
 
+              // Errors must be readable at a glance — never behind the
+              // collapsed "view return" toggle.
+              if (result.isError) {
+                return (
+                  <ToolScrollablePre className="max-h-56 bg-red-500/[0.05] text-red-700/90 dark:bg-red-500/[0.08] dark:text-red-300/90">
+                    {previewText(resultText, 6000)}
+                  </ToolScrollablePre>
+                );
+              }
+
               return (
                 <details className="group/result">
                   <summary className="flex cursor-pointer select-none items-center gap-1 text-[calc(10.5px*var(--zone-font-scale,1))] text-muted-foreground/50 transition-colors duration-150 hover:text-foreground/60">

--- a/crates/agent-gateway/web/src/pages/chat/assistant-bubble/ToolResultDisplay.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/assistant-bubble/ToolResultDisplay.tsx
@@ -1065,7 +1065,13 @@ export function ToolResultDisplay({
     );
   }
 
-  if (result.details && typeof result.details === "object") {
+  // Error results (and blocked calls) carry an empty details object — showing
+  // a literal "{}" would bury the actual error text, which renders below.
+  if (
+    result.details &&
+    typeof result.details === "object" &&
+    Object.keys(result.details).length > 0
+  ) {
     return (
       <ToolSurface className="overflow-hidden px-0 py-0">
         <ToolScrollablePre className="max-h-32 rounded-none">

--- a/crates/agent-gui/src/lib/providers/llm.ts
+++ b/crates/agent-gui/src/lib/providers/llm.ts
@@ -2,6 +2,13 @@ export { providerSupportsNativeWebSearch } from "./nativeWebSearch";
 export { attachAnthropicAutomaticCaching } from "./runtime/anthropicCache";
 export { attachCodexResponsesStorage } from "./runtime/codexStorage";
 export { normalizeErrorMessage } from "./runtime/errors";
+export {
+  appendGeminiGoogleSearchToolToPayload,
+  attachGeminiThoughtSignatureGuard,
+  isGemini3PlusModelId,
+  isOfficialGeminiApiBaseUrl,
+  normalizeGeminiThoughtSignatures,
+} from "./runtime/geminiToolPayload";
 export { assistantMessageToText, createStreamingTextReconciler } from "./runtime/messageUtils";
 export {
   createModelFromConfig,

--- a/crates/agent-gui/src/lib/providers/runtime/geminiToolPayload.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/geminiToolPayload.ts
@@ -1,0 +1,253 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { isRecord } from "./common";
+import type { StreamOptionsEx } from "./types";
+
+// ---------------------------------------------------------------------------
+// Gemini request-shape policy (google-generative-ai payloads).
+//
+// API rules this module encodes (ai.google.dev/gemini-api/docs, 2026-03):
+// - Mixing built-in server-side tools (googleSearch / urlContext / ...) with
+//   functionDeclarations in one generateContent request is supported on
+//   Gemini 3+ models only, and the Gemini Developer API additionally requires
+//   `toolConfig.includeServerSideToolInvocations: true` — otherwise it fails
+//   with 400 "Please enable tool_config.include_server_side_tool_invocations
+//   to use Built-in tools with Function calling."
+// - Gemini 2.x rejects the mix outright (400 "Built-in tools and Function
+//   Calling cannot be combined"), so function tools must win and the built-in
+//   tool is dropped from the request.
+// - The flag only survives on the official endpoint. Third-party relays
+//   (one-api/new-api style) re-serialize requests through their own structs
+//   and silently drop the 2026-03 field before forwarding — verified live
+//   against real relay deployments (2026-07): the mixed request still 400s
+//   with the flag set. Vertex-style endpoints reject the field outright
+//   ("Unknown name"). So mixing is enabled ONLY when talking directly to
+//   generativelanguage.googleapis.com; everywhere else function tools win.
+// - With the flag enabled, functionCallingConfig.mode AUTO is not supported;
+//   the server default (VALIDATED) is the documented mode for mixed tool use.
+// - Gemini 3 validates thoughtSignature echo-back on functionCall parts of
+//   the current turn (400 "Function call is missing a thought_signature in
+//   functionCall parts"). Signatures can be lost through model switches,
+//   tool-call recovery, and compaction rebuilds; Google documents a sentinel
+//   value that skips validation for exactly this situation.
+// - Real signatures only verify against the serving context that minted
+//   them. Relays rotate upstream channels per request, so echoing a real
+//   signature through one intermittently fails with 400 "Corrupted thought
+//   signature." — while the skip sentinel passed every rotation (measured
+//   live, 2026-07). Hence: official endpoint echoes real signatures and only
+//   fills gaps; relays always get the sentinel and never a real signature.
+// ---------------------------------------------------------------------------
+
+/** Documented by Google to bypass Gemini 3 thought-signature validation. */
+export const GEMINI_SKIP_THOUGHT_SIGNATURE_SENTINEL = "skip_thought_signature_validator";
+
+export function isGemini3PlusModelId(modelId: string): boolean {
+  const normalized = modelId
+    .trim()
+    .toLowerCase()
+    .replace(/^models\//, "");
+  const match = normalized.match(/^gemini(?:-live)?-(\d+)/);
+  if (match) return Number.parseInt(match[1], 10) >= 3;
+  // Rolling aliases currently resolve to the Gemini 3 flash family.
+  return normalized === "gemini-flash-latest" || normalized === "gemini-flash-lite-latest";
+}
+
+const GEMINI_BUILTIN_TOOL_KEYS = [
+  "googleSearch",
+  "google_search",
+  "googleSearchRetrieval",
+  "google_search_retrieval",
+  "urlContext",
+  "url_context",
+  "codeExecution",
+  "code_execution",
+  "fileSearch",
+  "file_search",
+  "googleMaps",
+  "google_maps",
+  "computerUse",
+  "computer_use",
+] as const;
+
+export function hasGeminiBuiltinServerSideTool(tool: unknown): boolean {
+  if (!isRecord(tool)) return false;
+  return GEMINI_BUILTIN_TOOL_KEYS.some((key) => Boolean(tool[key]));
+}
+
+function toolHasFunctionDeclarations(tool: unknown): boolean {
+  if (!isRecord(tool)) return false;
+  const declarations = tool.functionDeclarations ?? tool.function_declarations;
+  return Array.isArray(declarations) && declarations.length > 0;
+}
+
+export function geminiToolsHaveFunctionDeclarations(tools: unknown): boolean {
+  return Array.isArray(tools) && tools.some(toolHasFunctionDeclarations);
+}
+
+/**
+ * True only for the Gemini Developer API endpoint itself. Relays and other
+ * gateways cannot be trusted to forward the mixed-tools contract intact.
+ */
+export function isOfficialGeminiApiBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl?.trim()) return false;
+  try {
+    return new URL(baseUrl).hostname === "generativelanguage.googleapis.com";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * ToolConfig adjustment for a mixed built-in + function-declarations request.
+ * Returns `null` when function calling is explicitly disabled (mode NONE) —
+ * mixing is pointless there and the caller should skip the built-in tool.
+ */
+function normalizeGeminiMixedToolConfig(existing: unknown): Record<string, unknown> | null {
+  const base = isRecord(existing) ? existing : {};
+  const functionCallingConfig = isRecord(base.functionCallingConfig)
+    ? base.functionCallingConfig
+    : undefined;
+  const mode =
+    typeof functionCallingConfig?.mode === "string"
+      ? functionCallingConfig.mode.toUpperCase()
+      : undefined;
+  if (mode === "NONE") return null;
+
+  let nextFunctionCallingConfig = functionCallingConfig;
+  if (functionCallingConfig && (mode === "AUTO" || mode === "MODE_UNSPECIFIED")) {
+    const { mode: _dropped, ...rest } = functionCallingConfig;
+    nextFunctionCallingConfig = Object.keys(rest).length > 0 ? rest : undefined;
+  }
+
+  const next: Record<string, unknown> = { ...base };
+  delete next.functionCallingConfig;
+  if (nextFunctionCallingConfig) {
+    next.functionCallingConfig = nextFunctionCallingConfig;
+  }
+  next.includeServerSideToolInvocations = true;
+  return next;
+}
+
+/**
+ * Append `{ googleSearch: {} }` to a google-generative-ai payload, honoring
+ * the per-model-family mixing rules above. No-op when any built-in tool is
+ * already present, or when the model cannot mix it with function tools.
+ */
+export function appendGeminiGoogleSearchToolToPayload(
+  payload: Record<string, unknown>,
+  params: { modelId: string; baseUrl?: string },
+): Record<string, unknown> {
+  const config = isRecord(payload.config) ? payload.config : {};
+  const tools = Array.isArray(config.tools) ? config.tools : [];
+  if (tools.some(hasGeminiBuiltinServerSideTool)) return payload;
+
+  if (!geminiToolsHaveFunctionDeclarations(tools)) {
+    return {
+      ...payload,
+      config: {
+        ...config,
+        tools: [...tools, { googleSearch: {} }],
+      },
+    };
+  }
+
+  if (!isGemini3PlusModelId(params.modelId) || !isOfficialGeminiApiBaseUrl(params.baseUrl)) {
+    return payload;
+  }
+
+  const toolConfig = normalizeGeminiMixedToolConfig(config.toolConfig);
+  if (toolConfig === null) return payload;
+
+  return {
+    ...payload,
+    config: {
+      ...config,
+      tools: [...tools, { googleSearch: {} }],
+      toolConfig,
+    },
+  };
+}
+
+/**
+ * Thought-signature policy for Gemini 3+ request history.
+ *
+ * Official endpoint: real signatures are same-infrastructure and must be
+ * echoed byte-identical, so only *missing* functionCall signatures are filled
+ * with the documented skip sentinel.
+ *
+ * Non-official endpoints (relays): signatures are minted per upstream serving
+ * context, and relays rotate upstream channels per request — replaying a real
+ * signature intermittently fails with 400 "Corrupted thought signature."
+ * (verified live, 2026-07), while the skip sentinel passed every rotation.
+ * So through relays every functionCall carries the sentinel (validation
+ * demands one) and all other parts have their signature stripped.
+ */
+export function normalizeGeminiThoughtSignatures(
+  payload: Record<string, unknown>,
+  params: { modelId: string; baseUrl?: string },
+): Record<string, unknown> {
+  if (!isGemini3PlusModelId(params.modelId)) return payload;
+  if (!Array.isArray(payload.contents)) return payload;
+  const trustRealSignatures = isOfficialGeminiApiBaseUrl(params.baseUrl);
+
+  let changed = false;
+  const nextContents = payload.contents.map((item) => {
+    if (!isRecord(item) || item.role !== "model" || !Array.isArray(item.parts)) return item;
+    let turnChanged = false;
+    const nextParts = item.parts.map((part) => {
+      if (!isRecord(part)) return part;
+      const signature = part.thoughtSignature;
+      const hasSignature = typeof signature === "string" && signature.length > 0;
+
+      if (isRecord(part.functionCall)) {
+        if (
+          hasSignature &&
+          (trustRealSignatures || signature === GEMINI_SKIP_THOUGHT_SIGNATURE_SENTINEL)
+        ) {
+          return part;
+        }
+        turnChanged = true;
+        return { ...part, thoughtSignature: GEMINI_SKIP_THOUGHT_SIGNATURE_SENTINEL };
+      }
+
+      if (!trustRealSignatures && hasSignature) {
+        turnChanged = true;
+        const { thoughtSignature: _stripped, ...rest } = part;
+        return rest;
+      }
+      return part;
+    });
+    if (!turnChanged) return item;
+    changed = true;
+    return { ...item, parts: nextParts };
+  });
+
+  return changed ? { ...payload, contents: nextContents } : payload;
+}
+
+export function attachGeminiThoughtSignatureGuard(
+  options: StreamOptionsEx,
+  params: { providerId: string; baseUrl?: string },
+): StreamOptionsEx {
+  if (params.providerId !== "gemini") return options;
+
+  const previousOnPayload = options.onPayload;
+  return {
+    ...options,
+    onPayload: async (payload, model: Model<any>) => {
+      let nextPayload = payload;
+      if (previousOnPayload) {
+        const overridden = await previousOnPayload(nextPayload, model);
+        if (overridden !== undefined) {
+          nextPayload = overridden;
+        }
+      }
+      if (!isRecord(nextPayload) || model.api !== "google-generative-ai") {
+        return nextPayload;
+      }
+      return normalizeGeminiThoughtSignatures(nextPayload, {
+        modelId: model.id,
+        baseUrl: params.baseUrl,
+      });
+    },
+  };
+}

--- a/crates/agent-gui/src/lib/providers/runtime/nativeSearchPayload.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/nativeSearchPayload.ts
@@ -2,12 +2,12 @@ import type { Model } from "@earendil-works/pi-ai";
 import type { ProviderId } from "../../settings";
 import {
   hasAnthropicWebSearchTool,
-  hasGeminiGoogleSearchTool,
   hasOpenAIResponsesWebSearchTool,
   providerSupportsNativeWebSearch,
   resolveAnthropicWebSearchToolType,
 } from "../nativeWebSearch";
 import { isRecord } from "./common";
+import { appendGeminiGoogleSearchToolToPayload } from "./geminiToolPayload";
 import type { StreamOptionsEx } from "./types";
 
 function isOfficialOpenAIBaseUrl(baseUrl: string | undefined) {
@@ -34,20 +34,6 @@ function appendUniqueTool(
   return {
     ...payload,
     tools: [...tools, tool],
-  };
-}
-
-function appendGeminiGoogleSearchTool(payload: Record<string, unknown>) {
-  const config = isRecord(payload.config) ? payload.config : {};
-  const tools = Array.isArray(config.tools) ? config.tools : [];
-  if (tools.some(hasGeminiGoogleSearchTool)) return payload;
-
-  return {
-    ...payload,
-    config: {
-      ...config,
-      tools: [...tools, { googleSearch: {} }],
-    },
   };
 }
 
@@ -203,7 +189,10 @@ export function attachProviderNativeWebSearch(
       }
 
       if (providerId === "gemini") {
-        return appendGeminiGoogleSearchTool(nextPayload);
+        return appendGeminiGoogleSearchToolToPayload(nextPayload, {
+          modelId: model.id,
+          baseUrl: params?.baseUrl,
+        });
       }
 
       return nextPayload;

--- a/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
@@ -10,6 +10,7 @@ import {
 } from "../nativeResponsesAttachments";
 import { attachAnthropicAutomaticCaching } from "./anthropicCache";
 import { attachCodexResponsesStorage } from "./codexStorage";
+import { attachGeminiThoughtSignatureGuard } from "./geminiToolPayload";
 import { attachProviderNativeWebSearch } from "./nativeSearchPayload";
 import type { StreamOptionsEx } from "./types";
 
@@ -117,6 +118,11 @@ const finalizePayloadMiddlewares = composePayloadMiddlewares([
       providerId: params.providerId,
       baseUrl: params.baseUrl,
       model: params.model,
+    }),
+  (options, params) =>
+    attachGeminiThoughtSignatureGuard(options, {
+      providerId: params.providerId,
+      baseUrl: params.baseUrl,
     }),
   (options, params) => attachPayloadDebugLogging(options, params.debugLogger, params.extra),
 ]);

--- a/crates/agent-gui/src/pages/chat/components/assistant-bubble/ToolCallItem.tsx
+++ b/crates/agent-gui/src/pages/chat/components/assistant-bubble/ToolCallItem.tsx
@@ -500,6 +500,16 @@ function ToolCallItem({
                     );
                   }
 
+                  // Errors must be readable at a glance — never behind the
+                  // collapsed "view return" toggle.
+                  if (result.isError) {
+                    return (
+                      <ToolScrollablePre className="max-h-56 bg-red-500/[0.05] text-red-700/90 dark:bg-red-500/[0.08] dark:text-red-300/90">
+                        {previewText(resultText, 6000)}
+                      </ToolScrollablePre>
+                    );
+                  }
+
                   return (
                     <details className="group/result">
                       <summary className="flex cursor-pointer select-none items-center gap-1 text-[calc(10.5px*var(--zone-font-scale,1))] text-muted-foreground/50 transition-colors duration-150 hover:text-foreground/60">

--- a/crates/agent-gui/src/pages/chat/components/assistant-bubble/ToolResultDisplay.tsx
+++ b/crates/agent-gui/src/pages/chat/components/assistant-bubble/ToolResultDisplay.tsx
@@ -879,7 +879,13 @@ export function ToolResultDisplay({
     );
   }
 
-  if (result.details && typeof result.details === "object") {
+  // Error results (and blocked calls) carry an empty details object — showing
+  // a literal "{}" would bury the actual error text, which renders below.
+  if (
+    result.details &&
+    typeof result.details === "object" &&
+    Object.keys(result.details).length > 0
+  ) {
     return (
       <ToolSurface className="overflow-hidden px-0 py-0">
         <ToolScrollablePre className="max-h-32 rounded-none">

--- a/crates/agent-gui/test/providers/gemini-tool-payload.test.mjs
+++ b/crates/agent-gui/test/providers/gemini-tool-payload.test.mjs
@@ -1,0 +1,396 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const {
+  GEMINI_SKIP_THOUGHT_SIGNATURE_SENTINEL,
+  appendGeminiGoogleSearchToolToPayload,
+  attachGeminiThoughtSignatureGuard,
+  geminiToolsHaveFunctionDeclarations,
+  hasGeminiBuiltinServerSideTool,
+  isGemini3PlusModelId,
+  isOfficialGeminiApiBaseUrl,
+  normalizeGeminiThoughtSignatures,
+} = loader.loadModule("src/lib/providers/runtime/geminiToolPayload.ts");
+
+const OFFICIAL_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+const RELAY_BASE_URL = "https://gemini-relay.example.com";
+const { attachProviderNativeWebSearch } = loader.loadModule(
+  "src/lib/providers/runtime/nativeSearchPayload.ts",
+);
+
+const FUNCTION_TOOLS = [
+  {
+    functionDeclarations: [
+      { name: "Bash", description: "run a command", parametersJsonSchema: { type: "object" } },
+    ],
+  },
+];
+
+function createGeminiModel(id, overrides = {}) {
+  return {
+    id,
+    name: id,
+    api: "google-generative-ai",
+    provider: "google",
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_000_000,
+    maxTokens: 64_000,
+    ...overrides,
+  };
+}
+
+function buildAgentPayload(overrides = {}) {
+  return {
+    model: "gemini-3-pro-preview",
+    contents: [{ role: "user", parts: [{ text: "hi" }] }],
+    config: {
+      tools: FUNCTION_TOOLS,
+      toolConfig: { functionCallingConfig: { mode: "AUTO" } },
+      ...overrides,
+    },
+  };
+}
+
+test("isGemini3PlusModelId matches Gemini 3+ ids and rolling flash aliases only", () => {
+  assert.equal(isGemini3PlusModelId("gemini-3-pro-preview"), true);
+  assert.equal(isGemini3PlusModelId("gemini-3-flash-preview"), true);
+  assert.equal(isGemini3PlusModelId("gemini-3.1-flash-lite"), true);
+  assert.equal(isGemini3PlusModelId("gemini-3.1-pro-preview-customtools"), true);
+  assert.equal(isGemini3PlusModelId("gemini-3.5-flash"), true);
+  assert.equal(isGemini3PlusModelId("models/gemini-3-pro-preview"), true);
+  assert.equal(isGemini3PlusModelId("Gemini-3-Pro-Preview"), true);
+  assert.equal(isGemini3PlusModelId("gemini-flash-latest"), true);
+  assert.equal(isGemini3PlusModelId("gemini-flash-lite-latest"), true);
+
+  assert.equal(isGemini3PlusModelId("gemini-2.5-pro"), false);
+  assert.equal(isGemini3PlusModelId("gemini-2.5-flash"), false);
+  assert.equal(isGemini3PlusModelId("gemini-2.0-flash"), false);
+  assert.equal(isGemini3PlusModelId("gemini-exp-1206"), false);
+  assert.equal(isGemini3PlusModelId("gemma-4-27b"), false);
+  assert.equal(isGemini3PlusModelId(""), false);
+});
+
+test("hasGeminiBuiltinServerSideTool covers camelCase and snake_case built-in tools", () => {
+  assert.equal(hasGeminiBuiltinServerSideTool({ googleSearch: {} }), true);
+  assert.equal(hasGeminiBuiltinServerSideTool({ google_search: {} }), true);
+  assert.equal(hasGeminiBuiltinServerSideTool({ googleSearchRetrieval: {} }), true);
+  assert.equal(hasGeminiBuiltinServerSideTool({ urlContext: {} }), true);
+  assert.equal(hasGeminiBuiltinServerSideTool({ codeExecution: {} }), true);
+  assert.equal(hasGeminiBuiltinServerSideTool({ fileSearch: {} }), true);
+  assert.equal(hasGeminiBuiltinServerSideTool(FUNCTION_TOOLS[0]), false);
+  assert.equal(hasGeminiBuiltinServerSideTool(null), false);
+});
+
+test("geminiToolsHaveFunctionDeclarations detects camelCase and snake_case declarations", () => {
+  assert.equal(geminiToolsHaveFunctionDeclarations(FUNCTION_TOOLS), true);
+  assert.equal(geminiToolsHaveFunctionDeclarations([{ function_declarations: [{ name: "x" }] }]), true);
+  assert.equal(geminiToolsHaveFunctionDeclarations([{ functionDeclarations: [] }]), false);
+  assert.equal(geminiToolsHaveFunctionDeclarations([{ googleSearch: {} }]), false);
+  assert.equal(geminiToolsHaveFunctionDeclarations(undefined), false);
+});
+
+test("text-only payloads (no function tools) get googleSearch appended untouched", () => {
+  const payload = {
+    model: "gemini-2.5-flash",
+    contents: [],
+    config: { temperature: 1 },
+  };
+  const next = appendGeminiGoogleSearchToolToPayload(payload, { modelId: "gemini-2.5-flash" });
+  assert.deepEqual(next.config.tools, [{ googleSearch: {} }]);
+  assert.equal(next.config.toolConfig, undefined);
+  assert.equal(next.config.temperature, 1);
+});
+
+test("payloads that already carry a google search tool are returned as-is", () => {
+  const payload = {
+    model: "gemini-3-pro-preview",
+    contents: [],
+    config: { tools: [{ googleSearch: {} }] },
+  };
+  const next = appendGeminiGoogleSearchToolToPayload(payload, {
+    modelId: "gemini-3-pro-preview",
+  });
+  assert.equal(next, payload);
+});
+
+test("Gemini 3 + function tools: googleSearch appended with includeServerSideToolInvocations and AUTO mode dropped", () => {
+  const payload = buildAgentPayload();
+  const next = appendGeminiGoogleSearchToolToPayload(payload, {
+    modelId: "gemini-3-pro-preview",
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+  });
+  assert.deepEqual(next.config.tools, [...FUNCTION_TOOLS, { googleSearch: {} }]);
+  assert.equal(next.config.toolConfig.includeServerSideToolInvocations, true);
+  // AUTO is rejected alongside the flag; the server default (VALIDATED) applies.
+  assert.equal(next.config.toolConfig.functionCallingConfig, undefined);
+});
+
+test("Gemini 3 + function tools: ANY mode with allowedFunctionNames is preserved", () => {
+  const payload = buildAgentPayload({
+    toolConfig: { functionCallingConfig: { mode: "ANY", allowedFunctionNames: ["Bash"] } },
+  });
+  const next = appendGeminiGoogleSearchToolToPayload(payload, {
+    modelId: "gemini-3-flash-preview",
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+  });
+  assert.equal(next.config.toolConfig.includeServerSideToolInvocations, true);
+  assert.deepEqual(next.config.toolConfig.functionCallingConfig, {
+    mode: "ANY",
+    allowedFunctionNames: ["Bash"],
+  });
+});
+
+test("Gemini 3 + function tools with mode NONE keeps the payload unchanged", () => {
+  const payload = buildAgentPayload({
+    toolConfig: { functionCallingConfig: { mode: "NONE" } },
+  });
+  const next = appendGeminiGoogleSearchToolToPayload(payload, {
+    modelId: "gemini-3-pro-preview",
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+  });
+  assert.equal(next, payload);
+});
+
+test("Gemini 2.x + function tools never mixes in googleSearch (mixing is rejected upstream)", () => {
+  for (const modelId of ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"]) {
+    const payload = buildAgentPayload();
+    const next = appendGeminiGoogleSearchToolToPayload(payload, {
+      modelId,
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+    });
+    assert.equal(next, payload, modelId);
+  }
+});
+
+test("isOfficialGeminiApiBaseUrl accepts only the Gemini Developer API host", () => {
+  assert.equal(
+    isOfficialGeminiApiBaseUrl("https://generativelanguage.googleapis.com/v1beta"),
+    true,
+  );
+  assert.equal(isOfficialGeminiApiBaseUrl("https://generativelanguage.googleapis.com"), true);
+  assert.equal(isOfficialGeminiApiBaseUrl("https://gemini-relay.example.com"), false);
+  assert.equal(isOfficialGeminiApiBaseUrl("https://api.example.com/gemini"), false);
+  assert.equal(isOfficialGeminiApiBaseUrl("https://us-central1-aiplatform.googleapis.com"), false);
+  assert.equal(isOfficialGeminiApiBaseUrl(""), false);
+  assert.equal(isOfficialGeminiApiBaseUrl(undefined), false);
+});
+
+test("non-official endpoints (relays/Vertex) never mix googleSearch into function tools", () => {
+  // Relays re-serialize requests and drop includeServerSideToolInvocations
+  // before forwarding, so the mixed request would 400 upstream regardless.
+  for (const baseUrl of [
+    "https://gemini-relay.example.com",
+    "https://api.example.com/gemini",
+    "https://us-central1-aiplatform.googleapis.com/v1",
+    undefined,
+  ]) {
+    const payload = buildAgentPayload();
+    const next = appendGeminiGoogleSearchToolToPayload(payload, {
+      modelId: "gemini-3-pro-preview",
+      baseUrl,
+    });
+    assert.equal(next, payload, String(baseUrl));
+  }
+});
+
+test("non-official endpoints still get googleSearch in text-only payloads", () => {
+  const payload = { model: "gemini-3-pro-preview", contents: [], config: {} };
+  const next = appendGeminiGoogleSearchToolToPayload(payload, {
+    modelId: "gemini-3-pro-preview",
+    baseUrl: RELAY_BASE_URL,
+  });
+  assert.deepEqual(next.config.tools, [{ googleSearch: {} }]);
+});
+
+function buildSignaturePayload() {
+  return {
+    model: "gemini-3-pro-preview",
+    contents: [
+      { role: "user", parts: [{ text: "question" }] },
+      {
+        role: "model",
+        parts: [
+          { text: "answer text", thoughtSignature: "dGV4dHNpZw==" },
+          { functionCall: { name: "Bash", args: {} }, thoughtSignature: "aGVsbG8=" },
+          { functionCall: { name: "Read", args: {} } },
+        ],
+      },
+      { role: "user", parts: [{ functionResponse: { name: "Bash", response: { output: "ok" } } }] },
+    ],
+    config: {},
+  };
+}
+
+test("official endpoint: real signatures echoed, only missing functionCall signatures filled", () => {
+  const payload = buildSignaturePayload();
+  const next = normalizeGeminiThoughtSignatures(payload, {
+    modelId: "gemini-3-pro-preview",
+    baseUrl: OFFICIAL_BASE_URL,
+  });
+  const modelParts = next.contents[1].parts;
+  assert.equal(modelParts[0].thoughtSignature, "dGV4dHNpZw==");
+  assert.equal(modelParts[1].thoughtSignature, "aGVsbG8=");
+  assert.equal(modelParts[2].thoughtSignature, GEMINI_SKIP_THOUGHT_SIGNATURE_SENTINEL);
+  assert.equal(next.contents[0], payload.contents[0]);
+  assert.equal(next.contents[2], payload.contents[2]);
+});
+
+test("relay endpoints: functionCall signatures replaced with the sentinel, other signatures stripped", () => {
+  // Real signatures replayed through rotating relay channels intermittently
+  // fail upstream with "Corrupted thought signature."; the sentinel does not.
+  const payload = buildSignaturePayload();
+  const next = normalizeGeminiThoughtSignatures(payload, {
+    modelId: "gemini-3-pro-preview",
+    baseUrl: RELAY_BASE_URL,
+  });
+  const modelParts = next.contents[1].parts;
+  assert.equal(modelParts[0].thoughtSignature, undefined);
+  assert.equal(modelParts[0].text, "answer text");
+  assert.equal(modelParts[1].thoughtSignature, GEMINI_SKIP_THOUGHT_SIGNATURE_SENTINEL);
+  assert.equal(modelParts[2].thoughtSignature, GEMINI_SKIP_THOUGHT_SIGNATURE_SENTINEL);
+});
+
+test("normalizeGeminiThoughtSignatures is a no-op for pre-Gemini-3 models and covered payloads", () => {
+  const covered = {
+    contents: [
+      {
+        role: "model",
+        parts: [{ functionCall: { name: "Bash", args: {} }, thoughtSignature: "aGVsbG8=" }],
+      },
+    ],
+  };
+  assert.equal(
+    normalizeGeminiThoughtSignatures(covered, {
+      modelId: "gemini-3-pro-preview",
+      baseUrl: OFFICIAL_BASE_URL,
+    }),
+    covered,
+  );
+
+  const relayCoveredBySentinel = {
+    contents: [
+      {
+        role: "model",
+        parts: [
+          {
+            functionCall: { name: "Bash", args: {} },
+            thoughtSignature: GEMINI_SKIP_THOUGHT_SIGNATURE_SENTINEL,
+          },
+        ],
+      },
+    ],
+  };
+  assert.equal(
+    normalizeGeminiThoughtSignatures(relayCoveredBySentinel, {
+      modelId: "gemini-3-pro-preview",
+      baseUrl: RELAY_BASE_URL,
+    }),
+    relayCoveredBySentinel,
+  );
+
+  const uncovered = {
+    contents: [{ role: "model", parts: [{ functionCall: { name: "Bash", args: {} } }] }],
+  };
+  assert.equal(
+    normalizeGeminiThoughtSignatures(uncovered, {
+      modelId: "gemini-2.5-pro",
+      baseUrl: RELAY_BASE_URL,
+    }),
+    uncovered,
+  );
+});
+
+test("attachGeminiThoughtSignatureGuard chains prior onPayload and gates by provider/api", async () => {
+  const model = createGeminiModel("gemini-3-pro-preview");
+  const basePayload = {
+    contents: [
+      {
+        role: "model",
+        parts: [
+          { functionCall: { name: "Bash", args: {} } },
+          { functionCall: { name: "Read", args: {} }, thoughtSignature: "cmVhbHNpZw==" },
+        ],
+      },
+    ],
+    config: {},
+  };
+
+  const guarded = attachGeminiThoughtSignatureGuard(
+    {
+      onPayload: async (payload) => ({ ...payload, marked: true }),
+    },
+    { providerId: "gemini", baseUrl: RELAY_BASE_URL },
+  );
+  const result = await guarded.onPayload(basePayload, model);
+  assert.equal(result.marked, true);
+  assert.equal(
+    result.contents[0].parts[0].thoughtSignature,
+    GEMINI_SKIP_THOUGHT_SIGNATURE_SENTINEL,
+  );
+  assert.equal(
+    result.contents[0].parts[1].thoughtSignature,
+    GEMINI_SKIP_THOUGHT_SIGNATURE_SENTINEL,
+    "relay requests must not echo real signatures",
+  );
+
+  const official = attachGeminiThoughtSignatureGuard(
+    {},
+    { providerId: "gemini", baseUrl: OFFICIAL_BASE_URL },
+  );
+  const officialResult = await official.onPayload(basePayload, model);
+  assert.equal(officialResult.contents[0].parts[1].thoughtSignature, "cmVhbHNpZw==");
+
+  const otherProvider = attachGeminiThoughtSignatureGuard({}, { providerId: "codex" });
+  assert.equal(otherProvider.onPayload, undefined);
+
+  const nonGoogleModel = createGeminiModel("claude-x", { api: "anthropic-messages" });
+  const guardedNonGoogle = attachGeminiThoughtSignatureGuard(
+    {},
+    { providerId: "gemini", baseUrl: RELAY_BASE_URL },
+  );
+  const untouched = await guardedNonGoogle.onPayload(basePayload, nonGoogleModel);
+  assert.equal(untouched, basePayload);
+});
+
+test("attachProviderNativeWebSearch(gemini) routes agent payloads through the mixing rules", async () => {
+  const options = attachProviderNativeWebSearch("gemini", {}, true, {
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+  });
+
+  const gemini3 = createGeminiModel("gemini-3-pro-preview");
+  const mixed = await options.onPayload(buildAgentPayload(), gemini3);
+  assert.deepEqual(mixed.config.tools, [...FUNCTION_TOOLS, { googleSearch: {} }]);
+  assert.equal(mixed.config.toolConfig.includeServerSideToolInvocations, true);
+  assert.equal(mixed.config.toolConfig.functionCallingConfig, undefined);
+
+  const gemini25 = createGeminiModel("gemini-2.5-flash");
+  const untouched = await options.onPayload(buildAgentPayload(), gemini25);
+  assert.deepEqual(
+    untouched.config.tools,
+    FUNCTION_TOOLS,
+    "Gemini 2.x agent requests must not mix googleSearch into function tools",
+  );
+
+  const textPayload = { model: "gemini-2.5-flash", contents: [], config: {} };
+  const textMode = await options.onPayload(textPayload, gemini25);
+  assert.deepEqual(textMode.config.tools, [{ googleSearch: {} }]);
+
+  const relayOptions = attachProviderNativeWebSearch("gemini", {}, true, {
+    baseUrl: RELAY_BASE_URL,
+  });
+  const relayAgent = await relayOptions.onPayload(buildAgentPayload(), gemini3);
+  assert.deepEqual(
+    relayAgent.config.tools,
+    FUNCTION_TOOLS,
+    "relay endpoints must not mix googleSearch into function tools",
+  );
+
+  const disabled = attachProviderNativeWebSearch("gemini", {}, false, {});
+  assert.equal(disabled.onPayload, undefined);
+});

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -727,12 +727,23 @@ test("provider native web search injection is opt-in", async () => {
   });
   assert.equal(anthropicOptions.onPayload, undefined);
 
+  // Gemini always carries the thought-signature guard, so the hook exists;
+  // opting out of native web search must leave the payload untouched.
   const geminiOptions = providers.finalizeProviderStreamOptions({
     providerId: "gemini",
     baseUrl: "https://generativelanguage.googleapis.com/v1beta",
     options: {},
   });
-  assert.equal(geminiOptions.onPayload, undefined);
+  const geminiPayload = {
+    contents: [{ role: "user", parts: [{ text: "hello" }] }],
+    config: { tools: [{ functionDeclarations: [{ name: "Bash" }] }] },
+  };
+  const geminiResult = await geminiOptions.onPayload(geminiPayload, {
+    api: "google-generative-ai",
+    provider: "google",
+    id: "gemini-3-pro-preview",
+  });
+  assert.equal(geminiResult, geminiPayload);
 });
 
 test("provider payload finalization enables native web search for hosted search providers", async () => {


### PR DESCRIPTION
## Summary

Two fixes riding the same branch:

### 1. Gate Gemini tool mixing and thought signatures by endpoint (555a0f8)

Gemini agent requests failed with 400s in three ways: mixing the injected `googleSearch` built-in with `functionDeclarations` without the new `toolConfig.includeServerSideToolInvocations` flag (Gemini 3), mixing at all on Gemini 2.x, and echoing thought signatures that relay endpoints cannot verify.

- Centralize the request-shape policy in `runtime/geminiToolPayload.ts`
- Mix `googleSearch` with function tools only for Gemini 3+ directly on `generativelanguage.googleapis.com`, setting the flag and dropping the unsupported AUTO mode (server defaults to VALIDATED); relays strip the 2026-03 flag before forwarding (verified live), and Gemini 2.x rejects the mix outright, so function tools win everywhere else
- Split the Gemini 3 thought-signature policy by endpoint: the official API echoes real signatures and only fills missing ones with the documented skip sentinel, while relays always get the sentinel and never a real signature — relay channel rotation intermittently fails real-signature replay with 400 "Corrupted thought signature"

### 2. Surface tool error text instead of a literal `{}` in result cards (f971d5e)

Refused/failed tool calls (truncation-guard blocks, schema validation, token-limit truncation) carry an empty `details` object from pi-agent-core. The generic details fallback stringified it into a prominent `{}` while the actual error text stayed hidden behind the collapsed view-return toggle — e.g. a truncated TodoWrite call showed "失败 + {}" with no visible reason.

- Skip empty `details` objects in the `ToolResultDisplay` fallback
- Render error result text inline (red-tinted) instead of behind the collapsed toggle
- Mirrored across the desktop GUI and gateway WebUI

## Test plan

- [x] `tsc --noEmit` passes in both `crates/agent-gui` and `crates/agent-gateway/web`
- [x] Biome on changed files: only pre-existing `noArrayIndexKey` warnings on untouched lines
- [x] Live check: Gemini via official endpoint and via relay no longer 400s on tool calls
- [x] Live check: a refused tool call shows its error text directly in the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)