### PR TITLE
feat(composer): switch skill mention trigger from $ to /

### DIFF
--- a/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
@@ -867,11 +867,7 @@ function detectMention(root: HTMLElement, skillsEnabled: boolean): MentionContex
     }
     // "/" only triggers a skill mention at a word boundary; slashes inside an
     // @file query (e.g. "@docs/foo") must keep scanning back toward the "@".
-    if (
-      before[i] === "/" &&
-      skillsEnabled &&
-      (i === 0 || isMentionBoundaryChar(before[i - 1]))
-    ) {
+    if (before[i] === "/" && skillsEnabled && (i === 0 || isMentionBoundaryChar(before[i - 1]))) {
       triggerIdx = i;
       trigger = "skill";
       break;

--- a/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
@@ -107,7 +107,7 @@ type MentionSuggestion =
   | { type: "file"; entry: MentionFileEntry }
   | { type: "skill"; skill: MentionComposerSkill };
 
-/** Where the @/$ trigger lives inside a text node */
+/** Where the @ or / trigger lives inside a text node */
 interface MentionContext {
   trigger: "file" | "skill";
   query: string;
@@ -242,7 +242,7 @@ const GITHUB_ICON_SVG =
 /* ------------------------------------------------------------------ */
 
 function formatSkillMentionToken(skill: Pick<MentionComposerSkillMention, "name">) {
-  return `$${skill.name}`;
+  return `/${skill.name}`;
 }
 
 function formatCommitMentionToken(
@@ -848,7 +848,7 @@ function selectionTextPosition(root: HTMLElement): { textNode: Text; offset: num
   return null;
 }
 
-/** Detect an in-progress @file or $skill mention at the cursor position. */
+/** Detect an in-progress @file or /skill mention at the cursor position. */
 function detectMention(root: HTMLElement, skillsEnabled: boolean): MentionContext | null {
   const position = selectionTextPosition(root);
   if (!position) return null;
@@ -865,7 +865,13 @@ function detectMention(root: HTMLElement, skillsEnabled: boolean): MentionContex
       trigger = "file";
       break;
     }
-    if (before[i] === "$" && skillsEnabled) {
+    // "/" only triggers a skill mention at a word boundary; slashes inside an
+    // @file query (e.g. "@docs/foo") must keep scanning back toward the "@".
+    if (
+      before[i] === "/" &&
+      skillsEnabled &&
+      (i === 0 || isMentionBoundaryChar(before[i - 1]))
+    ) {
       triggerIdx = i;
       trigger = "skill";
       break;
@@ -873,6 +879,11 @@ function detectMention(root: HTMLElement, skillsEnabled: boolean): MentionContex
     if (isMentionBoundaryChar(before[i])) break;
   }
   if (triggerIdx < 0 || !trigger) return null;
+
+  // Typing a filesystem path ("/usr/bin") reaches a second "/", which can
+  // never appear in a skill name — drop the skill context instead of keeping
+  // an unmatchable popup query around.
+  if (trigger === "skill" && before.slice(triggerIdx + 1).includes("/")) return null;
 
   // Trigger must be preceded by whitespace or be the very first character.
   if (triggerIdx > 0) {

--- a/crates/agent-gateway/web/src/i18n/config.ts
+++ b/crates/agent-gateway/web/src/i18n/config.ts
@@ -124,7 +124,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "chat.runtime.reasoning": "思考程度",
     "chat.emptyRound": "（无回复）",
     "chat.inputHint": "输入消息，@ 引用文件，提示词可队列发送...",
-    "chat.inputHintWithSkills": "输入消息，@ 引用文件，$ 引用Skills，提示词可队列发送...",
+    "chat.inputHintWithSkills": "输入消息，@ 引用文件，/ 引用Skills，提示词可队列发送...",
     "chat.compactingContext": "正在压缩上下文",
     "chat.compactingContextWait": "正在压缩上下文，请稍候...",
     "chat.editMessage": "编辑消息",
@@ -1972,7 +1972,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "chat.emptyRound": "(No reply)",
     "chat.inputHint": "Type a message, @ to reference files, prompts can be queued...",
     "chat.inputHintWithSkills":
-      "Type a message, @ to reference files, $ to reference Skills, prompts can be queued...",
+      "Type a message, @ to reference files, / to reference Skills, prompts can be queued...",
     "chat.compactingContext": "Compressing context",
     "chat.compactingContextWait": "Compressing context, please wait...",
     "chat.editMessage": "Edit Message",

--- a/crates/agent-gateway/web/src/lib/chat/userMessageContent.tsx
+++ b/crates/agent-gateway/web/src/lib/chat/userMessageContent.tsx
@@ -59,7 +59,7 @@ function isCommonSkillMentionEnvVar(name: string) {
 }
 
 export function isSkillMentionToken(token: string) {
-  if (!token.startsWith("$")) return false;
+  if (!token.startsWith("/")) return false;
   const name = token.slice(1);
   return Boolean(name) && isSkillMentionName(name) && !isCommonSkillMentionEnvVar(name);
 }
@@ -388,7 +388,7 @@ function tokenizeInlineMentions(text: string): UserMessageSegment[] {
     }
 
     const marker = text[index];
-    if ((marker !== "@" && marker !== "$") || !isTokenBoundary(text, index)) {
+    if ((marker !== "@" && marker !== "/") || !isTokenBoundary(text, index)) {
       continue;
     }
 
@@ -415,6 +415,8 @@ function tokenizeInlineMentions(text: string): UserMessageSegment[] {
     while (nameEnd < text.length && /[A-Za-z0-9_:-]/.test(text[nameEnd])) {
       nameEnd += 1;
     }
+    // A slash right after the name means a filesystem path (/usr/bin), not a skill.
+    if (text[nameEnd] === "/") continue;
     const token = text.slice(index, nameEnd);
     if (!isSkillMentionToken(token)) continue;
     if (index > cursor) {

--- a/crates/agent-gateway/web/src/lib/skills/index.ts
+++ b/crates/agent-gateway/web/src/lib/skills/index.ts
@@ -213,7 +213,7 @@ export function extractSkillMentionNamesFromText(text: string): string[] {
   const seen = new Set<string>();
 
   for (let index = 0; index < text.length; index += 1) {
-    if (text[index] !== "$") continue;
+    if (text[index] !== "/") continue;
 
     const before = index > 0 ? text[index - 1] : "";
     if (before && !/\s/.test(before)) continue;
@@ -226,6 +226,8 @@ export function extractSkillMentionNamesFromText(text: string): string[] {
     while (nameEnd < text.length && isSkillMentionNameChar(text[nameEnd])) {
       nameEnd += 1;
     }
+    // A slash right after the name means a filesystem path (/usr/bin), not a skill.
+    if (text[nameEnd] === "/") continue;
 
     const name = text.slice(nameStart, nameEnd);
     if (isCommonSkillMentionEnvVar(name)) continue;
@@ -609,9 +611,9 @@ export function buildSkillsSystemPrompt(params: {
       ? [
           "",
           "Explicitly mentioned this turn:",
-          "- The user explicitly mentioned the following enabled Skills with `$skill-name` in this turn.",
+          "- The user explicitly mentioned the following enabled Skills with `/skill-name` in this turn.",
           "- Treat these mentions as user intent to prioritize those Skills. Read and follow the mentioned Skill instructions before acting when they are relevant.",
-          "- `$` mentions never grant access to disabled Skills; only the enabled Skills listed in this prompt are available.",
+          "- `/` mentions never grant access to disabled Skills; only the enabled Skills listed in this prompt are available.",
           ...explicit.map(
             (skill) => `- ${skill.name} (skillFile: ${skill.skillFile}, baseDir: ${skill.baseDir})`,
           ),

--- a/crates/agent-gui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gui/src/components/chat/MentionComposer.tsx
@@ -114,7 +114,7 @@ type ComposerContextMenuState = {
   hasContent: boolean;
 };
 
-/** Where the @/$ trigger lives inside a text node */
+/** Where the @ or / trigger lives inside a text node */
 interface MentionContext {
   trigger: "file" | "skill";
   query: string;
@@ -252,7 +252,7 @@ const GITHUB_ICON_SVG =
 /* ------------------------------------------------------------------ */
 
 function formatSkillMentionToken(skill: Pick<MentionComposerSkillMention, "name">) {
-  return `$${skill.name}`;
+  return `/${skill.name}`;
 }
 
 function formatCommitMentionToken(
@@ -1098,7 +1098,7 @@ function selectionTextPosition(root: HTMLElement): { textNode: Text; offset: num
   return null;
 }
 
-/** Detect an in-progress @file or $skill mention at the cursor position. */
+/** Detect an in-progress @file or /skill mention at the cursor position. */
 function detectMention(root: HTMLElement, skillsEnabled: boolean): MentionContext | null {
   const position = selectionTextPosition(root);
   if (!position) return null;
@@ -1115,7 +1115,13 @@ function detectMention(root: HTMLElement, skillsEnabled: boolean): MentionContex
       trigger = "file";
       break;
     }
-    if (before[i] === "$" && skillsEnabled) {
+    // "/" only triggers a skill mention at a word boundary; slashes inside an
+    // @file query (e.g. "@docs/foo") must keep scanning back toward the "@".
+    if (
+      before[i] === "/" &&
+      skillsEnabled &&
+      (i === 0 || isMentionBoundaryChar(before[i - 1]))
+    ) {
       triggerIdx = i;
       trigger = "skill";
       break;
@@ -1123,6 +1129,11 @@ function detectMention(root: HTMLElement, skillsEnabled: boolean): MentionContex
     if (isMentionBoundaryChar(before[i])) break;
   }
   if (triggerIdx < 0 || !trigger) return null;
+
+  // Typing a filesystem path ("/usr/bin") reaches a second "/", which can
+  // never appear in a skill name — drop the skill context instead of keeping
+  // an unmatchable popup query around.
+  if (trigger === "skill" && before.slice(triggerIdx + 1).includes("/")) return null;
 
   // Trigger must be preceded by whitespace or be the very first character.
   if (triggerIdx > 0) {

--- a/crates/agent-gui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gui/src/components/chat/MentionComposer.tsx
@@ -1117,11 +1117,7 @@ function detectMention(root: HTMLElement, skillsEnabled: boolean): MentionContex
     }
     // "/" only triggers a skill mention at a word boundary; slashes inside an
     // @file query (e.g. "@docs/foo") must keep scanning back toward the "@".
-    if (
-      before[i] === "/" &&
-      skillsEnabled &&
-      (i === 0 || isMentionBoundaryChar(before[i - 1]))
-    ) {
+    if (before[i] === "/" && skillsEnabled && (i === 0 || isMentionBoundaryChar(before[i - 1]))) {
       triggerIdx = i;
       trigger = "skill";
       break;

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -147,7 +147,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "chat.runtime.reasoning": "思考程度",
     "chat.emptyRound": "（无回复）",
     "chat.inputHint": "输入消息，@ 引用文件，提示词可队列发送...",
-    "chat.inputHintWithSkills": "输入消息，@ 引用文件，$ 引用Skills，提示词可队列发送...",
+    "chat.inputHintWithSkills": "输入消息，@ 引用文件，/ 引用Skills，提示词可队列发送...",
     "chat.compactingContext": "正在压缩上下文",
     "chat.compactingContextWait": "正在压缩上下文，请稍候...",
     "chat.editMessage": "编辑消息",
@@ -2076,7 +2076,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "chat.emptyRound": "(No reply)",
     "chat.inputHint": "Type a message, @ to reference files, prompts can be queued...",
     "chat.inputHintWithSkills":
-      "Type a message, @ to reference files, $ to reference Skills, prompts can be queued...",
+      "Type a message, @ to reference files, / to reference Skills, prompts can be queued...",
     "chat.compactingContext": "Compressing context",
     "chat.compactingContextWait": "Compressing context, please wait...",
     "chat.editMessage": "Edit Message",

--- a/crates/agent-gui/src/lib/chat/messages/userMessageContent.tsx
+++ b/crates/agent-gui/src/lib/chat/messages/userMessageContent.tsx
@@ -64,7 +64,7 @@ function isCommonSkillMentionEnvVar(name: string) {
 }
 
 export function isSkillMentionToken(token: string) {
-  if (!token.startsWith("$")) return false;
+  if (!token.startsWith("/")) return false;
   const name = token.slice(1);
   return Boolean(name) && isSkillMentionName(name) && !isCommonSkillMentionEnvVar(name);
 }
@@ -359,7 +359,8 @@ function tokenizeInlineMentions(text: string): UserMessageSegment[] {
       continue;
     }
 
-    if (text[index] !== "$" || !isTokenBoundary(text, index)) {
+    const marker = text[index];
+    if (marker !== "/" || !isTokenBoundary(text, index)) {
       continue;
     }
 
@@ -367,6 +368,8 @@ function tokenizeInlineMentions(text: string): UserMessageSegment[] {
     while (nameEnd < text.length && /[A-Za-z0-9_:-]/.test(text[nameEnd])) {
       nameEnd += 1;
     }
+    // A slash right after the name means a filesystem path (/usr/bin), not a skill.
+    if (text[nameEnd] === "/") continue;
     const token = text.slice(index, nameEnd);
     if (!isSkillMentionToken(token)) continue;
     if (index > cursor) {

--- a/crates/agent-gui/src/lib/skills/index.ts
+++ b/crates/agent-gui/src/lib/skills/index.ts
@@ -213,7 +213,7 @@ export function extractSkillMentionNamesFromText(text: string): string[] {
   const seen = new Set<string>();
 
   for (let index = 0; index < text.length; index += 1) {
-    if (text[index] !== "$") continue;
+    if (text[index] !== "/") continue;
 
     const before = index > 0 ? text[index - 1] : "";
     if (before && !/\s/.test(before)) continue;
@@ -226,6 +226,8 @@ export function extractSkillMentionNamesFromText(text: string): string[] {
     while (nameEnd < text.length && isSkillMentionNameChar(text[nameEnd])) {
       nameEnd += 1;
     }
+    // A slash right after the name means a filesystem path (/usr/bin), not a skill.
+    if (text[nameEnd] === "/") continue;
 
     const name = text.slice(nameStart, nameEnd);
     if (isCommonSkillMentionEnvVar(name)) continue;
@@ -609,9 +611,9 @@ export function buildSkillsSystemPrompt(params: {
       ? [
           "",
           "Explicitly mentioned this turn:",
-          "- The user explicitly mentioned the following enabled Skills with `$skill-name` in this turn.",
+          "- The user explicitly mentioned the following enabled Skills with `/skill-name` in this turn.",
           "- Treat these mentions as user intent to prioritize those Skills. Read and follow the mentioned Skill instructions before acting when they are relevant.",
-          "- `$` mentions never grant access to disabled Skills; only the enabled Skills listed in this prompt are available.",
+          "- `/` mentions never grant access to disabled Skills; only the enabled Skills listed in this prompt are available.",
           ...explicit.map(
             (skill) => `- ${skill.name} (skillFile: ${skill.skillFile}, baseDir: ${skill.baseDir})`,
           ),

--- a/crates/agent-gui/test/chat/user-message-content.test.mjs
+++ b/crates/agent-gui/test/chat/user-message-content.test.mjs
@@ -54,12 +54,29 @@ function compactSegments(segments) {
 }
 
 test("user message skill mentions style only skill-like tokens", () => {
-  assert.equal(userMessageContent.isSkillMentionToken("$code-review"), true);
-  assert.equal(userMessageContent.isSkillMentionToken("$release_notes"), true);
-  assert.equal(userMessageContent.isSkillMentionToken("$PATH"), false);
-  assert.equal(userMessageContent.isSkillMentionToken("$PATH:"), false);
-  assert.equal(userMessageContent.isSkillMentionToken("price$tag"), false);
-  assert.equal(userMessageContent.isSkillMentionToken("$bad.name"), false);
+  assert.equal(userMessageContent.isSkillMentionToken("/code-review"), true);
+  assert.equal(userMessageContent.isSkillMentionToken("/release_notes"), true);
+  assert.equal(userMessageContent.isSkillMentionToken("/PATH"), false);
+  assert.equal(userMessageContent.isSkillMentionToken("price/tag"), false);
+  assert.equal(userMessageContent.isSkillMentionToken("/bad.name"), false);
+  // "$" is no longer a skill mention marker.
+  assert.equal(userMessageContent.isSkillMentionToken("$code-review"), false);
+  assert.equal(userMessageContent.isSkillMentionToken("$release_notes"), false);
+});
+
+test("slash skill mentions tokenize at word boundaries but leave paths alone", () => {
+  assert.deepEqual(
+    compactSegments(userMessageContent.tokenizeUserMessage("请用 /code-review 检查", [])),
+    [
+      { type: "text", value: "请用 " },
+      { type: "skill" },
+      { type: "text", value: " 检查" },
+    ],
+  );
+  assert.deepEqual(
+    compactSegments(userMessageContent.tokenizeUserMessage("查看 /usr/bin 目录", [])),
+    [{ type: "text", value: "查看 /usr/bin 目录" }],
+  );
 });
 
 test("file mention markdown references round trip through transcript tokenization", () => {

--- a/crates/agent-gui/test/skills/explicit-skill-mentions.test.mjs
+++ b/crates/agent-gui/test/skills/explicit-skill-mentions.test.mjs
@@ -23,19 +23,24 @@ const enabledSkills = [
 test("extractSkillMentionNamesFromText finds explicit skill tokens without treating common env vars as skills", () => {
   assert.deepEqual(
     skills.extractSkillMentionNamesFromText(
-      "Use $code-review and $release_notes, keep $PATH literal and ignore price$tags.",
+      "Use /code-review and /release_notes, keep /usr/bin literal and ignore price/tags.",
     ),
     ["code-review", "release_notes"],
   );
-  assert.deepEqual(skills.extractSkillMentionNamesFromText("$liveagent-code-review"), [
+  assert.deepEqual(skills.extractSkillMentionNamesFromText("/liveagent-code-review"), [
     "liveagent-code-review",
   ]);
+  // "$" is no longer a skill mention marker.
+  assert.deepEqual(
+    skills.extractSkillMentionNamesFromText("Use $code-review and $release_notes."),
+    [],
+  );
 });
 
 test("resolveExplicitSkillMentions only returns enabled skills and deduplicates structured/text mentions", () => {
   assert.deepEqual(
     skills.resolveExplicitSkillMentions({
-      text: "$disabled $release_notes $code-review $code-review",
+      text: "/disabled /release_notes /code-review /code-review",
       structured: [
         {
           name: "code-review",
@@ -67,7 +72,7 @@ test("buildSkillsSystemPrompt marks explicit mentions without granting disabled 
   assert.match(prompt, /Explicitly mentioned this turn:/);
   assert.match(prompt, /- code-review \(skillFile: code-review\/SKILL\.md, baseDir: code-review\)/);
   assert.doesNotMatch(prompt, /disabled\/SKILL\.md/);
-  assert.ok(prompt.includes("`$` mentions never grant access to disabled Skills"));
+  assert.ok(prompt.includes("`/` mentions never grant access to disabled Skills"));
   assert.match(prompt, /skill:\/\/<baseDir>\/\.\.\./);
   assert.doesNotMatch(prompt, /root=["']skills["']/);
   assert.doesNotMatch(prompt, /Read\(root=/);


### PR DESCRIPTION
## Summary

Changes the skill mention trigger in the chat composer from `$` to `/`, mirrored across both frontends (agent-gui and agent-gateway/web).

- Typing `/` at a word boundary opens the skill suggestion popup; selected skills serialize as `/skill-name`.
- The `$` marker is fully removed from detection, tokenization, and explicit-mention extraction. Legacy `$skill` tokens in old transcripts intentionally render as plain text (no compatibility branch kept).
- Path disambiguation: a name followed by another slash (e.g. `/usr/bin`) is treated as a filesystem path, not a skill — enforced both in the composer's `detectMention` and in the text tokenizers.
- `/` only triggers at a word boundary, so slashes inside an `@file` query (e.g. `@docs/foo`) do not steal the trigger.
- Input hint copy (zh/en) and the skills system prompt updated to the new marker; `lib/skills/index.ts` kept byte-identical between the two frontends per the mirror manifest.

## Test plan

- [x] agent-gui full suite: 1060/1060 pass
- [x] agent-gateway/web full suite: 368/368 pass
- [x] `tsc --noEmit` clean on both frontends
- [x] Skill mention tests updated: `/` trigger positives, `/usr/bin` path negative, `$` tokens now asserted as non-mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)