### PR TITLE
fix(history): 删除对话时清理托管上传文件

### DIFF
--- a/crates/agent-gui/src-tauri/src/commands/app/mod.rs
+++ b/crates/agent-gui/src-tauri/src/commands/app/mod.rs
@@ -1,4 +1,5 @@
 pub mod app;
 pub mod custom_tools;
 pub mod system;
+pub mod upload_cleanup;
 pub mod update;

--- a/crates/agent-gui/src-tauri/src/commands/app/system.rs
+++ b/crates/agent-gui/src-tauri/src/commands/app/system.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::commands::upload_cleanup::{canonicalize_upload_workdir, create_managed_upload_batch};
 use crate::runtime::platform::expand_tilde_path;
 use crate::services::power_activity::PowerActivityManager;
 pub use crate::services::skills::{
@@ -105,26 +106,6 @@ fn sanitize_debug_file_stem(input: &str) -> Result<String, String> {
         return Ok(trimmed.to_string());
     }
     Err(format!("非法的对话 ID：{input}"))
-}
-
-fn canonicalize_upload_workdir(workdir: &str) -> Result<PathBuf, String> {
-    let raw = workdir.trim();
-    if raw.is_empty() {
-        return Err("项目目录未选择，无法导入文件".to_string());
-    }
-
-    let path = expand_tilde_path(raw);
-    if !path.is_absolute() {
-        return Err(format!("工作目录必须是绝对路径：{workdir}"));
-    }
-
-    let metadata =
-        fs::metadata(&path).map_err(|_| format!("工作目录不存在或不可访问：{workdir}"))?;
-    if !metadata.is_dir() {
-        return Err(format!("工作目录不是文件夹：{workdir}"));
-    }
-
-    fs::canonicalize(&path).map_err(|e| format!("无法解析工作目录：{e}"))
 }
 
 fn infer_image_upload_kind(path: &Path) -> Option<&'static str> {
@@ -483,16 +464,6 @@ fn rel_to_workdir_forward_slash(workdir: &Path, abs: &Path) -> Result<String, St
         .map_err(|_| format!("路径超出工作目录：{}", abs.display()))
 }
 
-fn upload_import_root(workdir: &Path) -> Result<PathBuf, String> {
-    let batch = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis();
-    let root = workdir.join("uploads").join(batch.to_string());
-    fs::create_dir_all(&root).map_err(|e| format!("创建上传目录失败 {}: {e}", root.display()))?;
-    Ok(root)
-}
-
 fn build_readable_file_entry(
     workdir: &Path,
     destination: &Path,
@@ -728,7 +699,7 @@ fn import_readable_file_paths_into_workdir(
             let import_root = match import_root.as_ref() {
                 Some(root) => root.clone(),
                 None => {
-                    let root = upload_import_root(workdir)?;
+                    let root = create_managed_upload_batch(workdir)?;
                     import_root = Some(root.clone());
                     root
                 }
@@ -805,7 +776,7 @@ pub(crate) fn system_import_uploaded_readable_files_sync(
         let import_root = match import_root.as_ref() {
             Some(root) => root.clone(),
             None => {
-                let root = upload_import_root(&workdir)?;
+                let root = create_managed_upload_batch(&workdir)?;
                 import_root = Some(root.clone());
                 root
             }
@@ -1274,7 +1245,7 @@ mod tests {
     }
 
     #[test]
-    fn upload_import_root_uses_workdir_uploads_directory() {
+    fn managed_upload_batch_uses_workdir_uploads_directory() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -1285,7 +1256,7 @@ mod tests {
         ));
         fs::create_dir_all(&workdir).expect("create test workdir");
 
-        let root = upload_import_root(&workdir).expect("create upload root");
+        let root = create_managed_upload_batch(&workdir).expect("create upload root");
 
         assert!(
             root.starts_with(workdir.join("uploads")),

--- a/crates/agent-gui/src-tauri/src/commands/app/upload_cleanup.rs
+++ b/crates/agent-gui/src-tauri/src/commands/app/upload_cleanup.rs
@@ -1,0 +1,334 @@
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::runtime::platform::expand_tilde_path;
+
+const MANAGED_UPLOAD_BATCH_MARKER: &str = ".liveagent-upload-batch";
+const MANAGED_UPLOAD_BATCH_MARKER_CONTENT: &[u8] = b"liveagent-managed-upload-v1\n";
+
+fn create_managed_upload_batch_marker(batch_dir: &Path) -> std::io::Result<()> {
+    let mut marker = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(batch_dir.join(MANAGED_UPLOAD_BATCH_MARKER))?;
+    marker.write_all(MANAGED_UPLOAD_BATCH_MARKER_CONTENT)
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct ManagedUploadCleanupResult {
+    pub removed_files: usize,
+    pub removed_batches: usize,
+    pub skipped: Vec<String>,
+}
+
+pub(crate) fn canonicalize_upload_workdir(workdir: &str) -> Result<PathBuf, String> {
+    let raw = workdir.trim();
+    if raw.is_empty() {
+        return Err("项目目录未选择，无法导入文件".to_string());
+    }
+
+    let path = expand_tilde_path(raw);
+    if !path.is_absolute() {
+        return Err(format!("工作目录必须是绝对路径：{workdir}"));
+    }
+
+    let metadata =
+        fs::metadata(&path).map_err(|_| format!("工作目录不存在或不可访问：{workdir}"))?;
+    if !metadata.is_dir() {
+        return Err(format!("工作目录不是文件夹：{workdir}"));
+    }
+
+    fs::canonicalize(&path).map_err(|e| format!("无法解析工作目录：{e}"))
+}
+
+fn canonical_managed_uploads_root(workdir: &Path) -> Result<Option<PathBuf>, String> {
+    let uploads_root = workdir.join("uploads");
+    let metadata = match fs::symlink_metadata(&uploads_root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "无法读取上传目录 {}: {error}",
+                uploads_root.display()
+            ));
+        }
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(format!(
+            "上传目录不是安全的普通目录：{}",
+            uploads_root.display()
+        ));
+    }
+
+    let canonical_root = fs::canonicalize(&uploads_root)
+        .map_err(|e| format!("无法解析上传目录 {}: {e}", uploads_root.display()))?;
+    if !canonical_root.starts_with(workdir) || canonical_root == workdir {
+        return Err(format!(
+            "上传目录超出工作目录：{}",
+            canonical_root.display()
+        ));
+    }
+    Ok(Some(canonical_root))
+}
+
+pub(crate) fn create_managed_upload_batch(workdir: &Path) -> Result<PathBuf, String> {
+    let canonical_workdir = fs::canonicalize(workdir)
+        .map_err(|e| format!("无法解析上传工作目录 {}: {e}", workdir.display()))?;
+    let uploads_root = canonical_workdir.join("uploads");
+    fs::create_dir_all(&uploads_root)
+        .map_err(|e| format!("创建上传目录失败 {}: {e}", uploads_root.display()))?;
+    let canonical_uploads_root = canonical_managed_uploads_root(&canonical_workdir)?
+        .ok_or_else(|| format!("上传目录不存在：{}", uploads_root.display()))?;
+
+    let mut batch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let root = loop {
+        let candidate = canonical_uploads_root.join(batch.to_string());
+        match fs::create_dir(&candidate) {
+            Ok(()) => break candidate,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                batch = batch.saturating_add(1);
+            }
+            Err(error) => {
+                return Err(format!(
+                    "创建上传批次目录失败 {}: {error}",
+                    candidate.display()
+                ));
+            }
+        }
+    };
+
+    if let Err(error) = create_managed_upload_batch_marker(&root) {
+        let _ = fs::remove_file(root.join(MANAGED_UPLOAD_BATCH_MARKER));
+        let _ = fs::remove_dir(&root);
+        return Err(format!("创建上传批次标记失败 {}: {error}", root.display()));
+    }
+    Ok(root)
+}
+
+fn parse_managed_upload_relative_path(relative_path: &str) -> Option<(&str, &str)> {
+    let normalized = relative_path.trim();
+    if normalized.is_empty() || normalized.contains('\\') {
+        return None;
+    }
+
+    let mut segments = normalized.split('/');
+    if segments.next()? != "uploads" {
+        return None;
+    }
+    let batch = segments.next()?;
+    let file_name = segments.next()?;
+    if segments.next().is_some()
+        || batch.is_empty()
+        || !batch.bytes().all(|byte| byte.is_ascii_digit())
+        || file_name.is_empty()
+        || file_name == MANAGED_UPLOAD_BATCH_MARKER
+        || !file_name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'))
+    {
+        return None;
+    }
+    Some((batch, file_name))
+}
+
+pub(crate) fn is_managed_upload_relative_path(relative_path: &str) -> bool {
+    parse_managed_upload_relative_path(relative_path).is_some()
+}
+
+pub(crate) fn managed_upload_batch_for_relative_path(relative_path: &str) -> Option<&str> {
+    parse_managed_upload_relative_path(relative_path).map(|(batch, _)| batch)
+}
+
+fn validate_managed_upload_batch(
+    uploads_root: &Path,
+    batch: &str,
+) -> Result<Option<PathBuf>, String> {
+    let batch_dir = uploads_root.join(batch);
+    let metadata = match fs::symlink_metadata(&batch_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "无法读取上传批次目录 {}: {error}",
+                batch_dir.display()
+            ));
+        }
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Ok(None);
+    }
+
+    let canonical_batch = fs::canonicalize(&batch_dir)
+        .map_err(|e| format!("无法解析上传批次目录 {}: {e}", batch_dir.display()))?;
+    if canonical_batch.parent() != Some(uploads_root) {
+        return Ok(None);
+    }
+
+    let marker = canonical_batch.join(MANAGED_UPLOAD_BATCH_MARKER);
+    let marker_metadata = match fs::symlink_metadata(&marker) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "无法读取上传批次标记 {}: {error}",
+                marker.display()
+            ));
+        }
+    };
+    if !marker_metadata.is_file() || marker_metadata.file_type().is_symlink() {
+        return Ok(None);
+    }
+    if marker_metadata.len() != MANAGED_UPLOAD_BATCH_MARKER_CONTENT.len() as u64 {
+        return Ok(None);
+    }
+    let marker_content =
+        fs::read(&marker).map_err(|e| format!("无法读取上传批次标记 {}: {e}", marker.display()))?;
+    if marker_content != MANAGED_UPLOAD_BATCH_MARKER_CONTENT {
+        return Ok(None);
+    }
+    Ok(Some(canonical_batch))
+}
+
+fn remove_managed_upload_batch(batch_dir: &Path) -> Result<Option<usize>, String> {
+    let marker = batch_dir.join(MANAGED_UPLOAD_BATCH_MARKER);
+    let entries = fs::read_dir(batch_dir)
+        .map_err(|e| format!("无法读取上传批次目录 {}: {e}", batch_dir.display()))?;
+    let mut files = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("无法读取上传批次目录项：{e}"))?;
+        let path = entry.path();
+        if path == marker {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|e| format!("无法读取上传批次文件 {}: {e}", path.display()))?;
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            return Ok(None);
+        }
+        let canonical_file = fs::canonicalize(&path)
+            .map_err(|e| format!("无法解析上传批次文件 {}: {e}", path.display()))?;
+        if canonical_file.parent() != Some(batch_dir) {
+            return Ok(None);
+        }
+        files.push(canonical_file);
+    }
+
+    files.sort();
+    for file in &files {
+        fs::remove_file(file).map_err(|e| format!("删除上传文件失败 {}: {e}", file.display()))?;
+    }
+    fs::remove_file(&marker)
+        .map_err(|e| format!("删除上传批次标记失败 {}: {e}", marker.display()))?;
+    if let Err(error) = fs::remove_dir(batch_dir) {
+        let _ = create_managed_upload_batch_marker(batch_dir);
+        return Err(format!(
+            "删除空上传批次目录失败 {}: {error}",
+            batch_dir.display()
+        ));
+    }
+    Ok(Some(files.len()))
+}
+
+pub(crate) fn cleanup_managed_upload_batches_sync(
+    workdir: &str,
+    batches: &[String],
+) -> Result<ManagedUploadCleanupResult, String> {
+    let canonical_workdir = canonicalize_upload_workdir(workdir)?;
+    let Some(uploads_root) = canonical_managed_uploads_root(&canonical_workdir)? else {
+        return Ok(ManagedUploadCleanupResult::default());
+    };
+
+    let mut result = ManagedUploadCleanupResult::default();
+    let mut seen_batches = std::collections::BTreeSet::new();
+    for batch in batches {
+        let batch = batch.trim();
+        if !seen_batches.insert(batch.to_string()) {
+            continue;
+        }
+        if batch.is_empty() || !batch.bytes().all(|byte| byte.is_ascii_digit()) {
+            result.skipped.push(batch.to_string());
+            continue;
+        }
+        let Some(batch_dir) = validate_managed_upload_batch(&uploads_root, batch)? else {
+            result.skipped.push(batch.to_string());
+            continue;
+        };
+        match remove_managed_upload_batch(&batch_dir)? {
+            Some(removed_files) => {
+                result.removed_files += removed_files;
+                result.removed_batches += 1;
+            }
+            None => result.skipped.push(batch.to_string()),
+        }
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn chat_history_managed_batch_cleanup_removes_owned_files() {
+        let temp = tempdir().expect("create temp dir");
+        let workdir = temp.path().join("workspace");
+        fs::create_dir_all(&workdir).expect("create workdir");
+        let batch_dir = create_managed_upload_batch(&workdir).expect("create managed batch");
+        fs::write(batch_dir.join("first.txt"), "first").expect("write first upload");
+        fs::write(batch_dir.join("second.txt"), "second").expect("write second upload");
+        let batch = batch_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("batch name")
+            .to_string();
+
+        let result = cleanup_managed_upload_batches_sync(&workdir.to_string_lossy(), &[batch])
+            .expect("cleanup managed batch");
+
+        assert_eq!(result.removed_files, 2);
+        assert_eq!(result.removed_batches, 1);
+        assert!(result.skipped.is_empty());
+        assert!(!batch_dir.exists());
+    }
+
+    #[test]
+    fn chat_history_managed_batch_cleanup_rejects_unowned_and_unsafe_batches() {
+        let temp = tempdir().expect("create temp dir");
+        let workdir = temp.path().join("workspace");
+        let unowned_batch = workdir.join("uploads").join("1234567890123");
+        fs::create_dir_all(&unowned_batch).expect("create unowned batch");
+        let unowned_file = unowned_batch.join("keep.txt");
+        fs::write(&unowned_file, "keep").expect("write unowned file");
+
+        let unsafe_batch = workdir.join("uploads").join("1234567890124");
+        fs::create_dir_all(unsafe_batch.join("nested")).expect("create unsafe nested directory");
+        fs::write(
+            unsafe_batch.join(MANAGED_UPLOAD_BATCH_MARKER),
+            MANAGED_UPLOAD_BATCH_MARKER_CONTENT,
+        )
+        .expect("write managed marker");
+        let nested_file = unsafe_batch.join("nested").join("keep.txt");
+        fs::write(&nested_file, "keep").expect("write nested file");
+        let batches = vec![
+            "1234567890123".to_string(),
+            "1234567890124".to_string(),
+            "../outside.txt".to_string(),
+        ];
+
+        let result = cleanup_managed_upload_batches_sync(&workdir.to_string_lossy(), &batches)
+            .expect("reject unsafe batches");
+
+        assert_eq!(result.removed_files, 0);
+        assert_eq!(result.removed_batches, 0);
+        assert_eq!(result.skipped.len(), batches.len());
+        assert!(unowned_file.is_file());
+        assert!(nested_file.is_file());
+    }
+}

--- a/crates/agent-gui/src-tauri/src/commands/history/chat_history/delete.rs
+++ b/crates/agent-gui/src-tauri/src/commands/history/chat_history/delete.rs
@@ -1,3 +1,175 @@
+#[derive(Debug)]
+struct ManagedUploadCleanupPlan {
+    workdir: String,
+    batches: Vec<String>,
+}
+
+fn collect_managed_upload_paths_from_value(
+    value: &Value,
+    path_pattern: &Regex,
+    paths: &mut std::collections::BTreeSet<String>,
+) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_managed_upload_paths_from_value(item, path_pattern, paths);
+            }
+        }
+        Value::Object(object) => {
+            for value in object.values() {
+                collect_managed_upload_paths_from_value(value, path_pattern, paths);
+            }
+        }
+        Value::String(text) => {
+            for matched in path_pattern.find_iter(text) {
+                let normalized = matched.as_str().replace('\\', "/");
+                let relative_path = normalized.as_str();
+                if crate::commands::upload_cleanup::is_managed_upload_relative_path(relative_path) {
+                    paths.insert(relative_path.to_string());
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_managed_upload_paths_from_json(
+    raw: &str,
+    path_pattern: &Regex,
+    paths: &mut std::collections::BTreeSet<String>,
+) -> Result<(), String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+    let parsed = serde_json::from_str::<Value>(trimmed)
+        .map_err(|error| format!("解析历史附件引用失败：{error}"))?;
+    collect_managed_upload_paths_from_value(&parsed, path_pattern, paths);
+    Ok(())
+}
+
+fn prepare_managed_upload_cleanup(
+    conn: &Connection,
+    conversation_id: &str,
+) -> Result<Option<ManagedUploadCleanupPlan>, String> {
+    let target_workdir = conn
+        .query_row(
+            "SELECT cwd FROM chatHistory WHERE id = ?1",
+            params![conversation_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .map_err(|error| format!("读取待删除对话工作目录失败：{error}"))?
+        .flatten()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let Some(target_workdir) = target_workdir else {
+        return Ok(None);
+    };
+    let canonical_target =
+        match crate::commands::upload_cleanup::canonicalize_upload_workdir(&target_workdir) {
+            Ok(path) => path,
+            Err(_) => return Ok(None),
+        };
+
+    let path_pattern = Regex::new(r"uploads[\\/][0-9]+[\\/][A-Za-z0-9._-]+")
+        .map_err(|error| format!("构建上传附件路径规则失败：{error}"))?;
+    let mut deleted_paths = std::collections::BTreeSet::new();
+    let mut stmt = conn
+        .prepare(
+            "
+            SELECT messages_json, summary_json
+            FROM chatHistorySegment
+            WHERE conversation_id = ?1
+            ",
+        )
+        .map_err(|error| format!("准备历史附件引用查询失败：{error}"))?;
+    let rows = stmt
+        .query_map(params![conversation_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })
+        .map_err(|error| format!("查询历史附件引用失败：{error}"))?;
+
+    for row in rows {
+        let (messages_json, summary_json) =
+            row.map_err(|error| format!("读取历史附件引用失败：{error}"))?;
+        collect_managed_upload_paths_from_json(&messages_json, &path_pattern, &mut deleted_paths)?;
+        if let Some(summary_json) = summary_json {
+            collect_managed_upload_paths_from_json(
+                &summary_json,
+                &path_pattern,
+                &mut deleted_paths,
+            )?;
+        }
+    }
+
+    let deleted_batches = deleted_paths
+        .iter()
+        .filter_map(|path| {
+            crate::commands::upload_cleanup::managed_upload_batch_for_relative_path(path)
+        })
+        .map(str::to_string)
+        .collect::<std::collections::BTreeSet<_>>();
+    if deleted_batches.is_empty() {
+        return Ok(None);
+    }
+
+    // Compare batches globally instead of resolving every history workdir. This avoids
+    // blocking on stale network paths and stays conservative when equivalent workdirs
+    // were stored with different spellings (for example, a trailing separator).
+    let mut retained_paths = std::collections::BTreeSet::new();
+    let mut stmt = conn
+        .prepare(
+            "
+            SELECT messages_json, summary_json
+            FROM chatHistorySegment
+            WHERE conversation_id <> ?1
+              AND (
+                instr(messages_json, 'uploads') > 0
+                OR instr(COALESCE(summary_json, ''), 'uploads') > 0
+              )
+            ",
+        )
+        .map_err(|error| format!("准备保留附件引用查询失败：{error}"))?;
+    let rows = stmt
+        .query_map(params![conversation_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })
+        .map_err(|error| format!("查询保留附件引用失败：{error}"))?;
+    for row in rows {
+        let (messages_json, summary_json) =
+            row.map_err(|error| format!("读取保留附件引用失败：{error}"))?;
+        collect_managed_upload_paths_from_json(&messages_json, &path_pattern, &mut retained_paths)?;
+        if let Some(summary_json) = summary_json {
+            collect_managed_upload_paths_from_json(
+                &summary_json,
+                &path_pattern,
+                &mut retained_paths,
+            )?;
+        }
+    }
+
+    let retained_batches = retained_paths
+        .iter()
+        .filter_map(|path| {
+            crate::commands::upload_cleanup::managed_upload_batch_for_relative_path(path)
+        })
+        .map(str::to_string)
+        .collect::<std::collections::BTreeSet<_>>();
+    let batches = deleted_batches
+        .difference(&retained_batches)
+        .cloned()
+        .collect::<Vec<_>>();
+    if batches.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(ManagedUploadCleanupPlan {
+        workdir: canonical_target.to_string_lossy().into_owned(),
+        batches,
+    }))
+}
+
 fn delete_chat_history_sync(
     conn: &mut Connection,
     id: &str,
@@ -23,6 +195,13 @@ fn delete_chat_history_sync(
     let tx = conn
         .transaction()
         .map_err(|e| format!("开启删除历史事务失败：{e}"))?;
+    let upload_cleanup = match prepare_managed_upload_cleanup(&tx, chat_id.as_str()) {
+        Ok(plan) => plan,
+        Err(error) => {
+            eprintln!("Failed to prepare deleted conversation upload cleanup: {error}");
+            None
+        }
+    };
     let subagent_prune_result =
         subagent_store::delete_subagent_history_for_parent_conversation(&tx, chat_id.as_str())?;
     delete_chat_history_conversation_fts(&tx, chat_id.as_str())?;
@@ -38,6 +217,24 @@ fn delete_chat_history_sync(
     .map_err(|e| format!("删除历史对话失败：{e}"))?;
     tx.commit()
         .map_err(|e| format!("提交删除历史事务失败：{e}"))?;
+
+    if let Some(plan) = upload_cleanup {
+        match crate::commands::upload_cleanup::cleanup_managed_upload_batches_sync(
+            &plan.workdir,
+            &plan.batches,
+        ) {
+            Ok(result) if !result.skipped.is_empty() => {
+                eprintln!(
+                    "Skipped some deleted conversation uploads: {}",
+                    result.skipped.join(", ")
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                eprintln!("Failed to cleanup deleted conversation uploads: {error}");
+            }
+        }
+    }
     Ok(subagent_prune_result)
 }
 

--- a/crates/agent-gui/src-tauri/src/commands/history/chat_history/tests.rs
+++ b/crates/agent-gui/src-tauri/src/commands/history/chat_history/tests.rs
@@ -895,6 +895,117 @@ mod tests {
     }
 
     #[test]
+    fn delete_conversation_cleans_upload_after_last_history_reference() {
+        let mut conn = open_test_db().expect("open test db");
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let workdir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workdir).expect("create workspace");
+        let mut uploaded_files =
+            crate::commands::system::system_import_uploaded_readable_files_sync(
+                workdir.to_string_lossy().into_owned(),
+                vec![
+                    crate::commands::system::SystemReadableFileUploadInput {
+                        file_name: "pasted-text-1.txt".to_string(),
+                        mime_type: Some("text/plain".to_string()),
+                        content: b"temporary conversation text".to_vec(),
+                    },
+                    crate::commands::system::SystemReadableFileUploadInput {
+                        file_name: "removed-from-draft.txt".to_string(),
+                        mime_type: Some("text/plain".to_string()),
+                        content: b"orphaned sibling".to_vec(),
+                    },
+                ],
+            )
+            .expect("import managed upload")
+            .files;
+        let upload = uploaded_files.remove(0);
+        let orphaned_sibling = uploaded_files.remove(0);
+        let upload_path = std::path::PathBuf::from(&upload.absolute_path);
+        let orphaned_sibling_path = std::path::PathBuf::from(&orphaned_sibling.absolute_path);
+        let upload_batch = upload_path.parent().expect("upload batch").to_path_buf();
+
+        let mut first = sample_conversation();
+        first.cwd = Some(workdir.to_string_lossy().into_owned());
+        upsert_chat_history_header(&conn, &first).expect("insert first conversation");
+        let first_messages = serde_json::to_string(&serde_json::json!([{
+            "id": "m-user-1",
+            "role": "user",
+            "content": format!("[Pasted text 1: {}]", upload.relative_path),
+            "liveAgentAttachments": [{
+                "relativePath": upload.relative_path.clone(),
+                "absolutePath": upload.absolute_path.clone(),
+                "fileName": upload.file_name.clone(),
+                "kind": upload.kind.clone(),
+                "sizeBytes": upload.size_bytes
+            }]
+        }]))
+        .expect("serialize first conversation messages");
+        upsert_single_segment(
+            &conn,
+            "conv-1",
+            &ChatHistorySegmentInput {
+                segment_index: 0,
+                segment_id: "segment-0".to_string(),
+                summary_json: None,
+                messages_json: first_messages,
+                message_count: 1,
+                start_message_id: Some("m-user-1".to_string()),
+                end_message_id: Some("m-user-1".to_string()),
+                created_at: 1_700_000_000_000,
+                updated_at: 1_700_000_000_100,
+            },
+        )
+        .expect("insert first conversation segment");
+
+        let mut second = sample_conversation();
+        second.id = "conv-2".to_string();
+        second.cwd = Some(format!(
+            "{}{}",
+            workdir.to_string_lossy(),
+            std::path::MAIN_SEPARATOR
+        ));
+        upsert_chat_history_header(&conn, &second).expect("insert second conversation");
+        let second_summary = serde_json::to_string(&serde_json::json!({
+            "summary": format!("Retain {} for the next turn", upload.relative_path)
+        }))
+        .expect("serialize second conversation summary");
+        upsert_single_segment(
+            &conn,
+            "conv-2",
+            &ChatHistorySegmentInput {
+                segment_index: 0,
+                segment_id: "segment-0".to_string(),
+                summary_json: Some(second_summary),
+                messages_json: "[]".to_string(),
+                message_count: 0,
+                start_message_id: None,
+                end_message_id: None,
+                created_at: 1_700_000_000_000,
+                updated_at: 1_700_000_000_100,
+            },
+        )
+        .expect("insert second conversation segment");
+
+        delete_chat_history_sync(&mut conn, "conv-1").expect("delete first conversation");
+        assert!(
+            upload_path.is_file(),
+            "another conversation still references the upload"
+        );
+        assert!(orphaned_sibling_path.is_file());
+
+        delete_chat_history_sync(&mut conn, "conv-2").expect("delete second conversation");
+        assert!(
+            !upload_path.exists(),
+            "last reference cleanup removes upload"
+        );
+        assert!(
+            !orphaned_sibling_path.exists(),
+            "batch cleanup removes an unreferenced sibling"
+        );
+        assert!(!upload_batch.exists(), "empty managed batch is pruned");
+    }
+
+    #[test]
     fn resolve_share_returns_full_conversation_segments() {
         let conn = open_test_db().expect("open test db");
         let conversation = sample_conversation();

--- a/crates/agent-gui/src-tauri/src/commands/mod.rs
+++ b/crates/agent-gui/src-tauri/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod workspace_commands;
 pub use app_commands::app;
 pub use app_commands::custom_tools;
 pub use app_commands::system;
+pub use app_commands::upload_cleanup;
 pub use app_commands::update;
 
 pub use automation_commands::cron;


### PR DESCRIPTION
## 变更

- 为新建的 `uploads/<batch>/` 写入 LiveAgent 专用标记，明确区分应用托管的临时文件与用户文件
- 删除对话时收集消息和摘要中的上传引用；仅在最后一个历史引用消失后删除整个上传批次
- GUI 与 WebUI 共用历史删除后端，因此两条删除路径都会执行清理
- 清理失败不会回滚已成功提交的历史删除

## 安全边界

- 不处理没有专用标记的旧批次，避免误删用户自行创建的 `uploads` 内容
- 批次内存在子目录、符号链接或特殊文件时拒绝删除
- 其他对话仍有引用时保留批次，即使工作目录字符串写法不同

## 验证

- `cargo check --manifest-path crates/agent-gui/src-tauri/Cargo.toml --tests`
- `cargo clippy --manifest-path crates/agent-gui/src-tauri/Cargo.toml --tests`
- 新增托管批次删除、非托管/不安全批次拒绝，以及跨对话最后引用清理测试

Closes #112