### PR TITLE
fix(model-picker): separate same-name providers

### DIFF
--- a/crates/agent-gateway/test/webui/web-settings.test.mjs
+++ b/crates/agent-gateway/test/webui/web-settings.test.mjs
@@ -6,7 +6,58 @@ const loader = createWebModuleLoader();
 const webSettings = loader.loadModule("src/lib/webSettings.ts");
 const settings = loader.loadModule("@/lib/settings/index.ts");
 const settingsSync = loader.loadModule("@/lib/settings/sync.ts");
+const chatHelpers = loader.loadModule("@/lib/chat/chatPageHelpers.ts");
 const RIGHT_DOCK_TAB_IDS = settings.RIGHT_DOCK_SINGLETON_TAB_IDS;
+
+test("gateway model picker keeps same-name provider instances in separate groups", () => {
+  const modelOptions = chatHelpers.buildModelOptions({
+    customProviders: [
+      {
+        id: "same-api-a",
+        name: "Shared",
+        type: "codex",
+        activeModels: ["shared-model", "model-a"],
+      },
+      { id: "same-api-b", name: "Shared", type: "codex", activeModels: ["shared-model"] },
+      { id: "different-api", name: "Shared", type: "claude_code", activeModels: ["model-c"] },
+    ],
+    selectedModel: { customProviderId: "same-api-b", model: "shared-model" },
+  });
+
+  const groups = chatHelpers.groupModelOptionsByProvider(modelOptions);
+
+  assert.deepEqual(
+    groups.map((group) => ({
+      id: group.id,
+      name: group.name,
+      type: group.providerType,
+      options: group.opts.map((option) => ({ value: option.value, model: option.model })),
+    })),
+    [
+      {
+        id: "same-api-b",
+        name: "Shared",
+        type: "codex",
+        options: [{ value: "same-api-b::shared-model", model: "shared-model" }],
+      },
+      {
+        id: "same-api-a",
+        name: "Shared",
+        type: "codex",
+        options: [
+          { value: "same-api-a::shared-model", model: "shared-model" },
+          { value: "same-api-a::model-a", model: "model-a" },
+        ],
+      },
+      {
+        id: "different-api",
+        name: "Shared",
+        type: "claude_code",
+        options: [{ value: "different-api::model-c", model: "model-c" }],
+      },
+    ],
+  );
+});
 
 function installWindow(origin = "https://gateway.example") {
   const store = new Map();

--- a/crates/agent-gateway/web/src/lib/chat/chatPageHelpers.ts
+++ b/crates/agent-gateway/web/src/lib/chat/chatPageHelpers.ts
@@ -5,6 +5,34 @@ const MODEL_GENERATING_STATUS_PATTERN = /^第\s*\d+\s*轮：模型生成中\.\.\
 
 export const VIBING_STATUS = "Vibing...";
 
+export type ModelOptionGroup = {
+  id: string;
+  name: string;
+  providerType: ModelOption["providerType"];
+  opts: ModelOption[];
+};
+
+export function groupModelOptionsByProvider(modelOptions: readonly ModelOption[]) {
+  const groups: ModelOptionGroup[] = [];
+  const groupMap = new Map<string, ModelOptionGroup>();
+  for (const option of modelOptions) {
+    const existing = groupMap.get(option.providerId);
+    if (existing) {
+      existing.opts.push(option);
+      continue;
+    }
+    const group: ModelOptionGroup = {
+      id: option.providerId,
+      name: option.providerName,
+      providerType: option.providerType,
+      opts: [option],
+    };
+    groupMap.set(option.providerId, group);
+    groups.push(group);
+  }
+  return groups;
+}
+
 export function buildModelOptions(
   settings: AppSettings,
   opts?: { floatSelectedFirst?: boolean },
@@ -14,6 +42,7 @@ export function buildModelOptions(
     for (const model of provider.activeModels) {
       options.push({
         providerType: provider.type,
+        providerId: provider.id,
         providerName: provider.name,
         model,
         value: toModelValue(provider.id, model),

--- a/crates/agent-gateway/web/src/lib/providers/llm.ts
+++ b/crates/agent-gateway/web/src/lib/providers/llm.ts
@@ -5,6 +5,7 @@ import type { ProviderId } from "../settings";
 export type ModelOption = {
   value: string;
   label: string;
+  providerId: string;
   providerName: string;
   providerType: ProviderId;
   model: string;

--- a/crates/agent-gateway/web/src/pages/chat/ChatHeader.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/ChatHeader.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "../../components/ui/dropdown-menu";
 import { useLocale } from "../../i18n";
+import { groupModelOptionsByProvider } from "../../lib/chat/chatPageHelpers";
 import { type ModelOption, parseModelValue } from "../../lib/providers/llm";
 import {
   type AppSettings,
@@ -90,33 +91,15 @@ export const ChatHeader = memo(function ChatHeader(props: {
     }
   }, [isModelMenuOpen]);
 
-  const groups = useMemo(() => {
-    const nextGroups: { name: string; providerType: ProviderId; opts: ModelOption[] }[] = [];
-    const groupMap = new Map<string, ModelOption[]>();
-    for (const option of modelOptions) {
-      const existing = groupMap.get(option.providerName);
-      if (existing) {
-        existing.push(option);
-        continue;
-      }
-      const nextGroup: ModelOption[] = [option];
-      groupMap.set(option.providerName, nextGroup);
-      nextGroups.push({
-        name: option.providerName,
-        providerType: option.providerType,
-        opts: nextGroup,
-      });
-    }
-    return nextGroups;
-  }, [modelOptions]);
+  const groups = useMemo(() => groupModelOptionsByProvider(modelOptions), [modelOptions]);
   const selectedOption = modelOptions.find((option) => option.value === selectedValue);
-  const selectedGroupName = selectedOption?.providerName;
+  const selectedGroupId = selectedOption?.providerId;
   // 默认全部折叠，仅当前选中模型所在分组展开
-  const isGroupExpanded = (name: string) => expandedGroups[name] ?? name === selectedGroupName;
-  const toggleGroup = (name: string) =>
+  const isGroupExpanded = (id: string) => expandedGroups[id] ?? id === selectedGroupId;
+  const toggleGroup = (id: string) =>
     setExpandedGroups((prev) => ({
       ...prev,
-      [name]: !(prev[name] ?? name === selectedGroupName),
+      [id]: !(prev[id] ?? id === selectedGroupId),
     }));
 
   return (
@@ -168,15 +151,15 @@ export const ChatHeader = memo(function ChatHeader(props: {
               {(() => {
                 let animationIndex = 0;
                 return groups.map((group, groupIndex) => {
-                  const expanded = isGroupExpanded(group.name);
+                  const expanded = isGroupExpanded(group.id);
                   return (
-                    <div key={group.name} className="flex flex-col gap-0.5">
+                    <div key={group.id} className="flex flex-col gap-0.5">
                       {groupIndex > 0 ? <DropdownMenuSeparator /> : null}
                       <DropdownMenuItem
                         onSelect={(event) => {
                           // 阻止 Radix 默认的选中即关闭：分组头只负责展开/收起
                           event.preventDefault();
-                          toggleGroup(group.name);
+                          toggleGroup(group.id);
                         }}
                         aria-expanded={expanded}
                         title={expanded ? t("chat.collapseProvider") : t("chat.expandProvider")}

--- a/crates/agent-gui/src/lib/chat/page/chatPageHelpers.ts
+++ b/crates/agent-gui/src/lib/chat/page/chatPageHelpers.ts
@@ -13,6 +13,34 @@ export const VIBING_STATUS = "Vibing...";
 // Must match BRANCH_DEFAULT_TITLE in src-tauri/src/commands/history/chat_history/branch.rs.
 export const BRANCH_CONVERSATION_DEFAULT_TITLE = "新分支";
 
+export type ModelOptionGroup = {
+  id: string;
+  name: string;
+  providerType: ModelOption["providerType"];
+  opts: ModelOption[];
+};
+
+export function groupModelOptionsByProvider(modelOptions: readonly ModelOption[]) {
+  const groups: ModelOptionGroup[] = [];
+  const groupMap = new Map<string, ModelOptionGroup>();
+  for (const option of modelOptions) {
+    const existing = groupMap.get(option.providerId);
+    if (existing) {
+      existing.opts.push(option);
+      continue;
+    }
+    const group: ModelOptionGroup = {
+      id: option.providerId,
+      name: option.providerName,
+      providerType: option.providerType,
+      opts: [option],
+    };
+    groupMap.set(option.providerId, group);
+    groups.push(group);
+  }
+  return groups;
+}
+
 export function buildModelOptions(
   settings: AppSettings,
   opts?: { floatSelectedFirst?: boolean },
@@ -22,6 +50,7 @@ export function buildModelOptions(
     for (const model of provider.activeModels) {
       options.push({
         providerType: provider.type,
+        providerId: provider.id,
         providerName: provider.name,
         model,
         value: toModelValue(provider.id, model),

--- a/crates/agent-gui/src/lib/providers/runtime/types.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/types.ts
@@ -10,7 +10,8 @@ import type { StreamRetryConfig } from "./streamRetry";
 export type ModelOption = {
   value: string; // encodes customProviderId::model
   label: string; // model id
-  providerName: string; // provider display name (for grouping)
+  providerId: string; // stable custom provider identity (for grouping)
+  providerName: string; // provider display name
   providerType: ProviderId; // routes Claude Code, Codex, Gemini, etc.
   model: string;
 };

--- a/crates/agent-gui/src/pages/chat/components/ChatHeader.tsx
+++ b/crates/agent-gui/src/pages/chat/components/ChatHeader.tsx
@@ -23,6 +23,7 @@ import {
   DropdownMenuTrigger,
 } from "../../../components/ui/dropdown-menu";
 import { useLocale } from "../../../i18n";
+import { groupModelOptionsByProvider } from "../../../lib/chat/page/chatPageHelpers";
 import { type ModelOption, parseModelValue } from "../../../lib/providers/llm";
 import {
   type AppSettings,
@@ -98,38 +99,19 @@ export const ChatHeader = memo(function ChatHeader(props: {
   }, [isModelMenuOpen]);
 
   const normalizedSearch = modelSearch.trim().toLowerCase();
-  const groups: {
-    name: string;
-    providerType: ProviderId;
-    opts: ModelOption[];
-  }[] = [];
-  const groupMap = new Map<string, ModelOption[]>();
-  for (const option of modelOptions) {
-    const existing = groupMap.get(option.providerName);
-    if (existing) {
-      existing.push(option);
-      continue;
-    }
-    const nextGroup: ModelOption[] = [option];
-    groupMap.set(option.providerName, nextGroup);
-    groups.push({
-      name: option.providerName,
-      providerType: option.providerType,
-      opts: nextGroup,
-    });
-  }
+  const groups = groupModelOptionsByProvider(modelOptions);
 
   const selectedOption = modelOptions.find((o) => o.value === selectedValue);
-  const selectedGroupName = selectedOption?.providerName;
+  const selectedGroupId = selectedOption?.providerId;
   // 默认全部折叠，仅当前选中模型所在分组展开；搜索时强制展开所有匹配分组
-  const isGroupExpanded = (name: string) =>
-    normalizedSearch.length > 0 || (expandedGroups[name] ?? name === selectedGroupName);
+  const isGroupExpanded = (id: string) =>
+    normalizedSearch.length > 0 || (expandedGroups[id] ?? id === selectedGroupId);
   // 基于存储态取反（而非 isGroupExpanded）：搜索强制展开是只读覆盖，
   // 不应让搜索期间的点击把折叠态写坏
-  const toggleGroup = (name: string) =>
+  const toggleGroup = (id: string) =>
     setExpandedGroups((prev) => ({
       ...prev,
-      [name]: !(prev[name] ?? name === selectedGroupName),
+      [id]: !(prev[id] ?? id === selectedGroupId),
     }));
 
   return (
@@ -223,13 +205,13 @@ export const ChatHeader = memo(function ChatHeader(props: {
                 }
 
                 return filteredGroups.map((group, groupIndex) => {
-                  const expanded = isGroupExpanded(group.name);
+                  const expanded = isGroupExpanded(group.id);
                   return (
-                    <div key={group.name} className="flex flex-col gap-0.5">
+                    <div key={group.id} className="flex flex-col gap-0.5">
                       {groupIndex > 0 ? <DropdownMenuSeparator className="bg-border/30" /> : null}
                       <DropdownMenuItem
                         closeOnClick={false}
-                        onSelect={() => toggleGroup(group.name)}
+                        onSelect={() => toggleGroup(group.id)}
                         aria-expanded={expanded}
                         title={expanded ? t("chat.collapseProvider") : t("chat.expandProvider")}
                         className="model-selector-group-label sticky top-0 z-10 flex h-[30px] shrink-0 cursor-pointer items-center gap-1.5 rounded-md bg-popover/60 px-2 py-0 text-xs font-medium uppercase tracking-wider text-muted-foreground/80 backdrop-blur-xl transition-colors data-[highlighted]:bg-muted/40 supports-[backdrop-filter]:bg-popover/40 dark:text-white/80"

--- a/crates/agent-gui/test/chat/messages.test.mjs
+++ b/crates/agent-gui/test/chat/messages.test.mjs
@@ -2272,3 +2272,53 @@ test("chat page helpers keep model options stable and normalize status/title edg
   assert.equal(chatHelpers.isAbortLikeError(new Error("AbortError: aborted")), true);
   assert.equal(chatHelpers.isAbortLikeError("network failed"), false);
 });
+
+test("chat page helpers keep same-name provider instances in separate model groups", () => {
+  const modelOptions = chatHelpers.buildModelOptions({
+    customProviders: [
+      {
+        id: "same-api-a",
+        name: "Shared",
+        type: "codex",
+        activeModels: ["shared-model", "model-a"],
+      },
+      { id: "same-api-b", name: "Shared", type: "codex", activeModels: ["shared-model"] },
+      { id: "different-api", name: "Shared", type: "claude_code", activeModels: ["model-c"] },
+    ],
+    selectedModel: { customProviderId: "same-api-b", model: "shared-model" },
+  });
+
+  const groups = chatHelpers.groupModelOptionsByProvider(modelOptions);
+
+  assert.deepEqual(
+    groups.map((group) => ({
+      id: group.id,
+      name: group.name,
+      type: group.providerType,
+      options: group.opts.map((option) => ({ value: option.value, model: option.model })),
+    })),
+    [
+      {
+        id: "same-api-b",
+        name: "Shared",
+        type: "codex",
+        options: [{ value: "same-api-b::shared-model", model: "shared-model" }],
+      },
+      {
+        id: "same-api-a",
+        name: "Shared",
+        type: "codex",
+        options: [
+          { value: "same-api-a::shared-model", model: "shared-model" },
+          { value: "same-api-a::model-a", model: "model-a" },
+        ],
+      },
+      {
+        id: "different-api",
+        name: "Shared",
+        type: "claude_code",
+        options: [{ value: "different-api::model-c", model: "model-c" }],
+      },
+    ],
+  );
+});


### PR DESCRIPTION
## 概述

修复模型选择器将同名供应商错误合并为同一分组的问题，桌面端与 Gateway Web 同步处理。

## 根因

模型选择器此前使用供应商展示名 `providerName` 作为分组、展开状态和 React key。不同供应商实例只要名称相同，无论接口类型是否相同，都会被当作同一供应商。

## 改动

- 在模型选项中显式携带稳定的自定义供应商 ID。
- 使用供应商 ID 构建模型分组，展示名仅用于界面显示。
- 展开状态、默认展开组和 React group key 全部改用供应商 ID。
- 为桌面端和 Gateway Web 增加回归测试，覆盖：
  - 同名、同接口、不同供应商实例；
  - 同名、不同接口；
  - 同名且模型 ID 相同；
  - 选中模型前置后的分组顺序与模型完整性。

## 用户影响

同名供应商现在会在模型列表中保持为独立分组，选择、展开和模型 key 不再互相冲突。

## 查重

未发现重复 Issue 或 PR。相关背景为已合并的 #82（引入供应商折叠功能），本 PR 是针对其分组身份逻辑的后续修复。

## 验证

- 桌面端相关测试：47/47 通过。
- Gateway Web 相关测试：28/28 通过。
- 桌面端与 Gateway Web TypeScript/生产构建通过。
- 本次修改的源文件 Biome lint 通过。
- subagent 对抗性审查未发现高或中严重度问题。