### PR TITLE
fix: skills download failing with HTTP 409 Conflict (ClawHub ownerHandle)

### DIFF
--- a/crates/agent-gateway/web/src/lib/skills/clawHub.ts
+++ b/crates/agent-gateway/web/src/lib/skills/clawHub.ts
@@ -84,7 +84,7 @@ function normalizeSkillCard(raw: unknown): ClawHubSkillCard | null {
     updatedAt: asNullableNumber(item.updatedAt),
     ownerHandle,
     webUrl: asString(item.webUrl) ?? buildClawHubWebUrl(ownerHandle, slug),
-    downloadUrl: asString(item.downloadUrl) ?? buildClawHubDownloadUrl(slug),
+    downloadUrl: asString(item.downloadUrl) ?? buildClawHubDownloadUrl(slug, ownerHandle),
   };
 }
 
@@ -166,8 +166,15 @@ export async function searchClawHubSkills(params: {
     : [];
 }
 
-export async function getClawHubSkillDetail(slug: string): Promise<ClawHubSkillDetail> {
+export async function getClawHubSkillDetail(
+  slug: string,
+  ownerHandle?: string | null,
+): Promise<ClawHubSkillDetail> {
   const url = new URL(`/api/v1/skills/${encodeURIComponent(slug)}`, CLAWHUB_API_BASE);
+  // ClawHub 对重名 slug 返回 409，须带 ownerHandle 消歧。
+  if (ownerHandle) {
+    url.searchParams.set("ownerHandle", ownerHandle);
+  }
   const detail = normalizeSkillDetail(await fetchClawHubJson(url));
   if (!detail) {
     throw new Error("ClawHub skill detail not found");
@@ -175,9 +182,12 @@ export async function getClawHubSkillDetail(slug: string): Promise<ClawHubSkillD
   return detail;
 }
 
-export function buildClawHubDownloadUrl(slug: string) {
+export function buildClawHubDownloadUrl(slug: string, ownerHandle?: string | null) {
   const url = new URL("/api/v1/download", CLAWHUB_API_BASE);
   url.searchParams.set("slug", slug);
   url.searchParams.set("tag", "latest");
+  if (ownerHandle) {
+    url.searchParams.set("ownerHandle", ownerHandle);
+  }
   return url.toString();
 }

--- a/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
@@ -744,9 +744,10 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
     setStoreError(null);
     try {
       const job = await startSkillInstallJob({
-        source: buildClawHubDownloadUrl(skill.slug),
+        source: buildClawHubDownloadUrl(skill.slug, skill.ownerHandle),
         label: skill.displayName,
         slug: skill.slug,
+        ownerHandle: skill.ownerHandle,
         version: skill.latestVersion,
         conflict: "backup",
       });
@@ -1967,7 +1968,7 @@ function SkillsStoreView(props: {
     setPreviewError(null);
     setPreviewLoading(true);
 
-    void getClawHubSkillDetail(previewSkill.slug)
+    void getClawHubSkillDetail(previewSkill.slug, previewSkill.ownerHandle)
       .then((detail) => {
         if (!cancelled) {
           setPreviewDetail(detail);

--- a/crates/agent-gui/src-tauri/src/services/skills/clawhub.rs
+++ b/crates/agent-gui/src-tauri/src/services/skills/clawhub.rs
@@ -68,7 +68,11 @@ pub(crate) fn json_optional_u64(item: &serde_json::Map<String, Value>, key: &str
     })
 }
 
-pub(crate) fn clawhub_download_url_for_slug(slug: &str, tag: Option<&str>) -> Result<String, String> {
+pub(crate) fn clawhub_download_url_for_slug(
+    slug: &str,
+    owner_handle: Option<&str>,
+    tag: Option<&str>,
+) -> Result<String, String> {
     let slug = slug.trim();
     if slug.is_empty() {
         return Err("SkillsManager clawhub_install requires slug".to_string());
@@ -83,6 +87,10 @@ pub(crate) fn clawhub_download_url_for_slug(slug: &str, tag: Option<&str>) -> Re
     url.query_pairs_mut()
         .append_pair("slug", slug)
         .append_pair("tag", tag);
+    // ClawHub 对重名 slug 返回 409，必须带 ownerHandle 消歧。
+    if let Some(owner) = owner_handle.map(str::trim).filter(|value| !value.is_empty()) {
+        url.query_pairs_mut().append_pair("ownerHandle", owner);
+    }
     Ok(url.into())
 }
 
@@ -105,7 +113,7 @@ pub(crate) fn normalize_clawhub_skill_card(raw: &Value) -> Option<SystemClawHubS
             .and_then(json_object)
             .and_then(|value| json_string(value, "handle"))
     });
-    let download_url = clawhub_download_url_for_slug(&slug, None).ok()?;
+    let download_url = clawhub_download_url_for_slug(&slug, owner_handle.as_deref(), None).ok()?;
     let web_url = owner_handle
         .as_ref()
         .map(|owner| format!("{CLAWHUB_API_BASE}/{owner}/{slug}"));
@@ -211,8 +219,10 @@ pub(crate) fn install_clawhub_skill_from_payload(
     let slug = object_string(payload, "slug")
         .ok_or_else(|| "SkillsManager clawhub_install requires slug".to_string())?
         .to_string();
+    let owner_handle =
+        object_string(payload, "ownerHandle").or_else(|| object_string(payload, "owner"));
     let version = object_string(payload, "version");
-    let download_url = clawhub_download_url_for_slug(&slug, version)?;
+    let download_url = clawhub_download_url_for_slug(&slug, owner_handle, version)?;
     let mut install_payload = payload.clone();
     install_payload.insert("action".to_string(), Value::String("install".to_string()));
     install_payload.insert("source".to_string(), Value::String(download_url.clone()));

--- a/crates/agent-gui/src-tauri/src/services/skills/install.rs
+++ b/crates/agent-gui/src-tauri/src/services/skills/install.rs
@@ -293,6 +293,8 @@ fn build_skill_source_metadata(
     let metadata = serde_json::json!({
         "registry": "clawhub",
         "slug": slug,
+        "ownerHandle": object_string(payload, "ownerHandle")
+            .or_else(|| object_string(payload, "owner")),
         "version": object_string(payload, "version"),
         "publishedAt": payload.get("publishedAt").and_then(Value::as_u64),
     });

--- a/crates/agent-gui/src-tauri/src/services/skills/sources.rs
+++ b/crates/agent-gui/src-tauri/src/services/skills/sources.rs
@@ -111,7 +111,16 @@ where
         .map_err(|e| format!("Failed to download Skill source: {e}"))?;
     let status = response.status();
     if !status.is_success() {
-        return Err(format!("Skill source download failed with HTTP {status}"));
+        // 注册表错误响应体通常带修复指引（如 ClawHub 409 要求 ownerHandle），截断后回显。
+        let mut raw = Vec::new();
+        let _ = response.take(2048).read_to_end(&mut raw);
+        let body = String::from_utf8_lossy(&raw);
+        let snippet = body.trim();
+        return Err(if snippet.is_empty() {
+            format!("Skill source download failed with HTTP {status}")
+        } else {
+            format!("Skill source download failed with HTTP {status}: {snippet}")
+        });
     }
     let total_bytes = response.content_length();
     if total_bytes

--- a/crates/agent-gui/src-tauri/src/services/skills/tests.rs
+++ b/crates/agent-gui/src-tauri/src/services/skills/tests.rs
@@ -349,7 +349,7 @@ fn install_source_from_local_skill_archive_installs_skill() {
 
 #[test]
 fn clawhub_download_url_preserves_slug_and_tag_params() {
-    let url = clawhub_download_url_for_slug("owner/example-skill", Some("v1.2.3"))
+    let url = clawhub_download_url_for_slug("owner/example-skill", None, Some("v1.2.3"))
         .expect("download url");
     let parsed = reqwest::Url::parse(&url).expect("parse url");
     let pairs = parsed
@@ -365,6 +365,26 @@ fn clawhub_download_url_preserves_slug_and_tag_params() {
         Some("owner/example-skill")
     );
     assert_eq!(pairs.get("tag").map(String::as_str), Some("v1.2.3"));
+    assert!(!pairs.contains_key("ownerHandle"));
+}
+
+#[test]
+fn clawhub_download_url_appends_owner_handle_for_disambiguation() {
+    let url = clawhub_download_url_for_slug("example-skill", Some("acme"), None)
+        .expect("download url");
+    let parsed = reqwest::Url::parse(&url).expect("parse url");
+    let pairs = parsed
+        .query_pairs()
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect::<HashMap<_, _>>();
+
+    assert_eq!(pairs.get("slug").map(String::as_str), Some("example-skill"));
+    assert_eq!(pairs.get("tag").map(String::as_str), Some("latest"));
+    assert_eq!(pairs.get("ownerHandle").map(String::as_str), Some("acme"));
+
+    let blank_owner = clawhub_download_url_for_slug("example-skill", Some("  "), None)
+        .expect("download url");
+    assert!(!blank_owner.contains("ownerHandle"));
 }
 
 #[test]
@@ -393,6 +413,7 @@ fn normalize_clawhub_skill_card_supports_search_shape() {
     assert_eq!(card.installs_current, 3);
     assert_eq!(card.owner_handle.as_deref(), Some("owner"));
     assert!(card.download_url.contains("/api/v1/download"));
+    assert!(card.download_url.contains("ownerHandle=owner"));
 }
 
 #[test]

--- a/crates/agent-gui/src/lib/skills/clawHub.ts
+++ b/crates/agent-gui/src/lib/skills/clawHub.ts
@@ -84,7 +84,7 @@ function normalizeSkillCard(raw: unknown): ClawHubSkillCard | null {
     updatedAt: asNullableNumber(item.updatedAt),
     ownerHandle,
     webUrl: asString(item.webUrl) ?? buildClawHubWebUrl(ownerHandle, slug),
-    downloadUrl: asString(item.downloadUrl) ?? buildClawHubDownloadUrl(slug),
+    downloadUrl: asString(item.downloadUrl) ?? buildClawHubDownloadUrl(slug, ownerHandle),
   };
 }
 
@@ -166,8 +166,15 @@ export async function searchClawHubSkills(params: {
     : [];
 }
 
-export async function getClawHubSkillDetail(slug: string): Promise<ClawHubSkillDetail> {
+export async function getClawHubSkillDetail(
+  slug: string,
+  ownerHandle?: string | null,
+): Promise<ClawHubSkillDetail> {
   const url = new URL(`/api/v1/skills/${encodeURIComponent(slug)}`, CLAWHUB_API_BASE);
+  // ClawHub 对重名 slug 返回 409，须带 ownerHandle 消歧。
+  if (ownerHandle) {
+    url.searchParams.set("ownerHandle", ownerHandle);
+  }
   const detail = normalizeSkillDetail(await fetchClawHubJson(url));
   if (!detail) {
     throw new Error("ClawHub skill detail not found");
@@ -175,9 +182,12 @@ export async function getClawHubSkillDetail(slug: string): Promise<ClawHubSkillD
   return detail;
 }
 
-export function buildClawHubDownloadUrl(slug: string) {
+export function buildClawHubDownloadUrl(slug: string, ownerHandle?: string | null) {
   const url = new URL("/api/v1/download", CLAWHUB_API_BASE);
   url.searchParams.set("slug", slug);
   url.searchParams.set("tag", "latest");
+  if (ownerHandle) {
+    url.searchParams.set("ownerHandle", ownerHandle);
+  }
   return url.toString();
 }

--- a/crates/agent-gui/src/lib/tools/skillTools.ts
+++ b/crates/agent-gui/src/lib/tools/skillTools.ts
@@ -137,6 +137,12 @@ const SKILL_MANAGER_PARAMETERS = Type.Object({
         "ClawHub skill slug for action=clawhub_install, as returned by action=clawhub_search.",
     }),
   ),
+  owner: Type.Optional(
+    Type.String({
+      description:
+        "ClawHub owner handle for action=clawhub_install, as returned by action=clawhub_search. Required to disambiguate when multiple publishers share the same slug (ClawHub rejects ambiguous downloads with HTTP 409).",
+    }),
+  ),
   version: Type.Optional(
     Type.String({
       description: "Optional ClawHub version/tag for action=clawhub_install. Defaults to latest.",
@@ -369,7 +375,7 @@ function normalizeSkillManagerPayload(
     const slug = optionalString(args, "slug");
     if (!slug) throw new Error("SkillsManager.slug is required for action=clawhub_install");
     payload.slug = slug;
-    for (const key of ["name", "conflict", "version"]) {
+    for (const key of ["name", "conflict", "version", "owner"]) {
       const value = optionalString(args, key);
       if (value) payload[key] = value;
     }
@@ -500,8 +506,9 @@ function formatManageSkillResultText(
       if (item.ownerHandle) lines.push(`  owner=${item.ownerHandle}`);
       if (item.downloadUrl) lines.push(`  downloadUrl=${item.downloadUrl}`);
       const versionArg = item.latestVersion ? `, version="${item.latestVersion}"` : "";
+      const ownerArg = item.ownerHandle ? `, owner="${item.ownerHandle}"` : "";
       lines.push(
-        `  install=SkillsManager(action="clawhub_install", slug="${item.slug}"${versionArg}, conflict="backup")`,
+        `  install=SkillsManager(action="clawhub_install", slug="${item.slug}"${ownerArg}${versionArg}, conflict="backup")`,
       );
     }
   } else if (result.action === "install" || result.action === "clawhub_install") {

--- a/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
@@ -744,9 +744,10 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
     setStoreError(null);
     try {
       const job = await startSkillInstallJob({
-        source: buildClawHubDownloadUrl(skill.slug),
+        source: buildClawHubDownloadUrl(skill.slug, skill.ownerHandle),
         label: skill.displayName,
         slug: skill.slug,
+        ownerHandle: skill.ownerHandle,
         version: skill.latestVersion,
         conflict: "backup",
       });
@@ -1966,7 +1967,7 @@ function SkillsStoreView(props: {
     setPreviewError(null);
     setPreviewLoading(true);
 
-    void getClawHubSkillDetail(previewSkill.slug)
+    void getClawHubSkillDetail(previewSkill.slug, previewSkill.ownerHandle)
       .then((detail) => {
         if (!cancelled) {
           setPreviewDetail(detail);

--- a/crates/agent-gui/test/tools/path-and-system-tools.test.mjs
+++ b/crates/agent-gui/test/tools/path-and-system-tools.test.mjs
@@ -1714,6 +1714,59 @@ test("SkillsManager install resolves local relative sources against the workspac
   );
 });
 
+test("SkillsManager clawhub_install forwards owner handle for slug disambiguation", async () => {
+  const invocations = [];
+  const skillLoader = createTsModuleLoader({
+    mocks: {
+      "@tauri-apps/api/core": {
+        async invoke(command, args) {
+          invocations.push({ command, args });
+          assert.equal(command, "system_manage_skill");
+          return {
+            action: "clawhub_install",
+            rootDir: "/Users/me/.liveagent/skills",
+            clawhubSlug: "example-skill",
+            clawhubDownloadUrl:
+              "https://clawhub.ai/api/v1/download?slug=example-skill&tag=latest&ownerHandle=acme",
+            installed: [
+              {
+                name: "example-skill",
+                target: "/Users/me/.liveagent/skills/example-skill",
+                backup: null,
+                skillFile: "example-skill/SKILL.md",
+              },
+            ],
+          };
+        },
+      },
+    },
+  });
+  const skillTools = skillLoader.loadModule("src/lib/tools/skillTools.ts");
+  const bundle = skillTools.createSkillTools({
+    skillAccessPolicy: {
+      allowedSkillNames: ["skills-installer"],
+      allowedSkillBaseDirs: ["skills-installer"],
+      allowSkillManagement: true,
+    },
+  });
+
+  const result = await bundle.executeToolCall({
+    type: "toolCall",
+    id: "clawhub-install-owner",
+    name: "SkillsManager",
+    arguments: {
+      action: "clawhub_install",
+      slug: "example-skill",
+      owner: "acme",
+      conflict: "backup",
+    },
+  });
+
+  assert.equal(result.isError, false);
+  assert.equal(invocations[0].args.payload.slug, "example-skill");
+  assert.equal(invocations[0].args.payload.owner, "acme");
+});
+
 test("SkillsManager blocks unread enabled-Skill policy violations before backend invoke", async () => {
   const invocations = [];
   const skillLoader = createTsModuleLoader({


### PR DESCRIPTION
## Summary

Skill installs from the ClawHub store started failing with `Skill source download failed with HTTP 409 Conflict`. The root cause is a ClawHub registry contract change, not a regression on our side: clawhub.ai now allows multiple publishers to share one slug, and `/api/v1/download` + `/api/v1/skills/{slug}` reject ambiguous slugs with HTTP 409, requiring an `ownerHandle` query param. Popular skills (e.g. `self-improving-agent` has 3 publishers) are practically all ambiguous now, so any download URL carrying only `slug`+`tag` fails.

This PR threads `ownerHandle` through the entire chain (store UI installs, detail previews, and the model-facing `SkillsManager` tool):

- **clawhub.rs**: `clawhub_download_url_for_slug` gains an owner param; search result cards build download URLs with owner; `clawhub_install` reads `ownerHandle`/`owner` from the payload
- **install.rs**: installed skill `_meta.json` now records `ownerHandle` (disambiguation for future update/reinstall flows)
- **sources.rs**: failed downloads surface the first 2 KB of the error response body — ClawHub's 409 body carries its own fix guidance ("Retry with ownerHandle…"), so users and the model see it instead of a bare status code
- **skillTools.ts**: optional `owner` param on `action=clawhub_install`; `clawhub_search` results embed `owner="..."` in the install hint so the model passes it naturally
- **clawHub.ts + SkillsHubPage.tsx** (gui/web hand-mirrored, kept byte-identical): `buildClawHubDownloadUrl` / `getClawHubSkillDetail` accept `ownerHandle`; the hub page passes `skill.ownerHandle` for install jobs and detail previews — this also fixes detail preview 409s for duplicated slugs

## Verification

- Probed the live API: ambiguous slug without owner → 409; with `ownerHandle` → 200 zip (both download and detail endpoints)
- Rust skills module: 38 tests pass (incl. new `clawhub_download_url_appends_owner_handle_for_disambiguation` and updated card-normalization assertions)
- GUI frontend suite: 303 pass (incl. new `clawhub_install` owner-passthrough test); web suite: 303 pass
- `tsc --noEmit` clean on both frontends; biome shows only pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)