### PR TITLE
fix(gateway): allow confirmed LAN provider URLs

### DIFF
--- a/crates/agent-gateway/internal/handler/outbound_http.go
+++ b/crates/agent-gateway/internal/handler/outbound_http.go
@@ -77,15 +77,29 @@ func buildOutboundAllowedPorts() []int {
 }
 
 func newSafeOutboundHTTPClient(timeout time.Duration) outboundHTTPClient {
+	return newSafeOutboundHTTPClientWithOptions(timeout, nil, validateSafeOutboundRedirect)
+}
+
+func newSafeOutboundHTTPClientWithOptions(
+	timeout time.Duration,
+	allowedIPs []netip.Addr,
+	checkRedirect func(req *http.Request, via []*http.Request) error,
+) outboundHTTPClient {
 	config := safeurl.GetConfigBuilder().
 		SetTimeout(timeout).
 		SetAllowedSchemes("http", "https").
 		SetAllowedPorts(outboundAllowedPorts...).
-		SetCheckRedirect(validateSafeOutboundRedirect).
+		SetCheckRedirect(checkRedirect).
 		EnableIPv6(true).
-		AllowSendingCredentials(false).
-		Build()
-	return safeurl.Client(config)
+		AllowSendingCredentials(false)
+	if len(allowedIPs) > 0 {
+		allowedIPStrings := make([]string, 0, len(allowedIPs))
+		for _, ip := range allowedIPs {
+			allowedIPStrings = append(allowedIPStrings, ip.String())
+		}
+		config.SetAllowedIPs(allowedIPStrings...)
+	}
+	return safeurl.Client(config.Build())
 }
 
 func validateSafeOutboundRedirect(req *http.Request, via []*http.Request) error {
@@ -114,6 +128,16 @@ func validateOutboundHTTPURL(raw string) (*url.URL, error) {
 }
 
 func validateParsedOutboundHTTPURL(parsed *url.URL) error {
+	if err := validateParsedOutboundHTTPURLShape(parsed); err != nil {
+		return err
+	}
+	if hostIP, err := netip.ParseAddr(parsed.Hostname()); err == nil && isBlockedOutboundIP(hostIP) {
+		return &unsafeOutboundURLError{message: "URL host resolves to a blocked IP range"}
+	}
+	return nil
+}
+
+func validateParsedOutboundHTTPURLShape(parsed *url.URL) error {
 	if parsed == nil {
 		return &unsafeOutboundURLError{message: "URL must be absolute"}
 	}
@@ -125,9 +149,6 @@ func validateParsedOutboundHTTPURL(parsed *url.URL) error {
 	}
 	if parsed.User != nil {
 		return &unsafeOutboundURLError{message: "URL cannot include embedded credentials"}
-	}
-	if hostIP, err := netip.ParseAddr(parsed.Hostname()); err == nil && isBlockedOutboundIP(hostIP) {
-		return &unsafeOutboundURLError{message: "URL host resolves to a blocked IP range"}
 	}
 	return nil
 }

--- a/crates/agent-gateway/internal/handler/provider_models.go
+++ b/crates/agent-gateway/internal/handler/provider_models.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"sort"
 	"strings"
@@ -18,6 +20,7 @@ const anthropicAPIVersion = "2023-06-01"
 type HTTPStatusError struct {
 	Status  int
 	Message string
+	Code    string
 }
 
 func (e *HTTPStatusError) Error() string {
@@ -38,6 +41,15 @@ var codexModelsSuffixes = []string{
 	"/response",
 }
 
+var providerModelsAllowedIPPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("fc00::/7"),
+}
+
 type providerModelsAttempt struct {
 	url     string
 	headers map[string]string
@@ -52,7 +64,15 @@ func FetchProviderModels(
 	ctx context.Context,
 	req ProviderModelsRequestBody,
 ) (*ProviderModelsResult, error) {
-	return fetchProviderModelsWithClient(ctx, req, newSafeOutboundHTTPClient(0))
+	attempts, err := prepareProviderModelsAttempts(req)
+	if err != nil {
+		return nil, err
+	}
+	client, err := newProviderModelsHTTPClient(ctx, attempts[0].url, req.AllowPrivateNetwork)
+	if err != nil {
+		return nil, err
+	}
+	return fetchProviderModelsAttemptsWithClient(ctx, attempts, client)
 }
 
 func fetchProviderModelsWithClient(
@@ -60,6 +80,14 @@ func fetchProviderModelsWithClient(
 	req ProviderModelsRequestBody,
 	client outboundHTTPClient,
 ) (*ProviderModelsResult, error) {
+	attempts, err := prepareProviderModelsAttempts(req)
+	if err != nil {
+		return nil, err
+	}
+	return fetchProviderModelsAttemptsWithClient(ctx, attempts, client)
+}
+
+func prepareProviderModelsAttempts(req ProviderModelsRequestBody) ([]providerModelsAttempt, error) {
 	providerType := strings.TrimSpace(req.Type)
 	baseURL := strings.TrimSpace(req.BaseURL)
 	apiKey := strings.TrimSpace(req.APIKey)
@@ -77,7 +105,14 @@ func fetchProviderModelsWithClient(
 			Message: err.Error(),
 		}
 	}
+	return attempts, nil
+}
 
+func fetchProviderModelsAttemptsWithClient(
+	ctx context.Context,
+	attempts []providerModelsAttempt,
+	client outboundHTTPClient,
+) (*ProviderModelsResult, error) {
 	var failures []providerModelsAttemptFailure
 	var emptyResult *ProviderModelsResult
 
@@ -101,6 +136,118 @@ func fetchProviderModelsWithClient(
 	}
 
 	return nil, pickProviderModelsFailure(failures)
+}
+
+func newProviderModelsHTTPClient(
+	ctx context.Context,
+	targetURL string,
+	allowPrivateNetwork bool,
+) (outboundHTTPClient, error) {
+	parsed, err := url.Parse(targetURL)
+	if err != nil {
+		return nil, &HTTPStatusError{
+			Status:  http.StatusBadRequest,
+			Message: "base_url is not allowed",
+			Code:    "provider_models_url_not_allowed",
+		}
+	}
+	if err := validateParsedOutboundHTTPURLShape(parsed); err != nil {
+		return nil, &HTTPStatusError{
+			Status:  http.StatusBadRequest,
+			Message: "base_url is not allowed",
+			Code:    "provider_models_url_not_allowed",
+		}
+	}
+
+	addresses := make([]netip.Addr, 0, 4)
+	if literal, err := netip.ParseAddr(parsed.Hostname()); err == nil {
+		addresses = append(addresses, literal.Unmap())
+	} else {
+		resolved, resolveErr := net.DefaultResolver.LookupNetIP(ctx, "ip", parsed.Hostname())
+		if resolveErr != nil {
+			return nil, &HTTPStatusError{
+				Status:  http.StatusBadGateway,
+				Message: "failed to resolve provider models URL",
+			}
+		}
+		addresses = append(addresses, resolved...)
+	}
+
+	allowedIPs := make([]netip.Addr, 0, len(addresses))
+	hasPrivateAddress := false
+	for _, address := range addresses {
+		address = address.Unmap()
+		if isProviderModelsAllowedIP(address) {
+			hasPrivateAddress = true
+			if allowPrivateNetwork {
+				allowedIPs = append(allowedIPs, address)
+			}
+			continue
+		}
+		if !isBlockedOutboundIP(address) {
+			allowedIPs = append(allowedIPs, address)
+		}
+	}
+
+	if hasPrivateAddress && !allowPrivateNetwork {
+		return nil, &HTTPStatusError{
+			Status:  http.StatusBadRequest,
+			Message: "provider models URL requires confirmation",
+			Code:    "provider_models_confirmation_required",
+		}
+	}
+	if len(allowedIPs) == 0 {
+		return nil, &HTTPStatusError{
+			Status:  http.StatusBadRequest,
+			Message: "base_url is not allowed",
+			Code:    "provider_models_url_not_allowed",
+		}
+	}
+
+	if !hasPrivateAddress {
+		return newSafeOutboundHTTPClient(0), nil
+	}
+	origin := providerModelsOrigin(parsed)
+	return newSafeOutboundHTTPClientWithOptions(
+		0,
+		allowedIPs,
+		func(req *http.Request, via []*http.Request) error {
+			return validateProviderModelsRedirect(origin, req, via)
+		},
+	), nil
+}
+
+func isProviderModelsAllowedIP(ip netip.Addr) bool {
+	if !ip.IsValid() {
+		return false
+	}
+	ip = ip.Unmap()
+	for _, prefix := range providerModelsAllowedIPPrefixes {
+		if prefix.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func providerModelsOrigin(parsed *url.URL) string {
+	return strings.ToLower(parsed.Scheme) + "://" + strings.ToLower(parsed.Host)
+}
+
+func validateProviderModelsRedirect(origin string, req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return &unsafeOutboundURLError{message: "too many redirects"}
+	}
+	if req == nil || req.URL == nil {
+		return &unsafeOutboundURLError{message: "redirect URL is required"}
+	}
+	if err := validateParsedOutboundHTTPURLShape(req.URL); err != nil {
+		return err
+	}
+	if providerModelsOrigin(req.URL) != origin {
+		return &unsafeOutboundURLError{message: "provider models redirect origin is not allowed"}
+	}
+	return nil
 }
 
 // runProviderModelsAttempt performs a single upstream request. A non-nil
@@ -337,7 +484,7 @@ func buildProviderModelsURL(providerType string, baseURL string, official bool) 
 	if parsed.RawQuery != "" || parsed.Fragment != "" {
 		return "", errors.New("base_url cannot contain query parameters or fragments")
 	}
-	if err := validateParsedOutboundHTTPURL(parsed); err != nil {
+	if err := validateParsedOutboundHTTPURLShape(parsed); err != nil {
 		return "", errors.New("base_url is not allowed")
 	}
 

--- a/crates/agent-gateway/internal/handler/provider_models_test.go
+++ b/crates/agent-gateway/internal/handler/provider_models_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -102,19 +104,31 @@ func TestBuildProviderModelsAttempts(t *testing.T) {
 	}
 }
 
-func TestBuildProviderModelsURLRejectsLoopback(t *testing.T) {
+func TestBuildProviderModelsURLAllowsPrivateAndLoopback(t *testing.T) {
 	t.Parallel()
 
-	if _, err := buildProviderModelsURL("codex", "http://127.0.0.1:11434", false); err == nil {
-		t.Fatal("buildProviderModelsURL() error = nil, want loopback rejection")
+	for _, baseURL := range []string{
+		"http://10.66.0.1:8787",
+		"http://10.66.0.1:8787/v1",
+		"http://127.0.0.1:11434",
+		"http://[::1]:11434",
+		"http://[fd00::1]:11434",
+	} {
+		got, err := buildProviderModelsURL("codex", baseURL, false)
+		if err != nil {
+			t.Fatalf("buildProviderModelsURL(%q) error = %v", baseURL, err)
+		}
+		if !strings.HasSuffix(got, "/v1/models") {
+			t.Fatalf("buildProviderModelsURL(%q) = %q, want /v1/models suffix", baseURL, got)
+		}
 	}
 }
 
-func TestBuildProviderModelsURLRejectsIPv4MappedLoopback(t *testing.T) {
+func TestBuildProviderModelsURLDefersAddressPolicy(t *testing.T) {
 	t.Parallel()
 
-	if _, err := buildProviderModelsURL("codex", "http://[::ffff:127.0.0.1]:11434", false); err == nil {
-		t.Fatal("buildProviderModelsURL() error = nil, want IPv4-mapped loopback rejection")
+	if _, err := buildProviderModelsURL("codex", "http://169.254.169.254/latest", false); err != nil {
+		t.Fatalf("buildProviderModelsURL() error = %v, want structural validation to pass", err)
 	}
 }
 
@@ -123,7 +137,7 @@ func TestFetchProviderModelsRejectsUnsafeURL(t *testing.T) {
 
 	_, err := FetchProviderModels(context.Background(), ProviderModelsRequestBody{
 		Type:    "codex",
-		BaseURL: "http://127.0.0.1:11434",
+		BaseURL: "http://169.254.169.254:80",
 		APIKey:  "test-key",
 	})
 	if err == nil {
@@ -135,6 +149,81 @@ func TestFetchProviderModelsRejectsUnsafeURL(t *testing.T) {
 	}
 	if statusErr.Status != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", statusErr.Status, http.StatusBadRequest)
+	}
+}
+
+func TestFetchProviderModelsRequiresConfirmationForPrivateURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := FetchProviderModels(context.Background(), ProviderModelsRequestBody{
+		Type:    "codex",
+		BaseURL: "http://10.66.0.1:8787",
+		APIKey:  "test-key",
+	})
+	if err == nil {
+		t.Fatal("FetchProviderModels() error = nil, want confirmation requirement")
+	}
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("FetchProviderModels() error = %T, want *HTTPStatusError", err)
+	}
+	if statusErr.Code != "provider_models_confirmation_required" {
+		t.Fatalf("code = %q, want confirmation code", statusErr.Code)
+	}
+}
+
+func TestFetchProviderModelsAllowsConfirmedLoopback(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/v1/models" {
+			t.Fatalf("path = %q, want /v1/models", req.URL.Path)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"data":[{"id":"local-model"}]}`))
+	}))
+	defer server.Close()
+
+	result, err := FetchProviderModels(context.Background(), ProviderModelsRequestBody{
+		Type:                "codex",
+		BaseURL:             server.URL,
+		APIKey:              "test-key",
+		AllowPrivateNetwork: true,
+	})
+	if err != nil {
+		t.Fatalf("FetchProviderModels() error = %v", err)
+	}
+	if !bytes.Contains(result.Body, []byte("local-model")) {
+		t.Fatalf("result body = %s, want local model", result.Body)
+	}
+}
+
+func TestFetchProviderModelsRejectsCrossOriginPrivateRedirect(t *testing.T) {
+	t.Parallel()
+
+	target := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"data":[{"id":"redirected-model"}]}`))
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		http.Redirect(writer, req, target.URL+"/v1/models", http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	_, err := FetchProviderModels(context.Background(), ProviderModelsRequestBody{
+		Type:                "codex",
+		BaseURL:             source.URL,
+		APIKey:              "test-key",
+		AllowPrivateNetwork: true,
+	})
+	if err == nil {
+		t.Fatal("FetchProviderModels() error = nil, want redirect rejection")
+	}
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) || statusErr.Message != "provider models URL is not allowed" {
+		t.Fatalf("error = %#v, want provider models URL rejection", err)
 	}
 }
 

--- a/crates/agent-gateway/internal/handler/types.go
+++ b/crates/agent-gateway/internal/handler/types.go
@@ -56,9 +56,10 @@ type CronManageRequestBody struct {
 }
 
 type ProviderModelsRequestBody struct {
-	Type    string `json:"type"`
-	BaseURL string `json:"base_url"`
-	APIKey  string `json:"api_key"`
+	Type                string `json:"type"`
+	BaseURL             string `json:"base_url"`
+	APIKey              string `json:"api_key"`
+	AllowPrivateNetwork bool   `json:"allow_private_network"`
 }
 
 func boolPtr(value bool) *bool {

--- a/crates/agent-gateway/internal/server/websocket.go
+++ b/crates/agent-gateway/internal/server/websocket.go
@@ -27,10 +27,11 @@ type websocketRequest struct {
 }
 
 type websocketEnvelope struct {
-	ID      string `json:"id,omitempty"`
-	Type    string `json:"type"`
-	Payload any    `json:"payload,omitempty"`
-	Error   string `json:"error,omitempty"`
+	ID        string `json:"id,omitempty"`
+	Type      string `json:"type"`
+	Payload   any    `json:"payload,omitempty"`
+	Error     string `json:"error,omitempty"`
+	ErrorCode string `json:"error_code,omitempty"`
 
 	// priority is transport-local metadata and is never serialized. It lets
 	// latency-sensitive acknowledgements bypass a congested data queue without
@@ -760,6 +761,15 @@ func (c *websocketConnection) writeError(requestID string, message string) error
 		ID:    requestID,
 		Type:  "error",
 		Error: message,
+	})
+}
+
+func (c *websocketConnection) writeErrorCode(requestID string, message string, code string) error {
+	return c.writeEnvelope(websocketEnvelope{
+		ID:        requestID,
+		Type:      "error",
+		Error:     message,
+		ErrorCode: code,
 	})
 }
 

--- a/crates/agent-gateway/internal/server/websocket_provider_handlers.go
+++ b/crates/agent-gateway/internal/server/websocket_provider_handlers.go
@@ -60,7 +60,11 @@ func (c *websocketConnection) handleProviderModels(req websocketRequest) {
 	if err != nil {
 		var statusErr *handler.HTTPStatusError
 		if errors.As(err, &statusErr) {
-			_ = c.writeError(req.ID, statusErr.Message)
+			if statusErr.Code != "" {
+				_ = c.writeErrorCode(req.ID, statusErr.Message, statusErr.Code)
+			} else {
+				_ = c.writeError(req.ID, statusErr.Message)
+			}
 			return
 		}
 		_ = c.writeError(req.ID, websocketErrorMessage(err))

--- a/crates/agent-gateway/web/src/i18n/config.ts
+++ b/crates/agent-gateway/web/src/i18n/config.ts
@@ -1205,6 +1205,13 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.fetchFailed": "无法获取模型列表，请点击刷新或手动添加",
     "settings.fetchHint": "填写 Base URL 和 API Key 后自动获取",
     "settings.noBaseUrlApiKey": "请先填写 Base URL 和 API Key",
+    "settings.providerNetworkWarningTitle": "确认访问局域网地址",
+    "settings.providerNetworkWarningDescription":
+      "此供应商位于本机或局域网，模型列表请求将访问该地址。请确认这是您信任的服务。",
+    "settings.providerNetworkWarningDetail":
+      "恶意地址可能探测或访问 Gateway 所在网络中的内部服务。",
+    "settings.providerNetworkWarningConfirm": "继续访问",
+    "settings.providerNetworkWarningCancelled": "已取消访问局域网供应商",
     "settings.activeModels": "个激活模型",
     "settings.noProviders": "暂无供应商",
     "settings.noBaseUrl": "未设置 Base URL",
@@ -2982,6 +2989,13 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.fetchFailed": "Failed to fetch model list. Click refresh or add manually.",
     "settings.fetchHint": "Fill in Base URL and API Key to auto-fetch",
     "settings.noBaseUrlApiKey": "Please fill in Base URL and API Key first",
+    "settings.providerNetworkWarningTitle": "Confirm local network access",
+    "settings.providerNetworkWarningDescription":
+      "This provider is hosted on the local machine or network. Fetching its model list will connect to this address. Continue only if you trust the service.",
+    "settings.providerNetworkWarningDetail":
+      "A malicious address could probe or access internal services reachable from the Gateway.",
+    "settings.providerNetworkWarningConfirm": "Continue",
+    "settings.providerNetworkWarningCancelled": "Local network access was cancelled",
     "settings.activeModels": " active models",
     "settings.noProviders": "No providers",
     "settings.noBaseUrl": "Base URL not set",

--- a/crates/agent-gateway/web/src/lib/gatewaySocket.ts
+++ b/crates/agent-gateway/web/src/lib/gatewaySocket.ts
@@ -74,7 +74,18 @@ type GatewaySocketEnvelope = {
   type: string;
   payload?: unknown;
   error?: string;
+  error_code?: string;
 };
+
+export class GatewayRequestError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code = "") {
+    super(message);
+    this.name = "GatewayRequestError";
+    this.code = code;
+  }
+}
 
 type StatusListener = (status: AgentStatus | null, error: string | null) => void;
 type HistoryListener = (event: GatewayHistoryEvent) => void;
@@ -2371,11 +2382,17 @@ export class GatewayWebSocketClient {
     });
   }
 
-  async getProviderModels(type: string, baseUrl: string, apiKey: string): Promise<unknown> {
+  async getProviderModels(
+    type: string,
+    baseUrl: string,
+    apiKey: string,
+    allowPrivateNetwork = false,
+  ): Promise<unknown> {
     return this.requestWithRecovery("provider.models", {
       type,
       base_url: baseUrl,
       api_key: apiKey,
+      allow_private_network: allowPrivateNetwork,
     });
   }
 
@@ -3072,7 +3089,10 @@ export class GatewayWebSocketClient {
 
     if (envelope.type === "error") {
       pending.reject(
-        new Error(typeof envelope.error === "string" ? envelope.error : "Request failed"),
+        new GatewayRequestError(
+          typeof envelope.error === "string" ? envelope.error : "Request failed",
+          typeof envelope.error_code === "string" ? envelope.error_code : "",
+        ),
       );
       return;
     }
@@ -3408,7 +3428,12 @@ export type GatewayWebSocketClientLike = {
   ): Promise<UploadedImagePreviewResponse>;
   readSkillMetadata(path: string): Promise<SkillMetadataResponse>;
   readSkillText(path: string, offset?: number, length?: number): Promise<SkillTextResponse>;
-  getProviderModels(type: string, baseUrl: string, apiKey: string): Promise<unknown>;
+  getProviderModels(
+    type: string,
+    baseUrl: string,
+    apiKey: string,
+    allowPrivateNetwork?: boolean,
+  ): Promise<unknown>;
   dispose(): void;
 };
 

--- a/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../components/icons";
 
 import { Button } from "../../components/ui/button";
+import { useConfirmDialog } from "../../components/ui/confirm-dialog";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import {
@@ -44,8 +45,11 @@ import {
   createDraftModelConfig,
   fetchModelsFromApi,
   isGatewayWebuiRuntime,
+  isProviderModelsConfirmationRequired,
+  isProviderModelsPrivateAddress,
   mergeFetchedModels,
   normalizeFetchedModels,
+  providerModelsConfirmationKey,
   sortModelsBySelection,
 } from "./providerUtils";
 import { ConfirmDeletePopover } from "./shared";
@@ -207,10 +211,14 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
   const [modelSearch, setModelSearch] = useState("");
   const [editingModel, setEditingModel] = useState<ProviderModelConfig | null>(null);
   const [showApiKey, setShowApiKey] = useState(false);
+  const { confirm, dialog } = useConfirmDialog();
   const { isClosing, modalState, requestClose } = useModalMotion(onClose);
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevFetchKey = useRef("");
+  const fetchSeq = useRef(0);
+  const confirmedPrivateUrls = useRef(new Set<string>());
+  const confirmationInFlight = useRef(new Map<string, Promise<boolean>>());
   const apiKeyIsRedactedDisplay = initialUsesRedactedApiKey && apiKey === REDACTED_API_KEY_DISPLAY;
   const apiKeyForRequest = apiKeyIsRedactedDisplay ? "" : apiKey.trim();
   const canFetchModels = baseUrl.trim().length > 0 && apiKeyForRequest.length > 0;
@@ -222,6 +230,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
     if (!trimUrl || !trimKey) return;
     if (key === prevFetchKey.current) return;
 
+    fetchSeq.current += 1;
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       prevFetchKey.current = key;
@@ -233,16 +242,61 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
     };
   }, [baseUrl, apiKeyForRequest]);
 
+  async function confirmPrivateProviderUrl(url: string) {
+    const confirmationKey = providerModelsConfirmationKey(url);
+    if (confirmedPrivateUrls.current.has(confirmationKey)) return true;
+    const existing = confirmationInFlight.current.get(confirmationKey);
+    if (existing) return existing;
+
+    const pending = confirm({
+      title: t("settings.providerNetworkWarningTitle"),
+      subtitle: url,
+      description: t("settings.providerNetworkWarningDescription"),
+      detail: t("settings.providerNetworkWarningDetail"),
+      confirmLabel: t("settings.providerNetworkWarningConfirm"),
+      cancelLabel: t("settings.cancel"),
+      tone: "warning",
+    }).then((accepted) => {
+      if (accepted) confirmedPrivateUrls.current.add(confirmationKey);
+      return accepted;
+    });
+    confirmationInFlight.current.set(confirmationKey, pending);
+    void pending.finally(() => confirmationInFlight.current.delete(confirmationKey));
+    return pending;
+  }
+
+  async function fetchModelsWithConfirmation(url: string, key: string) {
+    if (isProviderModelsPrivateAddress(url)) {
+      if (!(await confirmPrivateProviderUrl(url))) return null;
+      return fetchModelsFromApi(providerType, url, key, { allowPrivateNetwork: true });
+    }
+
+    try {
+      return await fetchModelsFromApi(providerType, url, key);
+    } catch (err) {
+      if (!isGatewayWebui || !isProviderModelsConfirmationRequired(err)) throw err;
+      if (!(await confirmPrivateProviderUrl(url))) return null;
+      return fetchModelsFromApi(providerType, url, key, { allowPrivateNetwork: true });
+    }
+  }
+
   async function doFetch(url: string, key: string) {
+    const requestSeq = ++fetchSeq.current;
     setFetchingModels(true);
     setFetchError(null);
     try {
-      const list = await fetchModelsFromApi(providerType, url, key);
-      setModels((prev) => mergeFetchedModels(list, prev));
+      const list = await fetchModelsWithConfirmation(url, key);
+      if (!list && requestSeq === fetchSeq.current) {
+        setFetchError(t("settings.providerNetworkWarningCancelled"));
+      } else if (list && requestSeq === fetchSeq.current) {
+        setModels((prev) => mergeFetchedModels(list, prev));
+      }
     } catch (err) {
-      setFetchError(err instanceof Error ? err.message : String(err));
+      if (requestSeq === fetchSeq.current) {
+        setFetchError(err instanceof Error ? err.message : String(err));
+      }
     } finally {
-      setFetchingModels(false);
+      if (requestSeq === fetchSeq.current) setFetchingModels(false);
     }
   }
 
@@ -607,6 +661,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
             onSave={saveModelSettings}
           />
         ) : null}
+        {dialog}
       </div>
     </div>,
     document.body,

--- a/crates/agent-gateway/web/src/pages/settings/providerUtils.ts
+++ b/crates/agent-gateway/web/src/pages/settings/providerUtils.ts
@@ -14,6 +14,59 @@ const CODEX_MODELS_SUFFIXES = ["/chat/completions", "/responses", "/response"];
 const GEMINI_GENERATE_SUFFIXES = [":streamGenerateContent", ":generateContent"];
 const ANTHROPIC_API_VERSION = "2023-06-01";
 
+export type ProviderModelsFetchOptions = {
+  allowPrivateNetwork?: boolean;
+};
+
+export function isProviderModelsConfirmationRequired(error: unknown) {
+  return (
+    error instanceof Error &&
+    (error as Error & { code?: unknown }).code === "provider_models_confirmation_required"
+  );
+}
+
+function isPrivateIPv4(host: string) {
+  const parts = host.split(".").map((part) => Number(part));
+  if (
+    parts.length !== 4 ||
+    parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+  ) {
+    return false;
+  }
+  return (
+    parts[0] === 10 ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168) ||
+    parts[0] === 127
+  );
+}
+
+export function isProviderModelsPrivateAddress(baseUrl: string) {
+  try {
+    const parsed = new URL(baseUrl.trim());
+    const host = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    return (
+      host === "localhost" ||
+      isPrivateIPv4(host) ||
+      host === "::1" ||
+      host.startsWith("fc") ||
+      host.startsWith("fd") ||
+      host.startsWith("::ffff:127.")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function providerModelsConfirmationKey(baseUrl: string) {
+  try {
+    const parsed = new URL(baseUrl.trim());
+    return parsed.origin.toLowerCase();
+  } catch {
+    return baseUrl.trim();
+  }
+}
+
 export function isGatewayWebuiRuntime() {
   return (
     typeof document !== "undefined" &&
@@ -199,6 +252,7 @@ async function fetchModelsThroughGateway(
   type: ProviderId,
   baseUrl: string,
   apiKey: string,
+  options?: ProviderModelsFetchOptions,
 ): Promise<ProviderModelConfig[]> {
   const token =
     typeof window !== "undefined"
@@ -212,6 +266,7 @@ async function fetchModelsThroughGateway(
     type,
     base_url: baseUrl,
     api_key: apiKey,
+    allow_private_network: options?.allowPrivateNetwork === true,
   } as any);
 
   const items = extractModelListItems(data);
@@ -331,11 +386,12 @@ export async function fetchModelsFromApi(
   type: ProviderId,
   baseUrl: string,
   apiKey: string,
+  options?: ProviderModelsFetchOptions,
 ): Promise<ProviderModelConfig[]> {
   const normalizedUrl = normalizeModelBaseUrl(type, baseUrl);
   const normalizedApiKey = apiKey.trim();
   if (isGatewayWebuiRuntime()) {
-    return fetchModelsThroughGateway(type, normalizedUrl, normalizedApiKey);
+    return fetchModelsThroughGateway(type, normalizedUrl, normalizedApiKey, options);
   }
 
   const attempts = buildProviderModelsAttempts(type, normalizedUrl, normalizedApiKey);

--- a/crates/agent-gateway/web/src/shims/tauriCore.ts
+++ b/crates/agent-gateway/web/src/shims/tauriCore.ts
@@ -306,6 +306,7 @@ export async function invoke<T>(command: string, args?: Record<string, unknown>)
         String(args?.type ?? ""),
         String(args?.base_url ?? ""),
         String(args?.api_key ?? ""),
+        args?.allow_private_network === true,
       )) as T;
     case "settings_reset_ssh_known_host": {
       const host = String(args?.host ?? "").trim();

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -1269,6 +1269,13 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.fetchFailed": "无法获取模型列表，请点击刷新或手动添加",
     "settings.fetchHint": "填写 Base URL 和 API Key 后自动获取",
     "settings.noBaseUrlApiKey": "请先填写 Base URL 和 API Key",
+    "settings.providerNetworkWarningTitle": "确认访问局域网地址",
+    "settings.providerNetworkWarningDescription":
+      "此供应商位于本机或局域网，模型列表请求将访问该地址。请确认这是您信任的服务。",
+    "settings.providerNetworkWarningDetail":
+      "恶意地址可能探测或访问 Gateway 所在网络中的内部服务。",
+    "settings.providerNetworkWarningConfirm": "继续访问",
+    "settings.providerNetworkWarningCancelled": "已取消访问局域网供应商",
     "settings.activeModels": "个激活模型",
     "settings.noProviders": "暂无供应商",
     "settings.noBaseUrl": "未设置 Base URL",
@@ -3120,6 +3127,13 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.fetchFailed": "Failed to fetch model list. Click refresh or add manually.",
     "settings.fetchHint": "Fill in Base URL and API Key to auto-fetch",
     "settings.noBaseUrlApiKey": "Please fill in Base URL and API Key first",
+    "settings.providerNetworkWarningTitle": "Confirm local network access",
+    "settings.providerNetworkWarningDescription":
+      "This provider is hosted on the local machine or network. Fetching its model list will connect to this address. Continue only if you trust the service.",
+    "settings.providerNetworkWarningDetail":
+      "A malicious address could probe or access internal services reachable from the Gateway.",
+    "settings.providerNetworkWarningConfirm": "Continue",
+    "settings.providerNetworkWarningCancelled": "Local network access was cancelled",
     "settings.activeModels": " active models",
     "settings.noProviders": "No providers",
     "settings.noBaseUrl": "Base URL not set",

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../components/icons";
 
 import { Button } from "../../components/ui/button";
+import { useConfirmDialog } from "../../components/ui/confirm-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -65,8 +66,11 @@ import {
   createDraftModelConfig,
   fetchModelsFromApi,
   isGatewayWebuiRuntime,
+  isProviderModelsConfirmationRequired,
+  isProviderModelsPrivateAddress,
   mergeFetchedModels,
   normalizeFetchedModels,
+  providerModelsConfirmationKey,
   sortModelsBySelection,
 } from "./providerUtils";
 import { ConfirmDeletePopover } from "./shared";
@@ -261,9 +265,13 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
   const [modelSearch, setModelSearch] = useState("");
   const [editingModel, setEditingModel] = useState<ProviderModelConfig | null>(null);
   const [showApiKey, setShowApiKey] = useState(false);
+  const { confirm, dialog } = useConfirmDialog();
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevFetchKey = useRef("");
+  const fetchSeq = useRef(0);
+  const confirmedPrivateUrls = useRef(new Set<string>());
+  const confirmationInFlight = useRef(new Map<string, Promise<boolean>>());
   const apiKeyIsRedactedDisplay = initialUsesRedactedApiKey && apiKey === REDACTED_API_KEY_DISPLAY;
   const apiKeyForRequest = apiKeyIsRedactedDisplay ? "" : apiKey.trim();
   const canFetchModels = baseUrl.trim().length > 0 && apiKeyForRequest.length > 0;
@@ -275,6 +283,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
     if (!trimUrl || !trimKey) return;
     if (key === prevFetchKey.current) return;
 
+    fetchSeq.current += 1;
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       prevFetchKey.current = key;
@@ -286,16 +295,61 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
     };
   }, [baseUrl, apiKeyForRequest]);
 
+  async function confirmPrivateProviderUrl(url: string) {
+    const confirmationKey = providerModelsConfirmationKey(url);
+    if (confirmedPrivateUrls.current.has(confirmationKey)) return true;
+    const existing = confirmationInFlight.current.get(confirmationKey);
+    if (existing) return existing;
+
+    const pending = confirm({
+      title: t("settings.providerNetworkWarningTitle"),
+      subtitle: url,
+      description: t("settings.providerNetworkWarningDescription"),
+      detail: t("settings.providerNetworkWarningDetail"),
+      confirmLabel: t("settings.providerNetworkWarningConfirm"),
+      cancelLabel: t("settings.cancel"),
+      tone: "warning",
+    }).then((accepted) => {
+      if (accepted) confirmedPrivateUrls.current.add(confirmationKey);
+      return accepted;
+    });
+    confirmationInFlight.current.set(confirmationKey, pending);
+    void pending.finally(() => confirmationInFlight.current.delete(confirmationKey));
+    return pending;
+  }
+
+  async function fetchModelsWithConfirmation(url: string, key: string) {
+    if (isProviderModelsPrivateAddress(url)) {
+      if (!(await confirmPrivateProviderUrl(url))) return null;
+      return fetchModelsFromApi(providerType, url, key, { allowPrivateNetwork: true });
+    }
+
+    try {
+      return await fetchModelsFromApi(providerType, url, key);
+    } catch (err) {
+      if (!isGatewayWebui || !isProviderModelsConfirmationRequired(err)) throw err;
+      if (!(await confirmPrivateProviderUrl(url))) return null;
+      return fetchModelsFromApi(providerType, url, key, { allowPrivateNetwork: true });
+    }
+  }
+
   async function doFetch(url: string, key: string) {
+    const requestSeq = ++fetchSeq.current;
     setFetchingModels(true);
     setFetchError(null);
     try {
-      const list = await fetchModelsFromApi(providerType, url, key);
-      setModels((prev) => mergeFetchedModels(list, prev));
+      const list = await fetchModelsWithConfirmation(url, key);
+      if (!list && requestSeq === fetchSeq.current) {
+        setFetchError(t("settings.providerNetworkWarningCancelled"));
+      } else if (list && requestSeq === fetchSeq.current) {
+        setModels((prev) => mergeFetchedModels(list, prev));
+      }
     } catch (err) {
-      setFetchError(err instanceof Error ? err.message : String(err));
+      if (requestSeq === fetchSeq.current) {
+        setFetchError(err instanceof Error ? err.message : String(err));
+      }
     } finally {
-      setFetchingModels(false);
+      if (requestSeq === fetchSeq.current) setFetchingModels(false);
     }
   }
 
@@ -657,6 +711,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
             onSave={saveModelSettings}
           />
         ) : null}
+        {dialog}
       </div>
     </div>,
     document.body,

--- a/crates/agent-gui/src/pages/settings/providerUtils.ts
+++ b/crates/agent-gui/src/pages/settings/providerUtils.ts
@@ -14,6 +14,59 @@ const CODEX_MODELS_SUFFIXES = ["/chat/completions", "/responses", "/response"];
 const GEMINI_GENERATE_SUFFIXES = [":streamGenerateContent", ":generateContent"];
 const ANTHROPIC_API_VERSION = "2023-06-01";
 
+export type ProviderModelsFetchOptions = {
+  allowPrivateNetwork?: boolean;
+};
+
+export function isProviderModelsConfirmationRequired(error: unknown) {
+  return (
+    error instanceof Error &&
+    (error as Error & { code?: unknown }).code === "provider_models_confirmation_required"
+  );
+}
+
+function isPrivateIPv4(host: string) {
+  const parts = host.split(".").map((part) => Number(part));
+  if (
+    parts.length !== 4 ||
+    parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+  ) {
+    return false;
+  }
+  return (
+    parts[0] === 10 ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168) ||
+    parts[0] === 127
+  );
+}
+
+export function isProviderModelsPrivateAddress(baseUrl: string) {
+  try {
+    const parsed = new URL(baseUrl.trim());
+    const host = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    return (
+      host === "localhost" ||
+      isPrivateIPv4(host) ||
+      host === "::1" ||
+      host.startsWith("fc") ||
+      host.startsWith("fd") ||
+      host.startsWith("::ffff:127.")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function providerModelsConfirmationKey(baseUrl: string) {
+  try {
+    const parsed = new URL(baseUrl.trim());
+    return parsed.origin.toLowerCase();
+  } catch {
+    return baseUrl.trim();
+  }
+}
+
 export function isGatewayWebuiRuntime() {
   return (
     typeof document !== "undefined" &&
@@ -199,6 +252,7 @@ async function fetchModelsThroughGateway(
   type: ProviderId,
   baseUrl: string,
   apiKey: string,
+  options?: ProviderModelsFetchOptions,
 ): Promise<ProviderModelConfig[]> {
   const token =
     typeof window !== "undefined"
@@ -212,6 +266,7 @@ async function fetchModelsThroughGateway(
     type,
     base_url: baseUrl,
     api_key: apiKey,
+    allow_private_network: options?.allowPrivateNetwork === true,
   } as any);
 
   const items = extractModelListItems(data);
@@ -331,11 +386,12 @@ export async function fetchModelsFromApi(
   type: ProviderId,
   baseUrl: string,
   apiKey: string,
+  options?: ProviderModelsFetchOptions,
 ): Promise<ProviderModelConfig[]> {
   const normalizedUrl = normalizeModelBaseUrl(type, baseUrl);
   const normalizedApiKey = apiKey.trim();
   if (isGatewayWebuiRuntime()) {
-    return fetchModelsThroughGateway(type, normalizedUrl, normalizedApiKey);
+    return fetchModelsThroughGateway(type, normalizedUrl, normalizedApiKey, options);
   }
 
   const attempts = buildProviderModelsAttempts(type, normalizedUrl, normalizedApiKey);

--- a/crates/agent-gui/test/settings/provider-models-fetch.test.mjs
+++ b/crates/agent-gui/test/settings/provider-models-fetch.test.mjs
@@ -72,6 +72,18 @@ test("buildProviderModelsUrl defaults to /v1/models and falls back to official e
   );
 });
 
+test("provider model URL safety helpers identify local network targets", () => {
+  assert.equal(providerUtils.isProviderModelsPrivateAddress("http://10.66.0.1:8787"), true);
+  assert.equal(providerUtils.isProviderModelsPrivateAddress("http://10.66.0.1:8787/v1"), true);
+  assert.equal(providerUtils.isProviderModelsPrivateAddress("http://127.0.0.1:11434"), true);
+  assert.equal(providerUtils.isProviderModelsPrivateAddress("http://localhost:11434"), true);
+  assert.equal(providerUtils.isProviderModelsPrivateAddress("https://api.example.com"), false);
+  assert.equal(
+    providerUtils.providerModelsConfirmationKey("HTTP://10.66.0.1:8787/v1"),
+    "http://10.66.0.1:8787",
+  );
+});
+
 test("buildProviderModelsAttempts orders default before official with provider headers", () => {
   const gemini = providerUtils.buildProviderModelsAttempts(
     "gemini",


### PR DESCRIPTION
## Summary
- allow confirmed RFC1918, IPv6 ULA, and loopback provider model endpoints
- add DNS preflight and structured confirmation error for private hostnames
- show bilingual confirmation warning in GUI and Gateway WebUI before model scans

## Verification
- Go: `go test ./...`
- GUI settings tests: 118 passed
- Gateway WebUI build and tests passed
- Gateway WebUI lint remains blocked by existing repository warnings
- Browser check confirmed the LAN warning appears and Cancel closes it without continuing

Production was not modified.