### PR TITLE
fix(skills-hub): 修复多选操作栏被撤销提示阻塞

### DIFF
--- a/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
@@ -1606,440 +1606,432 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
                     </div>
                   </GlassPanel>
                 </div>
-              ) : (
-                view === "installed" ? (
-                    <div
-                      className={cn(
-                        "h-full min-h-0 overflow-y-auto px-0.5 pr-1 pt-1.5",
-                        bulkMode ? "pb-24" : "pb-4",
-                      )}
-                    >
-                      <div className="flex flex-col gap-5">
-                        {loadError ? (
-                          <GlassPanel tone="error" className="hub-panel-enter">
-                            <div className="flex items-center gap-2">
-                              <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" />
-                              <span className="text-xs text-destructive">{loadError}</span>
-                            </div>
-                          </GlassPanel>
-                        ) : null}
+              ) : view === "installed" ? (
+                <div
+                  className={cn(
+                    "h-full min-h-0 overflow-y-auto px-0.5 pr-1 pt-1.5",
+                    bulkMode ? "pb-24" : "pb-4",
+                  )}
+                >
+                  <div className="flex flex-col gap-5">
+                    {loadError ? (
+                      <GlassPanel tone="error" className="hub-panel-enter">
+                        <div className="flex items-center gap-2">
+                          <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" />
+                          <span className="text-xs text-destructive">{loadError}</span>
+                        </div>
+                      </GlassPanel>
+                    ) : null}
 
-                        {!skillsEnabled ? (
-                          <GlassPanel tone="muted" className="hub-panel-enter">
-                            <div className="flex items-center gap-2">
-                              <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-                              <span className="text-xs text-muted-foreground">
-                                {t("settings.skillsDisabledHint")}
-                              </span>
-                            </div>
-                          </GlassPanel>
-                        ) : null}
+                    {!skillsEnabled ? (
+                      <GlassPanel tone="muted" className="hub-panel-enter">
+                        <div className="flex items-center gap-2">
+                          <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                          <span className="text-xs text-muted-foreground">
+                            {t("settings.skillsDisabledHint")}
+                          </span>
+                        </div>
+                      </GlassPanel>
+                    ) : null}
 
-                        {!loading && skills.length === 0 && !loadError ? (
-                          <GlassPanel className="hub-panel-enter">
-                            <div className="flex flex-col items-center gap-3 py-8 text-center">
-                              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/60">
-                                <BookOpen className="h-5 w-5 text-muted-foreground" />
+                    {!loading && skills.length === 0 && !loadError ? (
+                      <GlassPanel className="hub-panel-enter">
+                        <div className="flex flex-col items-center gap-3 py-8 text-center">
+                          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/60">
+                            <BookOpen className="h-5 w-5 text-muted-foreground" />
+                          </div>
+                          <div className="space-y-1">
+                            <p className="text-sm font-medium text-muted-foreground">
+                              {t("settings.skillsNotFound")}
+                            </p>
+                            <p className="text-xs text-muted-foreground/70">
+                              {t("settings.skillsNotFoundHint")}
+                            </p>
+                          </div>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="mt-1 gap-1.5 rounded-full"
+                            onClick={() => void refresh()}
+                          >
+                            <RefreshCw className="h-3.5 w-3.5" />
+                            {t("settings.skillsRescan")}
+                          </Button>
+                        </div>
+                      </GlassPanel>
+                    ) : null}
+
+                    {loading && skills.length === 0 ? (
+                      <>
+                        <div className="hub-frost-hero hub-panel-enter px-4 py-3.5">
+                          <div className="flex items-center gap-3.5">
+                            <FrostSpinner />
+                            <div className="min-w-0 flex-1">
+                              <div className="text-[13px] font-medium tracking-tight text-foreground">
+                                {t("settings.skillsScanning")}
                               </div>
-                              <div className="space-y-1">
-                                <p className="text-sm font-medium text-muted-foreground">
-                                  {t("settings.skillsNotFound")}
-                                </p>
-                                <p className="text-xs text-muted-foreground/70">
-                                  {t("settings.skillsNotFoundHint")}
-                                </p>
+                              <div className="mt-0.5 truncate text-[11px] text-muted-foreground/80">
+                                {t("settings.skillsHubScanning")}
                               </div>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                className="mt-1 gap-1.5 rounded-full"
-                                onClick={() => void refresh()}
-                              >
-                                <RefreshCw className="h-3.5 w-3.5" />
-                                {t("settings.skillsRescan")}
-                              </Button>
-                            </div>
-                          </GlassPanel>
-                        ) : null}
-
-                        {loading && skills.length === 0 ? (
-                          <>
-                            <div className="hub-frost-hero hub-panel-enter px-4 py-3.5">
-                              <div className="flex items-center gap-3.5">
-                                <FrostSpinner />
-                                <div className="min-w-0 flex-1">
-                                  <div className="text-[13px] font-medium tracking-tight text-foreground">
-                                    {t("settings.skillsScanning")}
-                                  </div>
-                                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground/80">
-                                    {t("settings.skillsHubScanning")}
-                                  </div>
-                                </div>
-                              </div>
-                              <div className="hub-frost-track mt-3.5" />
-                            </div>
-
-                            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                              {[1, 2, 3, 4, 5, 6].map((item) => (
-                                <div
-                                  key={item}
-                                  className="hub-frost-skeleton skill-card-enter p-3.5"
-                                >
-                                  <div className="flex items-center gap-3">
-                                    <div className="skills-skeleton-shimmer h-9 w-9 shrink-0 rounded-lg" />
-                                    <div className="flex-1 space-y-2">
-                                      <div className="skills-skeleton-shimmer h-3.5 w-28 rounded" />
-                                      <div className="skills-skeleton-shimmer h-3 w-full max-w-[12rem] rounded" />
-                                    </div>
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          </>
-                        ) : null}
-
-                        {filtered.length > 0 ? (
-                          <div className="flex flex-col gap-3">
-                            {bulkMode ? (
-                              <div className="hub-panel-enter flex items-center gap-2 text-[11px] text-muted-foreground/80">
-                                <ListChecks className="h-3.5 w-3.5 shrink-0" />
-                                <span>{t("settings.skillsBulkHint")}</span>
-                              </div>
-                            ) : null}
-                            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                              {filtered.map((skill) => {
-                                const alwaysEnabled = isAlwaysEnabledSkillName(skill.name);
-                                const checked = alwaysEnabled || selected.has(skill.name);
-                                const bulkSelected = bulkSelection.has(skill.name);
-                                const deleting = deletingSkillName === skill.name;
-                                const deleteDisabled = deletingSkillName !== null;
-                                const card = (
-                                  <>
-                                    <div className="flex items-start justify-between gap-2">
-                                      <div
-                                        className={cn(
-                                          "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border transition-all",
-                                          checked
-                                            ? "border-border/55 bg-background/80 text-foreground/85 shadow-[0_1px_0_rgba(255,255,255,0.55)_inset] dark:border-white/[0.09] dark:bg-white/[0.06] dark:shadow-[0_1px_0_rgba(255,255,255,0.06)_inset]"
-                                            : "border-border/30 bg-muted/50 text-muted-foreground group-hover:border-border/50 group-hover:bg-background/70 group-hover:text-foreground/85",
-                                        )}
-                                      >
-                                        <SkillIcon className="h-6 w-6" />
-                                      </div>
-
-                                      {alwaysEnabled && !bulkMode ? (
-                                        <div
-                                          className="inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.06] px-2 py-0.5 text-[10px] font-medium text-foreground/75 ring-1 ring-border/45"
-                                          title={t("settings.skillsAlwaysOn")}
-                                        >
-                                          <Lock className="h-2.5 w-2.5" />
-                                          <span>{t("settings.skillsAlwaysOn")}</span>
-                                        </div>
-                                      ) : bulkMode ? (
-                                        alwaysEnabled ? (
-                                          <div
-                                            className="flex shrink-0 items-center"
-                                            title={t("settings.skillsBulkAlwaysOnDisabled")}
-                                          >
-                                            <span
-                                              aria-hidden="true"
-                                              className="pointer-events-none flex h-5 w-5 items-center justify-center rounded-full border border-border/50 bg-muted/40 text-muted-foreground/50 opacity-60"
-                                            >
-                                              <Lock className="h-2.5 w-2.5" />
-                                            </span>
-                                          </div>
-                                        ) : (
-                                          <div
-                                            className="flex shrink-0 items-center"
-                                            onClick={(event) => event.stopPropagation()}
-                                            onKeyDown={(event) => event.stopPropagation()}
-                                          >
-                                            <label
-                                              className="relative flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center"
-                                              title={t("settings.skillsHubBulkSelectLabel")}
-                                            >
-                                              <input
-                                                type="checkbox"
-                                                checked={bulkSelection.has(skill.name)}
-                                                aria-label={`${t("settings.skillsHubBulkSelectLabel")}: ${skill.name}`}
-                                                onClick={(event) => event.stopPropagation()}
-                                                onChange={(event) => {
-                                                  event.stopPropagation();
-                                                  toggleBulkSelectionName(skill.name);
-                                                }}
-                                                className="peer sr-only"
-                                              />
-                                              <span
-                                                aria-hidden="true"
-                                                className={cn(
-                                                  "pointer-events-none flex h-5 w-5 items-center justify-center rounded-full border transition-all",
-                                                  bulkSelection.has(skill.name)
-                                                    ? "border-primary bg-primary text-primary-foreground"
-                                                    : "border-border bg-background group-hover:border-foreground/40",
-                                                )}
-                                              >
-                                                {bulkSelection.has(skill.name) ? (
-                                                  <Check className="h-3 w-3" />
-                                                ) : null}
-                                              </span>
-                                            </label>
-                                          </div>
-                                        )
-                                      ) : (
-                                        <div
-                                          className="flex shrink-0 items-center gap-1.5"
-                                          onClick={(event) => event.stopPropagation()}
-                                          onKeyDown={(event) => event.stopPropagation()}
-                                        >
-                                          <button
-                                            type="button"
-                                            aria-label={`${t("settings.skillsHubBulkSelectLabel")}: ${skill.name}`}
-                                            title={t("settings.skillsHubBulkSelect")}
-                                            onClick={(event) => {
-                                              event.stopPropagation();
-                                              enterBulkMode(skill.name);
-                                            }}
-                                            className={cn(
-                                              // Google Photos-style bulk entry: hover-faint, touch semi-visible.
-                                              "relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-border/60 bg-background/90 text-muted-foreground shadow-sm transition-all hover:border-primary/50 hover:text-foreground",
-                                              "opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-70",
-                                            )}
-                                          >
-                                            <span className="h-2 w-2 rounded-full border border-current opacity-40" />
-                                          </button>
-                                          <button
-                                            type="button"
-                                            role="switch"
-                                            aria-checked={checked}
-                                            aria-label={`${t("skills.select")}: ${skill.name}`}
-                                            title={
-                                              checked
-                                                ? t("settings.skillsHubToggleDisable")
-                                                : t("settings.skillsHubToggleEnable")
-                                            }
-                                            onClick={(event) => {
-                                              event.stopPropagation();
-                                              toggleSkill(skill.name, !checked);
-                                            }}
-                                            className={cn(
-                                              "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full ring-1 transition-all",
-                                              checked
-                                                ? "bg-emerald-500 ring-emerald-400/45"
-                                                : "bg-muted-foreground/25 ring-border/40",
-                                            )}
-                                          >
-                                            <span
-                                              className={cn(
-                                                "pointer-events-none inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform",
-                                                checked
-                                                  ? "translate-x-[1.05rem]"
-                                                  : "translate-x-[0.15rem]",
-                                              )}
-                                            />
-                                          </button>
-                                        </div>
-                                      )}
-                                    </div>
-
-                                    <div className="mt-2.5 min-w-0 flex-1">
-                                      <div className="flex min-w-0 items-center gap-1.5">
-                                        <div className="truncate text-[13px] font-semibold leading-tight text-foreground">
-                                          {skill.name}
-                                        </div>
-                                        {checked ? (
-                                          <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-500/12 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 ring-1 ring-emerald-500/25 dark:bg-emerald-400/12 dark:text-emerald-300 dark:ring-emerald-400/25">
-                                            {t("settings.skillsHubEnabledBadge")}
-                                          </span>
-                                        ) : null}
-                                      </div>
-                                      {skill.description ? (
-                                        <p className="mt-1 line-clamp-2 text-[11.5px] leading-[1.4] text-muted-foreground">
-                                          {skill.description}
-                                        </p>
-                                      ) : null}
-                                    </div>
-
-                                    <div className="mt-2.5 flex min-h-8 items-center gap-1 border-t border-border/30 pt-2 text-[10.5px] text-muted-foreground/70">
-                                      <FileText className="h-3 w-3 shrink-0" />
-                                      <span className="truncate">{skill.skillFile}</span>
-                                      {!alwaysEnabled && !bulkMode ? (
-                                        <div
-                                          className="ml-auto shrink-0"
-                                          onClick={(event) => event.stopPropagation()}
-                                          onKeyDown={(event) => event.stopPropagation()}
-                                        >
-                                          <ConfirmDeletePopover
-                                            name={skill.name}
-                                            onConfirm={() => void deleteSkill(skill)}
-                                          >
-                                            {(open) => (
-                                              <button
-                                                type="button"
-                                                disabled={deleteDisabled}
-                                                onClick={(event) => {
-                                                  event.stopPropagation();
-                                                  open();
-                                                }}
-                                                className={cn(
-                                                  "flex h-6 w-6 items-center justify-center rounded-md border border-border/35 bg-background/65 text-muted-foreground transition-all",
-                                                  "hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive",
-                                                  "disabled:cursor-not-allowed",
-                                                  // Hover-revealed on pointer devices; keyboard focus and
-                                                  // touch (no hover — webui mobile) keep it reachable.
-                                                  deleting
-                                                    ? "pointer-events-auto opacity-100"
-                                                    : cn(
-                                                        "pointer-events-none opacity-0 group-hover:pointer-events-auto focus-visible:pointer-events-auto [@media(hover:none)]:pointer-events-auto",
-                                                        deleteDisabled
-                                                          ? "group-hover:opacity-60 focus-visible:opacity-60 [@media(hover:none)]:opacity-60"
-                                                          : "group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100",
-                                                      ),
-                                                )}
-                                                title={t("settings.skillsHubDeleteSkill")}
-                                              >
-                                                {deleting ? (
-                                                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                                                ) : (
-                                                  <Trash2 className="h-3.5 w-3.5" />
-                                                )}
-                                              </button>
-                                            )}
-                                          </ConfirmDeletePopover>
-                                        </div>
-                                      ) : null}
-                                    </div>
-                                  </>
-                                );
-
-                                const key = `${skill.name}-${rootDir}`;
-                                if (alwaysEnabled) {
-                                  return (
-                                    <button
-                                      key={key}
-                                      type="button"
-                                      aria-label={`${t("settings.skillsInstalledPreviewOpen")}: ${skill.name}`}
-                                      onClick={() => {
-                                        if (bulkMode) return;
-                                        openInstalledSkillPreview(skill);
-                                      }}
-                                      className={cn(
-                                        "hub-skill-card skill-card-enter group flex h-full w-full cursor-pointer flex-col rounded-2xl border border-border/50 bg-background/75 p-3.5 text-left backdrop-blur-xl shadow-[0_1px_0_rgba(255,255,255,0.55)_inset,0_4px_18px_-12px_rgba(15,23,42,0.16)] transition-all hover:-translate-y-0.5 hover:border-border/60 hover:bg-background/85 hover:shadow-[0_4px_16px_-10px_rgba(15,23,42,0.18)] dark:border-white/[0.08] dark:bg-white/[0.05] dark:shadow-[0_1px_0_rgba(255,255,255,0.05)_inset,0_4px_18px_-12px_rgba(0,0,0,0.5)] dark:hover:border-white/[0.12] dark:hover:bg-white/[0.07] dark:hover:shadow-[0_4px_16px_-10px_rgba(0,0,0,0.55)] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-foreground/15",
-                                        bulkMode ? "cursor-default hover:translate-y-0" : null,
-                                      )}
-                                    >
-                                      {card}
-                                    </button>
-                                  );
-                                }
-
-                                return (
-                                  // biome-ignore lint/a11y/useSemanticElements: The card contains nested controls and cannot be a native button.
-                                  <div
-                                    key={key}
-                                    role="button"
-                                    tabIndex={0}
-                                    aria-label={`${t("settings.skillsInstalledPreviewOpen")}: ${skill.name}`}
-                                    onClick={(event) => {
-                                      if (bulkMode) {
-                                        handleBulkInstalledCardClick(
-                                          skill.name,
-                                          filtered.map((item) => item.name),
-                                          event.shiftKey,
-                                        );
-                                        return;
-                                      }
-                                      openInstalledSkillPreview(skill);
-                                    }}
-                                    onMouseDown={(event) => {
-                                      if (bulkMode && event.shiftKey) event.preventDefault();
-                                    }}
-                                    onKeyDown={(event) => {
-                                      if (
-                                        bulkMode &&
-                                        (event.key === "Enter" || event.key === " ")
-                                      ) {
-                                        event.preventDefault();
-                                        handleBulkInstalledCardClick(
-                                          skill.name,
-                                          filtered.map((item) => item.name),
-                                          event.shiftKey,
-                                        );
-                                        return;
-                                      }
-                                      handleInstalledSkillCardKeyDown(event, skill);
-                                    }}
-                                    className={cn(
-                                      "hub-skill-card skill-card-enter group relative flex h-full w-full flex-col rounded-2xl border p-3.5 text-left transition-all",
-                                      "cursor-pointer backdrop-blur-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-foreground/15",
-                                      checked
-                                        ? "border-emerald-500/35 bg-emerald-50/90 shadow-[0_1px_0_rgba(255,255,255,0.55)_inset,0_4px_14px_-12px_rgba(16,185,129,0.28)] dark:border-emerald-400/30 dark:bg-emerald-500/12 dark:shadow-[0_1px_0_rgba(255,255,255,0.05)_inset,0_4px_14px_-12px_rgba(16,185,129,0.22)]"
-                                        : "border-border/40 bg-muted/45 text-muted-foreground shadow-none hover:-translate-y-0.5 hover:border-border/55 hover:bg-muted/55 dark:border-white/[0.06] dark:bg-white/[0.025] dark:hover:border-white/[0.10] dark:hover:bg-white/[0.04]",
-                                      bulkSelected
-                                        ? "ring-2 ring-primary/50 ring-offset-1 ring-offset-background"
-                                        : null,
-                                    )}
-                                  >
-                                    {card}
-                                  </div>
-                                );
-                              })}
                             </div>
                           </div>
-                        ) : null}
+                          <div className="hub-frost-track mt-3.5" />
+                        </div>
 
-                        {filter.trim() && filtered.length === 0 && skills.length > 0 ? (
-                          <GlassPanel tone="muted" className="hub-panel-enter">
-                            <p className="py-2 text-center text-sm text-muted-foreground">
-                              {t("settings.skillsNoMatch").replace("{filter}", filter)}
-                            </p>
-                          </GlassPanel>
+                        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                          {[1, 2, 3, 4, 5, 6].map((item) => (
+                            <div key={item} className="hub-frost-skeleton skill-card-enter p-3.5">
+                              <div className="flex items-center gap-3">
+                                <div className="skills-skeleton-shimmer h-9 w-9 shrink-0 rounded-lg" />
+                                <div className="flex-1 space-y-2">
+                                  <div className="skills-skeleton-shimmer h-3.5 w-28 rounded" />
+                                  <div className="skills-skeleton-shimmer h-3 w-full max-w-[12rem] rounded" />
+                                </div>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </>
+                    ) : null}
+
+                    {filtered.length > 0 ? (
+                      <div className="flex flex-col gap-3">
+                        {bulkMode ? (
+                          <div className="hub-panel-enter flex items-center gap-2 text-[11px] text-muted-foreground/80">
+                            <ListChecks className="h-3.5 w-3.5 shrink-0" />
+                            <span>{t("settings.skillsBulkHint")}</span>
+                          </div>
                         ) : null}
+                        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                          {filtered.map((skill) => {
+                            const alwaysEnabled = isAlwaysEnabledSkillName(skill.name);
+                            const checked = alwaysEnabled || selected.has(skill.name);
+                            const bulkSelected = bulkSelection.has(skill.name);
+                            const deleting = deletingSkillName === skill.name;
+                            const deleteDisabled = deletingSkillName !== null;
+                            const card = (
+                              <>
+                                <div className="flex items-start justify-between gap-2">
+                                  <div
+                                    className={cn(
+                                      "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border transition-all",
+                                      checked
+                                        ? "border-border/55 bg-background/80 text-foreground/85 shadow-[0_1px_0_rgba(255,255,255,0.55)_inset] dark:border-white/[0.09] dark:bg-white/[0.06] dark:shadow-[0_1px_0_rgba(255,255,255,0.06)_inset]"
+                                        : "border-border/30 bg-muted/50 text-muted-foreground group-hover:border-border/50 group-hover:bg-background/70 group-hover:text-foreground/85",
+                                    )}
+                                  >
+                                    <SkillIcon className="h-6 w-6" />
+                                  </div>
+
+                                  {alwaysEnabled && !bulkMode ? (
+                                    <div
+                                      className="inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.06] px-2 py-0.5 text-[10px] font-medium text-foreground/75 ring-1 ring-border/45"
+                                      title={t("settings.skillsAlwaysOn")}
+                                    >
+                                      <Lock className="h-2.5 w-2.5" />
+                                      <span>{t("settings.skillsAlwaysOn")}</span>
+                                    </div>
+                                  ) : bulkMode ? (
+                                    alwaysEnabled ? (
+                                      <div
+                                        className="flex shrink-0 items-center"
+                                        title={t("settings.skillsBulkAlwaysOnDisabled")}
+                                      >
+                                        <span
+                                          aria-hidden="true"
+                                          className="pointer-events-none flex h-5 w-5 items-center justify-center rounded-full border border-border/50 bg-muted/40 text-muted-foreground/50 opacity-60"
+                                        >
+                                          <Lock className="h-2.5 w-2.5" />
+                                        </span>
+                                      </div>
+                                    ) : (
+                                      <div
+                                        className="flex shrink-0 items-center"
+                                        onClick={(event) => event.stopPropagation()}
+                                        onKeyDown={(event) => event.stopPropagation()}
+                                      >
+                                        <label
+                                          className="relative flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center"
+                                          title={t("settings.skillsHubBulkSelectLabel")}
+                                        >
+                                          <input
+                                            type="checkbox"
+                                            checked={bulkSelection.has(skill.name)}
+                                            aria-label={`${t("settings.skillsHubBulkSelectLabel")}: ${skill.name}`}
+                                            onClick={(event) => event.stopPropagation()}
+                                            onChange={(event) => {
+                                              event.stopPropagation();
+                                              toggleBulkSelectionName(skill.name);
+                                            }}
+                                            className="peer sr-only"
+                                          />
+                                          <span
+                                            aria-hidden="true"
+                                            className={cn(
+                                              "pointer-events-none flex h-5 w-5 items-center justify-center rounded-full border transition-all",
+                                              bulkSelection.has(skill.name)
+                                                ? "border-primary bg-primary text-primary-foreground"
+                                                : "border-border bg-background group-hover:border-foreground/40",
+                                            )}
+                                          >
+                                            {bulkSelection.has(skill.name) ? (
+                                              <Check className="h-3 w-3" />
+                                            ) : null}
+                                          </span>
+                                        </label>
+                                      </div>
+                                    )
+                                  ) : (
+                                    <div
+                                      className="flex shrink-0 items-center gap-1.5"
+                                      onClick={(event) => event.stopPropagation()}
+                                      onKeyDown={(event) => event.stopPropagation()}
+                                    >
+                                      <button
+                                        type="button"
+                                        aria-label={`${t("settings.skillsHubBulkSelectLabel")}: ${skill.name}`}
+                                        title={t("settings.skillsHubBulkSelect")}
+                                        onClick={(event) => {
+                                          event.stopPropagation();
+                                          enterBulkMode(skill.name);
+                                        }}
+                                        className={cn(
+                                          // Google Photos-style bulk entry: hover-faint, touch semi-visible.
+                                          "relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-border/60 bg-background/90 text-muted-foreground shadow-sm transition-all hover:border-primary/50 hover:text-foreground",
+                                          "opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-70",
+                                        )}
+                                      >
+                                        <span className="h-2 w-2 rounded-full border border-current opacity-40" />
+                                      </button>
+                                      <button
+                                        type="button"
+                                        role="switch"
+                                        aria-checked={checked}
+                                        aria-label={`${t("skills.select")}: ${skill.name}`}
+                                        title={
+                                          checked
+                                            ? t("settings.skillsHubToggleDisable")
+                                            : t("settings.skillsHubToggleEnable")
+                                        }
+                                        onClick={(event) => {
+                                          event.stopPropagation();
+                                          toggleSkill(skill.name, !checked);
+                                        }}
+                                        className={cn(
+                                          "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full ring-1 transition-all",
+                                          checked
+                                            ? "bg-emerald-500 ring-emerald-400/45"
+                                            : "bg-muted-foreground/25 ring-border/40",
+                                        )}
+                                      >
+                                        <span
+                                          className={cn(
+                                            "pointer-events-none inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform",
+                                            checked
+                                              ? "translate-x-[1.05rem]"
+                                              : "translate-x-[0.15rem]",
+                                          )}
+                                        />
+                                      </button>
+                                    </div>
+                                  )}
+                                </div>
+
+                                <div className="mt-2.5 min-w-0 flex-1">
+                                  <div className="flex min-w-0 items-center gap-1.5">
+                                    <div className="truncate text-[13px] font-semibold leading-tight text-foreground">
+                                      {skill.name}
+                                    </div>
+                                    {checked ? (
+                                      <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-500/12 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 ring-1 ring-emerald-500/25 dark:bg-emerald-400/12 dark:text-emerald-300 dark:ring-emerald-400/25">
+                                        {t("settings.skillsHubEnabledBadge")}
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                  {skill.description ? (
+                                    <p className="mt-1 line-clamp-2 text-[11.5px] leading-[1.4] text-muted-foreground">
+                                      {skill.description}
+                                    </p>
+                                  ) : null}
+                                </div>
+
+                                <div className="mt-2.5 flex min-h-8 items-center gap-1 border-t border-border/30 pt-2 text-[10.5px] text-muted-foreground/70">
+                                  <FileText className="h-3 w-3 shrink-0" />
+                                  <span className="truncate">{skill.skillFile}</span>
+                                  {!alwaysEnabled && !bulkMode ? (
+                                    <div
+                                      className="ml-auto shrink-0"
+                                      onClick={(event) => event.stopPropagation()}
+                                      onKeyDown={(event) => event.stopPropagation()}
+                                    >
+                                      <ConfirmDeletePopover
+                                        name={skill.name}
+                                        onConfirm={() => void deleteSkill(skill)}
+                                      >
+                                        {(open) => (
+                                          <button
+                                            type="button"
+                                            disabled={deleteDisabled}
+                                            onClick={(event) => {
+                                              event.stopPropagation();
+                                              open();
+                                            }}
+                                            className={cn(
+                                              "flex h-6 w-6 items-center justify-center rounded-md border border-border/35 bg-background/65 text-muted-foreground transition-all",
+                                              "hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive",
+                                              "disabled:cursor-not-allowed",
+                                              // Hover-revealed on pointer devices; keyboard focus and
+                                              // touch (no hover — webui mobile) keep it reachable.
+                                              deleting
+                                                ? "pointer-events-auto opacity-100"
+                                                : cn(
+                                                    "pointer-events-none opacity-0 group-hover:pointer-events-auto focus-visible:pointer-events-auto [@media(hover:none)]:pointer-events-auto",
+                                                    deleteDisabled
+                                                      ? "group-hover:opacity-60 focus-visible:opacity-60 [@media(hover:none)]:opacity-60"
+                                                      : "group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100",
+                                                  ),
+                                            )}
+                                            title={t("settings.skillsHubDeleteSkill")}
+                                          >
+                                            {deleting ? (
+                                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                            ) : (
+                                              <Trash2 className="h-3.5 w-3.5" />
+                                            )}
+                                          </button>
+                                        )}
+                                      </ConfirmDeletePopover>
+                                    </div>
+                                  ) : null}
+                                </div>
+                              </>
+                            );
+
+                            const key = `${skill.name}-${rootDir}`;
+                            if (alwaysEnabled) {
+                              return (
+                                <button
+                                  key={key}
+                                  type="button"
+                                  aria-label={`${t("settings.skillsInstalledPreviewOpen")}: ${skill.name}`}
+                                  onClick={() => {
+                                    if (bulkMode) return;
+                                    openInstalledSkillPreview(skill);
+                                  }}
+                                  className={cn(
+                                    "hub-skill-card skill-card-enter group flex h-full w-full cursor-pointer flex-col rounded-2xl border border-border/50 bg-background/75 p-3.5 text-left backdrop-blur-xl shadow-[0_1px_0_rgba(255,255,255,0.55)_inset,0_4px_18px_-12px_rgba(15,23,42,0.16)] transition-all hover:-translate-y-0.5 hover:border-border/60 hover:bg-background/85 hover:shadow-[0_4px_16px_-10px_rgba(15,23,42,0.18)] dark:border-white/[0.08] dark:bg-white/[0.05] dark:shadow-[0_1px_0_rgba(255,255,255,0.05)_inset,0_4px_18px_-12px_rgba(0,0,0,0.5)] dark:hover:border-white/[0.12] dark:hover:bg-white/[0.07] dark:hover:shadow-[0_4px_16px_-10px_rgba(0,0,0,0.55)] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-foreground/15",
+                                    bulkMode ? "cursor-default hover:translate-y-0" : null,
+                                  )}
+                                >
+                                  {card}
+                                </button>
+                              );
+                            }
+
+                            return (
+                              // biome-ignore lint/a11y/useSemanticElements: The card contains nested controls and cannot be a native button.
+                              <div
+                                key={key}
+                                role="button"
+                                tabIndex={0}
+                                aria-label={`${t("settings.skillsInstalledPreviewOpen")}: ${skill.name}`}
+                                onClick={(event) => {
+                                  if (bulkMode) {
+                                    handleBulkInstalledCardClick(
+                                      skill.name,
+                                      filtered.map((item) => item.name),
+                                      event.shiftKey,
+                                    );
+                                    return;
+                                  }
+                                  openInstalledSkillPreview(skill);
+                                }}
+                                onMouseDown={(event) => {
+                                  if (bulkMode && event.shiftKey) event.preventDefault();
+                                }}
+                                onKeyDown={(event) => {
+                                  if (bulkMode && (event.key === "Enter" || event.key === " ")) {
+                                    event.preventDefault();
+                                    handleBulkInstalledCardClick(
+                                      skill.name,
+                                      filtered.map((item) => item.name),
+                                      event.shiftKey,
+                                    );
+                                    return;
+                                  }
+                                  handleInstalledSkillCardKeyDown(event, skill);
+                                }}
+                                className={cn(
+                                  "hub-skill-card skill-card-enter group relative flex h-full w-full flex-col rounded-2xl border p-3.5 text-left transition-all",
+                                  "cursor-pointer backdrop-blur-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-foreground/15",
+                                  checked
+                                    ? "border-emerald-500/35 bg-emerald-50/90 shadow-[0_1px_0_rgba(255,255,255,0.55)_inset,0_4px_14px_-12px_rgba(16,185,129,0.28)] dark:border-emerald-400/30 dark:bg-emerald-500/12 dark:shadow-[0_1px_0_rgba(255,255,255,0.05)_inset,0_4px_14px_-12px_rgba(16,185,129,0.22)]"
+                                    : "border-border/40 bg-muted/45 text-muted-foreground shadow-none hover:-translate-y-0.5 hover:border-border/55 hover:bg-muted/55 dark:border-white/[0.06] dark:bg-white/[0.025] dark:hover:border-white/[0.10] dark:hover:bg-white/[0.04]",
+                                  bulkSelected
+                                    ? "ring-2 ring-primary/50 ring-offset-1 ring-offset-background"
+                                    : null,
+                                )}
+                              >
+                                {card}
+                              </div>
+                            );
+                          })}
+                        </div>
                       </div>
-                    </div>
-                  ) : view === "store" ? (
-                    <SkillsStoreView
-                      items={storeItems}
-                      query={storeQuery}
-                      sort={storeSort}
-                      loading={storeLoading}
-                      loadingMore={storeLoadingMore}
-                      error={storeError}
-                      cursor={storeCursor}
-                      installedKeys={installedStoreKeys}
-                      installedSlugs={installedStoreSlugs}
-                      pendingInstallKeys={pendingInstallKeys}
-                      installingByStoreKey={installingByStoreKey}
-                      installJobs={installJobs}
-                      onSortChange={setStoreSort}
-                      onLoadMore={() => void loadMoreStore()}
-                      onInstall={(skill) => void installStoreSkill(skill)}
-                    />
-                  ) : (
-                    <SkillsImportView
-                      scans={externalScans ?? []}
-                      loading={externalLoading}
-                      error={externalError}
-                      query={importQuery}
-                      selected={selectedExternal}
-                      installedNames={installedSkillNames}
-                      importProgress={importProgress}
-                      importErrors={importErrors}
-                      importedCount={importedCount}
-                      importToast={importToast}
-                      onDismissImportToast={() => {
-                        if (importToastTimerRef.current !== null) {
-                          window.clearTimeout(importToastTimerRef.current);
-                          importToastTimerRef.current = null;
-                        }
-                        setImportToast(null);
-                      }}
-                      bulkMode={bulkMode}
-                      onToggle={toggleExternalSkill}
-                      onBatchToggle={setExternalSkillsSelected}
-                      onRescan={() => void rescanExternalSkills()}
-                      onImport={() => void importSelectedExternalSkills()}
-                    />
-                  )
+                    ) : null}
+
+                    {filter.trim() && filtered.length === 0 && skills.length > 0 ? (
+                      <GlassPanel tone="muted" className="hub-panel-enter">
+                        <p className="py-2 text-center text-sm text-muted-foreground">
+                          {t("settings.skillsNoMatch").replace("{filter}", filter)}
+                        </p>
+                      </GlassPanel>
+                    ) : null}
+                  </div>
+                </div>
+              ) : view === "store" ? (
+                <SkillsStoreView
+                  items={storeItems}
+                  query={storeQuery}
+                  sort={storeSort}
+                  loading={storeLoading}
+                  loadingMore={storeLoadingMore}
+                  error={storeError}
+                  cursor={storeCursor}
+                  installedKeys={installedStoreKeys}
+                  installedSlugs={installedStoreSlugs}
+                  pendingInstallKeys={pendingInstallKeys}
+                  installingByStoreKey={installingByStoreKey}
+                  installJobs={installJobs}
+                  onSortChange={setStoreSort}
+                  onLoadMore={() => void loadMoreStore()}
+                  onInstall={(skill) => void installStoreSkill(skill)}
+                />
+              ) : (
+                <SkillsImportView
+                  scans={externalScans ?? []}
+                  loading={externalLoading}
+                  error={externalError}
+                  query={importQuery}
+                  selected={selectedExternal}
+                  installedNames={installedSkillNames}
+                  importProgress={importProgress}
+                  importErrors={importErrors}
+                  importedCount={importedCount}
+                  importToast={importToast}
+                  onDismissImportToast={() => {
+                    if (importToastTimerRef.current !== null) {
+                      window.clearTimeout(importToastTimerRef.current);
+                      importToastTimerRef.current = null;
+                    }
+                    setImportToast(null);
+                  }}
+                  bulkMode={bulkMode}
+                  onToggle={toggleExternalSkill}
+                  onBatchToggle={setExternalSkillsSelected}
+                  onRescan={() => void rescanExternalSkills()}
+                  onImport={() => void importSelectedExternalSkills()}
+                />
               )}
             </div>
           </div>
@@ -2059,9 +2051,9 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
       ) : null}
 
       {bulkMode &&
-        view === "installed" &&
-        !lockedByChatMode &&
-        (!bulkUndo || bulkSelection.size > 0) ? (
+      view === "installed" &&
+      !lockedByChatMode &&
+      (!bulkUndo || bulkSelection.size > 0) ? (
         <div className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center px-3">
           <div className="hub-panel-enter pointer-events-auto flex max-w-full flex-wrap items-center gap-2 rounded-full border border-border/50 bg-background/90 py-2 pl-4 pr-2 text-[12.5px] shadow-[0_8px_24px_-12px_rgba(15,23,42,0.35)] backdrop-blur-xl dark:border-white/[0.1] dark:bg-white/[0.08]">
             {bulkSelection.size > 0 ? (

--- a/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
@@ -1056,44 +1056,53 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
     bulkAnchorRef.current = null;
   }, []);
 
-  const enterBulkMode = useCallback((initialName?: string) => {
-    setBulkMode(true);
-    setPreviewInstalledSkill(null);
-    if (initialName && !isAlwaysEnabledSkillName(initialName)) {
+  const enterBulkMode = useCallback(
+    (initialName?: string) => {
+      setBulkMode(true);
+      setPreviewInstalledSkill(null);
+      if (initialName && !isAlwaysEnabledSkillName(initialName)) {
+        clearBulkUndoTimer();
+        setBulkUndo(null);
+        setBulkSelection(new Set([initialName]));
+        bulkAnchorRef.current = initialName;
+      }
+    },
+    [clearBulkUndoTimer],
+  );
+
+  const toggleBulkSelectionName = useCallback(
+    (name: string) => {
+      if (isAlwaysEnabledSkillName(name)) return;
       clearBulkUndoTimer();
       setBulkUndo(null);
-      setBulkSelection(new Set([initialName]));
-      bulkAnchorRef.current = initialName;
-    }
-  }, [clearBulkUndoTimer]);
+      setBulkSelection((prev) => {
+        const next = new Set(prev);
+        if (next.has(name)) next.delete(name);
+        else next.add(name);
+        return next;
+      });
+      bulkAnchorRef.current = name;
+    },
+    [clearBulkUndoTimer],
+  );
 
-  const toggleBulkSelectionName = useCallback((name: string) => {
-    if (isAlwaysEnabledSkillName(name)) return;
-    clearBulkUndoTimer();
-    setBulkUndo(null);
-    setBulkSelection((prev) => {
-      const next = new Set(prev);
-      if (next.has(name)) next.delete(name);
-      else next.add(name);
-      return next;
-    });
-    bulkAnchorRef.current = name;
-  }, [clearBulkUndoTimer]);
-
-  const setBulkSelectionRange = useCallback((names: readonly string[], select: boolean) => {
-    const selectable = names.filter((name) => !isAlwaysEnabledSkillName(name));
-    if (selectable.length === 0) return;
-    clearBulkUndoTimer();
-    setBulkUndo(null);
-    setBulkSelection((prev) => {
-      const next = new Set(prev);
-      for (const name of selectable) {
-        if (select) next.add(name);
-        else next.delete(name);
-      }
-      return next;
-    });
-  }, [clearBulkUndoTimer]);
+  const setBulkSelectionRange = useCallback(
+    (names: readonly string[], select: boolean) => {
+      const selectable = names.filter((name) => !isAlwaysEnabledSkillName(name));
+      if (selectable.length === 0) return;
+      clearBulkUndoTimer();
+      setBulkUndo(null);
+      setBulkSelection((prev) => {
+        const next = new Set(prev);
+        for (const name of selectable) {
+          if (select) next.add(name);
+          else next.delete(name);
+        }
+        return next;
+      });
+    },
+    [clearBulkUndoTimer],
+  );
 
   function handleBulkInstalledCardClick(name: string, orderedNames: string[], shiftKey: boolean) {
     if (isAlwaysEnabledSkillName(name)) return;

--- a/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
@@ -1607,8 +1607,7 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
                   </GlassPanel>
                 </div>
               ) : (
-                <>
-                  {view === "installed" ? (
+                view === "installed" ? (
                     <div
                       className={cn(
                         "h-full min-h-0 overflow-y-auto px-0.5 pr-1 pt-1.5",
@@ -2040,8 +2039,7 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
                       onRescan={() => void rescanExternalSkills()}
                       onImport={() => void importSelectedExternalSkills()}
                     />
-                  )}
-                </>
+                  )
               )}
             </div>
           </div>

--- a/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
@@ -1060,13 +1060,17 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
     setBulkMode(true);
     setPreviewInstalledSkill(null);
     if (initialName && !isAlwaysEnabledSkillName(initialName)) {
+      clearBulkUndoTimer();
+      setBulkUndo(null);
       setBulkSelection(new Set([initialName]));
       bulkAnchorRef.current = initialName;
     }
-  }, []);
+  }, [clearBulkUndoTimer]);
 
   const toggleBulkSelectionName = useCallback((name: string) => {
     if (isAlwaysEnabledSkillName(name)) return;
+    clearBulkUndoTimer();
+    setBulkUndo(null);
     setBulkSelection((prev) => {
       const next = new Set(prev);
       if (next.has(name)) next.delete(name);
@@ -1074,11 +1078,13 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
       return next;
     });
     bulkAnchorRef.current = name;
-  }, []);
+  }, [clearBulkUndoTimer]);
 
   const setBulkSelectionRange = useCallback((names: readonly string[], select: boolean) => {
     const selectable = names.filter((name) => !isAlwaysEnabledSkillName(name));
     if (selectable.length === 0) return;
+    clearBulkUndoTimer();
+    setBulkUndo(null);
     setBulkSelection((prev) => {
       const next = new Set(prev);
       for (const name of selectable) {
@@ -1087,7 +1093,7 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
       }
       return next;
     });
-  }, []);
+  }, [clearBulkUndoTimer]);
 
   function handleBulkInstalledCardClick(name: string, orderedNames: string[], shiftKey: boolean) {
     if (isAlwaysEnabledSkillName(name)) return;
@@ -2045,7 +2051,10 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
         />
       ) : null}
 
-      {bulkMode && view === "installed" && !lockedByChatMode && !bulkUndo ? (
+      {bulkMode &&
+        view === "installed" &&
+        !lockedByChatMode &&
+        (!bulkUndo || bulkSelection.size > 0) ? (
         <div className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center px-3">
           <div className="hub-panel-enter pointer-events-auto flex max-w-full flex-wrap items-center gap-2 rounded-full border border-border/50 bg-background/90 py-2 pl-4 pr-2 text-[12.5px] shadow-[0_8px_24px_-12px_rgba(15,23,42,0.35)] backdrop-blur-xl dark:border-white/[0.1] dark:bg-white/[0.08]">
             {bulkSelection.size > 0 ? (
@@ -2143,7 +2152,7 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
         </div>
       ) : null}
 
-      {bulkUndo ? (
+      {bulkUndo && bulkSelection.size === 0 ? (
         <div className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center">
           <div className="hub-panel-enter pointer-events-auto flex items-center gap-3 rounded-full border border-border/50 bg-background/90 py-2 pl-4 pr-2 text-[12.5px] shadow-[0_8px_24px_-12px_rgba(15,23,42,0.35)] backdrop-blur-xl dark:border-white/[0.1] dark:bg-white/[0.08]">
             <span className="text-foreground/85">

--- a/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
@@ -1693,460 +1693,455 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
                     </div>
                   </GlassPanel>
                 </div>
-              ) : (
-                view === "installed" ? (
-                    <div
-                      className={cn(
-                        "h-full min-h-0 overflow-y-auto px-0.5 pr-1 pt-1.5",
-                        bulkMode ? "pb-24" : "pb-4",
-                      )}
-                    >
-                      <div className="flex flex-col gap-5">
-                        {skills.length > 0 ? (
-                          <StoreCategoryChips
-                            value={installedCategory}
-                            counts={installedCategoryCounts}
-                            onChange={setInstalledCategory}
-                          />
-                        ) : null}
+              ) : view === "installed" ? (
+                <div
+                  className={cn(
+                    "h-full min-h-0 overflow-y-auto px-0.5 pr-1 pt-1.5",
+                    bulkMode ? "pb-24" : "pb-4",
+                  )}
+                >
+                  <div className="flex flex-col gap-5">
+                    {skills.length > 0 ? (
+                      <StoreCategoryChips
+                        value={installedCategory}
+                        counts={installedCategoryCounts}
+                        onChange={setInstalledCategory}
+                      />
+                    ) : null}
 
-                        {bulkMode ? (
-                          <div className="hub-panel-enter flex items-center gap-2 text-[11px] text-muted-foreground/80">
-                            <ListChecks className="h-3.5 w-3.5 shrink-0" />
-                            <span>{t("settings.skillsBulkHint")}</span>
+                    {bulkMode ? (
+                      <div className="hub-panel-enter flex items-center gap-2 text-[11px] text-muted-foreground/80">
+                        <ListChecks className="h-3.5 w-3.5 shrink-0" />
+                        <span>{t("settings.skillsBulkHint")}</span>
+                      </div>
+                    ) : null}
+
+                    {loadError ? (
+                      <GlassPanel tone="error" className="hub-panel-enter">
+                        <div className="flex items-center gap-2">
+                          <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" />
+                          <span className="text-xs text-destructive">{loadError}</span>
+                        </div>
+                      </GlassPanel>
+                    ) : null}
+
+                    {!skillsEnabled ? (
+                      <GlassPanel tone="muted" className="hub-panel-enter">
+                        <div className="flex items-center gap-2">
+                          <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                          <span className="text-xs text-muted-foreground">
+                            {t("settings.skillsDisabledHint")}
+                          </span>
+                        </div>
+                      </GlassPanel>
+                    ) : null}
+
+                    {!loading && skills.length === 0 && !loadError ? (
+                      <GlassPanel className="hub-panel-enter">
+                        <div className="flex flex-col items-center gap-3 py-8 text-center">
+                          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/60">
+                            <BookOpen className="h-5 w-5 text-muted-foreground" />
                           </div>
-                        ) : null}
+                          <div className="space-y-1">
+                            <p className="text-sm font-medium text-muted-foreground">
+                              {t("settings.skillsNotFound")}
+                            </p>
+                            <p className="text-xs text-muted-foreground/70">
+                              {t("settings.skillsNotFoundHint")}
+                            </p>
+                          </div>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="mt-1 gap-1.5 rounded-full"
+                            onClick={() => void refresh()}
+                          >
+                            <RefreshCw className="h-3.5 w-3.5" />
+                            {t("settings.skillsRescan")}
+                          </Button>
+                        </div>
+                      </GlassPanel>
+                    ) : null}
 
-                        {loadError ? (
-                          <GlassPanel tone="error" className="hub-panel-enter">
-                            <div className="flex items-center gap-2">
-                              <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" />
-                              <span className="text-xs text-destructive">{loadError}</span>
-                            </div>
-                          </GlassPanel>
-                        ) : null}
-
-                        {!skillsEnabled ? (
-                          <GlassPanel tone="muted" className="hub-panel-enter">
-                            <div className="flex items-center gap-2">
-                              <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-                              <span className="text-xs text-muted-foreground">
-                                {t("settings.skillsDisabledHint")}
-                              </span>
-                            </div>
-                          </GlassPanel>
-                        ) : null}
-
-                        {!loading && skills.length === 0 && !loadError ? (
-                          <GlassPanel className="hub-panel-enter">
-                            <div className="flex flex-col items-center gap-3 py-8 text-center">
-                              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/60">
-                                <BookOpen className="h-5 w-5 text-muted-foreground" />
+                    {loading && skills.length === 0 ? (
+                      <>
+                        <div className="hub-frost-hero hub-panel-enter px-4 py-3.5">
+                          <div className="flex items-center gap-3.5">
+                            <FrostSpinner />
+                            <div className="min-w-0 flex-1">
+                              <div className="text-[13px] font-medium tracking-tight text-foreground">
+                                {t("settings.skillsScanning")}
                               </div>
-                              <div className="space-y-1">
-                                <p className="text-sm font-medium text-muted-foreground">
-                                  {t("settings.skillsNotFound")}
-                                </p>
-                                <p className="text-xs text-muted-foreground/70">
-                                  {t("settings.skillsNotFoundHint")}
-                                </p>
+                              <div className="mt-0.5 truncate text-[11px] text-muted-foreground/80">
+                                {t("settings.skillsHubScanning")}
                               </div>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                className="mt-1 gap-1.5 rounded-full"
-                                onClick={() => void refresh()}
-                              >
-                                <RefreshCw className="h-3.5 w-3.5" />
-                                {t("settings.skillsRescan")}
-                              </Button>
                             </div>
-                          </GlassPanel>
-                        ) : null}
+                          </div>
+                          <div className="hub-frost-track mt-3.5" />
+                        </div>
 
-                        {loading && skills.length === 0 ? (
-                          <>
-                            <div className="hub-frost-hero hub-panel-enter px-4 py-3.5">
-                              <div className="flex items-center gap-3.5">
-                                <FrostSpinner />
-                                <div className="min-w-0 flex-1">
-                                  <div className="text-[13px] font-medium tracking-tight text-foreground">
-                                    {t("settings.skillsScanning")}
-                                  </div>
-                                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground/80">
-                                    {t("settings.skillsHubScanning")}
-                                  </div>
+                        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                          {[1, 2, 3, 4, 5, 6].map((item) => (
+                            <div key={item} className="hub-frost-skeleton skill-card-enter p-3.5">
+                              <div className="flex items-center gap-3">
+                                <div className="skills-skeleton-shimmer h-9 w-9 shrink-0 rounded-lg" />
+                                <div className="flex-1 space-y-2">
+                                  <div className="skills-skeleton-shimmer h-3.5 w-28 rounded" />
+                                  <div className="skills-skeleton-shimmer h-3 w-full max-w-[12rem] rounded" />
                                 </div>
                               </div>
-                              <div className="hub-frost-track mt-3.5" />
                             </div>
+                          ))}
+                        </div>
+                      </>
+                    ) : null}
 
-                            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                              {[1, 2, 3, 4, 5, 6].map((item) => (
+                    {filtered.length > 0 ? (
+                      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                        {filtered.map(({ skill, categories }) => {
+                          const alwaysEnabled = isAlwaysEnabledSkillName(skill.name);
+                          const checked = alwaysEnabled || selected.has(skill.name);
+                          const bulkSelected = bulkSelection.has(skill.name);
+                          const deleting = deletingSkillName === skill.name;
+                          const deleteDisabled = deletingSkillName !== null;
+                          const PrimaryCategoryIcon =
+                            STORE_CATEGORY_ICONS[categories[0] ?? "other"];
+                          const card = (
+                            <>
+                              <div className="flex items-start justify-between gap-2">
                                 <div
-                                  key={item}
-                                  className="hub-frost-skeleton skill-card-enter p-3.5"
-                                >
-                                  <div className="flex items-center gap-3">
-                                    <div className="skills-skeleton-shimmer h-9 w-9 shrink-0 rounded-lg" />
-                                    <div className="flex-1 space-y-2">
-                                      <div className="skills-skeleton-shimmer h-3.5 w-28 rounded" />
-                                      <div className="skills-skeleton-shimmer h-3 w-full max-w-[12rem] rounded" />
-                                    </div>
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          </>
-                        ) : null}
-
-                        {filtered.length > 0 ? (
-                          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                            {filtered.map(({ skill, categories }) => {
-                              const alwaysEnabled = isAlwaysEnabledSkillName(skill.name);
-                              const checked = alwaysEnabled || selected.has(skill.name);
-                              const bulkSelected = bulkSelection.has(skill.name);
-                              const deleting = deletingSkillName === skill.name;
-                              const deleteDisabled = deletingSkillName !== null;
-                              const PrimaryCategoryIcon =
-                                STORE_CATEGORY_ICONS[categories[0] ?? "other"];
-                              const card = (
-                                <>
-                                  <div className="flex items-start justify-between gap-2">
-                                    <div
-                                      className={cn(
-                                        "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border transition-all",
-                                        checked
-                                          ? "border-border/55 bg-background/80 text-foreground/85 shadow-[0_1px_0_rgba(255,255,255,0.55)_inset] dark:border-white/[0.09] dark:bg-white/[0.06] dark:shadow-[0_1px_0_rgba(255,255,255,0.06)_inset]"
-                                          : "border-border/30 bg-muted/50 text-muted-foreground group-hover:border-border/50 group-hover:bg-background/70 group-hover:text-foreground/85",
-                                      )}
-                                    >
-                                      <PrimaryCategoryIcon className="h-5 w-5" />
-                                    </div>
-
-                                    {alwaysEnabled && !bulkMode ? (
-                                      <div
-                                        className="inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.06] px-2 py-0.5 text-[10px] font-medium text-foreground/75 ring-1 ring-border/45"
-                                        title={t("settings.skillsAlwaysOn")}
-                                      >
-                                        <Lock className="h-2.5 w-2.5" />
-                                        <span>{t("settings.skillsAlwaysOn")}</span>
-                                      </div>
-                                    ) : bulkMode ? (
-                                      alwaysEnabled ? (
-                                        <div
-                                          className="flex shrink-0 items-center"
-                                          title={t("settings.skillsBulkAlwaysOnDisabled")}
-                                        >
-                                          <span
-                                            aria-hidden="true"
-                                            className="pointer-events-none flex h-5 w-5 items-center justify-center rounded-full border border-border/50 bg-muted/40 text-muted-foreground/50 opacity-60"
-                                          >
-                                            <Lock className="h-2.5 w-2.5" />
-                                          </span>
-                                        </div>
-                                      ) : (
-                                        <div
-                                          className="flex shrink-0 items-center"
-                                          onClick={(event) => event.stopPropagation()}
-                                          onKeyDown={(event) => event.stopPropagation()}
-                                        >
-                                          <label
-                                            className="relative flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center"
-                                            title={t("settings.skillsHubBulkSelectLabel")}
-                                          >
-                                            <input
-                                              type="checkbox"
-                                              checked={bulkSelection.has(skill.name)}
-                                              aria-label={`${t("settings.skillsHubBulkSelectLabel")}: ${skill.name}`}
-                                              onClick={(event) => event.stopPropagation()}
-                                              onChange={(event) => {
-                                                event.stopPropagation();
-                                                toggleBulkSelectionName(skill.name);
-                                              }}
-                                              className="peer sr-only"
-                                            />
-                                            <span
-                                              aria-hidden="true"
-                                              className={cn(
-                                                "pointer-events-none flex h-5 w-5 items-center justify-center rounded-full border transition-all",
-                                                bulkSelection.has(skill.name)
-                                                  ? "border-primary bg-primary text-primary-foreground"
-                                                  : "border-border bg-background group-hover:border-foreground/40",
-                                              )}
-                                            >
-                                              {bulkSelection.has(skill.name) ? (
-                                                <Check className="h-3 w-3" />
-                                              ) : null}
-                                            </span>
-                                          </label>
-                                        </div>
-                                      )
-                                    ) : (
-                                      <div
-                                        className="flex shrink-0 items-center gap-1.5"
-                                        onClick={(event) => event.stopPropagation()}
-                                        onKeyDown={(event) => event.stopPropagation()}
-                                      >
-                                        <button
-                                          type="button"
-                                          aria-label={`${t("settings.skillsHubBulkSelectLabel")}: ${skill.name}`}
-                                          title={t("settings.skillsHubBulkSelect")}
-                                          onClick={(event) => {
-                                            event.stopPropagation();
-                                            enterBulkMode(skill.name);
-                                          }}
-                                          className={cn(
-                                            // Google Photos-style bulk entry: hover-faint, touch semi-visible.
-                                            "relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-border/60 bg-background/90 text-muted-foreground shadow-sm transition-all hover:border-primary/50 hover:text-foreground",
-                                            "opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-70",
-                                          )}
-                                        >
-                                          <span className="h-2 w-2 rounded-full border border-current opacity-40" />
-                                        </button>
-                                        <button
-                                          type="button"
-                                          role="switch"
-                                          aria-checked={checked}
-                                          aria-label={`${t("skills.select")}: ${skill.name}`}
-                                          title={
-                                            checked
-                                              ? t("settings.skillsHubToggleDisable")
-                                              : t("settings.skillsHubToggleEnable")
-                                          }
-                                          onClick={(event) => {
-                                            event.stopPropagation();
-                                            toggleSkill(skill.name, !checked);
-                                          }}
-                                          className={cn(
-                                            "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full ring-1 transition-all",
-                                            checked
-                                              ? "bg-emerald-500 ring-emerald-400/45"
-                                              : "bg-muted-foreground/25 ring-border/40",
-                                          )}
-                                        >
-                                          <span
-                                            className={cn(
-                                              "pointer-events-none inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform",
-                                              checked
-                                                ? "translate-x-[1.05rem]"
-                                                : "translate-x-[0.15rem]",
-                                            )}
-                                          />
-                                        </button>
-                                      </div>
-                                    )}
-                                  </div>
-
-                                  <div className="mt-2.5 min-w-0 flex-1">
-                                    <div className="flex min-w-0 items-center gap-1.5">
-                                      <div className="truncate text-[13px] font-semibold leading-tight text-foreground">
-                                        {skill.name}
-                                      </div>
-                                      {checked ? (
-                                        <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-500/12 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 ring-1 ring-emerald-500/25 dark:bg-emerald-400/12 dark:text-emerald-300 dark:ring-emerald-400/25">
-                                          {t("settings.skillsHubEnabledBadge")}
-                                        </span>
-                                      ) : null}
-                                    </div>
-                                    {skill.description ? (
-                                      <p className="mt-1 line-clamp-2 text-[11.5px] leading-[1.4] text-muted-foreground">
-                                        {skill.description}
-                                      </p>
-                                    ) : null}
-                                    {!alwaysEnabled ? (
-                                      <div className="mt-2">
-                                        <SkillCategoryBadges
-                                          categories={categories}
-                                          onSelect={setInstalledCategory}
-                                        />
-                                      </div>
-                                    ) : null}
-                                  </div>
-
-                                  <div className="mt-2.5 flex min-h-8 items-center gap-1 border-t border-border/30 pt-2 text-[10.5px] text-muted-foreground/70">
-                                    <FileText className="h-3 w-3 shrink-0" />
-                                    <span className="truncate">{skill.skillFile}</span>
-                                    {!alwaysEnabled && !bulkMode ? (
-                                      <div
-                                        className="ml-auto shrink-0"
-                                        onClick={(event) => event.stopPropagation()}
-                                        onKeyDown={(event) => event.stopPropagation()}
-                                      >
-                                        <ConfirmDeletePopover
-                                          name={skill.name}
-                                          onConfirm={() => void deleteSkill(skill)}
-                                        >
-                                          {(open) => (
-                                            <button
-                                              type="button"
-                                              disabled={deleteDisabled}
-                                              onClick={(event) => {
-                                                event.stopPropagation();
-                                                open();
-                                              }}
-                                              className={cn(
-                                                "flex h-6 w-6 items-center justify-center rounded-md border border-border/35 bg-background/65 text-muted-foreground transition-all",
-                                                "hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive",
-                                                "disabled:cursor-not-allowed",
-                                                // Hover-revealed on pointer devices; keyboard focus and
-                                                // touch (no hover — webui mobile) keep it reachable.
-                                                deleting
-                                                  ? "pointer-events-auto opacity-100"
-                                                  : cn(
-                                                      "pointer-events-none opacity-0 group-hover:pointer-events-auto focus-visible:pointer-events-auto [@media(hover:none)]:pointer-events-auto",
-                                                      deleteDisabled
-                                                        ? "group-hover:opacity-60 focus-visible:opacity-60 [@media(hover:none)]:opacity-60"
-                                                        : "group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100",
-                                                    ),
-                                              )}
-                                              title={t("settings.skillsHubDeleteSkill")}
-                                            >
-                                              {deleting ? (
-                                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                                              ) : (
-                                                <Trash2 className="h-3.5 w-3.5" />
-                                              )}
-                                            </button>
-                                          )}
-                                        </ConfirmDeletePopover>
-                                      </div>
-                                    ) : null}
-                                  </div>
-                                </>
-                              );
-
-                              const key = `${skill.name}-${rootDir}`;
-                              if (alwaysEnabled) {
-                                return (
-                                  <button
-                                    key={key}
-                                    type="button"
-                                    aria-label={`${t("settings.skillsInstalledPreviewOpen")}: ${skill.name}`}
-                                    onClick={() => {
-                                      if (bulkMode) return;
-                                      openInstalledSkillPreview(skill);
-                                    }}
-                                    className={cn(
-                                      "hub-skill-card skill-card-enter group flex h-full w-full cursor-pointer flex-col rounded-2xl border border-border/50 bg-background/75 p-3.5 text-left backdrop-blur-xl shadow-[0_1px_0_rgba(255,255,255,0.55)_inset,0_4px_18px_-12px_rgba(15,23,42,0.16)] transition-all hover:-translate-y-0.5 hover:border-border/60 hover:bg-background/85 hover:shadow-[0_4px_16px_-10px_rgba(15,23,42,0.18)] dark:border-white/[0.08] dark:bg-white/[0.05] dark:shadow-[0_1px_0_rgba(255,255,255,0.05)_inset,0_4px_18px_-12px_rgba(0,0,0,0.5)] dark:hover:border-white/[0.12] dark:hover:bg-white/[0.07] dark:hover:shadow-[0_4px_16px_-10px_rgba(0,0,0,0.55)] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-foreground/15",
-                                      bulkMode ? "cursor-default hover:translate-y-0" : null,
-                                    )}
-                                  >
-                                    {card}
-                                  </button>
-                                );
-                              }
-
-                              return (
-                                // biome-ignore lint/a11y/useSemanticElements: The card contains nested controls and cannot be a native button.
-                                <div
-                                  key={key}
-                                  role="button"
-                                  tabIndex={0}
-                                  aria-label={`${t("settings.skillsInstalledPreviewOpen")}: ${skill.name}`}
-                                  onClick={(event) => {
-                                    if (bulkMode) {
-                                      handleBulkInstalledCardClick(
-                                        skill.name,
-                                        filtered.map((entry) => entry.skill.name),
-                                        event.shiftKey,
-                                      );
-                                      return;
-                                    }
-                                    openInstalledSkillPreview(skill);
-                                  }}
-                                  onMouseDown={(event) => {
-                                    // Shift+点击做区间选择时避免浏览器拖出文本选区
-                                    if (bulkMode && event.shiftKey) event.preventDefault();
-                                  }}
-                                  onKeyDown={(event) => {
-                                    if (bulkMode && (event.key === "Enter" || event.key === " ")) {
-                                      event.preventDefault();
-                                      handleBulkInstalledCardClick(
-                                        skill.name,
-                                        filtered.map((entry) => entry.skill.name),
-                                        event.shiftKey,
-                                      );
-                                      return;
-                                    }
-                                    handleInstalledSkillCardKeyDown(event, skill);
-                                  }}
                                   className={cn(
-                                    "hub-skill-card skill-card-enter group relative flex h-full w-full flex-col rounded-2xl border p-3.5 text-left transition-all",
-                                    "cursor-pointer backdrop-blur-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-foreground/15",
-                                    // Enabled style always visible; bulk selection overlays primary ring.
+                                    "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border transition-all",
                                     checked
-                                      ? "border-emerald-500/35 bg-emerald-50/90 shadow-[0_1px_0_rgba(255,255,255,0.55)_inset,0_4px_14px_-12px_rgba(16,185,129,0.28)] dark:border-emerald-400/30 dark:bg-emerald-500/12 dark:shadow-[0_1px_0_rgba(255,255,255,0.05)_inset,0_4px_14px_-12px_rgba(16,185,129,0.22)]"
-                                      : "border-border/40 bg-muted/45 text-muted-foreground shadow-none hover:-translate-y-0.5 hover:border-border/55 hover:bg-muted/55 dark:border-white/[0.06] dark:bg-white/[0.025] dark:hover:border-white/[0.10] dark:hover:bg-white/[0.04]",
-                                    bulkSelected
-                                      ? "ring-2 ring-primary/50 ring-offset-1 ring-offset-background"
-                                      : null,
+                                      ? "border-border/55 bg-background/80 text-foreground/85 shadow-[0_1px_0_rgba(255,255,255,0.55)_inset] dark:border-white/[0.09] dark:bg-white/[0.06] dark:shadow-[0_1px_0_rgba(255,255,255,0.06)_inset]"
+                                      : "border-border/30 bg-muted/50 text-muted-foreground group-hover:border-border/50 group-hover:bg-background/70 group-hover:text-foreground/85",
                                   )}
                                 >
-                                  {card}
+                                  <PrimaryCategoryIcon className="h-5 w-5" />
                                 </div>
-                              );
-                            })}
-                          </div>
-                        ) : null}
 
-                        {(filter.trim() || installedCategory !== "all") &&
-                        filtered.length === 0 &&
-                        skills.length > 0 ? (
-                          <GlassPanel tone="muted" className="hub-panel-enter">
-                            <p className="py-2 text-center text-sm text-muted-foreground">
-                              {filter.trim()
-                                ? t("settings.skillsNoMatch").replace("{filter}", filter)
-                                : t("settings.skillsStoreEmptyTitle")}
-                            </p>
-                          </GlassPanel>
-                        ) : null}
+                                {alwaysEnabled && !bulkMode ? (
+                                  <div
+                                    className="inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.06] px-2 py-0.5 text-[10px] font-medium text-foreground/75 ring-1 ring-border/45"
+                                    title={t("settings.skillsAlwaysOn")}
+                                  >
+                                    <Lock className="h-2.5 w-2.5" />
+                                    <span>{t("settings.skillsAlwaysOn")}</span>
+                                  </div>
+                                ) : bulkMode ? (
+                                  alwaysEnabled ? (
+                                    <div
+                                      className="flex shrink-0 items-center"
+                                      title={t("settings.skillsBulkAlwaysOnDisabled")}
+                                    >
+                                      <span
+                                        aria-hidden="true"
+                                        className="pointer-events-none flex h-5 w-5 items-center justify-center rounded-full border border-border/50 bg-muted/40 text-muted-foreground/50 opacity-60"
+                                      >
+                                        <Lock className="h-2.5 w-2.5" />
+                                      </span>
+                                    </div>
+                                  ) : (
+                                    <div
+                                      className="flex shrink-0 items-center"
+                                      onClick={(event) => event.stopPropagation()}
+                                      onKeyDown={(event) => event.stopPropagation()}
+                                    >
+                                      <label
+                                        className="relative flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center"
+                                        title={t("settings.skillsHubBulkSelectLabel")}
+                                      >
+                                        <input
+                                          type="checkbox"
+                                          checked={bulkSelection.has(skill.name)}
+                                          aria-label={`${t("settings.skillsHubBulkSelectLabel")}: ${skill.name}`}
+                                          onClick={(event) => event.stopPropagation()}
+                                          onChange={(event) => {
+                                            event.stopPropagation();
+                                            toggleBulkSelectionName(skill.name);
+                                          }}
+                                          className="peer sr-only"
+                                        />
+                                        <span
+                                          aria-hidden="true"
+                                          className={cn(
+                                            "pointer-events-none flex h-5 w-5 items-center justify-center rounded-full border transition-all",
+                                            bulkSelection.has(skill.name)
+                                              ? "border-primary bg-primary text-primary-foreground"
+                                              : "border-border bg-background group-hover:border-foreground/40",
+                                          )}
+                                        >
+                                          {bulkSelection.has(skill.name) ? (
+                                            <Check className="h-3 w-3" />
+                                          ) : null}
+                                        </span>
+                                      </label>
+                                    </div>
+                                  )
+                                ) : (
+                                  <div
+                                    className="flex shrink-0 items-center gap-1.5"
+                                    onClick={(event) => event.stopPropagation()}
+                                    onKeyDown={(event) => event.stopPropagation()}
+                                  >
+                                    <button
+                                      type="button"
+                                      aria-label={`${t("settings.skillsHubBulkSelectLabel")}: ${skill.name}`}
+                                      title={t("settings.skillsHubBulkSelect")}
+                                      onClick={(event) => {
+                                        event.stopPropagation();
+                                        enterBulkMode(skill.name);
+                                      }}
+                                      className={cn(
+                                        // Google Photos-style bulk entry: hover-faint, touch semi-visible.
+                                        "relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-border/60 bg-background/90 text-muted-foreground shadow-sm transition-all hover:border-primary/50 hover:text-foreground",
+                                        "opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-70",
+                                      )}
+                                    >
+                                      <span className="h-2 w-2 rounded-full border border-current opacity-40" />
+                                    </button>
+                                    <button
+                                      type="button"
+                                      role="switch"
+                                      aria-checked={checked}
+                                      aria-label={`${t("skills.select")}: ${skill.name}`}
+                                      title={
+                                        checked
+                                          ? t("settings.skillsHubToggleDisable")
+                                          : t("settings.skillsHubToggleEnable")
+                                      }
+                                      onClick={(event) => {
+                                        event.stopPropagation();
+                                        toggleSkill(skill.name, !checked);
+                                      }}
+                                      className={cn(
+                                        "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full ring-1 transition-all",
+                                        checked
+                                          ? "bg-emerald-500 ring-emerald-400/45"
+                                          : "bg-muted-foreground/25 ring-border/40",
+                                      )}
+                                    >
+                                      <span
+                                        className={cn(
+                                          "pointer-events-none inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform",
+                                          checked
+                                            ? "translate-x-[1.05rem]"
+                                            : "translate-x-[0.15rem]",
+                                        )}
+                                      />
+                                    </button>
+                                  </div>
+                                )}
+                              </div>
+
+                              <div className="mt-2.5 min-w-0 flex-1">
+                                <div className="flex min-w-0 items-center gap-1.5">
+                                  <div className="truncate text-[13px] font-semibold leading-tight text-foreground">
+                                    {skill.name}
+                                  </div>
+                                  {checked ? (
+                                    <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-500/12 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 ring-1 ring-emerald-500/25 dark:bg-emerald-400/12 dark:text-emerald-300 dark:ring-emerald-400/25">
+                                      {t("settings.skillsHubEnabledBadge")}
+                                    </span>
+                                  ) : null}
+                                </div>
+                                {skill.description ? (
+                                  <p className="mt-1 line-clamp-2 text-[11.5px] leading-[1.4] text-muted-foreground">
+                                    {skill.description}
+                                  </p>
+                                ) : null}
+                                {!alwaysEnabled ? (
+                                  <div className="mt-2">
+                                    <SkillCategoryBadges
+                                      categories={categories}
+                                      onSelect={setInstalledCategory}
+                                    />
+                                  </div>
+                                ) : null}
+                              </div>
+
+                              <div className="mt-2.5 flex min-h-8 items-center gap-1 border-t border-border/30 pt-2 text-[10.5px] text-muted-foreground/70">
+                                <FileText className="h-3 w-3 shrink-0" />
+                                <span className="truncate">{skill.skillFile}</span>
+                                {!alwaysEnabled && !bulkMode ? (
+                                  <div
+                                    className="ml-auto shrink-0"
+                                    onClick={(event) => event.stopPropagation()}
+                                    onKeyDown={(event) => event.stopPropagation()}
+                                  >
+                                    <ConfirmDeletePopover
+                                      name={skill.name}
+                                      onConfirm={() => void deleteSkill(skill)}
+                                    >
+                                      {(open) => (
+                                        <button
+                                          type="button"
+                                          disabled={deleteDisabled}
+                                          onClick={(event) => {
+                                            event.stopPropagation();
+                                            open();
+                                          }}
+                                          className={cn(
+                                            "flex h-6 w-6 items-center justify-center rounded-md border border-border/35 bg-background/65 text-muted-foreground transition-all",
+                                            "hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive",
+                                            "disabled:cursor-not-allowed",
+                                            // Hover-revealed on pointer devices; keyboard focus and
+                                            // touch (no hover — webui mobile) keep it reachable.
+                                            deleting
+                                              ? "pointer-events-auto opacity-100"
+                                              : cn(
+                                                  "pointer-events-none opacity-0 group-hover:pointer-events-auto focus-visible:pointer-events-auto [@media(hover:none)]:pointer-events-auto",
+                                                  deleteDisabled
+                                                    ? "group-hover:opacity-60 focus-visible:opacity-60 [@media(hover:none)]:opacity-60"
+                                                    : "group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100",
+                                                ),
+                                          )}
+                                          title={t("settings.skillsHubDeleteSkill")}
+                                        >
+                                          {deleting ? (
+                                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                          ) : (
+                                            <Trash2 className="h-3.5 w-3.5" />
+                                          )}
+                                        </button>
+                                      )}
+                                    </ConfirmDeletePopover>
+                                  </div>
+                                ) : null}
+                              </div>
+                            </>
+                          );
+
+                          const key = `${skill.name}-${rootDir}`;
+                          if (alwaysEnabled) {
+                            return (
+                              <button
+                                key={key}
+                                type="button"
+                                aria-label={`${t("settings.skillsInstalledPreviewOpen")}: ${skill.name}`}
+                                onClick={() => {
+                                  if (bulkMode) return;
+                                  openInstalledSkillPreview(skill);
+                                }}
+                                className={cn(
+                                  "hub-skill-card skill-card-enter group flex h-full w-full cursor-pointer flex-col rounded-2xl border border-border/50 bg-background/75 p-3.5 text-left backdrop-blur-xl shadow-[0_1px_0_rgba(255,255,255,0.55)_inset,0_4px_18px_-12px_rgba(15,23,42,0.16)] transition-all hover:-translate-y-0.5 hover:border-border/60 hover:bg-background/85 hover:shadow-[0_4px_16px_-10px_rgba(15,23,42,0.18)] dark:border-white/[0.08] dark:bg-white/[0.05] dark:shadow-[0_1px_0_rgba(255,255,255,0.05)_inset,0_4px_18px_-12px_rgba(0,0,0,0.5)] dark:hover:border-white/[0.12] dark:hover:bg-white/[0.07] dark:hover:shadow-[0_4px_16px_-10px_rgba(0,0,0,0.55)] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-foreground/15",
+                                  bulkMode ? "cursor-default hover:translate-y-0" : null,
+                                )}
+                              >
+                                {card}
+                              </button>
+                            );
+                          }
+
+                          return (
+                            // biome-ignore lint/a11y/useSemanticElements: The card contains nested controls and cannot be a native button.
+                            <div
+                              key={key}
+                              role="button"
+                              tabIndex={0}
+                              aria-label={`${t("settings.skillsInstalledPreviewOpen")}: ${skill.name}`}
+                              onClick={(event) => {
+                                if (bulkMode) {
+                                  handleBulkInstalledCardClick(
+                                    skill.name,
+                                    filtered.map((entry) => entry.skill.name),
+                                    event.shiftKey,
+                                  );
+                                  return;
+                                }
+                                openInstalledSkillPreview(skill);
+                              }}
+                              onMouseDown={(event) => {
+                                // Shift+点击做区间选择时避免浏览器拖出文本选区
+                                if (bulkMode && event.shiftKey) event.preventDefault();
+                              }}
+                              onKeyDown={(event) => {
+                                if (bulkMode && (event.key === "Enter" || event.key === " ")) {
+                                  event.preventDefault();
+                                  handleBulkInstalledCardClick(
+                                    skill.name,
+                                    filtered.map((entry) => entry.skill.name),
+                                    event.shiftKey,
+                                  );
+                                  return;
+                                }
+                                handleInstalledSkillCardKeyDown(event, skill);
+                              }}
+                              className={cn(
+                                "hub-skill-card skill-card-enter group relative flex h-full w-full flex-col rounded-2xl border p-3.5 text-left transition-all",
+                                "cursor-pointer backdrop-blur-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-foreground/15",
+                                // Enabled style always visible; bulk selection overlays primary ring.
+                                checked
+                                  ? "border-emerald-500/35 bg-emerald-50/90 shadow-[0_1px_0_rgba(255,255,255,0.55)_inset,0_4px_14px_-12px_rgba(16,185,129,0.28)] dark:border-emerald-400/30 dark:bg-emerald-500/12 dark:shadow-[0_1px_0_rgba(255,255,255,0.05)_inset,0_4px_14px_-12px_rgba(16,185,129,0.22)]"
+                                  : "border-border/40 bg-muted/45 text-muted-foreground shadow-none hover:-translate-y-0.5 hover:border-border/55 hover:bg-muted/55 dark:border-white/[0.06] dark:bg-white/[0.025] dark:hover:border-white/[0.10] dark:hover:bg-white/[0.04]",
+                                bulkSelected
+                                  ? "ring-2 ring-primary/50 ring-offset-1 ring-offset-background"
+                                  : null,
+                              )}
+                            >
+                              {card}
+                            </div>
+                          );
+                        })}
                       </div>
-                    </div>
-                  ) : view === "store" ? (
-                    <SkillsStoreView
-                      items={storeItems}
-                      query={storeQuery}
-                      sort={storeSort}
-                      loading={storeLoading}
-                      loadingMore={storeLoadingMore}
-                      error={storeError}
-                      cursor={storeCursor}
-                      installedKeys={installedStoreKeys}
-                      installedSlugs={installedStoreSlugs}
-                      pendingInstallKeys={pendingInstallKeys}
-                      installingByStoreKey={installingByStoreKey}
-                      installJobs={installJobs}
-                      onSortChange={setStoreSort}
-                      onLoadMore={() => void loadMoreStore()}
-                      onInstall={(skill) => void installStoreSkill(skill)}
-                    />
-                  ) : (
-                    <SkillsImportView
-                      scans={externalScans ?? []}
-                      loading={externalLoading}
-                      error={externalError}
-                      query={importQuery}
-                      selected={selectedExternal}
-                      installedNames={installedSkillNames}
-                      importProgress={importProgress}
-                      importErrors={importErrors}
-                      importedCount={importedCount}
-                      importToast={importToast}
-                      onDismissImportToast={() => {
-                        if (importToastTimerRef.current !== null) {
-                          window.clearTimeout(importToastTimerRef.current);
-                          importToastTimerRef.current = null;
-                        }
-                        setImportToast(null);
-                      }}
-                      bulkMode={bulkMode}
-                      onToggle={toggleExternalSkill}
-                      onBatchToggle={batchToggleExternalSkills}
-                      onRescan={() => void rescanExternalSkills()}
-                      onImport={() => void importSelectedExternalSkills()}
-                    />
-                  )
+                    ) : null}
+
+                    {(filter.trim() || installedCategory !== "all") &&
+                    filtered.length === 0 &&
+                    skills.length > 0 ? (
+                      <GlassPanel tone="muted" className="hub-panel-enter">
+                        <p className="py-2 text-center text-sm text-muted-foreground">
+                          {filter.trim()
+                            ? t("settings.skillsNoMatch").replace("{filter}", filter)
+                            : t("settings.skillsStoreEmptyTitle")}
+                        </p>
+                      </GlassPanel>
+                    ) : null}
+                  </div>
+                </div>
+              ) : view === "store" ? (
+                <SkillsStoreView
+                  items={storeItems}
+                  query={storeQuery}
+                  sort={storeSort}
+                  loading={storeLoading}
+                  loadingMore={storeLoadingMore}
+                  error={storeError}
+                  cursor={storeCursor}
+                  installedKeys={installedStoreKeys}
+                  installedSlugs={installedStoreSlugs}
+                  pendingInstallKeys={pendingInstallKeys}
+                  installingByStoreKey={installingByStoreKey}
+                  installJobs={installJobs}
+                  onSortChange={setStoreSort}
+                  onLoadMore={() => void loadMoreStore()}
+                  onInstall={(skill) => void installStoreSkill(skill)}
+                />
+              ) : (
+                <SkillsImportView
+                  scans={externalScans ?? []}
+                  loading={externalLoading}
+                  error={externalError}
+                  query={importQuery}
+                  selected={selectedExternal}
+                  installedNames={installedSkillNames}
+                  importProgress={importProgress}
+                  importErrors={importErrors}
+                  importedCount={importedCount}
+                  importToast={importToast}
+                  onDismissImportToast={() => {
+                    if (importToastTimerRef.current !== null) {
+                      window.clearTimeout(importToastTimerRef.current);
+                      importToastTimerRef.current = null;
+                    }
+                    setImportToast(null);
+                  }}
+                  bulkMode={bulkMode}
+                  onToggle={toggleExternalSkill}
+                  onBatchToggle={batchToggleExternalSkills}
+                  onRescan={() => void rescanExternalSkills()}
+                  onImport={() => void importSelectedExternalSkills()}
+                />
               )}
             </div>
           </div>
@@ -2166,9 +2161,9 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
       ) : null}
 
       {bulkMode &&
-        view === "installed" &&
-        !lockedByChatMode &&
-        (!bulkUndo || bulkSelection.size > 0) ? (
+      view === "installed" &&
+      !lockedByChatMode &&
+      (!bulkUndo || bulkSelection.size > 0) ? (
         <div className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center px-3">
           <div className="hub-panel-enter pointer-events-auto flex max-w-full flex-wrap items-center gap-2 rounded-full border border-border/50 bg-background/90 py-2 pl-4 pr-2 text-[12.5px] shadow-[0_8px_24px_-12px_rgba(15,23,42,0.35)] backdrop-blur-xl dark:border-white/[0.1] dark:bg-white/[0.08]">
             {bulkSelection.size > 0 ? (

--- a/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
@@ -1139,44 +1139,53 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
     bulkAnchorRef.current = null;
   }, []);
 
-  const enterBulkMode = useCallback((initialName?: string) => {
-    setBulkMode(true);
-    setPreviewInstalledSkill(null);
-    if (initialName && !isAlwaysEnabledSkillName(initialName)) {
+  const enterBulkMode = useCallback(
+    (initialName?: string) => {
+      setBulkMode(true);
+      setPreviewInstalledSkill(null);
+      if (initialName && !isAlwaysEnabledSkillName(initialName)) {
+        clearBulkUndoTimer();
+        setBulkUndo(null);
+        setBulkSelection(new Set([initialName]));
+        bulkAnchorRef.current = initialName;
+      }
+    },
+    [clearBulkUndoTimer],
+  );
+
+  const toggleBulkSelectionName = useCallback(
+    (name: string) => {
+      if (isAlwaysEnabledSkillName(name)) return;
       clearBulkUndoTimer();
       setBulkUndo(null);
-      setBulkSelection(new Set([initialName]));
-      bulkAnchorRef.current = initialName;
-    }
-  }, [clearBulkUndoTimer]);
+      setBulkSelection((prev) => {
+        const next = new Set(prev);
+        if (next.has(name)) next.delete(name);
+        else next.add(name);
+        return next;
+      });
+      bulkAnchorRef.current = name;
+    },
+    [clearBulkUndoTimer],
+  );
 
-  const toggleBulkSelectionName = useCallback((name: string) => {
-    if (isAlwaysEnabledSkillName(name)) return;
-    clearBulkUndoTimer();
-    setBulkUndo(null);
-    setBulkSelection((prev) => {
-      const next = new Set(prev);
-      if (next.has(name)) next.delete(name);
-      else next.add(name);
-      return next;
-    });
-    bulkAnchorRef.current = name;
-  }, [clearBulkUndoTimer]);
-
-  const setBulkSelectionRange = useCallback((names: readonly string[], select: boolean) => {
-    const selectable = names.filter((name) => !isAlwaysEnabledSkillName(name));
-    if (selectable.length === 0) return;
-    clearBulkUndoTimer();
-    setBulkUndo(null);
-    setBulkSelection((prev) => {
-      const next = new Set(prev);
-      for (const name of selectable) {
-        if (select) next.add(name);
-        else next.delete(name);
-      }
-      return next;
-    });
-  }, [clearBulkUndoTimer]);
+  const setBulkSelectionRange = useCallback(
+    (names: readonly string[], select: boolean) => {
+      const selectable = names.filter((name) => !isAlwaysEnabledSkillName(name));
+      if (selectable.length === 0) return;
+      clearBulkUndoTimer();
+      setBulkUndo(null);
+      setBulkSelection((prev) => {
+        const next = new Set(prev);
+        for (const name of selectable) {
+          if (select) next.add(name);
+          else next.delete(name);
+        }
+        return next;
+      });
+    },
+    [clearBulkUndoTimer],
+  );
 
   // 批量选择模式下点击卡片：只改 bulkSelection，不改启用状态、不打开预览。
   function handleBulkInstalledCardClick(name: string, orderedNames: string[], shiftKey: boolean) {

--- a/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
@@ -1143,13 +1143,17 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
     setBulkMode(true);
     setPreviewInstalledSkill(null);
     if (initialName && !isAlwaysEnabledSkillName(initialName)) {
+      clearBulkUndoTimer();
+      setBulkUndo(null);
       setBulkSelection(new Set([initialName]));
       bulkAnchorRef.current = initialName;
     }
-  }, []);
+  }, [clearBulkUndoTimer]);
 
   const toggleBulkSelectionName = useCallback((name: string) => {
     if (isAlwaysEnabledSkillName(name)) return;
+    clearBulkUndoTimer();
+    setBulkUndo(null);
     setBulkSelection((prev) => {
       const next = new Set(prev);
       if (next.has(name)) next.delete(name);
@@ -1157,11 +1161,13 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
       return next;
     });
     bulkAnchorRef.current = name;
-  }, []);
+  }, [clearBulkUndoTimer]);
 
   const setBulkSelectionRange = useCallback((names: readonly string[], select: boolean) => {
     const selectable = names.filter((name) => !isAlwaysEnabledSkillName(name));
     if (selectable.length === 0) return;
+    clearBulkUndoTimer();
+    setBulkUndo(null);
     setBulkSelection((prev) => {
       const next = new Set(prev);
       for (const name of selectable) {
@@ -1170,7 +1176,7 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
       }
       return next;
     });
-  }, []);
+  }, [clearBulkUndoTimer]);
 
   // 批量选择模式下点击卡片：只改 bulkSelection，不改启用状态、不打开预览。
   function handleBulkInstalledCardClick(name: string, orderedNames: string[], shiftKey: boolean) {
@@ -2152,7 +2158,10 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
         />
       ) : null}
 
-      {bulkMode && view === "installed" && !lockedByChatMode && !bulkUndo ? (
+      {bulkMode &&
+        view === "installed" &&
+        !lockedByChatMode &&
+        (!bulkUndo || bulkSelection.size > 0) ? (
         <div className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center px-3">
           <div className="hub-panel-enter pointer-events-auto flex max-w-full flex-wrap items-center gap-2 rounded-full border border-border/50 bg-background/90 py-2 pl-4 pr-2 text-[12.5px] shadow-[0_8px_24px_-12px_rgba(15,23,42,0.35)] backdrop-blur-xl dark:border-white/[0.1] dark:bg-white/[0.08]">
             {bulkSelection.size > 0 ? (
@@ -2250,7 +2259,7 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
         </div>
       ) : null}
 
-      {bulkUndo ? (
+      {bulkUndo && bulkSelection.size === 0 ? (
         <div className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center">
           <div className="hub-panel-enter pointer-events-auto flex items-center gap-3 rounded-full border border-border/50 bg-background/90 py-2 pl-4 pr-2 text-[12.5px] shadow-[0_8px_24px_-12px_rgba(15,23,42,0.35)] backdrop-blur-xl dark:border-white/[0.1] dark:bg-white/[0.08]">
             <span className="text-foreground/85">

--- a/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
@@ -1694,8 +1694,7 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
                   </GlassPanel>
                 </div>
               ) : (
-                <>
-                  {view === "installed" ? (
+                view === "installed" ? (
                     <div
                       className={cn(
                         "h-full min-h-0 overflow-y-auto px-0.5 pr-1 pt-1.5",
@@ -2147,8 +2146,7 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
                       onRescan={() => void rescanExternalSkills()}
                       onImport={() => void importSelectedExternalSkills()}
                     />
-                  )}
-                </>
+                  )
               )}
             </div>
           </div>


### PR DESCRIPTION
## 变更说明

- 在卡片选择、Shift 区间选择、全选及带初始项进入多选时立即清理 Undo 定时器和状态
- 新选择存在时优先显示批量操作栏，并确保操作栏与 Undo 提示条互斥
- 同步保持 GUI 与 Gateway Web 的 Skills Hub 行为一致

## 验证

- `crates/agent-gui`: `npm run build`
- `crates/agent-gateway/web`: `npm run build`
- `crates/agent-gui`: `npm run test:frontend`
- `crates/agent-gateway/web`: `npm test`
- 本地 Tauri 调试客户端人工验收通过