### PR TITLE
fix(markdown): render single-dollar inline math on both ends

### DIFF
--- a/crates/agent-gateway/test/webui/markdown-latex.test.mjs
+++ b/crates/agent-gateway/test/webui/markdown-latex.test.mjs
@@ -30,3 +30,13 @@ test("webui preserves code and supports an incomplete streaming formula", () => 
   assert.equal(normalizeLatexDelimiters(fenced, true), fenced);
   assert.equal(normalizeLatexDelimiters(String.raw`\(x`, true), "$$x");
 });
+
+test("webui converts single-dollar math and keeps currency literal", () => {
+  assert.equal(normalizeLatexDelimiters("质能方程 $E = mc^2$。"), "质能方程 $$E = mc^2$$。");
+
+  const currency = "价格 $5，成本 $10。";
+  assert.equal(normalizeLatexDelimiters(currency), currency);
+
+  const streamingInline = "计算 $E = mc^";
+  assert.equal(normalizeLatexDelimiters(streamingInline, true), streamingInline);
+});

--- a/crates/agent-gateway/web/src/lib/normalizeLatexDelimiters.ts
+++ b/crates/agent-gateway/web/src/lib/normalizeLatexDelimiters.ts
@@ -48,39 +48,120 @@ function nextClosingTokenIndexes(tokens: LatexDelimiterToken[]) {
   return closingIndexes;
 }
 
+function dollarRunLength(value: string, index: number) {
+  let length = 1;
+  while (value[index + length] === "$") length += 1;
+  return length;
+}
+
+function doubleDollarEnd(value: string, searchFrom: number) {
+  let cursor = searchFrom;
+  while (cursor < value.length) {
+    const dollarIndex = value.indexOf("$", cursor);
+    if (dollarIndex < 0) return -1;
+    if (isEscaped(value, dollarIndex)) {
+      cursor = dollarIndex + 1;
+      continue;
+    }
+    const runLength = dollarRunLength(value, dollarIndex);
+    if (runLength >= 2) return dollarIndex + runLength;
+    cursor = dollarIndex + runLength;
+  }
+  return -1;
+}
+
+// Pandoc's text-math closing rule, applied to the first unescaped "$" after
+// the opener: it must sit on the same line, directly after a non-space
+// character, and must not be followed by a digit — anything else rejects the
+// opener. This keeps currency ("$5 涨到 $10") and shell variables ("$PATH 和
+// $HOME") literal while "$E = mc^2$" converts.
+function singleDollarClose(value: string, openIndex: number) {
+  for (let index = openIndex + 1; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === "\n") return -1;
+    if (character !== "$" || isEscaped(value, index)) continue;
+    if (dollarRunLength(value, index) > 1) return -1;
+    const next = value[index + 1];
+    const closes = !/\s/.test(value[index - 1]) && (next === undefined || !/[0-9]/.test(next));
+    return closes ? index : -1;
+  }
+  return -1;
+}
+
 function normalizeLatexText(value: string, allowIncomplete: boolean) {
   const tokens = collectLatexDelimiterTokens(value);
-  if (tokens.length === 0) return value;
+  if (tokens.length === 0 && !value.includes("$")) return value;
 
-  const closingIndexes = nextClosingTokenIndexes(tokens);
+  const closingIndexes = tokens.length > 0 ? nextClosingTokenIndexes(tokens) : [];
   let normalized = "";
-  let sourceCursor = 0;
+  let plainStart = 0;
+  let tokenIndex = 0;
+  let index = 0;
 
-  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex += 1) {
-    const token = tokens[tokenIndex];
-    if (token.index < sourceCursor || (token.delimiter !== "(" && token.delimiter !== "[")) {
-      continue;
-    }
+  while (index < value.length) {
+    const character = value[index];
 
-    const closingTokenIndex = closingIndexes[tokenIndex];
-    if (closingTokenIndex < 0) {
-      if (allowIncomplete) {
-        normalized += `${value.slice(sourceCursor, token.index)}$$${value.slice(token.index + 2)}`;
-        return normalized;
+    if (character === "\\") {
+      while (tokenIndex < tokens.length && tokens[tokenIndex].index < index) tokenIndex += 1;
+      const token =
+        tokenIndex < tokens.length && tokens[tokenIndex].index === index
+          ? tokens[tokenIndex]
+          : undefined;
+      if (!token || (token.delimiter !== "(" && token.delimiter !== "[")) {
+        index += 1;
+        continue;
       }
+
+      const closingTokenIndex = closingIndexes[tokenIndex];
+      if (closingTokenIndex < 0) {
+        if (allowIncomplete) {
+          return `${normalized}${value.slice(plainStart, index)}$$${value.slice(index + 2)}`;
+        }
+        index += 2;
+        continue;
+      }
+
+      const closingToken = tokens[closingTokenIndex];
+      normalized += `${value.slice(plainStart, index)}$$${value.slice(
+        index + 2,
+        closingToken.index,
+      )}$$`;
+      plainStart = closingToken.index + 2;
+      index = plainStart;
       continue;
     }
 
-    const closingToken = tokens[closingTokenIndex];
-    normalized += `${value.slice(sourceCursor, token.index)}$$${value.slice(
-      token.index + 2,
-      closingToken.index,
-    )}$$`;
-    sourceCursor = closingToken.index + 2;
-    tokenIndex = closingTokenIndex;
+    if (character === "$" && !isEscaped(value, index)) {
+      const runLength = dollarRunLength(value, index);
+      if (runLength >= 2) {
+        // Existing "$$" math is already valid remark-math syntax; skip the
+        // whole span so its content is never rescanned. An unclosed "$$" is a
+        // display block still streaming in — leave the rest untouched.
+        const spanEnd = doubleDollarEnd(value, index + runLength);
+        if (spanEnd < 0) return normalized + value.slice(plainStart);
+        index = spanEnd;
+        continue;
+      }
+
+      const nextCharacter = value[index + 1];
+      const closeIndex =
+        nextCharacter !== undefined && !/\s/.test(nextCharacter)
+          ? singleDollarClose(value, index)
+          : -1;
+      if (closeIndex > index) {
+        normalized += `${value.slice(plainStart, index)}$$${value.slice(index + 1, closeIndex)}$$`;
+        plainStart = closeIndex + 1;
+        index = plainStart;
+        continue;
+      }
+      index += 1;
+      continue;
+    }
+
+    index += 1;
   }
 
-  return normalized + value.slice(sourceCursor);
+  return normalized + value.slice(plainStart);
 }
 
 function lineEndAfter(value: string, index: number) {
@@ -157,7 +238,7 @@ function htmlCodeEnd(value: string, lowerValue: string, openingIndex: number) {
 }
 
 export function normalizeLatexDelimiters(content: string, allowIncomplete = false) {
-  if (!content.includes("\\")) return content;
+  if (!content.includes("\\") && !content.includes("$")) return content;
 
   let lowerContent: string | null = null;
   let normalized = "";

--- a/crates/agent-gui/src/lib/normalizeLatexDelimiters.ts
+++ b/crates/agent-gui/src/lib/normalizeLatexDelimiters.ts
@@ -48,39 +48,120 @@ function nextClosingTokenIndexes(tokens: LatexDelimiterToken[]) {
   return closingIndexes;
 }
 
+function dollarRunLength(value: string, index: number) {
+  let length = 1;
+  while (value[index + length] === "$") length += 1;
+  return length;
+}
+
+function doubleDollarEnd(value: string, searchFrom: number) {
+  let cursor = searchFrom;
+  while (cursor < value.length) {
+    const dollarIndex = value.indexOf("$", cursor);
+    if (dollarIndex < 0) return -1;
+    if (isEscaped(value, dollarIndex)) {
+      cursor = dollarIndex + 1;
+      continue;
+    }
+    const runLength = dollarRunLength(value, dollarIndex);
+    if (runLength >= 2) return dollarIndex + runLength;
+    cursor = dollarIndex + runLength;
+  }
+  return -1;
+}
+
+// Pandoc's text-math closing rule, applied to the first unescaped "$" after
+// the opener: it must sit on the same line, directly after a non-space
+// character, and must not be followed by a digit — anything else rejects the
+// opener. This keeps currency ("$5 涨到 $10") and shell variables ("$PATH 和
+// $HOME") literal while "$E = mc^2$" converts.
+function singleDollarClose(value: string, openIndex: number) {
+  for (let index = openIndex + 1; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === "\n") return -1;
+    if (character !== "$" || isEscaped(value, index)) continue;
+    if (dollarRunLength(value, index) > 1) return -1;
+    const next = value[index + 1];
+    const closes = !/\s/.test(value[index - 1]) && (next === undefined || !/[0-9]/.test(next));
+    return closes ? index : -1;
+  }
+  return -1;
+}
+
 function normalizeLatexText(value: string, allowIncomplete: boolean) {
   const tokens = collectLatexDelimiterTokens(value);
-  if (tokens.length === 0) return value;
+  if (tokens.length === 0 && !value.includes("$")) return value;
 
-  const closingIndexes = nextClosingTokenIndexes(tokens);
+  const closingIndexes = tokens.length > 0 ? nextClosingTokenIndexes(tokens) : [];
   let normalized = "";
-  let sourceCursor = 0;
+  let plainStart = 0;
+  let tokenIndex = 0;
+  let index = 0;
 
-  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex += 1) {
-    const token = tokens[tokenIndex];
-    if (token.index < sourceCursor || (token.delimiter !== "(" && token.delimiter !== "[")) {
-      continue;
-    }
+  while (index < value.length) {
+    const character = value[index];
 
-    const closingTokenIndex = closingIndexes[tokenIndex];
-    if (closingTokenIndex < 0) {
-      if (allowIncomplete) {
-        normalized += `${value.slice(sourceCursor, token.index)}$$${value.slice(token.index + 2)}`;
-        return normalized;
+    if (character === "\\") {
+      while (tokenIndex < tokens.length && tokens[tokenIndex].index < index) tokenIndex += 1;
+      const token =
+        tokenIndex < tokens.length && tokens[tokenIndex].index === index
+          ? tokens[tokenIndex]
+          : undefined;
+      if (!token || (token.delimiter !== "(" && token.delimiter !== "[")) {
+        index += 1;
+        continue;
       }
+
+      const closingTokenIndex = closingIndexes[tokenIndex];
+      if (closingTokenIndex < 0) {
+        if (allowIncomplete) {
+          return `${normalized}${value.slice(plainStart, index)}$$${value.slice(index + 2)}`;
+        }
+        index += 2;
+        continue;
+      }
+
+      const closingToken = tokens[closingTokenIndex];
+      normalized += `${value.slice(plainStart, index)}$$${value.slice(
+        index + 2,
+        closingToken.index,
+      )}$$`;
+      plainStart = closingToken.index + 2;
+      index = plainStart;
       continue;
     }
 
-    const closingToken = tokens[closingTokenIndex];
-    normalized += `${value.slice(sourceCursor, token.index)}$$${value.slice(
-      token.index + 2,
-      closingToken.index,
-    )}$$`;
-    sourceCursor = closingToken.index + 2;
-    tokenIndex = closingTokenIndex;
+    if (character === "$" && !isEscaped(value, index)) {
+      const runLength = dollarRunLength(value, index);
+      if (runLength >= 2) {
+        // Existing "$$" math is already valid remark-math syntax; skip the
+        // whole span so its content is never rescanned. An unclosed "$$" is a
+        // display block still streaming in — leave the rest untouched.
+        const spanEnd = doubleDollarEnd(value, index + runLength);
+        if (spanEnd < 0) return normalized + value.slice(plainStart);
+        index = spanEnd;
+        continue;
+      }
+
+      const nextCharacter = value[index + 1];
+      const closeIndex =
+        nextCharacter !== undefined && !/\s/.test(nextCharacter)
+          ? singleDollarClose(value, index)
+          : -1;
+      if (closeIndex > index) {
+        normalized += `${value.slice(plainStart, index)}$$${value.slice(index + 1, closeIndex)}$$`;
+        plainStart = closeIndex + 1;
+        index = plainStart;
+        continue;
+      }
+      index += 1;
+      continue;
+    }
+
+    index += 1;
   }
 
-  return normalized + value.slice(sourceCursor);
+  return normalized + value.slice(plainStart);
 }
 
 function lineEndAfter(value: string, index: number) {
@@ -157,7 +238,7 @@ function htmlCodeEnd(value: string, lowerValue: string, openingIndex: number) {
 }
 
 export function normalizeLatexDelimiters(content: string, allowIncomplete = false) {
-  if (!content.includes("\\")) return content;
+  if (!content.includes("\\") && !content.includes("$")) return content;
 
   let lowerContent: string | null = null;
   let normalized = "";

--- a/crates/agent-gui/test/chat/markdown-latex.test.mjs
+++ b/crates/agent-gui/test/chat/markdown-latex.test.mjs
@@ -105,3 +105,65 @@ H = 18400`;
   assert.equal(normalizeLatexDelimiters(content, true), String.raw`推导中：$$
 H = 18400`);
 });
+
+test("converts single-dollar inline math to double-dollar", () => {
+  const content = String.raw`质能方程 $E = mc^2$，求根公式 $x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$。`;
+  assert.equal(
+    normalizeLatexDelimiters(content),
+    String.raw`质能方程 $$E = mc^2$$，求根公式 $$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$。`,
+  );
+});
+
+test("keeps currency, shell variables, and escaped dollars literal", () => {
+  const currency = "价格 $5，成本 $10。总共 $15 元。";
+  assert.equal(normalizeLatexDelimiters(currency), currency);
+
+  const shell = "检查 $PATH 和 $HOME 是否已导出。";
+  assert.equal(normalizeLatexDelimiters(shell), shell);
+
+  const escaped = String.raw`费用 \$5 和 \$10。`;
+  assert.equal(normalizeLatexDelimiters(escaped), escaped);
+
+  const digitAfterClose = "单价 $3$5 促销。";
+  assert.equal(normalizeLatexDelimiters(digitAfterClose), digitAfterClose);
+});
+
+test("single-dollar math must close on the same line", () => {
+  const content = "起价 $99\n次日 $x$ 恢复原价。";
+  assert.equal(normalizeLatexDelimiters(content), "起价 $99\n次日 $$x$$ 恢复原价。");
+});
+
+test("mixed currency and math on one line converts only the math pair", () => {
+  const content = "价格 $5，令 $x$ 表示价格。";
+  assert.equal(normalizeLatexDelimiters(content), "价格 $5，令 $$x$$ 表示价格。");
+});
+
+test("existing double-dollar spans stay opaque next to single-dollar math", () => {
+  assert.equal(normalizeLatexDelimiters("已有 $$x^2$$ 与 $y$。"), "已有 $$x^2$$ 与 $$y$$。");
+});
+
+test("streaming leaves unterminated dollar math untouched", () => {
+  const inline = "计算 $E = mc^";
+  assert.equal(normalizeLatexDelimiters(inline, true), inline);
+
+  const display = "$$\nE = mc^2";
+  assert.equal(normalizeLatexDelimiters(display, true), display);
+});
+
+test("does not convert dollars inside code spans or fences", () => {
+  const content = [
+    "行内 `sum $a$ b` 保留，公式 $c$ 转换。",
+    "",
+    "```sh",
+    "echo $HOME $USER",
+    "```",
+  ].join("\n");
+  const expected = [
+    "行内 `sum $a$ b` 保留，公式 $$c$$ 转换。",
+    "",
+    "```sh",
+    "echo $HOME $USER",
+    "```",
+  ].join("\n");
+  assert.equal(normalizeLatexDelimiters(content), expected);
+});


### PR DESCRIPTION
## Summary

Assistant output like `$E = mc^2$` rendered as raw text in the chat transcript (streaming and static alike). Root cause: `@streamdown/math`'s default export pins `singleDollarTextMath: false`, and the earlier normalization pass (2d2c763) only covered `\(...\)` / `\[...\]`.

The plugin flag stays **off on purpose** — micromark's single-dollar matcher is too loose and would swallow currency ("$5 和 $10") and shell variables ("$PATH 和 $HOME") into math. Instead, the existing `normalizeLatexDelimiters` preprocessing layer (single source of truth for delimiter policy, mirrored byte-identical on both ends) now also converts valid single-dollar pairs to `$$…$$`:

- **Pandoc closing rule, first-candidate bail**: the opener `$` must be followed by non-space; the *first* unescaped single `$` after it either closes the pair (same line, directly after non-space, not followed by a digit) or rejects the opener entirely. The bail keeps mixed lines safe — `价格 $5，令 $x$ 表示价格` converts only `$x$`.
- **Existing `$$` spans are opaque**: skipped whole so their content is never rescanned; everything after an unclosed `$$` (a display block still streaming in) is left untouched.
- **Streaming semantics**: an unterminated `$E = mc^` stays literal (completing it would inject a stray `$`) and converts on the frame its closing `$` arrives. Code fences / inline code / HTML code remain protected by the existing outer scan.
- Early-exit now also triggers on `$` (previously only `\`), so dollar-only content reaches the normalizer.

Both `normalizeLatexDelimiters.ts` copies are byte-identical (file is in `scripts/mirror-manifest.json`); no `Markdown.tsx` changes needed.

## Verification

| Check | Result |
|---|---|
| `agent-gui` `npm test` | 1036/1036 pass (7 new latex cases) |
| `agent-gateway/web` `npm test` | 360/360 pass (1 new mirrored case) |
| `tsc --noEmit` both ends | clean |
| `biome check` on touched files | clean |
| `node scripts/check-mirror.mjs` | 79 files pass |
| Real remark-math pipeline (plugin config) | raw `$…$` → 0 math nodes; normalized → `inlineMath` nodes with intact `\frac`/`\sum` content; currency stays literal; `$$` display block still parses |

New test coverage: quadratic/summation formulas, currency, shell vars, escaped `\$`, digit-after-close, same-line constraint, mixed currency+math lines, streaming unterminated inline/display math, code-span/fence protection.