### PR TITLE
feat(settings): make app proxy config an always-visible inline form

### DIFF
--- a/crates/agent-gateway/web/src/i18n/config.ts
+++ b/crates/agent-gateway/web/src/i18n/config.ts
@@ -995,12 +995,13 @@ export const translations: Record<Locale, Record<string, string>> = {
     /* ── Settings System ── */
     "settings.appearance": "外观主题",
     "settings.appearanceDesc": "选择应用的颜色主题，偏好会自动保存。",
-    "settings.systemProxy": "系统代理",
-    "settings.systemProxyEnable": "启用系统代理",
+    "settings.systemProxy": "应用代理",
+    "settings.systemProxyEnable": "启用应用代理",
     "settings.systemProxyDesc":
-      "生效范围：桌面端本地命令环境变量（Bash / 后台任务 / 自动化脚本）、勾选“应用系统代理”的供应商请求、更新检查与技能下载。",
+      "生效范围：桌面端本地命令环境变量（Bash / 后台任务 / 自动化脚本）、勾选“使用应用代理”的供应商请求、更新检查与技能下载。",
     "settings.systemProxyInvalid":
       "代理已启用，请填写有效的代理地址和端口；配置有效前相关请求将直接报错。",
+    "settings.systemProxyEnableHint": "请先填写有效的代理地址和端口后再启用代理。",
     "settings.systemProxyType": "代理类型",
     "settings.systemProxyHost": "代理地址",
     "settings.systemProxyPort": "端口",
@@ -1008,9 +1009,9 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.systemProxyPassword": "密码（可选）",
     "settings.systemProxyPasswordConfigured": "代理密码已保存",
     "settings.systemProxyPasswordClear": "清除",
-    "settings.providerUseSystemProxy": "应用系统代理",
+    "settings.providerUseSystemProxy": "使用应用代理",
     "settings.providerUseSystemProxyDesc":
-      "该供应商的模型请求经系统设置中配置的系统代理出网；系统代理未启用时保持直连。",
+      "该供应商的模型请求经应用代理出网；应用代理未启用时保持直连。",
     "settings.light": "浅色",
     "settings.lightDesc": "明亮清爽的浅色界面",
     "settings.dark": "深色",
@@ -2780,12 +2781,14 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.appearance": "Appearance",
     "settings.appearanceDesc":
       "Choose the color theme for the application. Your preference will be saved automatically.",
-    "settings.systemProxy": "System Proxy",
-    "settings.systemProxyEnable": "Enable system proxy",
+    "settings.systemProxy": "App Proxy",
+    "settings.systemProxyEnable": "Enable app proxy",
     "settings.systemProxyDesc":
-      "Applies to: local command environment on the desktop (Bash / background tasks / automation scripts), providers with “Use system proxy” checked, update checks and skill downloads.",
+      "Applies to: local command environment on the desktop (Bash / background tasks / automation scripts), providers with “Use app proxy” checked, update checks and skill downloads.",
     "settings.systemProxyInvalid":
       "The proxy is enabled. Enter a valid host and port; affected requests fail until the configuration is valid.",
+    "settings.systemProxyEnableHint":
+      "Enter a valid proxy host and port before enabling the proxy.",
     "settings.systemProxyType": "Proxy type",
     "settings.systemProxyHost": "Proxy host",
     "settings.systemProxyPort": "Port",
@@ -2793,9 +2796,9 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.systemProxyPassword": "Password (optional)",
     "settings.systemProxyPasswordConfigured": "Proxy password saved",
     "settings.systemProxyPasswordClear": "Clear",
-    "settings.providerUseSystemProxy": "Use system proxy",
+    "settings.providerUseSystemProxy": "Use app proxy",
     "settings.providerUseSystemProxyDesc":
-      "Route this provider's model requests through the system proxy configured in System settings. Falls back to a direct connection while the system proxy is disabled.",
+      "Route this provider's model requests through the app proxy. Falls back to a direct connection while the app proxy is disabled.",
     "settings.light": "Light",
     "settings.lightDesc": "Bright and clean light interface",
     "settings.dark": "Dark",

--- a/crates/agent-gateway/web/src/pages/settings/SystemSettingsForm.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/SystemSettingsForm.tsx
@@ -88,21 +88,26 @@ export function SystemSettingsForm(props: SettingsSectionProps) {
   }
 
   const systemProxy = settings.system.systemProxy;
-  // 护栏 A：host + port 有效才算配置可用（端口在启用时必填有效）。
-  const proxyConfigValid =
-    isValidSystemProxyHost(systemProxy.host) &&
-    Number.isInteger(systemProxy.port) &&
-    systemProxy.port >= 1 &&
-    systemProxy.port <= 65535;
-  const systemProxyInvalid = systemProxy.enabled && !proxyConfigValid;
-  // 配置无效且当前未启用时禁止开启开关（护栏 A）；已启用时始终允许关闭。
-  const proxyToggleDisabled = !systemProxy.enabled && !proxyConfigValid;
   // host/port/username/password 走"本地草稿 + blur 提交"：失焦才写入 settings，
   // 避免逐字符触发同步；且 WebUI 设置 state 持久前会脱敏密码，草稿避免输入即被清空。
   const [proxyHostDraft, setProxyHostDraft] = useState<string | null>(null);
   const [proxyPortDraft, setProxyPortDraft] = useState<string | null>(null);
   const [proxyUsernameDraft, setProxyUsernameDraft] = useState<string | null>(null);
   const [proxyPasswordDraft, setProxyPasswordDraft] = useState<string | null>(null);
+  // 护栏 A：host + port 有效才算配置可用（端口在启用时必填有效）。
+  // 用"草稿优先"的生效值计算：blur 提交前开关若仍禁用，点击开关触发的 blur
+  // 会先把按钮变回可用，但落在禁用按钮上的这次 click 已被浏览器吞掉，需点两次。
+  const effectiveProxyHost = (proxyHostDraft ?? systemProxy.host).trim();
+  const effectiveProxyPort =
+    proxyPortDraft !== null ? Number.parseInt(proxyPortDraft, 10) : systemProxy.port;
+  const proxyConfigValid =
+    isValidSystemProxyHost(effectiveProxyHost) &&
+    Number.isInteger(effectiveProxyPort) &&
+    effectiveProxyPort >= 1 &&
+    effectiveProxyPort <= 65535;
+  const systemProxyInvalid = systemProxy.enabled && !proxyConfigValid;
+  // 配置无效且当前未启用时禁止开启开关（护栏 A）；已启用时始终允许关闭。
+  const proxyToggleDisabled = !systemProxy.enabled && !proxyConfigValid;
 
   function patchSystemProxy(patch: Partial<SystemProxyConfig>) {
     setSettings((prev) =>

--- a/crates/agent-gateway/web/src/pages/settings/SystemSettingsForm.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/SystemSettingsForm.tsx
@@ -13,6 +13,13 @@ import {
 } from "../../components/icons";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../components/ui/select";
 import { SUPPORTED_LOCALES, useLocale } from "../../i18n";
 import {
   type ExecutionMode,
@@ -81,14 +88,20 @@ export function SystemSettingsForm(props: SettingsSectionProps) {
   }
 
   const systemProxy = settings.system.systemProxy;
-  const systemProxyInvalid =
-    systemProxy.enabled &&
-    (!isValidSystemProxyHost(systemProxy.host) ||
-      !Number.isInteger(systemProxy.port) ||
-      systemProxy.port < 1 ||
-      systemProxy.port > 65535);
-  // 密码走"本地草稿 + blur 提交"：WebUI 的设置 state 持久前会被脱敏（密码置空），
-  // 直接绑定 state 会导致输入即被清空；草稿只在提交时进入 settings。
+  // 护栏 A：host + port 有效才算配置可用（端口在启用时必填有效）。
+  const proxyConfigValid =
+    isValidSystemProxyHost(systemProxy.host) &&
+    Number.isInteger(systemProxy.port) &&
+    systemProxy.port >= 1 &&
+    systemProxy.port <= 65535;
+  const systemProxyInvalid = systemProxy.enabled && !proxyConfigValid;
+  // 配置无效且当前未启用时禁止开启开关（护栏 A）；已启用时始终允许关闭。
+  const proxyToggleDisabled = !systemProxy.enabled && !proxyConfigValid;
+  // host/port/username/password 走"本地草稿 + blur 提交"：失焦才写入 settings，
+  // 避免逐字符触发同步；且 WebUI 设置 state 持久前会脱敏密码，草稿避免输入即被清空。
+  const [proxyHostDraft, setProxyHostDraft] = useState<string | null>(null);
+  const [proxyPortDraft, setProxyPortDraft] = useState<string | null>(null);
+  const [proxyUsernameDraft, setProxyUsernameDraft] = useState<string | null>(null);
   const [proxyPasswordDraft, setProxyPasswordDraft] = useState<string | null>(null);
 
   function patchSystemProxy(patch: Partial<SystemProxyConfig>) {
@@ -97,6 +110,28 @@ export function SystemSettingsForm(props: SettingsSectionProps) {
         systemProxy: { ...prev.system.systemProxy, ...patch },
       }),
     );
+  }
+
+  function commitProxyHostDraft() {
+    if (proxyHostDraft !== null) {
+      patchSystemProxy({ host: proxyHostDraft.trim() });
+      setProxyHostDraft(null);
+    }
+  }
+
+  function commitProxyPortDraft() {
+    if (proxyPortDraft !== null) {
+      const parsed = Number.parseInt(proxyPortDraft, 10);
+      patchSystemProxy({ port: Number.isNaN(parsed) ? 0 : parsed });
+      setProxyPortDraft(null);
+    }
+  }
+
+  function commitProxyUsernameDraft() {
+    if (proxyUsernameDraft !== null) {
+      patchSystemProxy({ username: proxyUsernameDraft.trim() });
+      setProxyUsernameDraft(null);
+    }
   }
 
   function commitProxyPasswordDraft() {
@@ -326,116 +361,113 @@ export function SystemSettingsForm(props: SettingsSectionProps) {
           <AgentActivationSwitch
             checked={systemProxy.enabled}
             title={t("settings.systemProxyEnable")}
+            disabled={proxyToggleDisabled}
             onToggle={() => patchSystemProxy({ enabled: !systemProxy.enabled })}
           />
         </div>
         <p className="text-xs text-muted-foreground">{t("settings.systemProxyDesc")}</p>
         {systemProxyInvalid ? (
           <p className="text-xs text-destructive">{t("settings.systemProxyInvalid")}</p>
+        ) : proxyToggleDisabled ? (
+          <p className="text-xs text-muted-foreground">{t("settings.systemProxyEnableHint")}</p>
         ) : null}
-        {systemProxy.enabled ? (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <div className="space-y-1.5 sm:col-span-2">
-              <Label className="text-xs font-medium text-muted-foreground">
-                {t("settings.systemProxyType")}
-              </Label>
-              <div className="grid grid-cols-2 gap-2 rounded-xl border border-border/60 bg-background p-1">
-                {(["socks5", "http"] as SystemProxyType[]).map((type) => (
-                  <button
-                    key={type}
-                    type="button"
-                    className={`rounded-lg px-3 py-2 text-xs font-medium transition-colors ${
-                      systemProxy.type === type
-                        ? "bg-muted text-foreground shadow-sm"
-                        : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-                    }`}
-                    onClick={() => patchSystemProxy({ type })}
-                  >
-                    {type === "socks5" ? "SOCKS5" : "HTTP"}
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div className="space-y-1.5">
-              <Label
-                htmlFor="system-proxy-host"
-                className="text-xs font-medium text-muted-foreground"
-              >
-                {t("settings.systemProxyHost")}
-              </Label>
-              <Input
-                id="system-proxy-host"
-                value={systemProxy.host}
-                placeholder="127.0.0.1"
-                onChange={(event) => patchSystemProxy({ host: event.currentTarget.value })}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label
-                htmlFor="system-proxy-port"
-                className="text-xs font-medium text-muted-foreground"
-              >
-                {t("settings.systemProxyPort")}
-              </Label>
-              <Input
-                id="system-proxy-port"
-                type="number"
-                min={1}
-                max={65535}
-                value={systemProxy.port > 0 ? systemProxy.port : ""}
-                placeholder={systemProxy.type === "socks5" ? "1080" : "7890"}
-                onChange={(event) => {
-                  const parsed = Number.parseInt(event.currentTarget.value, 10);
-                  patchSystemProxy({ port: Number.isNaN(parsed) ? 0 : parsed });
-                }}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label
-                htmlFor="system-proxy-username"
-                className="text-xs font-medium text-muted-foreground"
-              >
-                {t("settings.systemProxyUsername")}
-              </Label>
-              <Input
-                id="system-proxy-username"
-                value={systemProxy.username}
-                onChange={(event) => patchSystemProxy({ username: event.currentTarget.value })}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label
-                htmlFor="system-proxy-password"
-                className="text-xs font-medium text-muted-foreground"
-              >
-                {t("settings.systemProxyPassword")}
-              </Label>
-              <Input
-                id="system-proxy-password"
-                type="password"
-                value={proxyPasswordDraft ?? systemProxy.password}
-                onChange={(event) => setProxyPasswordDraft(event.currentTarget.value)}
-                onBlur={commitProxyPasswordDraft}
-              />
-              {systemProxy.passwordConfigured &&
-              !(proxyPasswordDraft ?? systemProxy.password).trim() ? (
-                <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-                  <span>{t("settings.systemProxyPasswordConfigured")}</span>
-                  <button
-                    type="button"
-                    className="underline-offset-2 hover:text-foreground hover:underline"
-                    onClick={() => {
-                      setProxyPasswordDraft(null);
-                      patchSystemProxy({ password: "", passwordConfigured: false });
-                    }}
-                  >
-                    {t("settings.systemProxyPasswordClear")}
-                  </button>
-                </div>
-              ) : null}
-            </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-12 lg:items-start">
+          <div className="space-y-1.5 sm:col-span-2 lg:col-span-2">
+            <Label className="text-xs font-medium text-muted-foreground">
+              {t("settings.systemProxyType")}
+            </Label>
+            <Select
+              value={systemProxy.type}
+              onValueChange={(value) => patchSystemProxy({ type: value as SystemProxyType })}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue>{systemProxy.type === "socks5" ? "SOCKS5" : "HTTP"}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="http">HTTP</SelectItem>
+                <SelectItem value="socks5">SOCKS5</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
-        ) : null}
+          <div className="space-y-1.5 lg:col-span-4">
+            <Label
+              htmlFor="system-proxy-host"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              {t("settings.systemProxyHost")}
+            </Label>
+            <Input
+              id="system-proxy-host"
+              value={proxyHostDraft ?? systemProxy.host}
+              placeholder="127.0.0.1"
+              onChange={(event) => setProxyHostDraft(event.currentTarget.value)}
+              onBlur={commitProxyHostDraft}
+            />
+          </div>
+          <div className="space-y-1.5 lg:col-span-2">
+            <Label
+              htmlFor="system-proxy-port"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              {t("settings.systemProxyPort")}
+            </Label>
+            <Input
+              id="system-proxy-port"
+              type="number"
+              min={1}
+              max={65535}
+              value={proxyPortDraft ?? (systemProxy.port > 0 ? String(systemProxy.port) : "")}
+              placeholder={systemProxy.type === "socks5" ? "1080" : "7890"}
+              onChange={(event) => setProxyPortDraft(event.currentTarget.value)}
+              onBlur={commitProxyPortDraft}
+            />
+          </div>
+          <div className="space-y-1.5 lg:col-span-2">
+            <Label
+              htmlFor="system-proxy-username"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              {t("settings.systemProxyUsername")}
+            </Label>
+            <Input
+              id="system-proxy-username"
+              value={proxyUsernameDraft ?? systemProxy.username}
+              onChange={(event) => setProxyUsernameDraft(event.currentTarget.value)}
+              onBlur={commitProxyUsernameDraft}
+            />
+          </div>
+          <div className="space-y-1.5 lg:col-span-2">
+            <Label
+              htmlFor="system-proxy-password"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              {t("settings.systemProxyPassword")}
+            </Label>
+            <Input
+              id="system-proxy-password"
+              type="password"
+              value={proxyPasswordDraft ?? systemProxy.password}
+              onChange={(event) => setProxyPasswordDraft(event.currentTarget.value)}
+              onBlur={commitProxyPasswordDraft}
+            />
+            {systemProxy.passwordConfigured &&
+            !(proxyPasswordDraft ?? systemProxy.password).trim() ? (
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <span>{t("settings.systemProxyPasswordConfigured")}</span>
+                <button
+                  type="button"
+                  className="underline-offset-2 hover:text-foreground hover:underline"
+                  onClick={() => {
+                    setProxyPasswordDraft(null);
+                    patchSystemProxy({ password: "", passwordConfigured: false });
+                  }}
+                >
+                  {t("settings.systemProxyPasswordClear")}
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </div>
       </section>
 
       <section className="space-y-3 rounded-2xl border border-border/60 bg-card p-4">

--- a/crates/agent-gui/src-tauri/src/services/provider_models.rs
+++ b/crates/agent-gui/src-tauri/src/services/provider_models.rs
@@ -32,7 +32,7 @@ pub async fn fetch_provider_models(
     // fail fast，绝不静默降级；未勾选一律直连（忽略环境代理）。
     let client = if use_system_proxy {
         crate::services::system_proxy::cached_client()
-            .map_err(|error| format!("System proxy unavailable: {error}"))?
+            .map_err(|error| format!("App proxy unavailable: {error}"))?
     } else {
         direct_client()?
     };

--- a/crates/agent-gui/src-tauri/src/services/proxy.rs
+++ b/crates/agent-gui/src-tauri/src/services/proxy.rs
@@ -365,7 +365,7 @@ async fn handle_proxy(
             Err(error) => {
                 return error_response(
                     StatusCode::BAD_GATEWAY,
-                    &format!("System proxy unavailable: {error}"),
+                    &format!("App proxy unavailable: {error}"),
                     &headers,
                 );
             }

--- a/crates/agent-gui/src-tauri/src/services/system_proxy.rs
+++ b/crates/agent-gui/src-tauri/src/services/system_proxy.rs
@@ -126,7 +126,7 @@ fn parse_proxy_mode(raw: Option<&Value>) -> ProxyMode {
     };
     let mut config = match serde_json::from_value::<SystemProxyConfig>(raw.clone()) {
         Ok(config) => config,
-        Err(_) => return ProxyMode::Invalid("系统代理配置格式无效".to_string()),
+        Err(_) => return ProxyMode::Invalid("应用代理配置格式无效".to_string()),
     };
     if !config.enabled {
         return ProxyMode::Disabled;
@@ -139,7 +139,7 @@ fn parse_proxy_mode(raw: Option<&Value>) -> ProxyMode {
     ) || config.port == 0
         || !host_is_valid(&config.host)
     {
-        return ProxyMode::Invalid("系统代理已启用，但地址、端口或类型无效".to_string());
+        return ProxyMode::Invalid("应用代理已启用，但地址、端口或类型无效".to_string());
     }
     match build_proxy(&config) {
         Ok(_) => ProxyMode::Enabled(config),
@@ -200,7 +200,7 @@ pub fn shell_proxy_envs() -> Result<Vec<(String, String)>, String> {
 
 fn build_proxy(config: &SystemProxyConfig) -> Result<reqwest::Proxy, String> {
     reqwest::Proxy::all(config.proxy_url())
-        .map_err(|_| format!("系统代理地址无效：{}", config.display_target()))
+        .map_err(|_| format!("应用代理地址无效：{}", config.display_target()))
 }
 
 fn async_client_builder_for_mode(mode: &ProxyMode) -> Result<reqwest::ClientBuilder, String> {
@@ -239,7 +239,7 @@ pub fn cached_client() -> Result<reqwest::Client, String> {
     }
     let client = async_client_builder_for_mode(&snapshot.mode)?
         .build()
-        .map_err(|_| "创建系统代理 HTTP 客户端失败".to_string())?;
+        .map_err(|_| "创建应用代理 HTTP 客户端失败".to_string())?;
     let current_revision = current_snapshot().revision;
     if current_revision == snapshot.revision {
         *state()

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -1063,12 +1063,13 @@ export const translations: Record<Locale, Record<string, string>> = {
     /* ── Settings System ── */
     "settings.appearance": "外观主题",
     "settings.appearanceDesc": "选择应用的颜色主题，偏好会自动保存。",
-    "settings.systemProxy": "系统代理",
-    "settings.systemProxyEnable": "启用系统代理",
+    "settings.systemProxy": "应用代理",
+    "settings.systemProxyEnable": "启用应用代理",
     "settings.systemProxyDesc":
-      "生效范围：本地命令环境变量（Bash / 后台任务 / 自动化脚本）、勾选“应用系统代理”的供应商请求、更新检查与技能下载。",
+      "生效范围：本地命令环境变量（Bash / 后台任务 / 自动化脚本）、勾选“使用应用代理”的供应商请求、更新检查与技能下载。",
     "settings.systemProxyInvalid":
       "代理已启用，请填写有效的代理地址和端口；配置有效前相关请求将直接报错。",
+    "settings.systemProxyEnableHint": "请先填写有效的代理地址和端口后再启用代理。",
     "settings.systemProxyType": "代理类型",
     "settings.systemProxyHost": "代理地址",
     "settings.systemProxyPort": "端口",
@@ -1076,9 +1077,9 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.systemProxyPassword": "密码（可选）",
     "settings.systemProxyPasswordConfigured": "代理密码已保存",
     "settings.systemProxyPasswordClear": "清除",
-    "settings.providerUseSystemProxy": "应用系统代理",
+    "settings.providerUseSystemProxy": "使用应用代理",
     "settings.providerUseSystemProxyDesc":
-      "该供应商的模型请求经系统设置中配置的系统代理出网；系统代理未启用时保持直连。",
+      "该供应商的模型请求经应用代理出网；应用代理未启用时保持直连。",
     "settings.closeWindowBehavior": "关闭窗口",
     "settings.closeWindowMinimize": "最小化到托盘",
     "settings.closeWindowMinimizeDesc": "关闭窗口后应用继续在后台运行，可从托盘恢复。",
@@ -2918,12 +2919,14 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.appearance": "Appearance",
     "settings.appearanceDesc":
       "Choose the color theme for the application. Your preference will be saved automatically.",
-    "settings.systemProxy": "System Proxy",
-    "settings.systemProxyEnable": "Enable system proxy",
+    "settings.systemProxy": "App Proxy",
+    "settings.systemProxyEnable": "Enable app proxy",
     "settings.systemProxyDesc":
-      "Applies to: local command environment (Bash / background tasks / automation scripts), providers with “Use system proxy” checked, update checks and skill downloads.",
+      "Applies to: local command environment (Bash / background tasks / automation scripts), providers with “Use app proxy” checked, update checks and skill downloads.",
     "settings.systemProxyInvalid":
       "The proxy is enabled. Enter a valid host and port; affected requests fail until the configuration is valid.",
+    "settings.systemProxyEnableHint":
+      "Enter a valid proxy host and port before enabling the proxy.",
     "settings.systemProxyType": "Proxy type",
     "settings.systemProxyHost": "Proxy host",
     "settings.systemProxyPort": "Port",
@@ -2931,9 +2934,9 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.systemProxyPassword": "Password (optional)",
     "settings.systemProxyPasswordConfigured": "Proxy password saved",
     "settings.systemProxyPasswordClear": "Clear",
-    "settings.providerUseSystemProxy": "Use system proxy",
+    "settings.providerUseSystemProxy": "Use app proxy",
     "settings.providerUseSystemProxyDesc":
-      "Route this provider's model requests through the system proxy configured in System settings. Falls back to a direct connection while the system proxy is disabled.",
+      "Route this provider's model requests through the app proxy. Falls back to a direct connection while the app proxy is disabled.",
     "settings.closeWindowBehavior": "Close Window",
     "settings.closeWindowMinimize": "Minimize to tray",
     "settings.closeWindowMinimizeDesc":

--- a/crates/agent-gui/src/pages/settings/SystemSettingsForm.tsx
+++ b/crates/agent-gui/src/pages/settings/SystemSettingsForm.tsx
@@ -91,21 +91,26 @@ export function SystemSettingsForm(props: SettingsSectionProps) {
   }
 
   const systemProxy = settings.system.systemProxy;
-  // 护栏 A：host + port 有效才算配置可用（端口在启用时必填有效）。
-  const proxyConfigValid =
-    isValidSystemProxyHost(systemProxy.host) &&
-    Number.isInteger(systemProxy.port) &&
-    systemProxy.port >= 1 &&
-    systemProxy.port <= 65535;
-  const systemProxyInvalid = systemProxy.enabled && !proxyConfigValid;
-  // 配置无效且当前未启用时禁止开启开关（护栏 A）；已启用时始终允许关闭。
-  const proxyToggleDisabled = !systemProxy.enabled && !proxyConfigValid;
   // host/port/username/password 走"本地草稿 + blur 提交"：失焦才写入 settings，
   // 避免逐字符触发同步；且 WebUI 设置 state 持久前会脱敏密码，草稿避免输入即被清空。
   const [proxyHostDraft, setProxyHostDraft] = useState<string | null>(null);
   const [proxyPortDraft, setProxyPortDraft] = useState<string | null>(null);
   const [proxyUsernameDraft, setProxyUsernameDraft] = useState<string | null>(null);
   const [proxyPasswordDraft, setProxyPasswordDraft] = useState<string | null>(null);
+  // 护栏 A：host + port 有效才算配置可用（端口在启用时必填有效）。
+  // 用"草稿优先"的生效值计算：blur 提交前开关若仍禁用，点击开关触发的 blur
+  // 会先把按钮变回可用，但落在禁用按钮上的这次 click 已被浏览器吞掉，需点两次。
+  const effectiveProxyHost = (proxyHostDraft ?? systemProxy.host).trim();
+  const effectiveProxyPort =
+    proxyPortDraft !== null ? Number.parseInt(proxyPortDraft, 10) : systemProxy.port;
+  const proxyConfigValid =
+    isValidSystemProxyHost(effectiveProxyHost) &&
+    Number.isInteger(effectiveProxyPort) &&
+    effectiveProxyPort >= 1 &&
+    effectiveProxyPort <= 65535;
+  const systemProxyInvalid = systemProxy.enabled && !proxyConfigValid;
+  // 配置无效且当前未启用时禁止开启开关（护栏 A）；已启用时始终允许关闭。
+  const proxyToggleDisabled = !systemProxy.enabled && !proxyConfigValid;
 
   function patchSystemProxy(patch: Partial<SystemProxyConfig>) {
     setSettings((prev) =>

--- a/crates/agent-gui/src/pages/settings/SystemSettingsForm.tsx
+++ b/crates/agent-gui/src/pages/settings/SystemSettingsForm.tsx
@@ -15,6 +15,13 @@ import {
 } from "../../components/icons";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../components/ui/select";
 import { SUPPORTED_LOCALES, useLocale } from "../../i18n";
 import {
   CLOSE_WINDOW_BEHAVIOR_OPTIONS,
@@ -84,14 +91,20 @@ export function SystemSettingsForm(props: SettingsSectionProps) {
   }
 
   const systemProxy = settings.system.systemProxy;
-  const systemProxyInvalid =
-    systemProxy.enabled &&
-    (!isValidSystemProxyHost(systemProxy.host) ||
-      !Number.isInteger(systemProxy.port) ||
-      systemProxy.port < 1 ||
-      systemProxy.port > 65535);
-  // 密码走"本地草稿 + blur 提交"：WebUI 的设置 state 持久前会被脱敏（密码置空），
-  // 直接绑定 state 会导致输入即被清空；草稿只在提交时进入 settings。
+  // 护栏 A：host + port 有效才算配置可用（端口在启用时必填有效）。
+  const proxyConfigValid =
+    isValidSystemProxyHost(systemProxy.host) &&
+    Number.isInteger(systemProxy.port) &&
+    systemProxy.port >= 1 &&
+    systemProxy.port <= 65535;
+  const systemProxyInvalid = systemProxy.enabled && !proxyConfigValid;
+  // 配置无效且当前未启用时禁止开启开关（护栏 A）；已启用时始终允许关闭。
+  const proxyToggleDisabled = !systemProxy.enabled && !proxyConfigValid;
+  // host/port/username/password 走"本地草稿 + blur 提交"：失焦才写入 settings，
+  // 避免逐字符触发同步；且 WebUI 设置 state 持久前会脱敏密码，草稿避免输入即被清空。
+  const [proxyHostDraft, setProxyHostDraft] = useState<string | null>(null);
+  const [proxyPortDraft, setProxyPortDraft] = useState<string | null>(null);
+  const [proxyUsernameDraft, setProxyUsernameDraft] = useState<string | null>(null);
   const [proxyPasswordDraft, setProxyPasswordDraft] = useState<string | null>(null);
 
   function patchSystemProxy(patch: Partial<SystemProxyConfig>) {
@@ -100,6 +113,28 @@ export function SystemSettingsForm(props: SettingsSectionProps) {
         systemProxy: { ...prev.system.systemProxy, ...patch },
       }),
     );
+  }
+
+  function commitProxyHostDraft() {
+    if (proxyHostDraft !== null) {
+      patchSystemProxy({ host: proxyHostDraft.trim() });
+      setProxyHostDraft(null);
+    }
+  }
+
+  function commitProxyPortDraft() {
+    if (proxyPortDraft !== null) {
+      const parsed = Number.parseInt(proxyPortDraft, 10);
+      patchSystemProxy({ port: Number.isNaN(parsed) ? 0 : parsed });
+      setProxyPortDraft(null);
+    }
+  }
+
+  function commitProxyUsernameDraft() {
+    if (proxyUsernameDraft !== null) {
+      patchSystemProxy({ username: proxyUsernameDraft.trim() });
+      setProxyUsernameDraft(null);
+    }
   }
 
   function commitProxyPasswordDraft() {
@@ -329,116 +364,113 @@ export function SystemSettingsForm(props: SettingsSectionProps) {
           <AgentActivationSwitch
             checked={systemProxy.enabled}
             title={t("settings.systemProxyEnable")}
+            disabled={proxyToggleDisabled}
             onToggle={() => patchSystemProxy({ enabled: !systemProxy.enabled })}
           />
         </div>
         <p className="text-xs text-muted-foreground">{t("settings.systemProxyDesc")}</p>
         {systemProxyInvalid ? (
           <p className="text-xs text-destructive">{t("settings.systemProxyInvalid")}</p>
+        ) : proxyToggleDisabled ? (
+          <p className="text-xs text-muted-foreground">{t("settings.systemProxyEnableHint")}</p>
         ) : null}
-        {systemProxy.enabled ? (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <div className="space-y-1.5 sm:col-span-2">
-              <Label className="text-xs font-medium text-muted-foreground">
-                {t("settings.systemProxyType")}
-              </Label>
-              <div className="grid grid-cols-2 gap-2 rounded-xl border border-border/60 bg-background p-1">
-                {(["socks5", "http"] as SystemProxyType[]).map((type) => (
-                  <button
-                    key={type}
-                    type="button"
-                    className={`rounded-lg px-3 py-2 text-xs font-medium transition-colors ${
-                      systemProxy.type === type
-                        ? "bg-muted text-foreground shadow-sm"
-                        : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-                    }`}
-                    onClick={() => patchSystemProxy({ type })}
-                  >
-                    {type === "socks5" ? "SOCKS5" : "HTTP"}
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div className="space-y-1.5">
-              <Label
-                htmlFor="system-proxy-host"
-                className="text-xs font-medium text-muted-foreground"
-              >
-                {t("settings.systemProxyHost")}
-              </Label>
-              <Input
-                id="system-proxy-host"
-                value={systemProxy.host}
-                placeholder="127.0.0.1"
-                onChange={(event) => patchSystemProxy({ host: event.currentTarget.value })}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label
-                htmlFor="system-proxy-port"
-                className="text-xs font-medium text-muted-foreground"
-              >
-                {t("settings.systemProxyPort")}
-              </Label>
-              <Input
-                id="system-proxy-port"
-                type="number"
-                min={1}
-                max={65535}
-                value={systemProxy.port > 0 ? systemProxy.port : ""}
-                placeholder={systemProxy.type === "socks5" ? "1080" : "7890"}
-                onChange={(event) => {
-                  const parsed = Number.parseInt(event.currentTarget.value, 10);
-                  patchSystemProxy({ port: Number.isNaN(parsed) ? 0 : parsed });
-                }}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label
-                htmlFor="system-proxy-username"
-                className="text-xs font-medium text-muted-foreground"
-              >
-                {t("settings.systemProxyUsername")}
-              </Label>
-              <Input
-                id="system-proxy-username"
-                value={systemProxy.username}
-                onChange={(event) => patchSystemProxy({ username: event.currentTarget.value })}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label
-                htmlFor="system-proxy-password"
-                className="text-xs font-medium text-muted-foreground"
-              >
-                {t("settings.systemProxyPassword")}
-              </Label>
-              <Input
-                id="system-proxy-password"
-                type="password"
-                value={proxyPasswordDraft ?? systemProxy.password}
-                onChange={(event) => setProxyPasswordDraft(event.currentTarget.value)}
-                onBlur={commitProxyPasswordDraft}
-              />
-              {systemProxy.passwordConfigured &&
-              !(proxyPasswordDraft ?? systemProxy.password).trim() ? (
-                <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-                  <span>{t("settings.systemProxyPasswordConfigured")}</span>
-                  <button
-                    type="button"
-                    className="underline-offset-2 hover:text-foreground hover:underline"
-                    onClick={() => {
-                      setProxyPasswordDraft(null);
-                      patchSystemProxy({ password: "", passwordConfigured: false });
-                    }}
-                  >
-                    {t("settings.systemProxyPasswordClear")}
-                  </button>
-                </div>
-              ) : null}
-            </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-12 lg:items-start">
+          <div className="space-y-1.5 sm:col-span-2 lg:col-span-2">
+            <Label className="text-xs font-medium text-muted-foreground">
+              {t("settings.systemProxyType")}
+            </Label>
+            <Select
+              value={systemProxy.type}
+              onValueChange={(value) => patchSystemProxy({ type: value as SystemProxyType })}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue>{systemProxy.type === "socks5" ? "SOCKS5" : "HTTP"}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="http">HTTP</SelectItem>
+                <SelectItem value="socks5">SOCKS5</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
-        ) : null}
+          <div className="space-y-1.5 lg:col-span-4">
+            <Label
+              htmlFor="system-proxy-host"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              {t("settings.systemProxyHost")}
+            </Label>
+            <Input
+              id="system-proxy-host"
+              value={proxyHostDraft ?? systemProxy.host}
+              placeholder="127.0.0.1"
+              onChange={(event) => setProxyHostDraft(event.currentTarget.value)}
+              onBlur={commitProxyHostDraft}
+            />
+          </div>
+          <div className="space-y-1.5 lg:col-span-2">
+            <Label
+              htmlFor="system-proxy-port"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              {t("settings.systemProxyPort")}
+            </Label>
+            <Input
+              id="system-proxy-port"
+              type="number"
+              min={1}
+              max={65535}
+              value={proxyPortDraft ?? (systemProxy.port > 0 ? String(systemProxy.port) : "")}
+              placeholder={systemProxy.type === "socks5" ? "1080" : "7890"}
+              onChange={(event) => setProxyPortDraft(event.currentTarget.value)}
+              onBlur={commitProxyPortDraft}
+            />
+          </div>
+          <div className="space-y-1.5 lg:col-span-2">
+            <Label
+              htmlFor="system-proxy-username"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              {t("settings.systemProxyUsername")}
+            </Label>
+            <Input
+              id="system-proxy-username"
+              value={proxyUsernameDraft ?? systemProxy.username}
+              onChange={(event) => setProxyUsernameDraft(event.currentTarget.value)}
+              onBlur={commitProxyUsernameDraft}
+            />
+          </div>
+          <div className="space-y-1.5 lg:col-span-2">
+            <Label
+              htmlFor="system-proxy-password"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              {t("settings.systemProxyPassword")}
+            </Label>
+            <Input
+              id="system-proxy-password"
+              type="password"
+              value={proxyPasswordDraft ?? systemProxy.password}
+              onChange={(event) => setProxyPasswordDraft(event.currentTarget.value)}
+              onBlur={commitProxyPasswordDraft}
+            />
+            {systemProxy.passwordConfigured &&
+            !(proxyPasswordDraft ?? systemProxy.password).trim() ? (
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <span>{t("settings.systemProxyPasswordConfigured")}</span>
+                <button
+                  type="button"
+                  className="underline-offset-2 hover:text-foreground hover:underline"
+                  onClick={() => {
+                    setProxyPasswordDraft(null);
+                    patchSystemProxy({ password: "", passwordConfigured: false });
+                  }}
+                >
+                  {t("settings.systemProxyPasswordClear")}
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </div>
       </section>
 
       <section className="space-y-3 rounded-2xl border border-border/60 bg-card p-4">


### PR DESCRIPTION
## Summary\n- Rename user-facing copy from System Proxy to App Proxy / 应用代理 while keeping internal keys unchanged.\n- Make the app proxy settings always visible inline, with blur-to-save inputs and validation-gated enablement.\n- Mirror the settings UX and wording changes in both agent-gui and agent-gateway/web.\n\n## Validation\n- biome check\n- tsc --noEmit\n- i18n tests\n- check-mirror\n- git diff --check\n\n## Notes\n- Frontend test suite still has 5 pre-existing failures unrelated to this change.