### PR TITLE
chore(windows): dev-environment compatibility for build and tests

### DIFF
--- a/crates/agent-gui/src-tauri/build.rs
+++ b/crates/agent-gui/src-tauri/build.rs
@@ -47,5 +47,41 @@ fn main() {
         .compile_protos(&[proto_v1, proto_v2], &[gateway_root])
         .expect("compile gateway protos");
 
-    tauri_build::build()
+    let is_windows_msvc = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+    if is_windows_msvc {
+        let manifest_path = std::path::Path::new(
+            &std::env::var("OUT_DIR").expect("OUT_DIR for Windows app manifest"),
+        )
+        .join("windows-app-manifest.xml");
+        std::fs::write(
+            &manifest_path,
+            r#"<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>
+"#,
+        )
+        .expect("write Windows app manifest");
+        let attributes = tauri_build::Attributes::new()
+            .windows_attributes(tauri_build::WindowsAttributes::new_without_app_manifest());
+        tauri_build::try_build(attributes).expect("run Tauri build script");
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!(
+            "cargo:rustc-link-arg=/MANIFESTINPUT:{}",
+            manifest_path.display()
+        );
+    } else {
+        tauri_build::build();
+    }
 }

--- a/crates/agent-gui/src-tauri/src/commands/app/system.rs
+++ b/crates/agent-gui/src-tauri/src/commands/app/system.rs
@@ -1384,8 +1384,8 @@ mod tests {
         .expect("reuse existing dir");
 
         assert_eq!(
-            PathBuf::from(response.path),
-            existing.canonicalize().expect("canonicalize existing dir")
+            response.path,
+            project_folder_display_path(&existing.canonicalize().expect("canonicalize existing dir"))
         );
     }
 

--- a/crates/agent-gui/src-tauri/src/commands/workspace/git.rs
+++ b/crates/agent-gui/src-tauri/src/commands/workspace/git.rs
@@ -2819,6 +2819,7 @@ mod tests {
         }
         let temp = tempfile::tempdir().expect("temp repo");
         run_temp_git(temp.path(), &["init"]);
+        run_temp_git(temp.path(), &["config", "core.autocrlf", "false"]);
         run_temp_git(temp.path(), &["config", "user.name", "LiveAgent Test"]);
         run_temp_git(temp.path(), &["config", "user.email", "test@example.com"]);
         fs::write(temp.path().join("README.md"), "initial\n").expect("write readme");

--- a/crates/agent-gui/src-tauri/src/commands/workspace/subagent_worktree.rs
+++ b/crates/agent-gui/src-tauri/src/commands/workspace/subagent_worktree.rs
@@ -1199,6 +1199,7 @@ mod tests {
     fn init_repo(root: &Path) -> Result<(), String> {
         fs::create_dir_all(root).map_err(|err| format!("failed to create repo: {err}"))?;
         git(root, &["init"])?;
+        git(root, &["config", "core.autocrlf", "false"])?;
         git(
             root,
             &["config", "user.email", "liveagent-test@example.com"],

--- a/crates/agent-gui/test/skills/builtin-code-review.test.mjs
+++ b/crates/agent-gui/test/skills/builtin-code-review.test.mjs
@@ -12,7 +12,7 @@ const builtinRegistrySource = readFileSync(
 );
 
 test("built-in code review skill is registered under a collision-resistant name", () => {
-  assert.match(skillSource, /^---\nname: liveagent-code-review\n/m);
+  assert.match(skillSource, /^---\r?\nname: liveagent-code-review\r?\n/m);
   assert.match(builtinRegistrySource, /name: "liveagent-code-review"/);
   assert.match(
     builtinRegistrySource,

--- a/crates/agent-gui/test/tools/shell-tools.test.mjs
+++ b/crates/agent-gui/test/tools/shell-tools.test.mjs
@@ -207,6 +207,7 @@ test("Bash tool rejects background commands that keep stdio attached", async () 
   const bundle = createShellTools({
     workdir: "/repo",
     providerId: "claude_code",
+    runtimePlatform: "linux",
   });
 
   const result = await bundle.executeToolCall(
@@ -236,6 +237,7 @@ test("Bash tool rejects background commands when redirects belong to another com
   const bundle = createShellTools({
     workdir: "/repo",
     providerId: "claude_code",
+    runtimePlatform: "linux",
   });
 
   const result = await bundle.executeToolCall(
@@ -264,6 +266,7 @@ test("Bash tool rejects background commands with only stderr append redirected",
   const bundle = createShellTools({
     workdir: "/repo",
     providerId: "claude_code",
+    runtimePlatform: "linux",
   });
 
   const result = await bundle.executeToolCall(
@@ -454,6 +457,7 @@ test("ManagedProcess rejects nested shell background operators", async () => {
   const bundle = createShellTools({
     workdir: "/repo",
     providerId: "claude_code",
+    runtimePlatform: "linux",
   });
 
   const result = await bundle.executeToolCall({


### PR DESCRIPTION
从 #148 拆分出的 Windows 开发环境兼容改动（原作者 @AlphaCatMeow，与供应商弹框无关，按审核意见独立成 PR）：

- **build.rs**：Windows MSVC 构建嵌入 Common Controls v6 应用 manifest（`/MANIFEST:EMBED`），使生产与测试可执行文件都链接 comctl32 v6
- **git / subagent-worktree 测试仓库**：钉 `core.autocrlf=false`，避免 Windows 检出时内容 hash 与 fixture 不一致
- **shell-tools 测试**：显式传 `runtimePlatform: "linux"`（后台命令校验按平台门控）
- **builtin-code-review 测试**：正则容忍 CRLF 技能文件
- **fs_create_project_folder 测试**：断言改为比较 display path（Windows 规范化路径带 verbatim 前缀）

注：system.rs 的改动已在 main 最新版本（含 `system_pick_file`）上重新应用，仅保留测试断言那一处 diff。

验证：`cargo check --tests` 通过、`cargo test system` 22/22、受影响的两个 Node 测试文件 23/23（macOS）。Windows 侧行为在 #148 的原始验证中已由作者确认。