### PR TITLE
fix(history-share): cover all catalog tools in redaction

### DIFF
--- a/crates/agent-gateway/web/src/pages/chat/assistant-bubble/assistantBubbleUtils.ts
+++ b/crates/agent-gateway/web/src/pages/chat/assistant-bubble/assistantBubbleUtils.ts
@@ -345,9 +345,12 @@ export function isBuiltinShareToolName(name: string) {
     "McpManager",
     "MemoryManager",
     "Read",
+    "ReadTerminal",
+    "SendMessage",
     "SkillsManager",
     "SSHManager",
     "SshManager",
+    "TodoWrite",
     "TunnelManager",
     "Write",
   ].includes(trimmed);

--- a/crates/agent-gateway/web/test/assistant-bubble-utils.test.mjs
+++ b/crates/agent-gateway/web/test/assistant-bubble-utils.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createWebModuleLoader } from "../../test/helpers/load-web-module.mjs";
+
+const rootDir = fileURLToPath(new URL("../", import.meta.url));
+const loader = createWebModuleLoader({ rootDir });
+const { BUILTIN_TOOL_CATALOG } = loader.loadModule("src/lib/tools/builtinToolCatalog.ts");
+const { isBuiltinShareToolName } = loader.loadModule(
+  "src/pages/chat/assistant-bubble/assistantBubbleUtils.ts",
+);
+
+test("shared history recognizes every catalog tool as builtin", () => {
+  for (const entry of BUILTIN_TOOL_CATALOG) {
+    assert.equal(isBuiltinShareToolName(entry.toolName), true, entry.toolName);
+  }
+  assert.equal(isBuiltinShareToolName("mcp_docs_search"), true);
+  assert.equal(isBuiltinShareToolName("CustomTool"), false);
+});

--- a/crates/agent-gui/src-tauri/src/services/gateway_bridge.rs
+++ b/crates/agent-gui/src-tauri/src/services/gateway_bridge.rs
@@ -937,9 +937,13 @@ fn is_builtin_share_tool_name(name: &str) -> bool {
             | "McpManager"
             | "MemoryManager"
             | "Read"
+            | "ReadTerminal"
+            | "SendMessage"
             | "SkillsManager"
             | "SSHManager"
             | "SshManager"
+            | "TodoWrite"
+            | "TunnelManager"
             | "Write"
     )
 }
@@ -1598,8 +1602,9 @@ mod tests {
 
     use super::{
         build_history_prefix_segments, flatten_history_messages_json,
-        flatten_history_messages_json_window, history_message_content_hash, parse_runs_limit,
-        redact_builtin_tool_content_json, sanitize_provider_summaries,
+        flatten_history_messages_json_window, history_message_content_hash,
+        is_builtin_share_tool_name, parse_runs_limit, redact_builtin_tool_content_json,
+        sanitize_provider_summaries,
     };
     use crate::commands::chat_history::ChatHistorySegmentRecord;
 
@@ -1902,5 +1907,24 @@ mod tests {
         assert_eq!(blocks[2]["redacted"], true);
         assert_eq!(items[3]["content"][0]["text"], "工具调用内容已脱敏");
         assert_eq!(items[3]["details"]["kind"], "redacted_tool_content");
+    }
+
+    #[test]
+    fn shared_chat_history_builtin_policy_covers_the_tool_catalog() {
+        let catalog = include_str!("../../../src/lib/tools/builtinToolCatalog.ts");
+        let tool_names = catalog.lines().filter_map(|line| {
+            line.trim()
+                .strip_prefix("toolName: \"")
+                .and_then(|value| value.strip_suffix("\","))
+        });
+        let mut count = 0;
+        for tool_name in tool_names {
+            count += 1;
+            assert!(
+                is_builtin_share_tool_name(tool_name),
+                "{tool_name} is missing from share redaction"
+            );
+        }
+        assert!(count > 0, "catalog parser found no tools");
     }
 }


### PR DESCRIPTION
## Summary

- Add `ReadTerminal`, `SendMessage`, `TodoWrite`, and `TunnelManager` to the server-side public-share redaction policy.
- Add the three missing names to the Gateway WebUI builtin-tool policy (`TunnelManager` was already present there).
- Add catalog-driven regression tests on both sides so future builtin additions cannot silently drift out of the share policy.

## Scope

This is the focused replacement for #101. It intentionally keeps the existing share serialization, tool/result transformation, identifiers, hashes, and rendering behavior unchanged.

## Validation

- Gateway WebUI tests: 304 passed
- Gateway WebUI production build
- `cargo check --tests`
- `pnpm exec biome check src/pages/chat/assistant-bubble/assistantBubbleUtils.ts`
- `node scripts/check-mirror.mjs`: 69 mirrored files passed