### PR TITLE
fix: filter synthetic subagent cards from model history

### DIFF
--- a/crates/agent-gui/src/lib/chat/compaction/payload.ts
+++ b/crates/agent-gui/src/lib/chat/compaction/payload.ts
@@ -3,7 +3,10 @@ import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
 import type { StreamDebugLogger } from "../../debug/agentDebug";
 import { assistantMessageToText } from "../../providers/llm";
 import type { ProviderModelConfig } from "../../settings";
-import { sanitizeMessageForModelContext } from "../context/requestContextSanitizer";
+import {
+  sanitizeMessageForModelContext,
+  sanitizeMessagesForModelContext,
+} from "../context/requestContextSanitizer";
 import {
   type ConversationViewState,
   getActiveSegment,
@@ -198,6 +201,7 @@ export function buildCompactionPayload(params: {
   threshold: number;
 }): CompactionPayload {
   const activeSegment = getActiveSegment(params.state);
+  const activeSegmentMessages = sanitizeMessagesForModelContext(activeSegment.messages);
   return {
     compaction_reason: {
       trigger:
@@ -215,7 +219,7 @@ export function buildCompactionPayload(params: {
           summaryMeta: summaryMetaForPayload(activeSegment.summary.summaryMeta),
         }
       : null,
-    active_segment_messages: activeSegment.messages.map((message, index) =>
+    active_segment_messages: activeSegmentMessages.map((message, index) =>
       serializeMessageForCompaction(message, index),
     ),
     next_user_message: params.incomingUserText?.trim() ? params.incomingUserText : undefined,

--- a/crates/agent-gui/src/lib/chat/context/requestContextSanitizer.ts
+++ b/crates/agent-gui/src/lib/chat/context/requestContextSanitizer.ts
@@ -1,4 +1,5 @@
 import type { Context, Message, TextContent, ToolResultMessage } from "@earendil-works/pi-ai";
+import { isSubagentCardToolCall } from "../../subagents/card";
 import type { DisplayImageItemDetails, DisplayImageResultDetails } from "../../tools/builtinTypes";
 import { normalizeHostedSearchBlock } from "../messages/hostedSearch";
 import { isOnlyDsmlOrphanCloseTags, stripDsmlToolCallMarkup } from "../runner/deepSeekDsml";
@@ -150,6 +151,11 @@ export function sanitizeMessageForModelContext(message: Message): Message {
     const nextContent: unknown[] = [];
     let changed = false;
     for (const block of nextMessage.content as unknown[]) {
+      if (isSubagentCardToolCall(block)) {
+        changed = true;
+        continue;
+      }
+
       const hostedSearch = normalizeHostedSearchBlock(block);
       if (hostedSearch) {
         changed = true;
@@ -181,8 +187,30 @@ export function sanitizeMessageForModelContext(message: Message): Message {
   };
 }
 
+function collectSubagentCardToolCallIds(messages: Message[]) {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== "assistant" || !Array.isArray(message.content)) continue;
+    for (const block of message.content as unknown[]) {
+      if (!isSubagentCardToolCall(block) || !isRecord(block)) continue;
+      if (typeof block.id === "string" && block.id) ids.add(block.id);
+    }
+  }
+  return ids;
+}
+
+function isSubagentCardToolResult(message: Message, toolCallIds: Set<string>) {
+  return (
+    message.role === "toolResult" &&
+    (toolCallIds.has(message.toolCallId) ||
+      (isRecord(message.details) && message.details.kind === "subagent_card"))
+  );
+}
+
 export function sanitizeMessagesForModelContext(messages: Message[]): Message[] {
+  const subagentCardToolCallIds = collectSubagentCardToolCallIds(messages);
   return messages
+    .filter((message) => !isSubagentCardToolResult(message, subagentCardToolCallIds))
     .map(sanitizeMessageForModelContext)
     .filter(
       (message) =>

--- a/crates/agent-gui/src/lib/chat/conversation/chatAbort.ts
+++ b/crates/agent-gui/src/lib/chat/conversation/chatAbort.ts
@@ -1,6 +1,14 @@
-import type { AssistantMessage, Message, Model, Usage } from "@earendil-works/pi-ai";
+import type {
+  AssistantMessage,
+  Message,
+  Model,
+  ToolCall,
+  ToolResultMessage,
+  Usage,
+} from "@earendil-works/pi-ai";
 
 import type { ExecutionMode } from "../../settings";
+import { isSubagentCardToolCall } from "../../subagents/card";
 import {
   getRoundToolTrace,
   hasRoundContent,
@@ -14,6 +22,12 @@ export type LiveRoundSnapshot = {
   round: number;
   blocks: UiRoundContentBlock[];
   meta?: UiRoundMeta;
+};
+
+export type SuppressedToolTraceSnapshot = {
+  round: number;
+  toolCall: ToolCall;
+  toolResult?: ToolResultMessage;
 };
 
 const ZERO_USAGE: Usage = {
@@ -50,11 +64,14 @@ export function cloneLiveRoundSnapshots(rounds: LiveRoundSnapshot[]): LiveRoundS
 function buildAssistantMessage(params: {
   model: Model<any>;
   blocks?: UiRoundContentBlock[];
+  suppressedToolCalls?: ToolCall[];
   stopReason: AssistantMessage["stopReason"];
   timestamp: number;
 }): AssistantMessage | null {
   const content: AssistantMessage["content"] = [];
   for (const block of params.blocks ?? []) {
+    if (block.kind === "tool" && isSubagentCardToolCall(block.item.toolCall)) continue;
+
     if (block.kind === "thinking") {
       if (!block.text) continue;
       content.push({
@@ -78,6 +95,13 @@ function buildAssistantMessage(params: {
     content.push({
       ...block.item.toolCall,
       arguments: cloneValue(block.item.toolCall.arguments ?? {}),
+    });
+  }
+
+  for (const toolCall of params.suppressedToolCalls ?? []) {
+    content.push({
+      ...toolCall,
+      arguments: cloneValue(toolCall.arguments ?? {}),
     });
   }
 
@@ -107,6 +131,8 @@ export function buildAbortedMessagesFromSnapshot(params: {
   model: Model<any>;
   draftAssistantText: string;
   liveRounds: LiveRoundSnapshot[];
+  completedThroughRound?: number;
+  suppressedToolTrace?: SuppressedToolTraceSnapshot[];
   timestamp?: number;
 }): Message[] {
   const timestamp = params.timestamp ?? Date.now();
@@ -123,15 +149,36 @@ export function buildAbortedMessagesFromSnapshot(params: {
 
   const messages: Message[] = [];
   const rounds = params.liveRounds.filter((round) => hasRoundContent(round));
+  const completedThroughRound = params.completedThroughRound ?? 0;
 
   rounds.forEach((round, index) => {
     const isLastRound = index === rounds.length - 1;
-    const toolTrace = getRoundToolTrace(round);
+    const visibleToolTrace = getRoundToolTrace(round).filter(
+      (item) => !isSubagentCardToolCall(item.toolCall),
+    );
+    const visibleToolCallIds = new Set(visibleToolTrace.map((item) => item.toolCall.id));
+    const suppressedToolTrace = (params.suppressedToolTrace ?? []).filter(
+      (item) =>
+        item.round === round.round &&
+        !isSubagentCardToolCall(item.toolCall) &&
+        !visibleToolCallIds.has(item.toolCall.id),
+    );
+    const toolTrace = [...visibleToolTrace, ...suppressedToolTrace];
     const hasToolCalls = toolTrace.length > 0;
+    const roundCompleted = round.round <= completedThroughRound;
     const assistant = buildAssistantMessage({
       model: params.model,
       blocks: round.blocks,
-      stopReason: isLastRound ? "aborted" : hasToolCalls ? "toolUse" : "stop",
+      suppressedToolCalls: suppressedToolTrace.map((item) => item.toolCall),
+      stopReason: roundCompleted
+        ? hasToolCalls
+          ? "toolUse"
+          : "stop"
+        : isLastRound
+          ? "aborted"
+          : hasToolCalls
+            ? "toolUse"
+            : "stop",
       timestamp: timestamp + index,
     });
 
@@ -205,6 +252,8 @@ export function buildPersistableMessagesFromSnapshot(params: {
   model: Model<any>;
   draftAssistantText: string;
   liveRounds: LiveRoundSnapshot[];
+  completedThroughRound?: number;
+  suppressedToolTrace?: SuppressedToolTraceSnapshot[];
   timestamp?: number;
 }) {
   return sanitizeAbortedHistoryMessages(buildAbortedMessagesFromSnapshot(params));

--- a/crates/agent-gui/src/lib/chat/messages/uiMessages.ts
+++ b/crates/agent-gui/src/lib/chat/messages/uiMessages.ts
@@ -7,9 +7,9 @@ import type {
 } from "@earendil-works/pi-ai";
 import { assistantMessageToText } from "../../providers/llm";
 import { isProviderNativeWebSearchToolName } from "../../providers/nativeWebSearch";
+import { isSubagentCardToolCall } from "../../subagents/card";
 import {
   buildSubagentCardToolCallId,
-  isSubagentCardArguments,
   type SubagentBatchDetails,
   type SubagentCardDetails,
 } from "../../subagents/protocol";
@@ -655,10 +655,6 @@ function rebalanceHostedSearchTextBoundaries(blocks: UiRoundContentBlock[]): UiR
     out.push(current);
   }
   return out;
-}
-
-function isSubagentCardToolCall(toolCall: ToolCall) {
-  return toolCall.name === "Agent" && isSubagentCardArguments(toolCall.arguments);
 }
 
 function isParentAgentToolCall(toolCall: ToolCall) {

--- a/crates/agent-gui/src/lib/subagents/card.ts
+++ b/crates/agent-gui/src/lib/subagents/card.ts
@@ -1,0 +1,19 @@
+import type { ToolCall } from "@earendil-works/pi-ai";
+
+import { isSubagentCardArguments, type SubagentCardArguments } from "./protocol";
+import { AGENT_TOOL_NAME } from "./types";
+
+export type SubagentCardToolCall = ToolCall & {
+  name: typeof AGENT_TOOL_NAME;
+  arguments: SubagentCardArguments;
+};
+
+export function isSubagentCardToolCall(value: unknown): value is SubagentCardToolCall {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const toolCall = value as Record<string, unknown>;
+  return (
+    toolCall.type === "toolCall" &&
+    toolCall.name === AGENT_TOOL_NAME &&
+    isSubagentCardArguments(toolCall.arguments)
+  );
+}

--- a/crates/agent-gui/src/lib/subagents/index.ts
+++ b/crates/agent-gui/src/lib/subagents/index.ts
@@ -1,5 +1,6 @@
 export { createSubagentTools, type SubagentRuntimeConfig } from "./agentTool";
 export { renderMessageBusSnapshot } from "./bus";
+export { isSubagentCardToolCall } from "./card";
 export type { SubagentStoreIpc } from "./ipc/store";
 export type { SubagentWorktreeIpc } from "./ipc/worktree";
 export type {

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -42,7 +42,10 @@ import type { AppUpdateController } from "../lib/appUpdates";
 import { getAutomationState } from "../lib/automation";
 import { createHookRunScope } from "../lib/automation/hookRunner";
 import type { CompactionStatus } from "../lib/chat/compaction/types";
-import { buildPersistableMessagesFromSnapshot } from "../lib/chat/conversation/chatAbort";
+import {
+  buildPersistableMessagesFromSnapshot,
+  type SuppressedToolTraceSnapshot,
+} from "../lib/chat/conversation/chatAbort";
 import {
   appendMessagesToConversation,
   buildRequestContext,
@@ -4390,6 +4393,13 @@ export function ChatPage(props: ChatPageProps) {
     });
 
     let abortedConversationCommitted = false;
+    let persistableAgentProgress: {
+      completedThroughRound: number;
+      suppressedToolTrace: SuppressedToolTraceSnapshot[];
+    } = {
+      completedThroughRound: 0,
+      suppressedToolTrace: [],
+    };
     const commitVisibleAbortedConversation = () => {
       if (abortedConversationCommitted) return true;
 
@@ -4399,6 +4409,8 @@ export function ChatPage(props: ChatPageProps) {
         model: runtimeModel,
         draftAssistantText: snapshot.draftAssistantText,
         liveRounds: snapshot.liveRounds,
+        completedThroughRound: persistableAgentProgress.completedThroughRound,
+        suppressedToolTrace: persistableAgentProgress.suppressedToolTrace,
       });
 
       if (partialMessages.length === 0) return false;
@@ -4432,6 +4444,8 @@ export function ChatPage(props: ChatPageProps) {
         model: runtimeModel,
         draftAssistantText: snapshot.draftAssistantText,
         liveRounds: snapshot.liveRounds,
+        completedThroughRound: persistableAgentProgress.completedThroughRound,
+        suppressedToolTrace: persistableAgentProgress.suppressedToolTrace,
       });
       const errorAssistant = buildErrorAssistantMessage({
         model: runtimeModel,
@@ -4549,6 +4563,9 @@ export function ChatPage(props: ChatPageProps) {
             resetLiveTranscript,
             batchLiveRoundsUpdate,
             updateToolStatus,
+            updatePersistableAgentProgress: (progress) => {
+              persistableAgentProgress = progress;
+            },
             commitVisibleAbortedConversation,
             updateConversationRuntimeEntry,
             persistConversationWithHistorySync,

--- a/crates/agent-gui/src/pages/chat/components/assistant-bubble/ToolCallItem.tsx
+++ b/crates/agent-gui/src/pages/chat/components/assistant-bubble/ToolCallItem.tsx
@@ -18,6 +18,7 @@ import {
   toolResultMessageToText,
 } from "../../../../lib/chat/messages/uiMessages";
 import { cn } from "../../../../lib/shared/utils";
+import { isSubagentCardToolCall } from "../../../../lib/subagents/card";
 import {
   areStableValuesEqual,
   displayString,
@@ -25,7 +26,6 @@ import {
   getSubagentInlineSummary,
   getToolDisplayTitle,
   getToolMeta,
-  isSubagentCardToolCall,
   type MetaTag,
 } from "./assistantBubbleUtils";
 import { FileToolArgsDisplay } from "./FileToolArgs";

--- a/crates/agent-gui/src/pages/chat/components/assistant-bubble/assistantBubbleUtils.ts
+++ b/crates/agent-gui/src/pages/chat/components/assistant-bubble/assistantBubbleUtils.ts
@@ -92,13 +92,6 @@ export function compactInlineText(value: unknown, maxChars = 120) {
   return `${text.slice(0, maxChars)}...`;
 }
 
-export function isSubagentCardToolCall(toolCall: {
-  name: string;
-  arguments?: Record<string, unknown>;
-}) {
-  return toolCall.name === "Agent" && toolCall.arguments?.subagent_card === true;
-}
-
 export function getSubagentTask(agent: { prompt?: unknown }) {
   return displayString(agent.prompt);
 }

--- a/crates/agent-gui/src/pages/chat/turns/runAgentConversationTurn.ts
+++ b/crates/agent-gui/src/pages/chat/turns/runAgentConversationTurn.ts
@@ -7,7 +7,10 @@ import type {
 } from "@earendil-works/pi-ai";
 import type { CompactionController } from "../../../lib/chat/compaction/controller";
 import type { ProviderRuntimeConfig } from "../../../lib/chat/compaction/types";
-import { isAbortedAssistantMessage } from "../../../lib/chat/conversation/chatAbort";
+import {
+  isAbortedAssistantMessage,
+  type SuppressedToolTraceSnapshot,
+} from "../../../lib/chat/conversation/chatAbort";
 import {
   appendMessagesToConversation,
   appendRenderOnlyMessagesToConversation,
@@ -54,7 +57,7 @@ import {
   AGENT_TOOL_NAME,
   buildRosterReminder,
   createSubagentScheduler,
-  isSubagentCardArguments,
+  isSubagentCardToolCall,
   renderMessageBusSnapshot,
   SUBAGENT_PARENT_ID,
   type SubagentConversationStore,
@@ -173,10 +176,6 @@ function finishAgentPerfSpan(
   return durationMs;
 }
 
-function isSubagentCardToolCall(toolCall: ToolCall) {
-  return toolCall.name === AGENT_TOOL_NAME && isSubagentCardArguments(toolCall.arguments);
-}
-
 // Only enabled, non-empty templates are resolvable from Agent calls.
 function enabledSubagentTemplates(agentTemplates: AppSettings["agents"]): SubagentTemplate[] {
   return (agentTemplates ?? [])
@@ -254,6 +253,10 @@ export type RunAgentConversationTurnParams = {
     store: LiveTranscriptStore,
   ) => void;
   updateToolStatus: (status: string | null, store: LiveTranscriptStore) => void;
+  updatePersistableAgentProgress: (progress: {
+    completedThroughRound: number;
+    suppressedToolTrace: SuppressedToolTraceSnapshot[];
+  }) => void;
   commitVisibleAbortedConversation: () => boolean;
   updateConversationRuntimeEntry: (
     conversationId: string,
@@ -308,6 +311,7 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
     resetLiveTranscript,
     batchLiveRoundsUpdate,
     updateToolStatus,
+    updatePersistableAgentProgress,
     commitVisibleAbortedConversation,
     updateConversationRuntimeEntry,
     persistConversationWithHistorySync,
@@ -460,6 +464,7 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
   hookLifecycle.startAgent();
   let result: Awaited<ReturnType<typeof runAssistantWithTools>> | null = null;
   let latestAgentEmittedMessages: Message[] = [];
+  let suppressedToolTrace: SuppressedToolTraceSnapshot[] = [];
   let activeAgentRound = 0;
   let pendingAgentContext: Context | null = null;
   const pendingTerminalAssistantMetaRef: {
@@ -470,6 +475,45 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
   } = {
     current: null,
   };
+
+  function publishPersistableAgentProgress(
+    round: number,
+    assistant: AssistantMessage,
+    toolResults: ToolResultMessage[],
+  ) {
+    const toolResultsById = new Map(
+      toolResults.map((toolResult) => [toolResult.toolCallId, toolResult]),
+    );
+    const roundTrace = assistant.content
+      .filter(
+        (block): block is ToolCall =>
+          block.type === "toolCall" &&
+          block.name === AGENT_TOOL_NAME &&
+          !isSubagentCardToolCall(block),
+      )
+      .map((toolCall) => ({
+        round,
+        toolCall,
+        toolResult: toolResultsById.get(toolCall.id),
+      }));
+
+    suppressedToolTrace = [
+      ...suppressedToolTrace.filter((item) => item.round !== round),
+      ...roundTrace,
+    ];
+    updatePersistableAgentProgress({
+      completedThroughRound: round,
+      suppressedToolTrace: suppressedToolTrace.slice(),
+    });
+  }
+
+  function clearPersistableAgentProgress() {
+    suppressedToolTrace = [];
+    updatePersistableAgentProgress({
+      completedThroughRound: 0,
+      suppressedToolTrace: [],
+    });
+  }
 
   function commitAssistantRoundMeta(assistant: AssistantMessage, round: number) {
     gatewayBridgeEvents.queueToken("", {
@@ -786,7 +830,8 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
           gatewayBridgeEvents.queueToolStatus(s, false);
           updateToolStatus(s, transcriptStore);
         },
-        onBeforeNextTurn: async ({ emittedMessages }) => {
+        onBeforeNextTurn: async ({ round, assistant, toolResults, emittedMessages }) => {
+          publishPersistableAgentProgress(round, assistant, toolResults);
           latestAgentEmittedMessages = emittedMessages.slice();
           await refreshParentMessageBusSnapshot();
           const tempState = appendMessagesToConversation(
@@ -814,6 +859,7 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
               : null;
           }
           latestAgentEmittedMessages = [];
+          clearPersistableAgentProgress();
           return {
             context: withSubagentRuntimeContext(compactedContext),
             emittedMessages: [],
@@ -853,6 +899,7 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
       ]);
       latestAgentEmittedMessages = [];
       applyConversationState(tempState);
+      clearPersistableAgentProgress();
 
       const compactedContext = await compaction.compactDuringRun({
         trigger: "mid-stream",

--- a/crates/agent-gui/test/chat/agent-runner.test.mjs
+++ b/crates/agent-gui/test/chat/agent-runner.test.mjs
@@ -523,6 +523,46 @@ test("runAssistantWithTools calls onBeforeNextTurn only for toolUse turns with t
   );
 });
 
+// Mocked turn tests (agent-turn-cancelled-history.test.mjs) replay this payload
+// shape by hand; the assertions here are what keep those replicas honest.
+test("runAssistantWithTools reports 1-based monotonic rounds and paired tool results to onBeforeNextTurn", async () => {
+  const firstToolCall = createToolCall("call-read-1", "Read", { path: "a.ts" });
+  const secondToolCall = createToolCall("call-read-2", "Read", { path: "b.ts" });
+  resetFakeStreams(
+    createToolUseAssistant(firstToolCall),
+    createToolUseAssistant(secondToolCall),
+    createTextAssistant("final answer"),
+  );
+  const beforeNextTurnSnapshots = [];
+  const { params } = createBaseParams({
+    onBeforeNextTurn: async (snapshot) => {
+      beforeNextTurnSnapshots.push(snapshot);
+      return null;
+    },
+  });
+
+  await runAssistantWithTools(params);
+
+  assert.deepEqual(
+    beforeNextTurnSnapshots.map((snapshot) => snapshot.round),
+    [1, 2],
+  );
+  assert.deepEqual(
+    beforeNextTurnSnapshots.map((snapshot) =>
+      snapshot.assistant.content
+        .filter((block) => block.type === "toolCall")
+        .map((block) => block.id),
+    ),
+    [[firstToolCall.id], [secondToolCall.id]],
+  );
+  assert.deepEqual(
+    beforeNextTurnSnapshots.map((snapshot) =>
+      snapshot.toolResults.map((toolResult) => toolResult.toolCallId),
+    ),
+    [[firstToolCall.id], [secondToolCall.id]],
+  );
+});
+
 test("runAssistantWithTools canonicalizes builtin tool call name casing before execution", async () => {
   const lowerCaseWriteCall = createToolCall("call-write", "write", {
     path: "report.html",

--- a/crates/agent-gui/test/chat/agent-turn-cancelled-history.test.mjs
+++ b/crates/agent-gui/test/chat/agent-turn-cancelled-history.test.mjs
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const parentId = "call-parent|fc_parent";
+const cardId = `${parentId}:agent:1`;
+
+const parentToolCall = {
+  type: "toolCall",
+  id: parentId,
+  name: "Agent",
+  arguments: { agents: [{ id: "reviewer", prompt: "review" }] },
+};
+const cardToolCall = {
+  type: "toolCall",
+  id: cardId,
+  name: "Agent",
+  arguments: {
+    subagent_card: true,
+    parent_tool_call_id: parentId,
+    id: "reviewer",
+  },
+};
+const parentToolResult = {
+  role: "toolResult",
+  toolCallId: parentId,
+  toolName: "Agent",
+  content: [{ type: "text", text: "batch done" }],
+  details: { kind: "subagent_batch" },
+  isError: false,
+  timestamp: 3,
+};
+const cardToolResult = {
+  role: "toolResult",
+  toolCallId: cardId,
+  toolName: "Agent",
+  content: [{ type: "text", text: "reviewer done" }],
+  details: { kind: "subagent_card" },
+  isError: false,
+  timestamp: 3,
+};
+const toolUseAssistant = {
+  role: "assistant",
+  provider: "codex",
+  api: "openai-responses",
+  model: "gpt-5",
+  content: [parentToolCall, cardToolCall],
+  stopReason: "toolUse",
+  timestamp: 2,
+};
+const abortedAssistant = {
+  role: "assistant",
+  provider: "codex",
+  api: "openai-responses",
+  model: "gpt-5",
+  content: [{ type: "text", text: "partial final" }],
+  stopReason: "aborted",
+  timestamp: 4,
+};
+
+const agentRunnerPath = fileURLToPath(
+  new URL("../../src/lib/chat/runner/agentRunner.ts", import.meta.url),
+);
+const builtinRegistryPath = fileURLToPath(
+  new URL("../../src/lib/tools/builtinRegistry.ts", import.meta.url),
+);
+const runtimePlatformPath = fileURLToPath(
+  new URL("../../src/lib/runtimePlatform.ts", import.meta.url),
+);
+const memoryExtractionPath = fileURLToPath(
+  new URL("../../src/lib/chat/memory/extractionController.ts", import.meta.url),
+);
+const fileToolStatePath = fileURLToPath(
+  new URL("../../src/lib/tools/fileToolState.ts", import.meta.url),
+);
+const todoToolsPath = fileURLToPath(
+  new URL("../../src/lib/tools/todoTools.ts", import.meta.url),
+);
+
+const loader = createTsModuleLoader({
+  mocks: {
+    [agentRunnerPath]: {
+      async runAssistantWithTools(params) {
+        params.onTurnStart?.(1);
+        params.onToolCall?.(parentToolCall, 1);
+        params.onToolCall?.(cardToolCall, 1);
+        params.onToolResult?.(parentToolCall, parentToolResult, 1);
+        params.onToolResult?.(cardToolCall, cardToolResult, 1);
+        params.onAssistantMessage?.(toolUseAssistant, 1);
+        await params.onBeforeNextTurn?.({
+          round: 1,
+          assistant: toolUseAssistant,
+          toolResults: [parentToolResult, cardToolResult],
+          emittedMessages: [toolUseAssistant, parentToolResult, cardToolResult],
+          runtimeContext: params.context,
+          signal: params.signal,
+        });
+
+        params.onTurnStart?.(2);
+        params.onTextDelta?.("partial final", 2);
+        params.onAssistantMessage?.(abortedAssistant, 2);
+        return {
+          assistant: abortedAssistant,
+          messages: [toolUseAssistant, parentToolResult, cardToolResult, abortedAssistant],
+          emittedMessages: [
+            toolUseAssistant,
+            parentToolResult,
+            cardToolResult,
+            abortedAssistant,
+          ],
+        };
+      },
+    },
+    [builtinRegistryPath]: {
+      async buildBuiltinToolRegistry() {
+        return {
+          tools: [],
+          async executeToolCall() {
+            throw new Error("tool execution was not expected");
+          },
+        };
+      },
+    },
+    [runtimePlatformPath]: {
+      async resolveRuntimePlatform() {
+        return "win32";
+      },
+    },
+    [memoryExtractionPath]: {
+      memoryExtraction: {
+        noteTurnBoundary() {},
+      },
+    },
+    [fileToolStatePath]: {
+      createFileToolState() {
+        return {};
+      },
+    },
+    [todoToolsPath]: {
+      getOrCreateTodoToolState() {
+        return {};
+      },
+    },
+  },
+});
+
+const { runAgentConversationTurn } = loader.loadModule(
+  "src/pages/chat/turns/runAgentConversationTurn.ts",
+);
+const conversationState = loader.loadModule("src/lib/chat/conversation/conversationState.ts");
+
+function noOp() {}
+
+function createHookLifecycle() {
+  return {
+    startAgent: noOp,
+    startTurn: noOp,
+    ensureMessageEnded: noOp,
+    assistantMessageCompleted: noOp,
+    toolResultReceived: noOp,
+  };
+}
+
+test("agent turn preserves suppressed parent Agent trace for cancellation persistence", async () => {
+  let liveRounds = [];
+  const progressUpdates = [];
+  let committed = false;
+  const state = conversationState.createConversationStateFromContext({
+    systemPrompt: "",
+    messages: [],
+  });
+
+  await runAgentConversationTurn({
+    providerId: "codex",
+    model: "gpt-5",
+    runtime: {},
+    runtimeModel: {
+      provider: "codex",
+      api: "openai-responses",
+      id: "gpt-5",
+    },
+    selectedModel: { customProviderId: "codex", model: "gpt-5" },
+    effectiveWorkdir: "C:/workspace",
+    effectiveSkillsEnabled: false,
+    showSilentMemoryExtraction: false,
+    agentTemplates: [],
+    selectedSystemToolIds: [],
+    getMcpSettings: () => ({ servers: [], selected: [] }),
+    sessionId: "session-1",
+    conversationId: "conversation-1",
+    fallbackTitle: "title",
+    createdAt: 1,
+    titlePromise: null,
+    transcriptStore: {},
+    gatewayBridgeEvents: {
+      queueToken: noOp,
+      queueEvent: noOp,
+      queueToolStatus: noOp,
+    },
+    hookLifecycle: createHookLifecycle(),
+    conversationDebugLogger: { enabled: false, logResult: noOp },
+    getNextConversationState: () => state,
+    applyConversationState: noOp,
+    buildPreparedContext: () => ({ systemPrompt: "", messages: [] }),
+    compaction: {
+      async maybeCompactPreSend() {},
+      beginRequest: noOp,
+      shouldProtectMidStream: () => false,
+      async compactDuringRun() {
+        return null;
+      },
+    },
+    cancellation: {
+      deriveScope() {
+        return { controller: new AbortController(), release: noOp };
+      },
+    },
+    resetLiveTranscript: noOp,
+    batchLiveRoundsUpdate(updater) {
+      liveRounds = updater(liveRounds);
+    },
+    updateToolStatus: noOp,
+    updatePersistableAgentProgress(progress) {
+      progressUpdates.push(progress);
+    },
+    commitVisibleAbortedConversation() {
+      committed = true;
+      return true;
+    },
+    updateConversationRuntimeEntry: noOp,
+    async persistConversationWithHistorySync() {
+      return true;
+    },
+  });
+
+  assert.equal(committed, true);
+  assert.equal(progressUpdates.length, 1);
+  assert.equal(progressUpdates[0].completedThroughRound, 1);
+  assert.deepEqual(
+    progressUpdates[0].suppressedToolTrace.map((item) => [
+      item.round,
+      item.toolCall.id,
+      item.toolResult?.toolCallId,
+    ]),
+    [[1, parentId, parentId]],
+  );
+
+  const visibleToolCalls = liveRounds.flatMap((round) =>
+    round.blocks
+      .filter((block) => block.kind === "tool")
+      .map((block) => block.item.toolCall.id),
+  );
+  assert.deepEqual(visibleToolCalls, [cardId]);
+  assert.equal(visibleToolCalls.includes(parentId), false);
+});

--- a/crates/agent-gui/test/chat/agent-turn-cancelled-history.test.mjs
+++ b/crates/agent-gui/test/chat/agent-turn-cancelled-history.test.mjs
@@ -82,6 +82,9 @@ const todoToolsPath = fileURLToPath(
 const loader = createTsModuleLoader({
   mocks: {
     [agentRunnerPath]: {
+      // Replays the real runner's hook payload shape by hand; that contract
+      // (1-based rounds, results paired by toolCallId) is pinned against the
+      // real runner in agent-runner.test.mjs.
       async runAssistantWithTools(params) {
         params.onTurnStart?.(1);
         params.onToolCall?.(parentToolCall, 1);

--- a/crates/agent-gui/test/chat/cancelled-history.test.mjs
+++ b/crates/agent-gui/test/chat/cancelled-history.test.mjs
@@ -100,6 +100,73 @@ test("persistable cancelled snapshot keeps visible provider hosted search blocks
   assert.deepEqual(messages[0].content, [hostedSearch]);
 });
 
+test("persistable cancelled snapshot restores suppressed parent Agent trace without card artifacts", () => {
+  const parentId = "call-parent|fc_parent";
+  const cardId = `${parentId}:agent:1`;
+
+  const parentToolCall = toolCall(parentId, "Agent", { agents: [] });
+  const parentToolResult = {
+    ...toolResult(parentId, "Agent", "batch done"),
+    details: { kind: "subagent_batch" },
+  };
+  const messages = chatAbort.buildPersistableMessagesFromSnapshot({
+    executionMode: "agent",
+    model: {
+      api: "openai-responses",
+      provider: "codex",
+      id: "gpt-5",
+    },
+    draftAssistantText: "",
+    liveRounds: [
+      {
+        round: 1,
+        blocks: [
+          {
+            kind: "tool",
+            item: {
+              toolCall: toolCall(cardId, "Agent", {
+                subagent_card: true,
+                parent_tool_call_id: parentId,
+                id: "reviewer",
+              }),
+              toolResult: {
+                ...toolResult(cardId, "Agent", "done"),
+                details: { kind: "subagent_card" },
+              },
+            },
+          },
+        ],
+      },
+      {
+        round: 2,
+        blocks: [{ kind: "text", text: "Final visible text." }],
+      },
+    ],
+    completedThroughRound: 1,
+    suppressedToolTrace: [
+      {
+        round: 1,
+        toolCall: parentToolCall,
+        toolResult: parentToolResult,
+      },
+    ],
+    timestamp: 10,
+  });
+
+  assert.deepEqual(
+    messages.map((message) => message.role),
+    ["assistant", "toolResult", "assistant"],
+  );
+  assert.equal(messages[0].stopReason, "toolUse");
+  assert.deepEqual(
+    messages[0].content.map((block) => (block.type === "toolCall" ? block.id : block.type)),
+    [parentId],
+  );
+  assert.equal(messages[1].toolCallId, parentId);
+  assert.equal(messages[2].stopReason, "aborted");
+  assert.equal(JSON.stringify(messages).includes(cardId), false);
+});
+
 test("continuation request context skips cancelled rounds by default but can include them explicitly", () => {
   const state = conversationState.createConversationStateFromContext({
     messages: [
@@ -249,4 +316,53 @@ test("model request sanitizer drops assistant rounds that only contain hosted se
   const serialized = JSON.stringify(context.messages);
   assert.equal(serialized.includes("Provider-hosted web search"), false);
   assert.equal(serialized.includes("example.com/source"), false);
+});
+
+test("model request sanitizer removes persisted synthetic subagent cards", () => {
+  const parentId = "call-parent|fc_parent";
+  const cardId = `${parentId}:agent:1`;
+  const context = requestContextSanitizer.sanitizeContextForModelRequest({
+    messages: [
+      user("delegate", 1),
+      {
+        role: "assistant",
+        provider: "codex",
+        api: "openai-responses",
+        model: "gpt-5",
+        content: [
+          { type: "text", text: "Delegating work." },
+          toolCall(cardId, "Agent", {
+            subagent_card: true,
+            parent_tool_call_id: parentId,
+            id: "reviewer",
+          }),
+          toolCall(parentId, "Agent", { agents: [] }),
+        ],
+        stopReason: "toolUse",
+        timestamp: 2,
+      },
+      {
+        ...toolResult(cardId, "Agent", "done", 3),
+        details: { kind: "subagent_card" },
+      },
+      {
+        ...toolResult(parentId, "Agent", "batch done", 4),
+        details: { kind: "subagent_batch" },
+      },
+      user("continue", 5),
+    ],
+  });
+
+  assert.deepEqual(
+    context.messages.map((message) => message.role),
+    ["user", "assistant", "toolResult", "user"],
+  );
+  assert.deepEqual(
+    context.messages[1].content.map((block) =>
+      block.type === "toolCall" ? block.id : block.type,
+    ),
+    ["text", parentId],
+  );
+  assert.equal(context.messages[2].toolCallId, parentId);
+  assert.equal(JSON.stringify(context.messages).includes(cardId), false);
 });

--- a/crates/agent-gui/test/chat/compaction-payload.test.mjs
+++ b/crates/agent-gui/test/chat/compaction-payload.test.mjs
@@ -146,6 +146,64 @@ test("buildCompactionPayload carries the previous summary and the pending user t
   assert.equal(protectionPayload.next_user_message, undefined);
 });
 
+test("buildCompactionPayload removes synthetic subagent card calls and paired results", () => {
+  const parentId = "fc_parent";
+  const cardId = `${parentId}:agent:1`;
+  const state = buildState([
+    {
+      ...assistant("Delegating work."),
+      content: [
+        { type: "text", text: "Delegating work." },
+        { type: "toolCall", id: parentId, name: "Agent", arguments: { agents: [] } },
+        {
+          type: "toolCall",
+          id: cardId,
+          name: "Agent",
+          arguments: {
+            subagent_card: true,
+            parent_tool_call_id: parentId,
+            id: "reviewer",
+          },
+        },
+      ],
+      stopReason: "toolUse",
+    },
+    {
+      role: "toolResult",
+      toolCallId: cardId,
+      toolName: "Agent",
+      content: [{ type: "text", text: "synthetic card result" }],
+      isError: false,
+      timestamp: 3,
+    },
+    {
+      role: "toolResult",
+      toolCallId: parentId,
+      toolName: "Agent",
+      content: [{ type: "text", text: "real parent result" }],
+      details: { kind: "subagent_batch" },
+      isError: false,
+      timestamp: 4,
+    },
+  ]);
+
+  const payload = buildCompactionPayload({
+    state,
+    intent: "protection",
+    contextTokens: 1,
+    threshold: 1,
+  });
+
+  assert.deepEqual(
+    payload.active_segment_messages.map((message) => message.role),
+    ["assistant", "toolResult"],
+  );
+  assert.equal(payload.active_segment_messages[1].toolCallId, parentId);
+  assert.match(payload.active_segment_messages[0].toolCalls[0], /^Agent /);
+  assert.equal(JSON.stringify(payload).includes(cardId), false);
+  assert.equal(JSON.stringify(payload).includes("synthetic card result"), false);
+});
+
 test("shrink keeps head+tail and records the omitted count; summary-backed payloads drop the head", () => {
   const messages = Array.from({ length: 20 }, (_, i) =>
     serializeMessageForCompaction(user(`msg-${i}`, i), i),


### PR DESCRIPTION
## Summary
- filter synthetic subagent UI card tool calls and paired results from future model requests
- preserve legitimate parent `Agent` tool history in cancelled and errored conversation snapshots without changing visible card-only UI behavior
- sanitize full compaction segments, centralize synthetic-card detection, and add focused regressions

## Root cause
Synthetic per-agent card IDs include colon-delimited UI metadata. When those render-only tool calls were persisted into conversation history, OpenAI Responses later rejected the IDs with `400 invalid_value`.

## Validation
- `pnpm exec tsc --noEmit`
- focused Node tests: 86/86 passed
- `pnpm build`
- `git diff --check`
- full Node suite: 958 tests, 956 passed
- independent Standards and Spec reviews found no remaining issues

The two full-suite failures are unrelated environment/baseline failures: `cargo` is unavailable (`spawn cargo ENOENT`), and one built-in skill test expects LF while the checked file uses Windows CRLF.