### PR TITLE
fix(compaction): use medium reasoning for codex summarizer instead of minimal

### DIFF
--- a/crates/agent-gui/src/lib/chat/compaction/summarizer.ts
+++ b/crates/agent-gui/src/lib/chat/compaction/summarizer.ts
@@ -71,8 +71,9 @@ function isTransientError(error: unknown) {
 }
 
 function buildSummarizerRuntime(providerId: ProviderId, runtime: ProviderRuntimeConfig) {
-  // Codex 用最低推理档做摘要，避免长思考挤占摘要预算。
-  return providerId === "codex" ? { ...runtime, reasoning: "minimal" as const } : runtime;
+  // Codex 用 medium 档做摘要，避免长思考挤占摘要预算；不能用 minimal——
+  // GPT-5.6 世代已砍掉该档且 pi-ai 目录未标 null，clamp 不会兜底，API 会直接 400。
+  return providerId === "codex" ? { ...runtime, reasoning: "medium" as const } : runtime;
 }
 
 type SummarizerRequest = {


### PR DESCRIPTION
## Problem

With the OpenAI provider (internally `codex`) and a GPT-5.6 generation model (e.g. `gpt-5.6-sol`), context compaction always fails with:

> 上下文压缩失败：level "minimal" not supported, valid levels: low, medium, high, xhigh, max

## Root cause

- `buildSummarizerRuntime` in `compaction/summarizer.ts` hardcoded `reasoning: "minimal"` for the codex provider to keep long thinking from eating the summary budget.
- GPT-5.6 generation models dropped the `minimal` reasoning effort (valid levels are low/medium/high/xhigh/max).
- The clamp safety net (`clampOpenAIReasoningEffort` → pi-ai `clampThinkingLevel`) doesn't catch this: the pi-ai catalog entry for `gpt-5.6-sol` has `thinkingLevelMap: { off: "none", xhigh: "xhigh", max: "max" }`, and only levels explicitly mapped to `null` are excluded from the supported set — so `minimal` passes through verbatim and the API returns a 400.

## Fix

Hardcode `medium` instead of `minimal` for the codex summarizer. `medium` is supported by both old and new OpenAI models, and still keeps summary requests from burning excessive thinking tokens. `claude_code` and `gemini` are unaffected (they keep passing the user-selected level through unchanged).

## Testing

- `node --test test/chat/compaction-*.test.mjs` — all 62 tests pass; no existing test asserted the old `minimal` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)