### PR TITLE
fix(debug): redact credentials from persisted request logs

### DIFF
--- a/crates/agent-gui/package.json
+++ b/crates/agent-gui/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "test": "node --test test/**/*.test.mjs",
-    "test:frontend": "node --test test/settings/*.test.mjs test/chat/*.test.mjs test/memory/*.test.mjs test/providers/*.test.mjs test/subagents/*.test.mjs test/tools/*.test.mjs test/i18n/*.test.mjs test/skills/*.test.mjs",
+    "test:frontend": "node --test test/settings/*.test.mjs test/chat/*.test.mjs test/debug/*.test.mjs test/memory/*.test.mjs test/providers/*.test.mjs test/subagents/*.test.mjs test/tools/*.test.mjs test/i18n/*.test.mjs test/skills/*.test.mjs",
     "test:backend": "node --test test/backend/*.test.mjs",
     "test:release": "node --test test/backend/release-*.test.mjs",
     "export:models": "node ./test/get-providers-get-models-example.js --save",

--- a/crates/agent-gui/src/lib/debug/agentDebug.ts
+++ b/crates/agent-gui/src/lib/debug/agentDebug.ts
@@ -24,6 +24,48 @@ export type StreamDebugLogger = {
 };
 
 const writeQueues = new Map<string, Promise<void>>();
+const REDACTED_DEBUG_CREDENTIAL = "[redacted credential]";
+
+const SAFE_TOKEN_METADATA_KEYS = new Set([
+  "hasapikey",
+  "inputtoken",
+  "inputtokens",
+  "outputtoken",
+  "outputtokens",
+  "maxtoken",
+  "maxtokens",
+  "totaltoken",
+  "totaltokens",
+  "contexttoken",
+  "contexttokens",
+  "prompttoken",
+  "prompttokens",
+  "completiontoken",
+  "completiontokens",
+]);
+
+function isSensitiveDebugKey(key: string) {
+  const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  if (SAFE_TOKEN_METADATA_KEYS.has(normalized)) return false;
+  return [
+    "apikey",
+    "apikeys",
+    "authorization",
+    "cookie",
+    "cookies",
+    "credential",
+    "credentials",
+    "password",
+    "passwords",
+    "passwd",
+    "passphrase",
+    "privatekey",
+    "secret",
+    "secrets",
+    "token",
+    "tokens",
+  ].some((suffix) => normalized.endsWith(suffix));
+}
 
 function sanitizeDebugString(value: string) {
   const dataUrlMatch = value.match(/^data:([^;,]+);base64,(.*)$/s);
@@ -81,7 +123,9 @@ function sanitizeDebugValue(value: unknown, seen = new WeakSet<object>()): unkno
       inlineDataMimeType.trim().length > 0;
     const out: Record<string, unknown> = {};
     for (const [key, nested] of Object.entries(record)) {
-      if (isBase64Source && key === "data") {
+      if (isSensitiveDebugKey(key)) {
+        out[key] = REDACTED_DEBUG_CREDENTIAL;
+      } else if (isBase64Source && key === "data") {
         out[key] = `[redacted base64: ${sourceMimeType}, chars=${sourceData.length}]`;
       } else if (isTextDocumentSource && key === "data") {
         out[key] = `[redacted text document: ${sourceMimeType}, chars=${sourceData.length}]`;

--- a/crates/agent-gui/test/debug/agent-debug.test.mjs
+++ b/crates/agent-gui/test/debug/agent-debug.test.mjs
@@ -67,3 +67,63 @@ test("debug sanitizer redacts base64 data URLs", () => {
     "[redacted inlineData: image/png, chars=8]",
   );
 });
+
+test("debug sanitizer redacts nested credentials without hiding token usage", () => {
+  const payload = {
+    apiKey: "raw-api-key",
+    headers: {
+      Authorization: "Bearer raw-authorization",
+      "X-API-Key": "raw-header-key",
+      Cookie: "session=raw-cookie",
+    },
+    provider: {
+      client_secret: "raw-client-secret",
+      refreshToken: "raw-refresh-token",
+      password: "raw-password",
+    },
+    hasApiKey: true,
+    inputTokens: 123,
+    maxTokens: 456,
+  };
+
+  const sanitized = agentDebug.__agentDebugTest.sanitizeDebugValue(payload);
+  const serialized = JSON.stringify(sanitized);
+
+  for (const secret of [
+    "raw-api-key",
+    "raw-authorization",
+    "raw-header-key",
+    "raw-cookie",
+    "raw-client-secret",
+    "raw-refresh-token",
+    "raw-password",
+  ]) {
+    assert.equal(serialized.includes(secret), false, `leaked ${secret}`);
+  }
+  assert.equal(sanitized.apiKey, "[redacted credential]");
+  assert.equal(sanitized.headers.Authorization, "[redacted credential]");
+  assert.equal(sanitized.provider.client_secret, "[redacted credential]");
+  assert.equal(sanitized.hasApiKey, true);
+  assert.equal(sanitized.inputTokens, 123);
+  assert.equal(sanitized.maxTokens, 456);
+});
+
+test("stream request debug payload never includes runtime or option credentials", () => {
+  const payload = agentDebug.buildStreamRequestDebugPayload({
+    runtime: {
+      baseUrl: "https://example.test/v1",
+      apiKey: "raw-runtime-key",
+    },
+    context: { messages: [] },
+    options: {
+      apiKey: "raw-option-key",
+      headers: { authorization: "Bearer raw-option-auth" },
+    },
+  });
+  const serialized = JSON.stringify(payload);
+
+  assert.equal(payload.runtime.hasApiKey, true);
+  assert.equal(serialized.includes("raw-runtime-key"), false);
+  assert.equal(serialized.includes("raw-option-key"), false);
+  assert.equal(serialized.includes("raw-option-auth"), false);
+});


### PR DESCRIPTION
## Summary

- Add key-aware redaction to the existing Agent Dev debug sanitizer.
- Redact nested API keys, authorization headers, cookies, credentials, passwords, secrets, and tokens regardless of casing or separators.
- Preserve non-secret fields such as `hasApiKey`, token-usage counters, and existing attachment redaction.
- Include the existing debug test directory in the frontend CI test command.

## Scope

This is the focused replacement for #100. It intentionally does not change the backend log format, storage directory, retention policy, startup behavior, or IPC contract.

## Validation

- Agent debug tests: 3 passed
- `pnpm test:frontend`: 840 passed
- `pnpm build`
- `pnpm exec biome check src/lib/debug/agentDebug.ts` (one pre-existing `Function` type warning)
- `node scripts/check-mirror.mjs`: 69 mirrored files passed