### PR TITLE
fix(compaction): keep mid-stream resume history provider-safe

### DIFF
--- a/crates/agent-gui/src/lib/chat/compaction/controller.ts
+++ b/crates/agent-gui/src/lib/chat/compaction/controller.ts
@@ -85,6 +85,11 @@ export type CompactionTurnBinding = {
   presend?: CompactionPreSendBinding;
 };
 
+export type CompactionDuringRunResult = {
+  context: Context | null;
+  shouldDisableProtection: boolean;
+};
+
 type RollbackSnapshot = {
   state: ConversationViewState;
   composerText?: string;
@@ -242,9 +247,11 @@ export class CompactionController {
     tools?: Context["tools"];
     includeAbortedMessages?: boolean;
     includeUploadedFilesMetadata?: boolean;
-  }): Promise<Context | null> {
+  }): Promise<CompactionDuringRunResult> {
     const binding = this.binding;
-    if (!binding) return null;
+    if (!binding) {
+      return { context: null, shouldDisableProtection: false };
+    }
     // 覆盖"mid-stream abort 后、summarizer 启动前"用户恰好点停止的间隙。
     if (binding.cancellation.userStop.signal.aborted) {
       throw createCompactionAbortError();
@@ -253,6 +260,19 @@ export class CompactionController {
     const buildOptions: ContextBuildOptions = {
       includeAbortedMessages: params.includeAbortedMessages,
       includeUploadedFilesMetadata: params.includeUploadedFilesMetadata,
+    };
+    const buildFallbackContext = (state: ConversationViewState): Context => {
+      if (params.trigger !== "mid-stream") {
+        return binding.buildPreparedContext(state, params.tools, buildOptions);
+      }
+      const messages = getActiveSegment(state)?.messages ?? [];
+      const lastTimestamp = messages[messages.length - 1]?.timestamp;
+      const resumeMessage = createSyntheticContinueUserMessage(
+        typeof lastTimestamp === "number" ? lastTimestamp + 1 : now,
+      );
+      return binding.buildResumeContext(state, resumeMessage, params.tools, {
+        includeUploadedFilesMetadata: params.includeUploadedFilesMetadata,
+      });
     };
 
     let workingState = params.state;
@@ -277,9 +297,17 @@ export class CompactionController {
     if (!decision.shouldCompact) {
       if (pruned) {
         binding.sinks.applyStateMidRun?.(pruned.state);
-        return binding.buildPreparedContext(pruned.state, params.tools, buildOptions);
+        return {
+          context: buildFallbackContext(pruned.state),
+          shouldDisableProtection: false,
+        };
       }
-      return null;
+      return params.trigger === "mid-stream"
+        ? {
+            context: buildFallbackContext(workingState),
+            shouldDisableProtection: true,
+          }
+        : { context: null, shouldDisableProtection: false };
     }
 
     this.rollbackSnapshot = { state: params.state, persistOnRollback: true };
@@ -314,7 +342,7 @@ export class CompactionController {
         includeUploadedFilesMetadata: params.includeUploadedFilesMetadata,
       });
       this.notePostCompactionPressure(resumeContext, outcome.state, decision.threshold);
-      return resumeContext;
+      return { context: resumeContext, shouldDisableProtection: false };
     } catch (error) {
       if (this.isAbortOutcome(scope.controller.signal, error)) {
         throw error;
@@ -326,13 +354,21 @@ export class CompactionController {
         binding.sinks.applyStateMidRun?.(fallback.state);
         this.settleFailed(params.trigger, PRUNE_FALLBACK_NOTICE);
         binding.sinks.setBridgeToolStatus?.(buildPruneFallbackStatus(fallback.prunedMessageCount));
-        return binding.buildPreparedContext(fallback.state, params.tools, buildOptions);
+        return {
+          context: buildFallbackContext(fallback.state),
+          shouldDisableProtection: false,
+        };
       }
       this.settleFailed(
         params.trigger,
         (error instanceof Error ? error.message : String(error)) || "压缩失败",
       );
-      return null;
+      return params.trigger === "mid-stream"
+        ? {
+            context: buildFallbackContext(workingState),
+            shouldDisableProtection: true,
+          }
+        : { context: null, shouldDisableProtection: false };
     } finally {
       scope.release();
       this.inFlight = false;

--- a/crates/agent-gui/src/lib/subagents/run.ts
+++ b/crates/agent-gui/src/lib/subagents/run.ts
@@ -615,7 +615,7 @@ export async function executeSubagentRun(
 
         // controller 内部消化非中止失败（含 prune 降级）；用户中止会原样抛出。
         compactionAppliedState = null;
-        const compactedContext = await compaction.compactDuringRun({
+        const { context: compactedContext } = await compaction.compactDuringRun({
           trigger: "post-tool",
           state: view,
         });

--- a/crates/agent-gui/src/pages/chat/turns/runAgentConversationTurn.ts
+++ b/crates/agent-gui/src/pages/chat/turns/runAgentConversationTurn.ts
@@ -843,7 +843,7 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
               includeUploadedFilesMetadata: true,
             }),
           );
-          const compactedContext = await compaction.compactDuringRun({
+          const { context: compactedContext } = await compaction.compactDuringRun({
             trigger: "post-tool",
             state: tempState,
             budgetContext: tempContext,
@@ -901,7 +901,7 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
       applyConversationState(tempState);
       clearPersistableAgentProgress();
 
-      const compactedContext = await compaction.compactDuringRun({
+      const compactionResult = await compaction.compactDuringRun({
         trigger: "mid-stream",
         state: tempState,
         budgetContext: withSubagentRuntimeContext(
@@ -915,16 +915,12 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
         includeUploadedFilesMetadata: true,
       });
 
-      if (compactedContext) {
-        pendingAgentContext = compactedContext;
-      } else {
-        // 压缩与 prune 均不可用：本轮禁用 mid-stream 保护，带原上下文续跑，
-        // 让真正的溢出错误由 provider 显式暴露，而不是让整轮失败。
+      if (!compactionResult.context) {
+        throw new Error("Mid-stream compaction did not provide a continuation context.");
+      }
+      pendingAgentContext = compactionResult.context;
+      if (compactionResult.shouldDisableProtection) {
         midStreamProtectionDisabled = true;
-        pendingAgentContext = buildPreparedContext(tempState, combinedTools, {
-          includeAbortedMessages: true,
-          includeUploadedFilesMetadata: true,
-        });
       }
     } finally {
       scope.release();

--- a/crates/agent-gui/src/pages/chat/turns/runTextConversationTurn.ts
+++ b/crates/agent-gui/src/pages/chat/turns/runTextConversationTurn.ts
@@ -322,21 +322,19 @@ export async function runTextConversationTurn(params: RunTextConversationTurnPar
             );
           }
 
-          const compactedContext = await compaction.compactDuringRun({
+          const compactionResult = await compaction.compactDuringRun({
             trigger: "mid-stream",
             state: getNextConversationState(),
             includeAbortedMessages: true,
             includeUploadedFilesMetadata: true,
           });
 
-          if (compactedContext) {
-            pendingTextContext = compactedContext;
-          } else {
+          if (!compactionResult.context) {
+            throw new Error("Mid-stream compaction did not provide a continuation context.");
+          }
+          pendingTextContext = compactionResult.context;
+          if (compactionResult.shouldDisableProtection) {
             protectionCompactionDisabled = true;
-            pendingTextContext = buildPreparedContext(getNextConversationState(), undefined, {
-              includeAbortedMessages: true,
-              includeUploadedFilesMetadata: true,
-            });
           }
           textRound += 1;
           continue textResponseLoop;

--- a/crates/agent-gui/test/chat/agent-turn-cancelled-history.test.mjs
+++ b/crates/agent-gui/test/chat/agent-turn-cancelled-history.test.mjs
@@ -212,7 +212,7 @@ test("agent turn preserves suppressed parent Agent trace for cancellation persis
       beginRequest: noOp,
       shouldProtectMidStream: () => false,
       async compactDuringRun() {
-        return null;
+        return { context: null, shouldDisableProtection: false };
       },
     },
     cancellation: {

--- a/crates/agent-gui/test/chat/compaction-controller.test.mjs
+++ b/crates/agent-gui/test/chat/compaction-controller.test.mjs
@@ -126,9 +126,10 @@ function bindController(controller, overrides = {}) {
     },
     cancellation,
     sinks: recorder.sinks,
-    buildPreparedContext: (state) => conversationState.buildRequestContext(state),
-    buildResumeContext: (state, resumeMessage) => {
-      const context = conversationState.buildRequestContext(state);
+    buildPreparedContext: (state, _tools, options) =>
+      conversationState.buildRequestContext(state, options),
+    buildResumeContext: (state, resumeMessage, _tools, options) => {
+      const context = conversationState.buildRequestContext(state, options);
       return resumeMessage
         ? { ...context, messages: [...context.messages, resumeMessage] }
         : context;
@@ -213,7 +214,7 @@ test("below-threshold decisions are side-effect free", async () => {
   });
 
   assert.equal(applied, false);
-  assert.equal(midRun, null);
+  assert.equal(midRun.context, null);
   assert.equal(completeCalls, 0);
   assert.equal(recorder.events.length, 0);
 });
@@ -238,11 +239,11 @@ test("single-flight: a concurrent trigger is rejected while a compaction is in f
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(controller.shouldProtectMidStream(1_000_000), false);
   const second = await controller.compactDuringRun({ trigger: "post-tool", state });
-  assert.equal(second, null);
+  assert.equal(second.context, null);
 
   release();
   const firstContext = await first;
-  assert.ok(firstContext);
+  assert.ok(firstContext.context);
   assert.equal(completeCalls, 1);
 });
 
@@ -302,7 +303,7 @@ test("summarizer failure degrades to prune and still returns a usable context", 
 
   const context = await controller.compactDuringRun({ trigger: "post-tool", state });
 
-  assert.ok(context);
+  assert.ok(context.context);
   const [, prunedState] = recorder.byKind("applyStateMidRun")[0];
   const prunedMessages = prunedState.segments[0].messages.filter(
     (message) =>
@@ -317,6 +318,92 @@ test("summarizer failure degrades to prune and still returns a usable context", 
     .find((status) => status.phase === "failed");
   assert.match(failedStatus.message, /prune 降级/);
   assert.equal(recorder.byKind("bridge").at(-1)[1], null);
+});
+
+test("mid-stream compaction failure returns a safe continuation and disables protection", async () => {
+  const controller = new CompactionController();
+  const abortedAssistant = {
+    ...assistantWithUsage("working on src/app.ts", 190_000, 4),
+    stopReason: "aborted",
+  };
+  const state = conversationState.createConversationStateFromContext({
+    systemPrompt: "sys",
+    messages: [
+      user("please fix src/app.ts", 1),
+      user("continue with src/app.ts", 2),
+      user("check src/app.ts again", 3),
+      abortedAssistant,
+    ],
+  });
+  bindController(controller, {
+    complete: async () => {
+      throw new Error("invalid api key");
+    },
+  });
+
+  const result = await controller.compactDuringRun({
+    trigger: "mid-stream",
+    state,
+    includeAbortedMessages: true,
+  });
+
+  assert.ok(result.context);
+  assert.equal(result.shouldDisableProtection, true);
+  assert.equal(
+    result.context.messages.some(
+      (message) => message.role === "assistant" && message.stopReason === "aborted",
+    ),
+    false,
+  );
+  assert.equal(result.context.messages.at(-1)?.role, "user");
+  assert.equal(
+    result.context.messages.at(-1)?.content,
+    conversationState.INTERNAL_RESUME_MESSAGE_TEXT,
+  );
+});
+
+test("mid-stream prune fallback also returns a safe continuation", async () => {
+  const controller = new CompactionController();
+  const abortedAssistant = {
+    ...assistantWithUsage("working on src/app.ts", 190_000, 5),
+    stopReason: "aborted",
+  };
+  const state = conversationState.createConversationStateFromContext({
+    systemPrompt: "sys",
+    messages: [
+      user("please fix src/app.ts", 1),
+      toolResultBig(200_000, 2),
+      user("continue with src/app.ts", 3),
+      user("check src/app.ts again", 4),
+      abortedAssistant,
+    ],
+  });
+  const { recorder } = bindController(controller, {
+    complete: async () => {
+      throw new Error("invalid api key");
+    },
+  });
+
+  const result = await controller.compactDuringRun({
+    trigger: "mid-stream",
+    state,
+    includeAbortedMessages: true,
+  });
+
+  assert.ok(result.context);
+  assert.equal(result.shouldDisableProtection, false);
+  assert.equal(
+    result.context.messages.some(
+      (message) => message.role === "assistant" && message.stopReason === "aborted",
+    ),
+    false,
+  );
+  assert.equal(result.context.messages.at(-1)?.role, "user");
+  assert.equal(
+    result.context.messages.at(-1)?.content,
+    conversationState.INTERNAL_RESUME_MESSAGE_TEXT,
+  );
+  assert.equal(recorder.byKind("applyStateMidRun").length, 1);
 });
 
 test("escalation ladder: consecutive ineffective compactions advise but never hard-refuse", async () => {
@@ -339,7 +426,7 @@ test("escalation ladder: consecutive ineffective compactions advise but never ha
       trigger: "post-tool",
       state: bigState(),
     });
-    assert.ok(context, `compaction round ${round} must not be refused`);
+    assert.ok(context.context, `compaction round ${round} must not be refused`);
   }
 
   assert.equal(completeCalls, 3);

--- a/crates/agent-gui/test/subagents/harness.mjs
+++ b/crates/agent-gui/test/subagents/harness.mjs
@@ -324,7 +324,7 @@ export function createDefaultCompactionMock(compactionCalls) {
 
     async compactDuringRun() {
       compactionCalls.push({ phase: "mid" });
-      return null;
+      return { context: null, shouldDisableProtection: false };
     }
 
     async handleTurnAbort() {


### PR DESCRIPTION
## Summary
Mid-stream compaction 失败后，续跑请求可能以 aborted assistant 结尾，严格供应商会拒绝并报：
`Cannot continue from message role: assistant`

修复：压缩控制器统一输出 provider-safe 的续跑上下文——过滤 aborted assistant、追加内部 user 续跑消息；当 compaction 与 prune 都不可用时，禁用本轮 mid-stream 保护。

- Mid-stream compaction failure could resume with an aborted assistant as the last message
- Strict providers then reject continuation with `Cannot continue from message role: assistant`
- Always continue with a safe resume context; disable further mid-stream protection when both compaction and prune fail

## Test plan
- [x] mid-stream compaction failure / prune fallback controller tests
- [x] related frontend turn/subagent tests updated for the new return shape
- [x] manual desktop reproduction with original provider/model no longer hits the role error