### PR TITLE
feat(providers): send official CLI identity headers on Anthropic/Codex requests

### DIFF
--- a/crates/agent-gateway/web/src/i18n/config.ts
+++ b/crates/agent-gateway/web/src/i18n/config.ts
@@ -1214,7 +1214,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.addCustomHeader": "添加请求头",
     "settings.removeCustomHeader": "删除请求头",
     "settings.invalidCustomHeaderKey":
-      "请求头名称无效。仅支持合法 HTTP Header 名称，例如 anthropic-beta、X-Request-ID。",
+      "请求头名称无效。仅支持合法 HTTP Header 名称，例如 X-Environment、X-Request-ID。",
     "settings.close": "关闭",
     "settings.hideApiKey": "隐藏 API Key",
     "settings.showApiKey": "显示 API Key",
@@ -3102,7 +3102,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.addCustomHeader": "Add header",
     "settings.removeCustomHeader": "Remove header",
     "settings.invalidCustomHeaderKey":
-      "Invalid HTTP header name. Examples: anthropic-beta, X-Request-ID.",
+      "Invalid HTTP header name. Examples: X-Environment, X-Request-ID.",
     "settings.close": "Close",
     "settings.hideApiKey": "Hide API Key",
     "settings.showApiKey": "Show API Key",

--- a/crates/agent-gateway/web/src/lib/providers/customHeaders.ts
+++ b/crates/agent-gateway/web/src/lib/providers/customHeaders.ts
@@ -4,12 +4,83 @@ const RESERVED_CUSTOM_HEADER_KEYS = new Set([
   "authorization",
   "x-api-key",
   "x-goog-api-key",
-  "anthropic-version",
-  "content-type",
+  "anthropic-beta",
   "host",
   "content-length",
 ]);
 const HTTP_HEADER_TOKEN_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+export const ANTHROPIC_DEFAULT_REQUEST_HEADERS = {
+  "x-app": "cli",
+  "User-Agent": "claude-cli/2.1.71 (external, cli)",
+  "Content-Type": "application/json",
+  "X-Stainless-OS": "MacOS",
+  "X-Stainless-Arch": "arm64",
+  "X-Stainless-Lang": "js",
+  "anthropic-version": "2023-06-01",
+  "X-Stainless-Runtime": "node",
+  "X-Stainless-Timeout": "600",
+  "x-stainless-retry-count": "0",
+  "X-Stainless-Package-Version": "0.74.0",
+  "X-Stainless-Runtime-Version": "v22.19.0",
+  "anthropic-dangerous-direct-browser-access": "true",
+} as const;
+
+export const CODEX_DEFAULT_USER_AGENT =
+  "codex_cli_rs/0.72.0 (Ubuntu 24.4.0; x86_64) WindowsTerminal";
+export const CODEX_SESSION_ID_HEADER = "session_id";
+export const CODEX_CONVERSATION_ID_HEADER = "conversation_id";
+
+const COMMON_CUSTOM_HEADER_KEY_PRESETS = [
+  "X-Request-ID",
+  "X-User-ID",
+  "X-Environment",
+  "HTTP-Referer",
+  "X-Title",
+] as const;
+
+const ANTHROPIC_CUSTOM_HEADER_KEY_PRESETS: readonly string[] = [
+  ...Object.keys(ANTHROPIC_DEFAULT_REQUEST_HEADERS),
+  ...COMMON_CUSTOM_HEADER_KEY_PRESETS,
+];
+
+const CODEX_CUSTOM_HEADER_KEY_PRESETS: readonly string[] = [
+  "User-Agent",
+  CODEX_SESSION_ID_HEADER,
+  CODEX_CONVERSATION_ID_HEADER,
+  ...COMMON_CUSTOM_HEADER_KEY_PRESETS,
+];
+
+const CUSTOM_HEADER_KEY_PRESETS: Record<CustomProvider["type"], readonly string[]> = {
+  claude_code: ANTHROPIC_CUSTOM_HEADER_KEY_PRESETS,
+  codex: CODEX_CUSTOM_HEADER_KEY_PRESETS,
+  gemini: COMMON_CUSTOM_HEADER_KEY_PRESETS,
+};
+
+export function getCustomHeaderKeyPresets(providerId: CustomProvider["type"]): readonly string[] {
+  return CUSTOM_HEADER_KEY_PRESETS[providerId];
+}
+
+export function isAnthropicOAuthApiKey(apiKey: string | undefined): boolean {
+  return Boolean(apiKey?.includes("sk-ant-oat"));
+}
+
+function findHeaderKey(
+  headers: Record<string, string | null | undefined>,
+  name: string,
+): string | undefined {
+  const expected = name.toLowerCase();
+  return Object.keys(headers).find((key) => key.toLowerCase() === expected);
+}
+
+export function readHeaderValue(
+  headers: Record<string, string | null | undefined> | undefined,
+  name: string,
+): string | undefined {
+  if (!headers) return undefined;
+  const key = findHeaderKey(headers, name);
+  return key === undefined ? undefined : (headers[key] ?? undefined);
+}
 
 export function isValidCustomHeaderKey(key: string): boolean {
   return HTTP_HEADER_TOKEN_PATTERN.test(key);
@@ -29,10 +100,8 @@ export function mergeCustomHeaders(
       continue;
     }
 
-    const existingKey = Object.keys(merged).find(
-      (key) => key.toLowerCase() === header.key.toLowerCase(),
-    );
-    if (existingKey) delete merged[existingKey];
+    const existingKey = findHeaderKey(merged, header.key);
+    if (existingKey !== undefined) delete merged[existingKey];
     merged[header.key] = header.value;
   }
 

--- a/crates/agent-gateway/web/src/lib/providers/proxy.ts
+++ b/crates/agent-gateway/web/src/lib/providers/proxy.ts
@@ -1,9 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
 
 import type { ProviderId } from "../settings";
+import { readHeaderValue } from "./customHeaders";
 
 export const LIVEAGENT_PROXY_TOKEN_HEADER = "x-liveagent-proxy-token";
 export const LIVEAGENT_UPSTREAM_ORIGIN_HEADER = "x-liveagent-upstream-origin";
+export const LIVEAGENT_UPSTREAM_USER_AGENT_HEADER = "x-liveagent-upstream-user-agent";
+export const LIVEAGENT_UPSTREAM_CONTENT_TYPE_HEADER = "x-liveagent-upstream-content-type";
 // 布尔标记头：声明该请求经系统代理出网。代理地址/凭据只存于桌面 Rust 侧，
 // 由本地反代按此头选择带代理的 client（x-liveagent-* 头不会转发给上游）。
 export const LIVEAGENT_USE_SYSTEM_PROXY_HEADER = "x-liveagent-use-system-proxy";
@@ -17,6 +20,17 @@ export type PreparedProxyRequest = {
   baseUrl: string;
   headers: Record<string, string>;
 };
+
+export function buildUpstreamHeaderOverrideHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const userAgent = readHeaderValue(headers, "user-agent");
+  const contentType = readHeaderValue(headers, "content-type");
+  return {
+    ...(userAgent !== undefined ? { [LIVEAGENT_UPSTREAM_USER_AGENT_HEADER]: userAgent } : {}),
+    ...(contentType !== undefined ? { [LIVEAGENT_UPSTREAM_CONTENT_TYPE_HEADER]: contentType } : {}),
+  };
+}
 
 let proxyServerInfoPromise: Promise<ProxyServerInfo> | null = null;
 
@@ -182,6 +196,7 @@ export async function prepareProxyRequest(
     baseUrl,
     headers: {
       ...headers,
+      ...buildUpstreamHeaderOverrideHeaders(headers),
       [LIVEAGENT_UPSTREAM_ORIGIN_HEADER]: upstreamOrigin,
       [LIVEAGENT_PROXY_TOKEN_HEADER]: proxyServerInfo.token,
       ...(options?.useSystemProxy ? { [LIVEAGENT_USE_SYSTEM_PROXY_HEADER]: "1" } : {}),

--- a/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
@@ -31,6 +31,7 @@ import {
 import { useLocale } from "../../i18n";
 import { buildModelOptions } from "../../lib/chat/chatPageHelpers";
 import {
+  getCustomHeaderKeyPresets,
   isReservedCustomHeaderKey,
   isValidCustomHeaderKey,
 } from "../../lib/providers/customHeaders";
@@ -77,14 +78,6 @@ type ModelEditDraft = {
 };
 const PROVIDER_TABS: ProviderId[] = ["claude_code", "codex", "gemini"];
 const TITLE_MODEL_FOLLOW_CURRENT_VALUE = "__conversation_title_follow_current__";
-const CUSTOM_HEADER_KEY_PRESETS = [
-  "anthropic-beta",
-  "X-Request-ID",
-  "X-User-ID",
-  "X-Environment",
-  "HTTP-Referer",
-  "X-Title",
-] as const;
 const MODEL_CAPABILITIES: ModelCapability[] = ["reasoning", "vision", "tools"];
 const PROVIDER_LABELS: Record<ProviderId, string> = {
   claude_code: "Anthropic",
@@ -456,7 +449,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
   );
   const headerSuggestItems = headerSuggest
     ? headerSuggestQuery
-      ? CUSTOM_HEADER_KEY_PRESETS.filter((preset) => {
+      ? getCustomHeaderKeyPresets(providerType).filter((preset) => {
           const lower = preset.toLowerCase();
           if (headerSuggestUsed.has(lower)) return false;
           return lower.includes(headerSuggestQuery) && lower !== headerSuggestQuery;

--- a/crates/agent-gui/src-tauri/src/services/provider_models.rs
+++ b/crates/agent-gui/src-tauri/src/services/provider_models.rs
@@ -373,6 +373,31 @@ mod tests {
         .is_err());
     }
 
+    #[test]
+    fn provider_model_headers_exclude_inference_identity() {
+        for provider_type in ["claude_code", "codex", "gemini"] {
+            for official in [false, true] {
+                let headers = build_provider_models_headers(provider_type, "key", official);
+                let names = headers
+                    .iter()
+                    .map(|(name, _)| name.to_ascii_lowercase())
+                    .collect::<Vec<_>>();
+
+                assert!(!names.iter().any(|name| name.starts_with("x-stainless-")));
+                for forbidden in [
+                    "x-app",
+                    "user-agent",
+                    "anthropic-beta",
+                    "anthropic-dangerous-direct-browser-access",
+                    "session_id",
+                    "conversation_id",
+                ] {
+                    assert!(!names.iter().any(|name| name == forbidden));
+                }
+            }
+        }
+    }
+
     #[tokio::test]
     async fn provider_models_request_uses_explicit_proxy_client() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind proxy listener");

--- a/crates/agent-gui/src-tauri/src/services/proxy.rs
+++ b/crates/agent-gui/src-tauri/src/services/proxy.rs
@@ -37,8 +37,10 @@ const TRAILER: &str = "trailer";
 const TRANSFER_ENCODING: &str = "transfer-encoding";
 const UPGRADE: &str = "upgrade";
 const UPSTREAM_ORIGIN_HEADER: &str = "x-liveagent-upstream-origin";
+const UPSTREAM_USER_AGENT_HEADER: &str = "x-liveagent-upstream-user-agent";
+const UPSTREAM_CONTENT_TYPE_HEADER: &str = "x-liveagent-upstream-content-type";
 const USE_SYSTEM_PROXY_HEADER: &str = "x-liveagent-use-system-proxy";
-const DEFAULT_ALLOW_HEADERS: &str = "authorization,content-type,x-api-key,x-goog-api-key,anthropic-version,x-liveagent-upstream-origin,x-liveagent-proxy-token,x-liveagent-use-system-proxy";
+const DEFAULT_ALLOW_HEADERS: &str = "authorization,content-type,x-api-key,x-goog-api-key,anthropic-version,x-liveagent-upstream-origin,x-liveagent-upstream-user-agent,x-liveagent-upstream-content-type,x-liveagent-proxy-token,x-liveagent-use-system-proxy";
 const ALLOW_METHODS_VALUE: &str = "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD";
 const VARY_VALUE: &str = "Origin, Access-Control-Request-Method, Access-Control-Request-Headers";
 const IMAGE_PROXY_MAX_BYTES: usize = 25 * 1024 * 1024;
@@ -373,12 +375,9 @@ async fn handle_proxy(
     } else {
         state.client.clone()
     };
-    let mut request = client.request(method, target_url);
-    for (name, value) in &headers {
-        if should_forward_request_header(name) {
-            request = request.header(name, value);
-        }
-    }
+    let mut request = client
+        .request(method, target_url)
+        .headers(build_upstream_request_headers(&headers));
     if !body_bytes.is_empty() {
         request = request.body(body_bytes);
     }
@@ -540,6 +539,22 @@ fn should_forward_request_header(name: &HeaderName) -> bool {
             | ACCESS_CONTROL_REQUEST_HEADERS
     ) && !lowered.starts_with(ACCESS_CONTROL_PREFIX)
         && !lowered.starts_with(PROXY_PREFIX)
+}
+
+fn build_upstream_request_headers(headers: &HeaderMap) -> HeaderMap {
+    let mut upstream_headers = HeaderMap::new();
+    for (name, value) in headers {
+        if should_forward_request_header(name) {
+            upstream_headers.append(name, value.clone());
+        }
+    }
+    if let Some(value) = headers.get(UPSTREAM_USER_AGENT_HEADER) {
+        upstream_headers.insert(HeaderName::from_static("user-agent"), value.clone());
+    }
+    if let Some(value) = headers.get(UPSTREAM_CONTENT_TYPE_HEADER) {
+        upstream_headers.insert(HeaderName::from_static(CONTENT_TYPE), value.clone());
+    }
+    upstream_headers
 }
 
 fn should_forward_response_header(name: &HeaderName) -> bool {
@@ -714,5 +729,43 @@ mod tests {
         assert!(should_forward_request_header(&HeaderName::from_static(
             "anthropic-version"
         )));
+    }
+
+    #[test]
+    fn applies_explicit_upstream_header_overrides_last() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("user-agent"),
+            HeaderValue::from_static("WebView/1.0"),
+        );
+        headers.insert(
+            HeaderName::from_static(CONTENT_TYPE),
+            HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            HeaderName::from_static(UPSTREAM_USER_AGENT_HEADER),
+            HeaderValue::from_static("codex_cli_rs/0.72.0"),
+        );
+        headers.insert(
+            HeaderName::from_static(UPSTREAM_CONTENT_TYPE_HEADER),
+            HeaderValue::from_static("application/custom+json"),
+        );
+
+        let upstream_headers = build_upstream_request_headers(&headers);
+
+        assert_eq!(
+            upstream_headers
+                .get("user-agent")
+                .and_then(|value| value.to_str().ok()),
+            Some("codex_cli_rs/0.72.0")
+        );
+        assert_eq!(
+            upstream_headers
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("application/custom+json")
+        );
+        assert!(!upstream_headers.contains_key(UPSTREAM_USER_AGENT_HEADER));
+        assert!(!upstream_headers.contains_key(UPSTREAM_CONTENT_TYPE_HEADER));
     }
 }

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -1277,7 +1277,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.addCustomHeader": "添加请求头",
     "settings.removeCustomHeader": "删除请求头",
     "settings.invalidCustomHeaderKey":
-      "请求头名称无效。仅支持合法 HTTP Header 名称，例如 anthropic-beta、X-Request-ID。",
+      "请求头名称无效。仅支持合法 HTTP Header 名称，例如 X-Environment、X-Request-ID。",
     "settings.close": "关闭",
     "settings.hideApiKey": "隐藏 API Key",
     "settings.showApiKey": "显示 API Key",
@@ -3253,7 +3253,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.addCustomHeader": "Add header",
     "settings.removeCustomHeader": "Remove header",
     "settings.invalidCustomHeaderKey":
-      "Invalid HTTP header name. Examples: anthropic-beta, X-Request-ID.",
+      "Invalid HTTP header name. Examples: X-Environment, X-Request-ID.",
     "settings.close": "Close",
     "settings.hideApiKey": "Hide API Key",
     "settings.showApiKey": "Show API Key",

--- a/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
+++ b/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
@@ -17,7 +17,7 @@ import {
   withHostedSearchProbeHeader,
 } from "../../providers/hostedSearchEvents";
 import {
-  buildProviderAuthHeaders,
+  buildProviderRequestHeaders,
   buildProviderRequestMetadata,
   createModelFromConfig,
   createStreamingTextReconciler,
@@ -708,7 +708,7 @@ export async function runAssistantWithTools(params: {
       params.providerId,
       params.runtime.baseUrl.trim(),
       mergeCustomHeaders(
-        buildProviderAuthHeaders(params.providerId, params.runtime.apiKey),
+        buildProviderRequestHeaders(params.providerId, params.runtime.apiKey, params.sessionId),
         params.runtime.customHeaders,
       ),
       { useSystemProxy: params.runtime.useSystemProxy === true },

--- a/crates/agent-gui/src/lib/providers/customHeaders.ts
+++ b/crates/agent-gui/src/lib/providers/customHeaders.ts
@@ -4,12 +4,83 @@ const RESERVED_CUSTOM_HEADER_KEYS = new Set([
   "authorization",
   "x-api-key",
   "x-goog-api-key",
-  "anthropic-version",
-  "content-type",
+  "anthropic-beta",
   "host",
   "content-length",
 ]);
 const HTTP_HEADER_TOKEN_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+export const ANTHROPIC_DEFAULT_REQUEST_HEADERS = {
+  "x-app": "cli",
+  "User-Agent": "claude-cli/2.1.71 (external, cli)",
+  "Content-Type": "application/json",
+  "X-Stainless-OS": "MacOS",
+  "X-Stainless-Arch": "arm64",
+  "X-Stainless-Lang": "js",
+  "anthropic-version": "2023-06-01",
+  "X-Stainless-Runtime": "node",
+  "X-Stainless-Timeout": "600",
+  "x-stainless-retry-count": "0",
+  "X-Stainless-Package-Version": "0.74.0",
+  "X-Stainless-Runtime-Version": "v22.19.0",
+  "anthropic-dangerous-direct-browser-access": "true",
+} as const;
+
+export const CODEX_DEFAULT_USER_AGENT =
+  "codex_cli_rs/0.72.0 (Ubuntu 24.4.0; x86_64) WindowsTerminal";
+export const CODEX_SESSION_ID_HEADER = "session_id";
+export const CODEX_CONVERSATION_ID_HEADER = "conversation_id";
+
+const COMMON_CUSTOM_HEADER_KEY_PRESETS = [
+  "X-Request-ID",
+  "X-User-ID",
+  "X-Environment",
+  "HTTP-Referer",
+  "X-Title",
+] as const;
+
+const ANTHROPIC_CUSTOM_HEADER_KEY_PRESETS: readonly string[] = [
+  ...Object.keys(ANTHROPIC_DEFAULT_REQUEST_HEADERS),
+  ...COMMON_CUSTOM_HEADER_KEY_PRESETS,
+];
+
+const CODEX_CUSTOM_HEADER_KEY_PRESETS: readonly string[] = [
+  "User-Agent",
+  CODEX_SESSION_ID_HEADER,
+  CODEX_CONVERSATION_ID_HEADER,
+  ...COMMON_CUSTOM_HEADER_KEY_PRESETS,
+];
+
+const CUSTOM_HEADER_KEY_PRESETS: Record<CustomProvider["type"], readonly string[]> = {
+  claude_code: ANTHROPIC_CUSTOM_HEADER_KEY_PRESETS,
+  codex: CODEX_CUSTOM_HEADER_KEY_PRESETS,
+  gemini: COMMON_CUSTOM_HEADER_KEY_PRESETS,
+};
+
+export function getCustomHeaderKeyPresets(providerId: CustomProvider["type"]): readonly string[] {
+  return CUSTOM_HEADER_KEY_PRESETS[providerId];
+}
+
+export function isAnthropicOAuthApiKey(apiKey: string | undefined): boolean {
+  return Boolean(apiKey?.includes("sk-ant-oat"));
+}
+
+function findHeaderKey(
+  headers: Record<string, string | null | undefined>,
+  name: string,
+): string | undefined {
+  const expected = name.toLowerCase();
+  return Object.keys(headers).find((key) => key.toLowerCase() === expected);
+}
+
+export function readHeaderValue(
+  headers: Record<string, string | null | undefined> | undefined,
+  name: string,
+): string | undefined {
+  if (!headers) return undefined;
+  const key = findHeaderKey(headers, name);
+  return key === undefined ? undefined : (headers[key] ?? undefined);
+}
 
 export function isValidCustomHeaderKey(key: string): boolean {
   return HTTP_HEADER_TOKEN_PATTERN.test(key);
@@ -29,10 +100,8 @@ export function mergeCustomHeaders(
       continue;
     }
 
-    const existingKey = Object.keys(merged).find(
-      (key) => key.toLowerCase() === header.key.toLowerCase(),
-    );
-    if (existingKey) delete merged[existingKey];
+    const existingKey = findHeaderKey(merged, header.key);
+    if (existingKey !== undefined) delete merged[existingKey];
     merged[header.key] = header.value;
   }
 

--- a/crates/agent-gui/src/lib/providers/llm.ts
+++ b/crates/agent-gui/src/lib/providers/llm.ts
@@ -27,7 +27,7 @@ export {
 export {
   buildDualAuthHeaders,
   buildGeminiAuthHeaders,
-  buildProviderAuthHeaders,
+  buildProviderRequestHeaders,
   buildProviderRequestMetadata,
   isValidCustomHeaderKey,
   mergeCustomHeaders,

--- a/crates/agent-gui/src/lib/providers/proxy.ts
+++ b/crates/agent-gui/src/lib/providers/proxy.ts
@@ -1,9 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
 
 import type { ProviderId } from "../settings";
+import { readHeaderValue } from "./customHeaders";
 
 export const LIVEAGENT_PROXY_TOKEN_HEADER = "x-liveagent-proxy-token";
 export const LIVEAGENT_UPSTREAM_ORIGIN_HEADER = "x-liveagent-upstream-origin";
+export const LIVEAGENT_UPSTREAM_USER_AGENT_HEADER = "x-liveagent-upstream-user-agent";
+export const LIVEAGENT_UPSTREAM_CONTENT_TYPE_HEADER = "x-liveagent-upstream-content-type";
 // 布尔标记头：声明该请求经系统代理出网。代理地址/凭据只存于桌面 Rust 侧，
 // 由本地反代按此头选择带代理的 client（x-liveagent-* 头不会转发给上游）。
 export const LIVEAGENT_USE_SYSTEM_PROXY_HEADER = "x-liveagent-use-system-proxy";
@@ -17,6 +20,17 @@ export type PreparedProxyRequest = {
   baseUrl: string;
   headers: Record<string, string>;
 };
+
+export function buildUpstreamHeaderOverrideHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const userAgent = readHeaderValue(headers, "user-agent");
+  const contentType = readHeaderValue(headers, "content-type");
+  return {
+    ...(userAgent !== undefined ? { [LIVEAGENT_UPSTREAM_USER_AGENT_HEADER]: userAgent } : {}),
+    ...(contentType !== undefined ? { [LIVEAGENT_UPSTREAM_CONTENT_TYPE_HEADER]: contentType } : {}),
+  };
+}
 
 let proxyServerInfoPromise: Promise<ProxyServerInfo> | null = null;
 
@@ -182,6 +196,7 @@ export async function prepareProxyRequest(
     baseUrl,
     headers: {
       ...headers,
+      ...buildUpstreamHeaderOverrideHeaders(headers),
       [LIVEAGENT_UPSTREAM_ORIGIN_HEADER]: upstreamOrigin,
       [LIVEAGENT_PROXY_TOKEN_HEADER]: proxyServerInfo.token,
       ...(options?.useSystemProxy ? { [LIVEAGENT_USE_SYSTEM_PROXY_HEADER]: "1" } : {}),

--- a/crates/agent-gui/src/lib/providers/runtime/anthropicLongContext.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/anthropicLongContext.ts
@@ -5,6 +5,7 @@ import {
   getAnthropicCompat,
   shouldSendAnthropicLongContextHeader,
 } from "../anthropicModels";
+import { isAnthropicOAuthApiKey } from "../customHeaders";
 import type { StreamOptionsEx } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -18,47 +19,13 @@ export const ANTHROPIC_CONTEXT_1M_BETA = "context-1m-2025-08-07";
 const ANTHROPIC_INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14";
 const ANTHROPIC_FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14";
 
-// pi-ai 对 OAuth token 注入 claude-code/oauth beta 组合且官方 GA 后 OAuth 原生
-// 支持 1M；覆盖 anthropic-beta 会破坏鉴权，OAuth 请求一律不改写。
-function isAnthropicOAuthKey(apiKey: string | undefined) {
-  return Boolean(apiKey?.includes("sk-ant-oat"));
-}
-
 // pi-ai 的 mergeHeaders 对 options.headers 是整键覆盖而非追加，因此这里必须
 // 复现 createClient() 为非 OAuth 请求计算的基础 beta 集（顺序一致），再追加
 // context-1m。两个镜像条件与 pi-ai dist/api/anthropic-messages.js 逐字对应，
 // 由 anthropic-long-context 测试锁定；pi-ai 升级新增 beta 时需同步。
-function getHeaderValue(
-  headers: Record<string, string | null | undefined> | undefined,
-  name: string,
-): string | undefined {
-  const expected = name.toLowerCase();
-  for (const [key, value] of Object.entries(headers ?? {})) {
-    if (key.toLowerCase() === expected && value?.trim()) return value;
-  }
-  return undefined;
-}
-
-function mergeAnthropicBetaValues(...values: Array<string | undefined>): string {
-  const merged: string[] = [];
-  const seen = new Set<string>();
-  for (const value of values) {
-    for (const beta of value?.split(",") ?? []) {
-      const normalized = beta.trim();
-      if (!normalized) continue;
-      const key = normalized.toLowerCase();
-      if (seen.has(key)) continue;
-      seen.add(key);
-      merged.push(normalized);
-    }
-  }
-  return merged.join(",");
-}
-
 function buildAnthropicBetaHeaderValue(
   model: Model<"anthropic-messages">,
   context: Context | undefined,
-  existingValues: Array<string | undefined>,
 ): string {
   const compat = getAnthropicCompat(model);
   const betas: string[] = [];
@@ -69,7 +36,7 @@ function buildAnthropicBetaHeaderValue(
     betas.push(ANTHROPIC_INTERLEAVED_THINKING_BETA);
   }
   betas.push(ANTHROPIC_CONTEXT_1M_BETA);
-  return mergeAnthropicBetaValues(...existingValues, betas.join(","));
+  return betas.join(",");
 }
 
 export function attachAnthropicLongContextBeta(
@@ -86,21 +53,13 @@ export function attachAnthropicLongContextBeta(
   if (model?.api !== "anthropic-messages") return options;
   if (!shouldSendAnthropicLongContextHeader(params.baseUrl)) return options;
   if ((model.contextWindow ?? 0) <= ANTHROPIC_STANDARD_CONTEXT_WINDOW) return options;
-  if (isAnthropicOAuthKey(options.apiKey)) return options;
+  if (isAnthropicOAuthApiKey(options.apiKey)) return options;
 
-  const existingBetaHeaders = [
-    getHeaderValue(model.headers, "anthropic-beta"),
-    getHeaderValue(options.headers, "anthropic-beta"),
-  ];
   const headers = { ...options.headers };
   for (const key of Object.keys(headers)) {
     if (key.toLowerCase() === "anthropic-beta") delete headers[key];
   }
-  headers["anthropic-beta"] = buildAnthropicBetaHeaderValue(
-    model,
-    params.context,
-    existingBetaHeaders,
-  );
+  headers["anthropic-beta"] = buildAnthropicBetaHeaderValue(model, params.context);
 
   return {
     ...options,

--- a/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
@@ -1,6 +1,14 @@
 import type { CacheRetention, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import type { CustomProvider, ProviderId, ReasoningLevel } from "../../settings";
-import { mergeCustomHeaders as mergeCustomHeadersBase } from "../customHeaders";
+import { createUuid } from "../../shared/id";
+import {
+  ANTHROPIC_DEFAULT_REQUEST_HEADERS,
+  CODEX_CONVERSATION_ID_HEADER,
+  CODEX_DEFAULT_USER_AGENT,
+  CODEX_SESSION_ID_HEADER,
+  isAnthropicOAuthApiKey,
+  mergeCustomHeaders as mergeCustomHeadersBase,
+} from "../customHeaders";
 import { normalizeSessionId } from "./common";
 
 export { isValidCustomHeaderKey } from "../customHeaders";
@@ -18,11 +26,33 @@ export function buildGeminiAuthHeaders(apiKey: string): Record<string, string> {
   };
 }
 
-export function buildProviderAuthHeaders(
+function buildProviderAuthHeaders(providerId: ProviderId, apiKey: string): Record<string, string> {
+  return providerId === "gemini" ? buildGeminiAuthHeaders(apiKey) : buildDualAuthHeaders(apiKey);
+}
+
+export function buildProviderRequestHeaders(
   providerId: ProviderId,
   apiKey: string,
+  sessionId?: string,
 ): Record<string, string> {
-  return providerId === "gemini" ? buildGeminiAuthHeaders(apiKey) : buildDualAuthHeaders(apiKey);
+  const authHeaders = buildProviderAuthHeaders(providerId, apiKey);
+  if (providerId === "claude_code") {
+    if (isAnthropicOAuthApiKey(apiKey)) return {};
+    return {
+      ...authHeaders,
+      ...ANTHROPIC_DEFAULT_REQUEST_HEADERS,
+    };
+  }
+  if (providerId === "codex") {
+    const requestSessionId = normalizeSessionId(sessionId) ?? createUuid();
+    return {
+      ...authHeaders,
+      "User-Agent": CODEX_DEFAULT_USER_AGENT,
+      [CODEX_SESSION_ID_HEADER]: requestSessionId,
+      [CODEX_CONVERSATION_ID_HEADER]: requestSessionId,
+    };
+  }
+  return authHeaders;
 }
 
 export function mergeCustomHeaders(

--- a/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
@@ -22,7 +22,7 @@ import { createStreamingTextReconciler } from "./messageUtils";
 import { createModelFromConfig } from "./modelFactory";
 import { finalizeProviderStreamOptions } from "./payloadPipeline";
 import {
-  buildProviderAuthHeaders,
+  buildProviderRequestHeaders,
   buildProviderRequestMetadata,
   mergeCustomHeaders,
   resolveProviderCacheRetention,
@@ -139,7 +139,7 @@ export async function streamAssistantMessage(params: {
     params.providerId,
     params.runtime.baseUrl.trim(),
     mergeCustomHeaders(
-      buildProviderAuthHeaders(params.providerId, params.runtime.apiKey),
+      buildProviderRequestHeaders(params.providerId, params.runtime.apiKey, params.sessionId),
       params.runtime.customHeaders,
     ),
     { useSystemProxy: params.runtime.useSystemProxy === true },
@@ -332,7 +332,7 @@ export async function completeAssistantMessage(params: {
     params.providerId,
     params.runtime.baseUrl.trim(),
     mergeCustomHeaders(
-      buildProviderAuthHeaders(params.providerId, params.runtime.apiKey),
+      buildProviderRequestHeaders(params.providerId, params.runtime.apiKey, params.sessionId),
       params.runtime.customHeaders,
     ),
     { useSystemProxy: params.runtime.useSystemProxy === true },

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -47,6 +47,7 @@ import {
 import { useLocale } from "../../i18n";
 import { buildModelOptions } from "../../lib/chat/page/chatPageHelpers";
 import {
+  getCustomHeaderKeyPresets,
   isReservedCustomHeaderKey,
   isValidCustomHeaderKey,
 } from "../../lib/providers/customHeaders";
@@ -113,14 +114,6 @@ type CcsProvidersResponse = {
 };
 
 const PROVIDER_TABS: ProviderId[] = ["claude_code", "codex", "gemini"];
-const CUSTOM_HEADER_KEY_PRESETS = [
-  "anthropic-beta",
-  "X-Request-ID",
-  "X-User-ID",
-  "X-Environment",
-  "HTTP-Referer",
-  "X-Title",
-] as const;
 const MODEL_CAPABILITIES: ModelCapability[] = ["reasoning", "vision", "tools"];
 const TITLE_MODEL_FOLLOW_CURRENT_VALUE = "__conversation_title_follow_current__";
 const PROVIDER_LABELS: Record<ProviderId, string> = {
@@ -512,7 +505,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
   );
   const headerSuggestItems = headerSuggest
     ? headerSuggestQuery
-      ? CUSTOM_HEADER_KEY_PRESETS.filter((preset) => {
+      ? getCustomHeaderKeyPresets(providerType).filter((preset) => {
           const lower = preset.toLowerCase();
           if (headerSuggestUsed.has(lower)) return false;
           return lower.includes(headerSuggestQuery) && lower !== headerSuggestQuery;

--- a/crates/agent-gui/test/chat/agent-runner.test.mjs
+++ b/crates/agent-gui/test/chat/agent-runner.test.mjs
@@ -248,7 +248,7 @@ const llmMock = {
       "x-api-key": apiKey,
     };
   },
-  buildProviderAuthHeaders(_providerId, apiKey) {
+  buildProviderRequestHeaders(_providerId, apiKey, _sessionId) {
     return {
       Authorization: `Bearer ${apiKey}`,
       "x-api-key": apiKey,

--- a/crates/agent-gui/test/providers/anthropic-long-context.test.mjs
+++ b/crates/agent-gui/test/providers/anthropic-long-context.test.mjs
@@ -78,7 +78,7 @@ test("长上下文 beta：compat 关闭 eager streaming 且带工具时镜像 fi
   assert.equal(next.headers["anthropic-beta"], `${FINE_GRAINED_BETA},${CONTEXT_1M_BETA}`);
 });
 
-test("长上下文 beta：合并并去重已有 anthropic-beta，不覆盖自定义 beta", () => {
+test("长上下文 beta：忽略已有值，仅使用 pi-ai 动态 beta 与 context-1m", () => {
   const next = longContext.attachAnthropicLongContextBeta(
     {
       apiKey: "sk-relay-key",
@@ -90,13 +90,13 @@ test("长上下文 beta：合并并去重已有 anthropic-beta，不覆盖自定
     {
       providerId: "claude_code",
       baseUrl: "https://relay.example.com/v1",
-      model: makeAnthropicModel({ compat: undefined }),
+      model: makeAnthropicModel({
+        compat: undefined,
+        headers: { "anthropic-beta": "model-custom-beta" },
+      }),
     },
   );
-  assert.equal(
-    next.headers["anthropic-beta"],
-    `prompt-caching-scope-2026-01-05,${CONTEXT_1M_BETA},${INTERLEAVED_BETA}`,
-  );
+  assert.equal(next.headers["anthropic-beta"], `${INTERLEAVED_BETA},${CONTEXT_1M_BETA}`);
   assert.equal(next.headers["Anthropic-Beta"], undefined);
   assert.equal(next.headers.Authorization, "Bearer sk-relay-key");
 });

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -5,6 +5,7 @@ import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 const loader = createTsModuleLoader();
 const providers = loader.loadModule("src/lib/providers/llm.ts");
 const proxy = loader.loadModule("src/lib/providers/proxy.ts");
+const customHeaderHelpers = loader.loadModule("src/lib/providers/customHeaders.ts");
 const providerUtils = loader.loadModule("src/pages/settings/providerUtils.ts");
 
 function createMockAssistantStream() {
@@ -67,7 +68,7 @@ test("llm facade preserves provider runtime exports", () => {
     "attachProviderNativeWebSearch",
     "buildDualAuthHeaders",
     "buildGeminiAuthHeaders",
-    "buildProviderAuthHeaders",
+    "buildProviderRequestHeaders",
     "buildProviderRequestMetadata",
     "isValidCustomHeaderKey",
     "mergeCustomHeaders",
@@ -137,13 +138,43 @@ test("provider request helpers normalize auth, metadata, errors, and model value
   assert.deepEqual(providers.buildGeminiAuthHeaders("secret"), {
     "x-goog-api-key": "secret",
   });
-  assert.deepEqual(providers.buildProviderAuthHeaders("gemini", "secret"), {
-    "x-goog-api-key": "secret",
-  });
-  assert.deepEqual(providers.buildProviderAuthHeaders("codex", "secret"), {
+  assert.deepEqual(
+    providers.buildProviderRequestHeaders("claude_code", "secret", "conversation-1"),
+    {
+      Authorization: "Bearer secret",
+      "x-api-key": "secret",
+      "x-app": "cli",
+      "User-Agent": "claude-cli/2.1.71 (external, cli)",
+      "Content-Type": "application/json",
+      "X-Stainless-OS": "MacOS",
+      "X-Stainless-Arch": "arm64",
+      "X-Stainless-Lang": "js",
+      "anthropic-version": "2023-06-01",
+      "X-Stainless-Runtime": "node",
+      "X-Stainless-Timeout": "600",
+      "x-stainless-retry-count": "0",
+      "X-Stainless-Package-Version": "0.74.0",
+      "X-Stainless-Runtime-Version": "v22.19.0",
+      "anthropic-dangerous-direct-browser-access": "true",
+    },
+  );
+  assert.deepEqual(
+    providers.buildProviderRequestHeaders("claude_code", "sk-ant-oat01-test", "conversation-1"),
+    {},
+  );
+  assert.deepEqual(providers.buildProviderRequestHeaders("codex", "secret", "conversation-1"), {
     Authorization: "Bearer secret",
     "x-api-key": "secret",
+    "User-Agent": "codex_cli_rs/0.72.0 (Ubuntu 24.4.0; x86_64) WindowsTerminal",
+    session_id: "conversation-1",
+    conversation_id: "conversation-1",
   });
+  assert.deepEqual(providers.buildProviderRequestHeaders("gemini", "secret", "conversation-1"), {
+    "x-goog-api-key": "secret",
+  });
+  const generatedCodexHeaders = providers.buildProviderRequestHeaders("codex", "secret");
+  assert.match(generatedCodexHeaders.session_id, /^[0-9a-f-]{36}$/i);
+  assert.equal(generatedCodexHeaders.conversation_id, generatedCodexHeaders.session_id);
   assert.equal(providers.toSimpleStreamReasoning("off"), undefined);
   assert.equal(providers.toSimpleStreamReasoning("high"), "high");
   assert.equal(providers.toSimpleStreamReasoning("max"), "max");
@@ -197,6 +228,36 @@ test("provider request helpers normalize auth, metadata, errors, and model value
   assert.equal(
     providers.normalizeErrorMessage('prefix {"error":{"message":"nested failure"}}'),
     "nested failure",
+  );
+});
+
+test("provider-specific custom header suggestions include standard model headers", () => {
+  const anthropicPresets = customHeaderHelpers.getCustomHeaderKeyPresets("claude_code");
+  assert.ok(anthropicPresets.includes("User-Agent"));
+  assert.ok(anthropicPresets.includes("Content-Type"));
+  assert.ok(anthropicPresets.includes("anthropic-version"));
+  assert.ok(anthropicPresets.includes("X-Stainless-Runtime-Version"));
+  assert.ok(anthropicPresets.includes("anthropic-dangerous-direct-browser-access"));
+  assert.ok(!anthropicPresets.includes("anthropic-beta"));
+  assert.ok(!anthropicPresets.includes("session_id"));
+
+  const codexPresets = customHeaderHelpers.getCustomHeaderKeyPresets("codex");
+  assert.ok(codexPresets.includes("User-Agent"));
+  assert.ok(codexPresets.includes("session_id"));
+  assert.ok(codexPresets.includes("conversation_id"));
+  assert.ok(!codexPresets.includes("anthropic-version"));
+});
+
+test("local proxy preserves explicit user-agent and content-type values for the upstream hop", () => {
+  assert.deepEqual(
+    proxy.buildUpstreamHeaderOverrideHeaders({
+      "user-agent": "custom-agent/1.0",
+      "CONTENT-TYPE": "application/custom+json",
+    }),
+    {
+      "x-liveagent-upstream-user-agent": "custom-agent/1.0",
+      "x-liveagent-upstream-content-type": "application/custom+json",
+    },
   );
 });
 
@@ -1174,11 +1235,12 @@ test("custom provider headers merge without mutating the base headers", () => {
   assert.deepEqual(base, { Accept: "application/json", "X-Tenant": "old" });
 });
 
-test("custom provider headers cannot override reserved headers case-insensitively", () => {
+test("custom provider headers override model defaults but not credential or protocol headers", () => {
   const base = {
     Authorization: "Bearer real",
     "x-api-key": "real-api-key",
     "x-goog-api-key": "real-google-key",
+    "anthropic-beta": "context-1m-2025-08-07",
     "anthropic-version": "2023-06-01",
     "Content-Type": "application/json",
     Host: "api.example.com",
@@ -1189,12 +1251,22 @@ test("custom provider headers cannot override reserved headers case-insensitivel
       { key: "authorization", value: "Bearer attacker" },
       { key: "X-API-KEY", value: "attacker" },
       { key: "X-GOOG-API-KEY", value: "attacker" },
+      { key: "Anthropic-Beta", value: "custom-beta" },
       { key: "Anthropic-Version", value: "attacker" },
       { key: "content-type", value: "text/plain" },
       { key: "host", value: "attacker.example" },
       { key: "content-length", value: "0" },
     ]),
-    base,
+    {
+      Authorization: "Bearer real",
+      "x-api-key": "real-api-key",
+      "x-goog-api-key": "real-google-key",
+      "anthropic-beta": "context-1m-2025-08-07",
+      "Anthropic-Version": "attacker",
+      "content-type": "text/plain",
+      Host: "api.example.com",
+      "Content-Length": "42",
+    },
   );
 });
 
@@ -1210,6 +1282,7 @@ test("custom provider headers filter invalid HTTP token keys", () => {
     { "X.Valid-Header_1": "kept" },
   );
   assert.equal(providers.isValidCustomHeaderKey("anthropic-beta"), true);
+  assert.equal(customHeaderHelpers.isReservedCustomHeaderKey("Anthropic-Beta"), true);
   assert.equal(providers.isValidCustomHeaderKey("X-Request-ID"), true);
   assert.equal(providers.isValidCustomHeaderKey("Bad Header"), false);
 });
@@ -1219,4 +1292,3 @@ test("custom provider headers accept undefined and empty arrays", () => {
   assert.deepEqual(providers.mergeCustomHeaders(base, undefined), base);
   assert.deepEqual(providers.mergeCustomHeaders(base, []), base);
 });
-

--- a/crates/agent-gui/test/settings/provider-models-fetch.test.mjs
+++ b/crates/agent-gui/test/settings/provider-models-fetch.test.mjs
@@ -114,6 +114,20 @@ test("buildProviderModelsAttempts orders default before official with provider h
   assert.equal(codex[0].headers["x-api-key"], "test-key");
   assert.equal(codex[1].headers["x-api-key"], undefined);
   assert.equal(codex[1].headers.Authorization, "Bearer test-key");
+
+  const inferenceOnlyHeaders = [
+    "x-app",
+    "user-agent",
+    "anthropic-beta",
+    "anthropic-dangerous-direct-browser-access",
+    "session_id",
+    "conversation_id",
+  ];
+  for (const attempt of [...gemini, ...claude, ...codex]) {
+    const headerNames = Object.keys(attempt.headers).map((name) => name.toLowerCase());
+    assert.ok(!headerNames.some((name) => name.startsWith("x-stainless-")));
+    for (const name of inferenceOnlyHeaders) assert.ok(!headerNames.includes(name), name);
+  }
 });
 
 test("provider model fetch identity changes when system proxy routing changes", () => {


### PR DESCRIPTION
## Summary

- `buildProviderRequestHeaders` (renamed from `buildProviderAuthHeaders`) attaches provider default identity headers: Anthropic API-key requests get the claude-cli header set (`x-app`, `User-Agent`, `X-Stainless-*`, `anthropic-version`, …), Codex gets the `codex_cli_rs` User-Agent plus `session_id`/`conversation_id` derived from the chat session (fresh UUID fallback). Anthropic OAuth requests stay untouched.
- The desktop reverse proxy learns `x-liveagent-upstream-user-agent` / `x-liveagent-upstream-content-type` override headers so the WebView-forced User-Agent/Content-Type can be replaced on the upstream request. Overrides are applied last and the marker headers are never forwarded upstream; both are added to the CORS allow-list.
- `anthropic-beta` becomes a reserved custom header (removed from suggestions and i18n examples) while `anthropic-version`/`Content-Type` open up; the settings header-key suggestions are now per-provider presets sourced from the default header sets.
- `anthropicLongContext` builds the beta header fresh instead of merging pre-existing values, and shares `isAnthropicOAuthApiKey` with `customHeaders`.
- New Rust test locks model-list fetches to exclude inference identity headers (no `X-Stainless-*`, `x-app`, `session_id`, …).

## Testing

- `node --test` on the four touched GUI test files: 91 pass
- `cargo test --lib -- services::proxy services::provider_models`: 16 pass
- `node scripts/check-mirror.mjs`: 87 mirrored files identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)