### PR TITLE
fix(webui): align skill paths with current tool schema

### DIFF
--- a/crates/agent-gateway/web/src/lib/skills/clawHub.ts
+++ b/crates/agent-gateway/web/src/lib/skills/clawHub.ts
@@ -4,6 +4,8 @@ export type ClawHubSkillCard = {
   slug: string;
   displayName: string;
   summary: string;
+  /** ClawHub 上的自由标签，用于本地分类与卡片标签展示。 */
+  topics: string[];
   latestVersion: string | null;
   downloads: number;
   stars: number;
@@ -78,6 +80,7 @@ export function normalizeClawHubSkillCard(raw: unknown): ClawHubSkillCard | null
     slug,
     displayName: asString(item.displayName) ?? slug,
     summary: asString(item.summary) ?? "",
+    topics: asStringArray(item.topics),
     latestVersion:
       asString(latestVersion.version) ?? asString(tags.latest) ?? asString(item.version),
     downloads: asNullableNumber(item.downloads) ?? asNullableNumber(stats.downloads) ?? 0,

--- a/crates/agent-gateway/web/src/lib/skills/index.ts
+++ b/crates/agent-gateway/web/src/lib/skills/index.ts
@@ -155,7 +155,7 @@ type SystemManageSkillResponse = {
 export type ExternalSkillEntry = {
   name: string;
   description: string;
-  /** 技能目录绝对路径（桌面端机器上），可直接作为 install 动作的 source */
+  /** 技能目录绝对路径，可直接作为 install 动作的 source */
   baseDir: string;
   skillFile: string;
 };
@@ -580,18 +580,18 @@ export function buildSkillsSystemPrompt(params: {
   });
 
   return [
-    'The following Skills are enabled by the user (discovered from the fixed Skills directory exposed to file tools as root="skills").',
+    "The following Skills are enabled by the user. Skill files are exposed to file tools through skill://<baseDir>/... paths.",
     "",
     "Usage Rules (aligned with Claude Code behavior):",
     "- Skills with metadata use progressive disclosure; their full contents are not automatically injected into context.",
     "- README.md fallback Skills without metadata are loaded inline below because there is no metadata to disclose progressively.",
     "- Only the Skills listed below are enabled for this conversation. SkillsManager(action=list) may be used to review the enabled Skills visible to this chat, but it must not be used to enumerate or infer other installed Skills.",
     "- Only when you determine that a metadata Skill is genuinely needed should you call SkillsManager with action=read to read the full Skill file and then follow its workflow exactly.",
-    "- SkillsManager.path uses the skillFile below. It is relative to the fixed Skills root directory and may point to SKILL.md, skill.md, skill.json, or README.md.",
-    '- For files referenced inside an enabled Skill, use file tools with root="skills" and a path relative to the fixed Skills root, for example Read(root="skills", path="<baseDir>/references/guide.md"), List, Glob, Grep, Write, Edit, or Delete.',
+    "- SkillsManager.path uses the skillFile below and may point to SKILL.md, skill.md, skill.json, or README.md.",
+    '- For files referenced inside an enabled Skill, use file tools with skill://<baseDir>/... paths, for example Read(path="skill://<baseDir>/references/guide.md"), List, Glob, Grep, Write, Edit, or Delete.',
     "- You may update files inside enabled Skills when the user asks you to optimize or maintain them. Create, install, search/install from ClawHub, validate, package, or delete user Skills through SkillsManager actions.",
-    '- Never expand the fixed Skills root into an absolute local path in any tool call. If a path belongs to a Skill, keep it root-relative and set root="skills".',
-    '- If Skill content contains absolute local paths, home-directory paths, drive-letter paths, or shell snippets that read Skill files with cat/ls/find/grep, treat those path fragments as non-portable examples and convert them to root="skills" file-tool calls.',
+    "- Absolute local paths, ~/..., and file:// forms are auto-normalized by file tools; prefer skill://<baseDir>/... for enabled Skill files.",
+    "- If Skill content contains shell snippets that read Skill files with cat/ls/find/grep, route those reads through Read/List/Glob/Grep instead of Bash.",
     "- Do not guess a Skill's exact instructions or script paths before reading the Skill file.",
     "- Relative paths inside a Skill (scripts/, references/, assets/, and so on) are resolved relative to baseDir.",
     "- If a Skill contains the {baseDir} placeholder, interpret it as the baseDir value in the metadata below (relative to the Skills root directory).",

--- a/crates/agent-gateway/web/test/skills-prompt-contract.test.mjs
+++ b/crates/agent-gateway/web/test/skills-prompt-contract.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createWebModuleLoader } from "../../test/helpers/load-web-module.mjs";
+
+const loader = createWebModuleLoader({
+  rootDir: fileURLToPath(new URL("../", import.meta.url)),
+});
+const skills = loader.loadModule("src/lib/skills/index.ts");
+
+const enabledSkills = [
+  {
+    name: "code-review",
+    description: "Review local code changes",
+    skillFile: "code-review/SKILL.md",
+    baseDir: "code-review",
+  },
+];
+
+test("buildSkillsSystemPrompt uses skill:// paths instead of the removed root-scoped contract", () => {
+  const prompt = skills.buildSkillsSystemPrompt({
+    rootDir: "/skills",
+    selected: enabledSkills,
+  });
+
+  assert.match(prompt, /skill:\/\/<baseDir>\/\.\.\./);
+  assert.doesNotMatch(prompt, /root=["']skills["']/);
+  assert.doesNotMatch(prompt, /Read\(root=/);
+});

--- a/crates/agent-gui/test/skills/explicit-skill-mentions.test.mjs
+++ b/crates/agent-gui/test/skills/explicit-skill-mentions.test.mjs
@@ -68,4 +68,7 @@ test("buildSkillsSystemPrompt marks explicit mentions without granting disabled 
   assert.match(prompt, /- code-review \(skillFile: code-review\/SKILL\.md, baseDir: code-review\)/);
   assert.doesNotMatch(prompt, /disabled\/SKILL\.md/);
   assert.ok(prompt.includes("`$` mentions never grant access to disabled Skills"));
+  assert.match(prompt, /skill:\/\/<baseDir>\/\.\.\./);
+  assert.doesNotMatch(prompt, /root=["']skills["']/);
+  assert.doesNotMatch(prompt, /Read\(root=/);
 });

--- a/scripts/mirror-manifest.json
+++ b/scripts/mirror-manifest.json
@@ -76,6 +76,7 @@
     "lib/tools/systemToolOptions.ts",
     "lib/tools/builtinToolCatalog.ts",
     "lib/skills/builtin.ts",
+    "lib/skills/index.ts",
     "lib/shared/id.ts",
     "pages/settings/SystemToolsSection.tsx",
     "pages/mcp-hub/McpHubPage.tsx",

--- a/scripts/mirror-manifest.json
+++ b/scripts/mirror-manifest.json
@@ -76,6 +76,7 @@
     "lib/tools/systemToolOptions.ts",
     "lib/tools/builtinToolCatalog.ts",
     "lib/skills/builtin.ts",
+    "lib/skills/clawHub.ts",
     "lib/skills/index.ts",
     "lib/shared/id.ts",
     "pages/settings/SystemToolsSection.tsx",


### PR DESCRIPTION
## Summary

- update the Gateway WebUI Skills prompt to use the current `skill://<baseDir>/...` file-tool path contract
- remove guidance that asks models to send the obsolete `root="skills"` argument
- add prompt-contract regression assertions (GUI suite + a direct WebUI suite)
- sync `lib/skills/clawHub.ts` to the GUI copy (web was missing `ClawHubSkillCard.topics`) and pin both `lib/skills/index.ts` and `lib/skills/clawHub.ts` in the GUI/WebUI mirror manifest

## Root cause

The root-scoped file-tool API was replaced by the unified path resolver in 9aafeb5 (and the prompt wording later revised in dedd020), but only the desktop GUI copy of `buildSkillsSystemPrompt` was migrated — the WebUI mirror copy kept the old `root="skills"` contract because `lib/skills/index.ts` was not pinned in the mirror manifest.

Note on impact: the WebUI copy of `buildSkillsSystemPrompt` currently has no caller — WebUI sends run via `chat.command` and the system prompt is assembled desktop-side — so this drift was latent, not a user-visible bug. The fix is contract alignment plus mirror pinning so the copy can never drift again if it gets wired up.

## Validation

- `node --test test/skills/explicit-skill-mentions.test.mjs` (GUI)
- `pnpm -C crates/agent-gateway/web test` (353 pass, includes new `skills-prompt-contract.test.mjs`)
- `pnpm -C crates/agent-gui build`
- `pnpm -C crates/agent-gateway/web build`
- `pnpm -C crates/agent-gui lint`
- `pnpm -C crates/agent-gateway/web lint`
- `node scripts/check-mirror.mjs` (79 files)
- `git diff --check`
