### PR TITLE
fix(webui): add UUID fallback for legacy WebViews

### DIFF
--- a/crates/agent-gateway/test/webui/browser-uuid.test.mjs
+++ b/crates/agent-gateway/test/webui/browser-uuid.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createWebModuleLoader } from "../helpers/load-web-module.mjs";
+
+const loader = createWebModuleLoader();
+const { createUuid } = loader.loadModule("@/lib/shared/id.ts");
+const { createEmptyRequestDraft } = loader.loadModule("@/pages/settings/httpRequestEditor.tsx");
+const { normalizeAgentPromptTemplate, normalizeCustomProvider, normalizeSshSettings } =
+  loader.loadModule("@/lib/settings/index.ts");
+
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function withCrypto(value, run) {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+  if (value === undefined) {
+    delete globalThis.crypto;
+  } else {
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value,
+    });
+  }
+  try {
+    return run();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(globalThis, "crypto", descriptor);
+    } else {
+      delete globalThis.crypto;
+    }
+  }
+}
+
+test("createUuid uses crypto.randomUUID when available", () => {
+  withCrypto({ randomUUID: () => "native-uuid" }, () => {
+    assert.equal(createUuid(), "native-uuid");
+  });
+});
+
+test("createUuid falls back to an RFC 4122 v4 UUID without randomUUID", () => {
+  withCrypto({}, () => {
+    assert.match(createUuid(), UUID_V4_PATTERN);
+  });
+});
+
+test("createUuid works when global crypto is unavailable", () => {
+  withCrypto(undefined, () => {
+    assert.match(createUuid(), UUID_V4_PATTERN);
+  });
+});
+
+test("createUuid falls back when browser crypto methods throw", () => {
+  withCrypto(
+    {
+      randomUUID() {
+        throw new Error("randomUUID unavailable");
+      },
+      getRandomValues() {
+        throw new Error("getRandomValues unavailable");
+      },
+    },
+    () => {
+      assert.match(createUuid(), UUID_V4_PATTERN);
+    },
+  );
+});
+
+test("createUuid fallback remains unique when time and randomness repeat", () => {
+  const originalNow = Date.now;
+  const originalRandom = Math.random;
+  Date.now = () => 123;
+  Math.random = () => 0;
+  try {
+    withCrypto({}, () => {
+      assert.notEqual(createUuid(), createUuid());
+    });
+  } finally {
+    Date.now = originalNow;
+    Math.random = originalRandom;
+  }
+});
+
+test("settings normalize generated IDs without crypto.randomUUID", () => {
+  withCrypto({}, () => {
+    const provider = normalizeCustomProvider({ name: "Provider", type: "codex" });
+    const agent = normalizeAgentPromptTemplate({ name: "Agent" });
+    const ssh = normalizeSshSettings({
+      hosts: [
+        { id: "duplicate", host: "first.example" },
+        { id: "duplicate", host: "second.example" },
+        { host: "third.example" },
+      ],
+    });
+
+    assert.match(provider.id, UUID_V4_PATTERN);
+    assert.match(agent.id, UUID_V4_PATTERN);
+    assert.equal(new Set(ssh.hosts.map((host) => host.id)).size, 3);
+  });
+});
+
+test("Hook/Cron HTTP request drafts work without crypto.randomUUID", () => {
+  withCrypto({}, () => {
+    assert.match(createEmptyRequestDraft().id, UUID_V4_PATTERN);
+  });
+});

--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -95,6 +95,7 @@ import {
   type WorkspaceProject,
   workspaceProjectPathKey,
 } from "@/lib/settings";
+import { createUuid } from "@/lib/shared/id";
 import { mergeAlwaysEnabledSkillNames } from "@/lib/skills";
 import { terminalSessionBelongsToProject } from "@/lib/terminal/sessionStore";
 import type { TerminalSession } from "@/lib/terminal/types";
@@ -110,7 +111,7 @@ import { SkillsHubPage } from "@/pages/skills-hub/SkillsHubPage";
 
 const LOCAL_DRAFT_PREFIX = "__local_draft__:";
 function createLocalDraftConversationId() {
-  return `${LOCAL_DRAFT_PREFIX}${crypto.randomUUID()}`;
+  return `${LOCAL_DRAFT_PREFIX}${createUuid()}`;
 }
 function isLocalDraftConversationId(id: string) {
   return id.trim().startsWith(LOCAL_DRAFT_PREFIX);
@@ -1867,7 +1868,7 @@ export default function GatewayApp() {
     }
     clearCachedComposerDraft(activeConversationId);
 
-    const clientRequestId = options?.clientRequestId?.trim() || crypto.randomUUID();
+    const clientRequestId = options?.clientRequestId?.trim() || createUuid();
     const startedAt = Date.now();
     const persistedConversationWorkdir = sidebarStore.peek(activeConversationId)?.cwd?.trim() || "";
     const runtimeConversationWorkdir =
@@ -2084,7 +2085,7 @@ export default function GatewayApp() {
           ),
           systemSettings: buildGatewaySystemSettings(settings, workdirForTurn),
           uploadedFiles: materialized.uploadedFiles,
-          clientRequestId: crypto.randomUUID(),
+          clientRequestId: createUuid(),
           runtimeControls: chatRuntimeControlsForCurrentProvider,
           queuePolicy,
         });

--- a/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
@@ -28,6 +28,7 @@ import {
   formatMarkdownReferenceDestination,
 } from "../../lib/chat/mentionReferences";
 import { extractClipboardFiles } from "../../lib/clipboardFiles";
+import { createUuid } from "../../lib/shared/id";
 import { cn } from "../../lib/shared/utils";
 import { invokeFs } from "../../lib/tools/fsBackend";
 import { Blend, SKILL_ICON_SVG_MARKUP } from "../icons";
@@ -1834,7 +1835,7 @@ export const MentionComposer = memo(
       const index = largePasteCounterRef.current + 1;
       largePasteCounterRef.current = index;
       return {
-        id: `large-paste-${Date.now()}-${crypto.randomUUID()}`,
+        id: `large-paste-${Date.now()}-${createUuid()}`,
         label: `Pasted text ${index}`,
         text,
         charCount: text.length,

--- a/crates/agent-gateway/web/src/lib/chat/uploadedFiles.ts
+++ b/crates/agent-gateway/web/src/lib/chat/uploadedFiles.ts
@@ -1,4 +1,5 @@
 import type { Message, UserMessage } from "../agentTypes";
+import { createUuid } from "../shared/id";
 
 export type UploadedReadableFileKind =
   | "text"
@@ -23,11 +24,7 @@ const DISPLAY_CONTENT_FIELD = "liveAgentDisplayContent";
 const ATTACHMENTS_FIELD = "liveAgentAttachments";
 
 function createUserMessageId() {
-  const id =
-    typeof globalThis.crypto?.randomUUID === "function"
-      ? globalThis.crypto.randomUUID()
-      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-  return `user-${id}`;
+  return `user-${createUuid()}`;
 }
 
 export type PendingUploadedFile = {

--- a/crates/agent-gateway/web/src/lib/chatUi.ts
+++ b/crates/agent-gateway/web/src/lib/chatUi.ts
@@ -8,6 +8,7 @@ import {
   getUserMessageDisplayText,
   type PendingUploadedFile,
 } from "@/lib/chat/uploadedFiles";
+import { createUuid } from "@/lib/shared/id";
 
 import type { ChatCheckpointPayload, ChatEvent, ConversationSummary } from "./gatewayTypes";
 
@@ -133,7 +134,7 @@ const LIVE_UPLOADED_FILE_KINDS = new Set<string>([
 ]);
 
 function randomId(prefix: string) {
-  return `${prefix}-${crypto.randomUUID()}`;
+  return `${prefix}-${createUuid()}`;
 }
 
 export function hashText(value: string) {

--- a/crates/agent-gateway/web/src/lib/gatewaySocket.ts
+++ b/crates/agent-gateway/web/src/lib/gatewaySocket.ts
@@ -21,6 +21,7 @@ import type {
   SftpTransferEvent,
   SftpTransferResponse,
 } from "@/lib/sftp/types";
+import { createUuid } from "@/lib/shared/id";
 import { BrowserGatewayTerminalStreamClient } from "@/lib/terminal/gatewayTerminalStreamClient";
 import type {
   SshTerminalTab,
@@ -553,14 +554,10 @@ function buildWebSocketUrl() {
 function createChatClientRequestId(input: GatewayChatCommandInput) {
   const commandType = input.type.trim() || "chat.command";
   const conversationId = input.conversationId?.trim() || "new";
-  const randomPart =
-    typeof globalThis.crypto?.randomUUID === "function"
-      ? globalThis.crypto.randomUUID()
-      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
   return `webui-${commandType.replace(/[^a-z0-9._-]/gi, "_")}-${conversationId.replace(
     /[^a-z0-9._-]/gi,
     "_",
-  )}-${randomPart}`;
+  )}-${createUuid()}`;
 }
 
 function buildChatCommandPayload(input: GatewayChatCommandInput) {

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -2,6 +2,7 @@ import type { KnownProvider, ModelThinkingLevel } from "@earendil-works/pi-ai";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import { DEFAULT_LOCALE, type Locale, normalizeLocale } from "../../i18n/config";
+import { createUuid } from "../shared/id";
 import { mergeAlwaysEnabledSkillNames } from "../skills/builtin";
 import { SYSTEM_TOOL_OPTIONS, type SystemToolId } from "../tools/systemToolOptions";
 import { normalizeApiKey, normalizeBaseUrl, normalizeModels } from "./normalize";
@@ -497,7 +498,7 @@ function normalizeWorkspaceProject(input: unknown): WorkspaceProject | null {
   const obj = (input && typeof input === "object" ? input : {}) as Record<string, unknown>;
   const path = normalizeWorkspaceProjectPath(obj.path);
   if (!path) return null;
-  const id = typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : crypto.randomUUID();
+  const id = typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : createUuid();
   const name =
     typeof obj.name === "string" && obj.name.trim()
       ? obj.name.trim()
@@ -549,7 +550,7 @@ function normalizeWorkspaceProjects(input: unknown): WorkspaceProject[] {
     seenPaths.add(pathKey);
     let id = project.id;
     if (seenIds.has(id)) {
-      id = crypto.randomUUID();
+      id = createUuid();
     }
     seenIds.add(id);
     out.push({ ...project, id });
@@ -635,7 +636,7 @@ export function resolveWorkspaceProjects(
     seenPaths.add(pathKey);
     let id = project.id;
     if (!id || id === DEFAULT_WORKSPACE_PROJECT_ID || seenIds.has(id)) {
-      id = crypto.randomUUID();
+      id = createUuid();
     }
     seenIds.add(id);
     projects.push({
@@ -1298,7 +1299,7 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
   const models = normalizeProviderModelConfigs(obj.models, type);
   const validModelIds = new Set(models.map((model) => model.id));
   const apiKey = normalizeApiKey(typeof obj.apiKey === "string" ? obj.apiKey : "");
-  const id = typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : crypto.randomUUID();
+  const id = typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : createUuid();
 
   return {
     id,
@@ -1324,7 +1325,7 @@ export function normalizeAgentPromptTemplate(input: unknown): AgentPromptTemplat
   const obj = (input && typeof input === "object" ? input : {}) as Record<string, unknown>;
 
   return {
-    id: typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : crypto.randomUUID(),
+    id: typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : createUuid(),
     name: typeof obj.name === "string" && obj.name.trim() ? obj.name.trim() : "未命名模板",
     description: normalizeOptionalText(obj.description),
     prompt: normalizeOptionalText(obj.prompt),
@@ -1396,7 +1397,7 @@ export function normalizeSshHostConfig(input: unknown): SshHostConfig {
     (privateKeyPassphrase.length > 0 || obj.privateKeyPassphraseConfigured === true);
 
   return {
-    id: typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : crypto.randomUUID(),
+    id: typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : createUuid(),
     name,
     description: normalizeOptionalText(obj.description),
     host,
@@ -1424,7 +1425,7 @@ export function normalizeSshSettings(input: unknown): SshSettings {
       seenIds.add(normalized.id);
       return normalized;
     }
-    const id = crypto.randomUUID();
+    const id = createUuid();
     seenIds.add(id);
     return { ...normalized, id };
   });

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -2217,11 +2217,7 @@ const RIGHT_DOCK_WRITER_ID_STORAGE_KEY = "liveagent.client-id";
 let cachedRightDockWriterId = "";
 
 function generateRightDockWriterId(): string {
-  const uuid =
-    typeof globalThis.crypto?.randomUUID === "function"
-      ? globalThis.crypto.randomUUID()
-      : `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
-  return uuid.replace(/-/g, "").slice(0, 12);
+  return createUuid().replace(/-/g, "").slice(0, 12);
 }
 
 // Stable per-client id used to break stateVersion ties deterministically in

--- a/crates/agent-gateway/web/src/lib/shared/id.ts
+++ b/crates/agent-gateway/web/src/lib/shared/id.ts
@@ -1,0 +1,42 @@
+let fallbackSequence = 0;
+
+function fillFallbackBytes(bytes: Uint8Array) {
+  const timestamp = Date.now();
+  fallbackSequence = (fallbackSequence + 1) >>> 0;
+
+  for (let index = 0; index < bytes.length; index += 1) {
+    const timeByte = Math.floor(timestamp / 2 ** ((index % 6) * 8)) & 0xff;
+    const sequenceByte = (fallbackSequence >>> ((index % 4) * 8)) & 0xff;
+    bytes[index] = Math.floor(Math.random() * 256) ^ timeByte ^ sequenceByte;
+  }
+}
+
+export function createUuid(): string {
+  const crypto = globalThis.crypto;
+  if (typeof crypto?.randomUUID === "function") {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      // Some embedded WebViews expose the API but fail when it is called.
+    }
+  }
+
+  const bytes = new Uint8Array(16);
+  if (typeof crypto?.getRandomValues === "function") {
+    try {
+      crypto.getRandomValues(bytes);
+    } catch {
+      fillFallbackBytes(bytes);
+    }
+  } else {
+    fillFallbackBytes(bytes);
+  }
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, "0"));
+  return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex
+    .slice(6, 8)
+    .join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
+}

--- a/crates/agent-gateway/web/src/lib/shared/id.ts
+++ b/crates/agent-gateway/web/src/lib/shared/id.ts
@@ -11,6 +11,12 @@ function fillFallbackBytes(bytes: Uint8Array) {
   }
 }
 
+/**
+ * UUID v4 with fallbacks for legacy/embedded WebViews where crypto.randomUUID
+ * is missing or throws when called. The last-resort path is Math.random-based
+ * and NOT cryptographically secure — use only for identifiers, never for
+ * security tokens or secrets.
+ */
 export function createUuid(): string {
   const crypto = globalThis.crypto;
   if (typeof crypto?.randomUUID === "function") {

--- a/crates/agent-gateway/web/src/pages/settings/AgentsSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/AgentsSection.tsx
@@ -5,6 +5,7 @@ import { BookOpen, Eye, Pencil, Plus, Trash2, X } from "../../components/icons";
 import { Button } from "../../components/ui/button";
 import { useLocale } from "../../i18n";
 import { type AgentPromptTemplate, updateAgents } from "../../lib/settings";
+import { createUuid } from "../../lib/shared/id";
 import { useModalMotion } from "../../lib/shared/modalMotion";
 import { AgentPromptTemplateModal } from "./AgentPromptTemplateModal";
 import { AgentActivationSwitch, ConfirmDeletePopover } from "./shared";
@@ -44,7 +45,7 @@ export function AgentsSection(props: SettingsSectionProps) {
       }
 
       const newTemplate: AgentPromptTemplate = {
-        id: crypto.randomUUID(),
+        id: createUuid(),
         ...data,
         enabled: false,
       };

--- a/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
@@ -38,6 +38,7 @@ import {
   updateCustomProviders,
   updateCustomSettings,
 } from "../../lib/settings";
+import { createUuid } from "../../lib/shared/id";
 import { useModalMotion } from "../../lib/shared/modalMotion";
 import {
   createDraftModelConfig,
@@ -874,7 +875,7 @@ export function ProvidersSection(props: SettingsSectionProps) {
       }
 
       const newProvider: CustomProvider = {
-        id: crypto.randomUUID(),
+        id: createUuid(),
         ...data,
       };
       return updateCustomProviders(prev, [...prev.customProviders, newProvider]);

--- a/crates/agent-gateway/web/src/pages/settings/SshSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/SshSection.tsx
@@ -31,6 +31,7 @@ import {
   type SshProxyType,
   updateSsh,
 } from "../../lib/settings";
+import { createUuid } from "../../lib/shared/id";
 import { useModalMotion } from "../../lib/shared/modalMotion";
 import {
   type SshImportCandidate,
@@ -1058,7 +1059,7 @@ export function SshSection(props: SettingsSectionProps) {
         hosts: [
           ...prev.ssh.hosts,
           {
-            id: crypto.randomUUID(),
+            id: createUuid(),
             ...data,
           },
         ],
@@ -1125,7 +1126,7 @@ export function SshSection(props: SettingsSectionProps) {
           ...candidates.map((candidate) => {
             const { id: _id, source: _source, duplicate: _duplicate, ...host } = candidate;
             return {
-              id: crypto.randomUUID(),
+              id: createUuid(),
               ...host,
             };
           }),

--- a/crates/agent-gateway/web/src/pages/settings/httpRequestEditor.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/httpRequestEditor.tsx
@@ -16,6 +16,7 @@ import {
   type HttpMethod,
   type HttpRequestSpec,
 } from "../../lib/automation";
+import { createUuid } from "../../lib/shared/id";
 
 export type HttpRequestDraft = {
   id: string;
@@ -27,7 +28,7 @@ export type HttpRequestDraft = {
 
 export function createEmptyRequestDraft(): HttpRequestDraft {
   return {
-    id: crypto.randomUUID(),
+    id: createUuid(),
     url: "",
     method: "POST",
     headersText: "",

--- a/crates/agent-gui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gui/src/components/chat/MentionComposer.tsx
@@ -27,6 +27,7 @@ import {
   formatFileMentionToken,
   formatMarkdownReferenceDestination,
 } from "../../lib/chat/messages/mentionReferences";
+import { createUuid } from "../../lib/shared/id";
 import { cn } from "../../lib/shared/utils";
 import { invokeFs } from "../../lib/tools/fsBackend";
 import { Blend, ClipboardPaste, Copy, ScanText, Scissors, SKILL_ICON_SVG_MARKUP } from "../icons";
@@ -2143,7 +2144,7 @@ export const MentionComposer = memo(
       const index = largePasteCounterRef.current + 1;
       largePasteCounterRef.current = index;
       return {
-        id: `large-paste-${Date.now()}-${crypto.randomUUID()}`,
+        id: `large-paste-${Date.now()}-${createUuid()}`,
         label: `Pasted text ${index}`,
         text,
         charCount: text.length,

--- a/crates/agent-gui/src/lib/automation/hookRunner.ts
+++ b/crates/agent-gui/src/lib/automation/hookRunner.ts
@@ -5,6 +5,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 
+import { createUuid } from "../shared/id";
 import type { HookDef, HookEvent, HookType } from "./types";
 
 export type HookRunWarning = {
@@ -90,7 +91,7 @@ export function createHookRunScope(params: {
   workdir?: string;
   onWarning?: (warning: HookRunWarning) => void;
 }): HookRunScope {
-  const scopeId = crypto.randomUUID();
+  const scopeId = createUuid();
   const hooksByEvent = new Map<HookEvent, HookDef[]>();
   for (const hook of params.hooks) {
     if (!hook.enabled) continue;

--- a/crates/agent-gui/src/lib/chat/compaction/engine.ts
+++ b/crates/agent-gui/src/lib/chat/compaction/engine.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage, UserMessage } from "@earendil-works/pi-ai";
 
 import type { StreamDebugLogger } from "../../debug/agentDebug";
 import type { ProviderId } from "../../settings";
+import { createUuid } from "../../shared/id";
 import {
   applyCompactionCheckpoint,
   type CompactionCheckpointStats,
@@ -24,18 +25,12 @@ export type CompactionOutcome = {
   newSegmentIndex: number;
 };
 
-function randomId() {
-  return typeof globalThis.crypto?.randomUUID === "function"
-    ? globalThis.crypto.randomUUID()
-    : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-}
-
 export function createSyntheticContinueUserMessage(
   timestamp = Date.now(),
 ): UserMessage & { id: string } {
   return {
     role: "user",
-    id: `user-${randomId()}`,
+    id: `user-${createUuid()}`,
     // 必须与 conversationState 的常量逐字节一致：normalizeSegment 依赖它过滤持久化。
     content: INTERNAL_RESUME_MESSAGE_TEXT,
     timestamp,
@@ -60,7 +55,7 @@ function buildCheckpointMessage(params: {
     content: [{ type: "text", text: params.summaryText }],
     stopReason: "stop",
     timestamp: params.timestamp,
-    responseId: params.responseId || `liveagent-compaction-${params.timestamp}-${randomId()}`,
+    responseId: params.responseId || `liveagent-compaction-${params.timestamp}-${createUuid()}`,
     // checkpoint 消息自身的 usage 恒为零：summarizer 请求的真实用量走 compactionStats，
     // 绝不冒充会话上下文规模（旧实现的 usage 污染即源于此）。
     usage: {

--- a/crates/agent-gui/src/lib/chat/conversation/conversationState.ts
+++ b/crates/agent-gui/src/lib/chat/conversation/conversationState.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, Context, Message } from "@earendil-works/pi-ai";
 
 import { assistantMessageToText } from "../../providers/llm";
+import { createUuid } from "../../shared/id";
 import {
   type FileLedger,
   formatFileLedgerBlock,
@@ -144,7 +145,7 @@ export type ConversationViewState = {
 function createEmptySegment(index: number, timestamp = Date.now()): StoredContextSegment {
   return {
     segmentIndex: index,
-    segmentId: crypto.randomUUID(),
+    segmentId: createUuid(),
     messages: [],
     messageCount: 0,
     createdAt: timestamp,
@@ -548,7 +549,7 @@ function normalizeSegment(
 
   return {
     segmentIndex,
-    segmentId: segment.segmentId || crypto.randomUUID(),
+    segmentId: segment.segmentId || createUuid(),
     summary: segment.summary,
     messages,
     messageCount,

--- a/crates/agent-gui/src/lib/chat/messages/uploadedFiles.ts
+++ b/crates/agent-gui/src/lib/chat/messages/uploadedFiles.ts
@@ -1,5 +1,7 @@
 import type { Message, UserMessage } from "@earendil-works/pi-ai";
 
+import { createUuid } from "../../shared/id";
+
 export type UploadedReadableFileKind =
   | "text"
   | "image"
@@ -23,11 +25,7 @@ const DISPLAY_CONTENT_FIELD = "liveAgentDisplayContent";
 const ATTACHMENTS_FIELD = "liveAgentAttachments";
 
 function createUserMessageId() {
-  const id =
-    typeof globalThis.crypto?.randomUUID === "function"
-      ? globalThis.crypto.randomUUID()
-      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-  return `user-${id}`;
+  return `user-${createUuid()}`;
 }
 
 export type PendingUploadedFile = {

--- a/crates/agent-gui/src/lib/chat/page/chatPageHelpers.ts
+++ b/crates/agent-gui/src/lib/chat/page/chatPageHelpers.ts
@@ -1,6 +1,7 @@
 import type { Context } from "@earendil-works/pi-ai";
 import { type ModelOption, toModelValue } from "../../providers/llm";
 import type { AppSettings } from "../../settings";
+import { createUuid } from "../../shared/id";
 import type { ChatHistorySummary } from "../history/chatHistory";
 import { getMessageText } from "../messages/uiMessages";
 
@@ -134,7 +135,7 @@ export function createPendingHistoryItem(params: {
 }
 
 export function createConversationIdentity() {
-  const conversationId = crypto.randomUUID();
+  const conversationId = createUuid();
   return {
     conversationId,
     sessionId: conversationId,

--- a/crates/agent-gui/src/lib/chat/runner/flattenedToolCallText.ts
+++ b/crates/agent-gui/src/lib/chat/runner/flattenedToolCallText.ts
@@ -1,4 +1,5 @@
 import type { ToolCall } from "@earendil-works/pi-ai";
+import { createUuid } from "../../shared/id";
 
 const FLATTENED_TOOL_REQUEST_LABELS = [
   "Previous assistant tool request:",
@@ -166,7 +167,7 @@ export function parseFlattenedToolRequestAtStart(value: string): ParsedFlattened
   return {
     toolCall: {
       type: "toolCall",
-      id: (match[1] ?? "").trim() || `flattened-context-tool-call-${crypto.randomUUID()}`,
+      id: (match[1] ?? "").trim() || `flattened-context-tool-call-${createUuid()}`,
       name: toolName,
       arguments: parsed,
     },

--- a/crates/agent-gui/src/lib/chat/runner/seedToolCalls.ts
+++ b/crates/agent-gui/src/lib/chat/runner/seedToolCalls.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage, ToolCall } from "@earendil-works/pi-ai";
+import { createUuid } from "../../shared/id";
 import {
   hasDsmlToolCallMarkup,
   isOnlyDsmlOrphanCloseTags,
@@ -134,7 +135,7 @@ function parseSeedToolCallMarkup(markup: string): ToolCall | null {
 
   return {
     type: "toolCall",
-    id: `seed-tool-call-${crypto.randomUUID()}`,
+    id: `seed-tool-call-${createUuid()}`,
     name: toolName,
     arguments: args,
   };

--- a/crates/agent-gui/src/lib/debug/seedLongConversation.ts
+++ b/crates/agent-gui/src/lib/debug/seedLongConversation.ts
@@ -5,6 +5,7 @@ import {
   normalizeConversationState,
 } from "../chat/conversation/conversationState";
 import { persistConversationState } from "../chat/history/chatHistory";
+import { createUuid } from "../shared/id";
 
 // Dev-only transcript stress fixture: builds a large conversation with the
 // content shapes that dominate real rendering cost (long prose, big code
@@ -209,7 +210,7 @@ export type SeedLongConversationOptions = {
 
 export async function seedLongConversation(options: SeedLongConversationOptions = {}) {
   const turns = Math.max(1, options.turns ?? 240);
-  const conversationId = crypto.randomUUID();
+  const conversationId = createUuid();
   const startedAt = Date.now() - turns * 60_000;
 
   let state = normalizeConversationState({ meta: {}, segments: [] });

--- a/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
+++ b/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
@@ -6,6 +6,7 @@ import {
   normalizeHostedSearchStatus,
 } from "../chat/messages/hostedSearch";
 import type { ProviderId } from "../settings";
+import { createUuid } from "../shared/id";
 
 type HostedSearchUpdate = {
   id?: string;
@@ -39,16 +40,11 @@ type HostedSearchFetchProbeController = {
 
 const activeFetchProbes = new Set<FetchProbe>();
 let originalFetch: typeof globalThis.fetch | null = null;
-let hostedSearchProbeSequence = 0;
 
 export const HOSTED_SEARCH_PROBE_HEADER = "x-liveagent-hosted-search-probe";
 
 export function createHostedSearchProbeId(providerId: ProviderId) {
-  const random =
-    typeof globalThis.crypto?.randomUUID === "function"
-      ? globalThis.crypto.randomUUID()
-      : `${Date.now().toString(36)}-${++hostedSearchProbeSequence}`;
-  return `hosted-search-${providerId}-${random}`;
+  return `hosted-search-${providerId}-${createUuid()}`;
 }
 
 export function withHostedSearchProbeHeader(

--- a/crates/agent-gui/src/lib/settings/index.ts
+++ b/crates/agent-gui/src/lib/settings/index.ts
@@ -10,6 +10,7 @@ import {
   shouldSendAnthropicLongContextHeader,
 } from "../providers/anthropicModels";
 import { getAvailableThinkingLevelsForModel } from "../providers/runtime/modelFactory";
+import { createUuid } from "../shared/id";
 import { mergeAlwaysEnabledSkillNames } from "../skills/builtin";
 import { SYSTEM_TOOL_OPTIONS, type SystemToolId } from "../tools/systemToolOptions";
 import { normalizeApiKey, normalizeBaseUrl, normalizeModels } from "./normalize";
@@ -517,7 +518,7 @@ function normalizeWorkspaceProject(input: unknown): WorkspaceProject | null {
   const obj = (input && typeof input === "object" ? input : {}) as Record<string, unknown>;
   const path = normalizeWorkspaceProjectPath(obj.path);
   if (!path) return null;
-  const id = typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : crypto.randomUUID();
+  const id = typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : createUuid();
   const name =
     typeof obj.name === "string" && obj.name.trim()
       ? obj.name.trim()
@@ -569,7 +570,7 @@ function normalizeWorkspaceProjects(input: unknown): WorkspaceProject[] {
     seenPaths.add(pathKey);
     let id = project.id;
     if (seenIds.has(id)) {
-      id = crypto.randomUUID();
+      id = createUuid();
     }
     seenIds.add(id);
     out.push({ ...project, id });
@@ -652,7 +653,7 @@ export function resolveWorkspaceProjects(
     seenPaths.add(pathKey);
     let id = project.id;
     if (!id || id === DEFAULT_WORKSPACE_PROJECT_ID || seenIds.has(id)) {
-      id = crypto.randomUUID();
+      id = createUuid();
     }
     seenIds.add(id);
     projects.push({
@@ -1163,7 +1164,7 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
   const models = normalizeProviderModelConfigs(obj.models, type);
   const validModelIds = new Set(models.map((model) => model.id));
   const apiKey = normalizeApiKey(typeof obj.apiKey === "string" ? obj.apiKey : "");
-  const id = typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : crypto.randomUUID();
+  const id = typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : createUuid();
 
   return {
     id,
@@ -1189,7 +1190,7 @@ export function normalizeAgentPromptTemplate(input: unknown): AgentPromptTemplat
   const obj = (input && typeof input === "object" ? input : {}) as Record<string, unknown>;
 
   return {
-    id: typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : crypto.randomUUID(),
+    id: typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : createUuid(),
     name: typeof obj.name === "string" && obj.name.trim() ? obj.name.trim() : "未命名模板",
     description: normalizeOptionalText(obj.description),
     prompt: normalizeOptionalText(obj.prompt),
@@ -1261,7 +1262,7 @@ export function normalizeSshHostConfig(input: unknown): SshHostConfig {
     (privateKeyPassphrase.length > 0 || obj.privateKeyPassphraseConfigured === true);
 
   return {
-    id: typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : crypto.randomUUID(),
+    id: typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : createUuid(),
     name,
     description: normalizeOptionalText(obj.description),
     host,
@@ -1289,7 +1290,7 @@ export function normalizeSshSettings(input: unknown): SshSettings {
       seenIds.add(normalized.id);
       return normalized;
     }
-    const id = crypto.randomUUID();
+    const id = createUuid();
     seenIds.add(id);
     return { ...normalized, id };
   });

--- a/crates/agent-gui/src/lib/settings/index.ts
+++ b/crates/agent-gui/src/lib/settings/index.ts
@@ -2097,11 +2097,7 @@ const RIGHT_DOCK_WRITER_ID_STORAGE_KEY = "liveagent.client-id";
 let cachedRightDockWriterId = "";
 
 function generateRightDockWriterId(): string {
-  const uuid =
-    typeof globalThis.crypto?.randomUUID === "function"
-      ? globalThis.crypto.randomUUID()
-      : `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
-  return uuid.replace(/-/g, "").slice(0, 12);
+  return createUuid().replace(/-/g, "").slice(0, 12);
 }
 
 // Stable per-client id used to break stateVersion ties deterministically in

--- a/crates/agent-gui/src/lib/shared/id.ts
+++ b/crates/agent-gui/src/lib/shared/id.ts
@@ -1,0 +1,42 @@
+let fallbackSequence = 0;
+
+function fillFallbackBytes(bytes: Uint8Array) {
+  const timestamp = Date.now();
+  fallbackSequence = (fallbackSequence + 1) >>> 0;
+
+  for (let index = 0; index < bytes.length; index += 1) {
+    const timeByte = Math.floor(timestamp / 2 ** ((index % 6) * 8)) & 0xff;
+    const sequenceByte = (fallbackSequence >>> ((index % 4) * 8)) & 0xff;
+    bytes[index] = Math.floor(Math.random() * 256) ^ timeByte ^ sequenceByte;
+  }
+}
+
+export function createUuid(): string {
+  const crypto = globalThis.crypto;
+  if (typeof crypto?.randomUUID === "function") {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      // Some embedded WebViews expose the API but fail when it is called.
+    }
+  }
+
+  const bytes = new Uint8Array(16);
+  if (typeof crypto?.getRandomValues === "function") {
+    try {
+      crypto.getRandomValues(bytes);
+    } catch {
+      fillFallbackBytes(bytes);
+    }
+  } else {
+    fillFallbackBytes(bytes);
+  }
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, "0"));
+  return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex
+    .slice(6, 8)
+    .join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
+}

--- a/crates/agent-gui/src/lib/shared/id.ts
+++ b/crates/agent-gui/src/lib/shared/id.ts
@@ -11,6 +11,12 @@ function fillFallbackBytes(bytes: Uint8Array) {
   }
 }
 
+/**
+ * UUID v4 with fallbacks for legacy/embedded WebViews where crypto.randomUUID
+ * is missing or throws when called. The last-resort path is Math.random-based
+ * and NOT cryptographically secure — use only for identifiers, never for
+ * security tokens or secrets.
+ */
 export function createUuid(): string {
   const crypto = globalThis.crypto;
   if (typeof crypto?.randomUUID === "function") {

--- a/crates/agent-gui/src/lib/subagents/utils.ts
+++ b/crates/agent-gui/src/lib/subagents/utils.ts
@@ -1,5 +1,6 @@
 import type { Message } from "@earendil-works/pi-ai";
 
+import { createUuid } from "../shared/id";
 import { MAX_SUMMARY_CHARS } from "./types";
 
 export function asObject(value: unknown): Record<string, unknown> {
@@ -60,10 +61,7 @@ export function createSequentialQueue() {
 }
 
 export function randomIdSuffix() {
-  if (typeof globalThis.crypto?.randomUUID === "function") {
-    return globalThis.crypto.randomUUID();
-  }
-  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return createUuid();
 }
 
 export async function runWithConcurrency<T, R>(

--- a/crates/agent-gui/src/lib/system/powerActivity.ts
+++ b/crates/agent-gui/src/lib/system/powerActivity.ts
@@ -1,13 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
 
+import { createUuid } from "../shared/id";
+
 const POWER_ACTIVITY_TTL_MS = 15 * 60_000;
 const POWER_ACTIVITY_REFRESH_MS = Math.floor(POWER_ACTIVITY_TTL_MS / 2);
 
 function createActivityId(scope: string) {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return `${scope}:${crypto.randomUUID()}`;
-  }
-  return `${scope}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+  return `${scope}:${createUuid()}`;
 }
 
 async function beginPowerActivity(activityId: string, reason: string) {

--- a/crates/agent-gui/src/lib/tools/cronTools.ts
+++ b/crates/agent-gui/src/lib/tools/cronTools.ts
@@ -10,6 +10,7 @@ import {
   listCronRuns,
   refreshAutomationSnapshot,
 } from "../automation";
+import { createUuid } from "../shared/id";
 import { type BuiltinToolBundle, createBuiltinMetadataMap } from "./builtinTypes";
 
 type SelectedModelInput = {
@@ -191,7 +192,7 @@ function collectTaskFields(
       const request = asRecord(entry) ?? {};
       return {
         ...request,
-        id: normalizeText(request.id) || crypto.randomUUID(),
+        id: normalizeText(request.id) || createUuid(),
       };
     });
   }

--- a/crates/agent-gui/src/lib/tools/shellTools.ts
+++ b/crates/agent-gui/src/lib/tools/shellTools.ts
@@ -8,6 +8,7 @@ import {
   runtimePlatformLabel,
 } from "../runtimePlatform";
 import type { ProviderId } from "../settings";
+import { createUuid } from "../shared/id";
 import {
   type BashTimeoutPolicy,
   GLOBAL_BASH_MAX_TIMEOUT_MS,
@@ -86,11 +87,7 @@ function asErrorMessage(err: unknown) {
 }
 
 function createShellRunId(toolCallId: string) {
-  const suffix =
-    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-      ? crypto.randomUUID()
-      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  return `bash-${toolCallId || "tool"}-${suffix}`;
+  return `bash-${toolCallId || "tool"}-${createUuid()}`;
 }
 
 function delay(ms: number) {

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -148,6 +148,7 @@ import {
   workspaceProjectPathKey,
 } from "../lib/settings";
 import { tauriSftpClient } from "../lib/sftp/tauriSftpClient";
+import { createUuid } from "../lib/shared/id";
 import { cn } from "../lib/shared/utils";
 import { createGuiSidebarBackend } from "../lib/sidebar/guiSidebarBackend";
 import {
@@ -279,11 +280,7 @@ const WorkspaceSshTerminalOverlay = lazy(async () => {
 });
 
 function createLocalGatewayChatRunId(conversationId: string) {
-  const suffix =
-    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-      ? crypto.randomUUID()
-      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  return `conversation-live-${conversationId}-${suffix}`;
+  return `conversation-live-${conversationId}-${createUuid()}`;
 }
 
 type ChatPageProps = {

--- a/crates/agent-gui/src/pages/chat/gateway/useGatewayBridgeListeners.ts
+++ b/crates/agent-gui/src/pages/chat/gateway/useGatewayBridgeListeners.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 
 import type { HistoryMessageRef } from "../../../lib/chat/conversation/conversationState";
 import { normalizeChatRuntimeControls, normalizeSystemToolSelection } from "../../../lib/settings";
+import { createUuid } from "../../../lib/shared/id";
 import {
   type ActiveGatewayBridgeRequest,
   type GatewayBridgeRuntimeRefs,
@@ -140,10 +141,7 @@ export function useGatewayBridgeListeners(params: UseGatewayBridgeListenersParam
   latestParamsRef.current = params;
   const workerIdRef = useRef("");
   if (!workerIdRef.current) {
-    workerIdRef.current =
-      typeof crypto !== "undefined" && "randomUUID" in crypto
-        ? `gateway-chat-runtime-${crypto.randomUUID()}`
-        : `gateway-chat-runtime-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    workerIdRef.current = `gateway-chat-runtime-${createUuid()}`;
   }
 
   useEffect(() => {

--- a/crates/agent-gui/src/pages/settings/AgentsSection.tsx
+++ b/crates/agent-gui/src/pages/settings/AgentsSection.tsx
@@ -5,6 +5,7 @@ import { BookOpen, Eye, Pencil, Plus, Trash2, X } from "../../components/icons";
 import { Button } from "../../components/ui/button";
 import { useLocale } from "../../i18n";
 import { type AgentPromptTemplate, updateAgents } from "../../lib/settings";
+import { createUuid } from "../../lib/shared/id";
 import { AgentPromptTemplateModal } from "./AgentPromptTemplateModal";
 import { AgentActivationSwitch, ConfirmDeletePopover } from "./shared";
 import type { SettingsSectionProps } from "./types";
@@ -43,7 +44,7 @@ export function AgentsSection(props: SettingsSectionProps) {
       }
 
       const newTemplate: AgentPromptTemplate = {
-        id: crypto.randomUUID(),
+        id: createUuid(),
         ...data,
         enabled: false,
       };

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -54,6 +54,7 @@ import {
   updateCustomProviders,
   updateCustomSettings,
 } from "../../lib/settings";
+import { createUuid } from "../../lib/shared/id";
 import { cn } from "../../lib/shared/utils";
 import {
   type CherryProviderImportItem,
@@ -1852,7 +1853,7 @@ export function ProvidersSection(props: SettingsSectionProps) {
       }
 
       const newProvider: CustomProvider = {
-        id: crypto.randomUUID(),
+        id: createUuid(),
         ...data,
       };
       return updateCustomProviders(prev, [...prev.customProviders, newProvider]);

--- a/crates/agent-gui/src/pages/settings/SshSection.tsx
+++ b/crates/agent-gui/src/pages/settings/SshSection.tsx
@@ -31,6 +31,7 @@ import {
   type SshProxyType,
   updateSsh,
 } from "../../lib/settings";
+import { createUuid } from "../../lib/shared/id";
 import { useModalMotion } from "../../lib/shared/modalMotion";
 import {
   type SshImportCandidate,
@@ -1058,7 +1059,7 @@ export function SshSection(props: SettingsSectionProps) {
         hosts: [
           ...prev.ssh.hosts,
           {
-            id: crypto.randomUUID(),
+            id: createUuid(),
             ...data,
           },
         ],
@@ -1125,7 +1126,7 @@ export function SshSection(props: SettingsSectionProps) {
           ...candidates.map((candidate) => {
             const { id: _id, source: _source, duplicate: _duplicate, ...host } = candidate;
             return {
-              id: crypto.randomUUID(),
+              id: createUuid(),
               ...host,
             };
           }),

--- a/crates/agent-gui/src/pages/settings/httpRequestEditor.tsx
+++ b/crates/agent-gui/src/pages/settings/httpRequestEditor.tsx
@@ -16,6 +16,7 @@ import {
   type HttpMethod,
   type HttpRequestSpec,
 } from "../../lib/automation";
+import { createUuid } from "../../lib/shared/id";
 
 export type HttpRequestDraft = {
   id: string;
@@ -27,7 +28,7 @@ export type HttpRequestDraft = {
 
 export function createEmptyRequestDraft(): HttpRequestDraft {
   return {
-    id: crypto.randomUUID(),
+    id: createUuid(),
     url: "",
     method: "POST",
     headersText: "",

--- a/crates/agent-gui/test/settings/browser-uuid.test.mjs
+++ b/crates/agent-gui/test/settings/browser-uuid.test.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const { createUuid } = loader.loadModule("src/lib/shared/id.ts");
+const { createHookRunScope } = loader.loadModule("src/lib/automation/hookRunner.ts");
+const { createEmptyRequestDraft } = loader.loadModule("src/pages/settings/httpRequestEditor.tsx");
+const { normalizeAgentPromptTemplate, normalizeCustomProvider, normalizeSshSettings } =
+  loader.loadModule("src/lib/settings/index.ts");
+
+let capturedCronOps = [];
+const cronLoader = createTsModuleLoader({
+  mocks: {
+    "../automation": {
+      async applyCronOps(ops) {
+        capturedCronOps = ops;
+        return {
+          tasks: [
+            {
+              id: "task-id",
+              name: "HTTP task",
+              type: "http",
+              cron: "0 * * * *",
+              enabled: true,
+              requests: ops[0].item.requests,
+            },
+          ],
+        };
+      },
+      getAutomationState() {
+        return { cron: { tasks: [] } };
+      },
+      async initAutomation() {},
+      async listCronRuns() {
+        return [];
+      },
+      async refreshAutomationSnapshot() {},
+    },
+  },
+});
+const { createCronTools } = cronLoader.loadModule("src/lib/tools/cronTools.ts");
+
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function withCrypto(value, run) {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+  if (value === undefined) {
+    delete globalThis.crypto;
+  } else {
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value,
+    });
+  }
+  try {
+    return run();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(globalThis, "crypto", descriptor);
+    } else {
+      delete globalThis.crypto;
+    }
+  }
+}
+
+async function withCryptoAsync(value, run) {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value,
+  });
+  try {
+    return await run();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(globalThis, "crypto", descriptor);
+    } else {
+      delete globalThis.crypto;
+    }
+  }
+}
+
+test("createUuid uses crypto.randomUUID when available", () => {
+  withCrypto({ randomUUID: () => "native-uuid" }, () => {
+    assert.equal(createUuid(), "native-uuid");
+  });
+});
+
+test("createUuid falls back to an RFC 4122 v4 UUID without randomUUID", () => {
+  withCrypto({}, () => {
+    assert.match(createUuid(), UUID_V4_PATTERN);
+  });
+});
+
+test("createUuid works when global crypto is unavailable", () => {
+  withCrypto(undefined, () => {
+    assert.match(createUuid(), UUID_V4_PATTERN);
+  });
+});
+
+test("createUuid falls back when browser crypto methods throw", () => {
+  withCrypto(
+    {
+      randomUUID() {
+        throw new Error("randomUUID unavailable");
+      },
+      getRandomValues() {
+        throw new Error("getRandomValues unavailable");
+      },
+    },
+    () => {
+      assert.match(createUuid(), UUID_V4_PATTERN);
+    },
+  );
+});
+
+test("createUuid fallback remains unique when time and randomness repeat", () => {
+  const originalNow = Date.now;
+  const originalRandom = Math.random;
+  Date.now = () => 123;
+  Math.random = () => 0;
+  try {
+    withCrypto({}, () => {
+      assert.notEqual(createUuid(), createUuid());
+    });
+  } finally {
+    Date.now = originalNow;
+    Math.random = originalRandom;
+  }
+});
+
+test("settings normalize generated IDs without crypto.randomUUID", () => {
+  withCrypto({}, () => {
+    const provider = normalizeCustomProvider({ name: "Provider", type: "codex" });
+    const agent = normalizeAgentPromptTemplate({ name: "Agent" });
+    const ssh = normalizeSshSettings({
+      hosts: [
+        { id: "duplicate", host: "first.example" },
+        { id: "duplicate", host: "second.example" },
+        { host: "third.example" },
+      ],
+    });
+
+    assert.match(provider.id, UUID_V4_PATTERN);
+    assert.match(agent.id, UUID_V4_PATTERN);
+    assert.equal(new Set(ssh.hosts.map((host) => host.id)).size, 3);
+  });
+});
+
+test("hook scopes and Hook/Cron HTTP request drafts work without crypto.randomUUID", () => {
+  withCrypto({}, () => {
+    const scope = createHookRunScope({ hooks: [], conversationId: "conversation-id" });
+    const request = createEmptyRequestDraft();
+
+    scope.close();
+    assert.match(request.id, UUID_V4_PATTERN);
+  });
+});
+
+test("CronTaskManager generates request IDs without crypto.randomUUID", async () => {
+  capturedCronOps = [];
+  await withCryptoAsync({}, async () => {
+    const cronTools = createCronTools({});
+    const result = await cronTools.executeToolCall({
+      id: "tool-call-id",
+      name: "CronTaskManager",
+      arguments: {
+        action: "create",
+        name: "HTTP task",
+        type: "http",
+        cron: "0 * * * *",
+        requests: [{ method: "GET", url: "https://example.com" }],
+      },
+    });
+
+    assert.equal(result.isError, false);
+    assert.match(capturedCronOps[0].item.requests[0].id, UUID_V4_PATTERN);
+  });
+});

--- a/scripts/mirror-manifest.json
+++ b/scripts/mirror-manifest.json
@@ -75,6 +75,7 @@
     "lib/tools/systemToolOptions.ts",
     "lib/tools/builtinToolCatalog.ts",
     "lib/skills/builtin.ts",
+    "lib/shared/id.ts",
     "pages/settings/SystemToolsSection.tsx"
   ]
 }


### PR DESCRIPTION
## 概述

修复旧版或嵌入式 WebView 中 UUID 生成失败的问题，桌面端与 Gateway Web 同步使用兼容的 UUID 生成逻辑。

## 根因

项目中多处直接调用 crypto.randomUUID()。部分旧版 WebView 不提供该 API，或者虽然暴露了该 API，但实际调用时会抛出异常，导致会话、设置、SSH、文件上传和自动化相关流程无法继续。

## 改动

- 新增统一的 createUuid() 工具，优先使用 crypto.randomUUID()。
- 在 randomUUID() 不可用或调用失败时，回退到 crypto.getRandomValues()。
- 在浏览器 crypto API 不可用时，使用带版本和变体标记的本地 UUID v4 回退逻辑。
- 替换 Gateway WebUI 与桌面 GUI 中直接调用 crypto.randomUUID() 的代码。
- 为 Gateway WebUI 和桌面 GUI 增加 UUID 生成及相关 ID 派生逻辑的浏览器测试。

## 用户影响

旧版或能力不完整的嵌入式 WebView 可以继续创建会话、配置供应商、SSH 主机、上传文件和自动化请求；现代浏览器仍优先使用原生 crypto.randomUUID()。

## 查重

未发现重复 Issue 或 PR；已检索上游仓库中与 UUID、randomUUID、WebView 相关的 Issue 和 PR。

## 验证

- 桌面端 pnpm build 通过。
- 桌面端 pnpm lint 通过。
- 桌面端 pnpm test:frontend 通过：951 项测试全部通过。
- git diff --check 通过。
- Gateway Web 的 pnpm build、pnpm lint 和 pnpm test 未能在当前环境执行：pnpm 阻止 @google/genai、protobufjs 的依赖构建脚本，并要求显式 approve-builds。
