### PR TITLE
fix(composer): insert external mentions at the saved caret, never inside a chip

### DIFF
--- a/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
@@ -435,6 +435,18 @@ function editorHasNoContent(editor: HTMLElement) {
   return removeCaretAnchors(editor.textContent || "").length === 0;
 }
 
+function editorRangeIsInsideRoot(root: HTMLElement, range: Range) {
+  const commonAncestor = range.commonAncestorContainer;
+  return commonAncestor === root || root.contains(commonAncestor);
+}
+
+function editorSelectionRange(root: HTMLElement) {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return null;
+  const range = selection.getRangeAt(0);
+  return editorRangeIsInsideRoot(root, range) ? range : null;
+}
+
 function normalizeMentionQuery(query: string) {
   return removeCaretAnchors(query).trim().replace(/\\/g, "/").toLowerCase();
 }
@@ -1091,24 +1103,41 @@ function createLargePasteChip(paste: MentionComposerLargePaste) {
   return chip;
 }
 
-function insertNodeAtCursor(root: HTMLElement, node: Node) {
-  const anchor = createCaretAnchorText("");
-  const afterNode = document.createTextNode(anchor.text);
+function insertNodeAtCursor(root: HTMLElement, node: HTMLElement) {
   const sel = window.getSelection();
   if (sel && sel.rangeCount > 0) {
     const range = sel.getRangeAt(0);
-    if (root.contains(range.commonAncestorContainer)) {
-      range.deleteContents();
-      range.insertNode(afterNode);
+    if (editorRangeIsInsideRoot(root, range)) {
+      // A restored selection can carry boundaries inside a non-editable chip
+      // (clicks and double-clicks land there); hop them outside so the new
+      // chip never nests into an existing chip and never guts its label.
+      const startChip = closestComposerChipFromNode(root, range.startContainer);
+      if (startChip) {
+        range.setStartAfter(startChip);
+      }
+      const endChip = closestComposerChipFromNode(root, range.endContainer);
+      if (endChip) {
+        range.setEndBefore(endChip);
+      }
+      if (!range.collapsed) {
+        range.deleteContents();
+      }
       range.insertNode(node);
-      placeCaretInTextNode(afterNode, anchor.caretOffset);
+      // Reuse the split-off text node as the caret anchor instead of minting
+      // a fresh one, so mid-text inserts leave no empty text-node leftovers.
+      const anchor = ensureCaretAnchorAfterChip(node);
+      if (anchor) {
+        placeCaretInTextNode(anchor.textNode, anchor.offset);
+      }
       return;
     }
   }
 
   root.appendChild(node);
-  root.appendChild(afterNode);
-  placeCaretInTextNode(afterNode, anchor.caretOffset);
+  const anchor = ensureCaretAnchorAfterChip(node);
+  if (anchor) {
+    placeCaretInTextNode(anchor.textNode, anchor.offset);
+  }
 }
 
 function scrollSelectionIntoComposerView(root: HTMLElement) {
@@ -1786,6 +1815,32 @@ export const MentionComposer = memo(
       setCommitTooltip(null);
     }, []);
 
+    const lastEditorSelectionRef = useRef<Range | null>(null);
+    const rememberEditorSelection = useCallback(() => {
+      const editor = editorRef.current;
+      if (!editor) return;
+      const range = editorSelectionRange(editor);
+      if (range) {
+        lastEditorSelectionRef.current = range.cloneRange();
+      }
+    }, []);
+    const focusEditorAtSavedSelection = useCallback(() => {
+      const editor = editorRef.current;
+      if (!editor) return;
+      const range = lastEditorSelectionRef.current;
+      editor.focus({ preventScroll: true });
+      if (!range || !editorRangeIsInsideRoot(editor, range)) return;
+      const selection = window.getSelection();
+      if (!selection) return;
+      selection.removeAllRanges();
+      selection.addRange(range.cloneRange());
+    }, []);
+
+    useEffect(() => {
+      document.addEventListener("selectionchange", rememberEditorSelection);
+      return () => document.removeEventListener("selectionchange", rememberEditorSelection);
+    }, [rememberEditorSelection]);
+
     const setBusy = useCallback(
       (nextBusy: boolean) => {
         if (isBusyRef.current === nextBusy) return;
@@ -2257,7 +2312,7 @@ export const MentionComposer = memo(
           if (!el) return;
           finishTypewriter();
           resetPromptHistoryRecall();
-          el.focus();
+          focusEditorAtSavedSelection();
           const chip = createFileMentionChip(path, kind);
           if (!chip) return;
           insertNodeAtCursor(el, chip);
@@ -2269,7 +2324,7 @@ export const MentionComposer = memo(
           if (!el) return;
           finishTypewriter();
           resetPromptHistoryRecall();
-          el.focus();
+          focusEditorAtSavedSelection();
           insertNodeAtCursor(el, createSkillMentionChip(skill));
           closeMentionSession();
           refreshEmptyState();
@@ -2279,7 +2334,7 @@ export const MentionComposer = memo(
           if (!el) return;
           finishTypewriter();
           resetPromptHistoryRecall();
-          el.focus();
+          focusEditorAtSavedSelection();
           insertNodeAtCursor(el, createCommitMentionChip(commit));
           closeMentionSession();
           refreshEmptyState();
@@ -2289,7 +2344,7 @@ export const MentionComposer = memo(
           if (!el) return;
           finishTypewriter();
           resetPromptHistoryRecall();
-          el.focus();
+          focusEditorAtSavedSelection();
           insertNodeAtCursor(el, createGitFileMentionChip(file));
           closeMentionSession();
           refreshEmptyState();
@@ -2299,7 +2354,7 @@ export const MentionComposer = memo(
           if (!el) return;
           finishTypewriter();
           resetPromptHistoryRecall();
-          el.focus();
+          focusEditorAtSavedSelection();
           const chip = createCodeMentionChip(reference);
           if (!chip) return;
           insertNodeAtCursor(el, chip);
@@ -2407,6 +2462,7 @@ export const MentionComposer = memo(
         closeCommitTooltip,
         closeMentionSession,
         finishTypewriter,
+        focusEditorAtSavedSelection,
         insertLargePaste,
         placeCaretAtEditorEnd,
         refreshEmptyState,
@@ -2895,6 +2951,7 @@ export const MentionComposer = memo(
     }, [refreshEmptyState, refreshMention, scheduleBusyRelease]);
 
     const handleBlur = useCallback(() => {
+      rememberEditorSelection();
       isComposingRef.current = false;
       compositionEnterKeyRef.current = false;
       lastCompositionEndAtRef.current = 0;
@@ -2907,7 +2964,13 @@ export const MentionComposer = memo(
       closeMentionSession();
       cancelCommitTooltipClose();
       closeCommitTooltip();
-    }, [cancelCommitTooltipClose, closeCommitTooltip, closeMentionSession, setBusy]);
+    }, [
+      cancelCommitTooltipClose,
+      closeCommitTooltip,
+      closeMentionSession,
+      rememberEditorSelection,
+      setBusy,
+    ]);
 
     return (
       <div ref={wrapperRef} className="relative w-full min-w-0 max-w-full flex-1">

--- a/crates/agent-gateway/web/src/components/project-tools/file-tree/index.tsx
+++ b/crates/agent-gateway/web/src/components/project-tools/file-tree/index.tsx
@@ -271,7 +271,6 @@ export function FileTreePanel(props: { active: boolean }) {
     (event: ReactMouseEvent, path: string) => {
       event.preventDefault();
       event.stopPropagation();
-      window.getSelection()?.removeAllRanges();
       const targetPath = nodesRef.current[path] ? path : ROOT_PATH;
       selectPath(targetPath);
       const rect = panelRef.current?.getBoundingClientRect();

--- a/crates/agent-gateway/web/src/components/project-tools/git-review/HistoryView.tsx
+++ b/crates/agent-gateway/web/src/components/project-tools/git-review/HistoryView.tsx
@@ -788,7 +788,6 @@ export function GitReviewHistoryView(props: {
     ) => {
       event.preventDefault();
       event.stopPropagation();
-      window.getSelection()?.removeAllRanges();
       const panelRect = panelRef.current?.getBoundingClientRect();
       // Raw pointer position; the measured-clamp layout effect corrects it.
       const x = panelRect ? event.clientX - panelRect.left : event.clientX;

--- a/crates/agent-gateway/web/src/components/project-tools/git-review/StatusView.tsx
+++ b/crates/agent-gateway/web/src/components/project-tools/git-review/StatusView.tsx
@@ -264,7 +264,6 @@ export function GitReviewStatusView(props: {
     (event: ReactMouseEvent, entry: GitStatusEntry, section: ChangeListSection) => {
       event.preventDefault();
       event.stopPropagation();
-      window.getSelection()?.removeAllRanges();
       setChangesMenu(null);
       const panelRect = panelRef.current?.getBoundingClientRect();
       // Raw pointer position; the measured-clamp layout effect corrects it.
@@ -420,11 +419,6 @@ export function GitReviewStatusView(props: {
           selected && "border-l-emerald-500 bg-emerald-500/10",
           contextMenuOpen && "border-l-primary bg-primary/10 ring-1 ring-inset ring-primary/35",
         )}
-        onMouseDown={(event) => {
-          if (event.button === 2) {
-            window.getSelection()?.removeAllRanges();
-          }
-        }}
         onContextMenu={(event) => openChangeContextMenu(event, entry, section)}
       >
         <button

--- a/crates/agent-gui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gui/src/components/chat/MentionComposer.tsx
@@ -1335,24 +1335,41 @@ function createLargePasteChip(paste: MentionComposerLargePaste) {
   return chip;
 }
 
-function insertNodeAtCursor(root: HTMLElement, node: Node) {
-  const anchor = createCaretAnchorText("");
-  const afterNode = document.createTextNode(anchor.text);
+function insertNodeAtCursor(root: HTMLElement, node: HTMLElement) {
   const sel = window.getSelection();
   if (sel && sel.rangeCount > 0) {
     const range = sel.getRangeAt(0);
-    if (root.contains(range.commonAncestorContainer)) {
-      range.deleteContents();
-      range.insertNode(afterNode);
+    if (editorRangeIsInsideRoot(root, range)) {
+      // A restored selection can carry boundaries inside a non-editable chip
+      // (clicks and double-clicks land there); hop them outside so the new
+      // chip never nests into an existing chip and never guts its label.
+      const startChip = closestComposerChipFromNode(root, range.startContainer);
+      if (startChip) {
+        range.setStartAfter(startChip);
+      }
+      const endChip = closestComposerChipFromNode(root, range.endContainer);
+      if (endChip) {
+        range.setEndBefore(endChip);
+      }
+      if (!range.collapsed) {
+        range.deleteContents();
+      }
       range.insertNode(node);
-      placeCaretInTextNode(afterNode, anchor.caretOffset);
+      // Reuse the split-off text node as the caret anchor instead of minting
+      // a fresh one, so mid-text inserts leave no empty text-node leftovers.
+      const anchor = ensureCaretAnchorAfterChip(node);
+      if (anchor) {
+        placeCaretInTextNode(anchor.textNode, anchor.offset);
+      }
       return;
     }
   }
 
   root.appendChild(node);
-  root.appendChild(afterNode);
-  placeCaretInTextNode(afterNode, anchor.caretOffset);
+  const anchor = ensureCaretAnchorAfterChip(node);
+  if (anchor) {
+    placeCaretInTextNode(anchor.textNode, anchor.offset);
+  }
 }
 
 function scrollSelectionIntoComposerView(root: HTMLElement) {
@@ -2040,6 +2057,32 @@ export const MentionComposer = memo(
       setComposerContextMenu(null);
     }, []);
 
+    const lastEditorSelectionRef = useRef<Range | null>(null);
+    const rememberEditorSelection = useCallback(() => {
+      const editor = editorRef.current;
+      if (!editor) return;
+      const range = editorSelectionRange(editor);
+      if (range) {
+        lastEditorSelectionRef.current = range.cloneRange();
+      }
+    }, []);
+    const focusEditorAtSavedSelection = useCallback(() => {
+      const editor = editorRef.current;
+      if (!editor) return;
+      const range = lastEditorSelectionRef.current;
+      editor.focus({ preventScroll: true });
+      if (!range || !editorRangeIsInsideRoot(editor, range)) return;
+      const selection = window.getSelection();
+      if (!selection) return;
+      selection.removeAllRanges();
+      selection.addRange(range.cloneRange());
+    }, []);
+
+    useEffect(() => {
+      document.addEventListener("selectionchange", rememberEditorSelection);
+      return () => document.removeEventListener("selectionchange", rememberEditorSelection);
+    }, [rememberEditorSelection]);
+
     const setBusy = useCallback(
       (nextBusy: boolean) => {
         if (isBusyRef.current === nextBusy) return;
@@ -2545,7 +2588,7 @@ export const MentionComposer = memo(
           if (!el) return;
           finishTypewriter();
           resetPromptHistoryRecall();
-          el.focus();
+          focusEditorAtSavedSelection();
           const chip = createFileMentionChip(path, kind);
           if (!chip) return;
           insertNodeAtCursor(el, chip);
@@ -2557,7 +2600,7 @@ export const MentionComposer = memo(
           if (!el) return;
           finishTypewriter();
           resetPromptHistoryRecall();
-          el.focus();
+          focusEditorAtSavedSelection();
           insertNodeAtCursor(el, createSkillMentionChip(skill));
           closeMentionSession();
           refreshEmptyState();
@@ -2567,7 +2610,7 @@ export const MentionComposer = memo(
           if (!el) return;
           finishTypewriter();
           resetPromptHistoryRecall();
-          el.focus();
+          focusEditorAtSavedSelection();
           insertNodeAtCursor(el, createCommitMentionChip(commit));
           closeMentionSession();
           refreshEmptyState();
@@ -2577,7 +2620,7 @@ export const MentionComposer = memo(
           if (!el) return;
           finishTypewriter();
           resetPromptHistoryRecall();
-          el.focus();
+          focusEditorAtSavedSelection();
           insertNodeAtCursor(el, createGitFileMentionChip(file));
           closeMentionSession();
           refreshEmptyState();
@@ -2587,7 +2630,7 @@ export const MentionComposer = memo(
           if (!el) return;
           finishTypewriter();
           resetPromptHistoryRecall();
-          el.focus();
+          focusEditorAtSavedSelection();
           const chip = createCodeMentionChip(reference);
           if (!chip) return;
           insertNodeAtCursor(el, chip);
@@ -2698,6 +2741,7 @@ export const MentionComposer = memo(
         closeComposerContextMenu,
         closeMentionSession,
         finishTypewriter,
+        focusEditorAtSavedSelection,
         insertLargePaste,
         placeCaretAtEditorEnd,
         refreshEmptyState,
@@ -3367,6 +3411,7 @@ export const MentionComposer = memo(
     }, [refreshEmptyState, refreshMention, scheduleBusyRelease]);
 
     const handleBlur = useCallback(() => {
+      rememberEditorSelection();
       isComposingRef.current = false;
       compositionEnterKeyRef.current = false;
       lastCompositionEndAtRef.current = 0;
@@ -3385,6 +3430,7 @@ export const MentionComposer = memo(
       closeCommitTooltip,
       closeComposerContextMenu,
       closeMentionSession,
+      rememberEditorSelection,
       setBusy,
     ]);
 

--- a/crates/agent-gui/src/components/project-tools/file-tree/index.tsx
+++ b/crates/agent-gui/src/components/project-tools/file-tree/index.tsx
@@ -271,7 +271,6 @@ export function FileTreePanel(props: { active: boolean }) {
     (event: ReactMouseEvent, path: string) => {
       event.preventDefault();
       event.stopPropagation();
-      window.getSelection()?.removeAllRanges();
       const targetPath = nodesRef.current[path] ? path : ROOT_PATH;
       selectPath(targetPath);
       const rect = panelRef.current?.getBoundingClientRect();

--- a/crates/agent-gui/src/components/project-tools/git-review/HistoryView.tsx
+++ b/crates/agent-gui/src/components/project-tools/git-review/HistoryView.tsx
@@ -788,7 +788,6 @@ export function GitReviewHistoryView(props: {
     ) => {
       event.preventDefault();
       event.stopPropagation();
-      window.getSelection()?.removeAllRanges();
       const panelRect = panelRef.current?.getBoundingClientRect();
       // Raw pointer position; the measured-clamp layout effect corrects it.
       const x = panelRect ? event.clientX - panelRect.left : event.clientX;

--- a/crates/agent-gui/src/components/project-tools/git-review/StatusView.tsx
+++ b/crates/agent-gui/src/components/project-tools/git-review/StatusView.tsx
@@ -264,7 +264,6 @@ export function GitReviewStatusView(props: {
     (event: ReactMouseEvent, entry: GitStatusEntry, section: ChangeListSection) => {
       event.preventDefault();
       event.stopPropagation();
-      window.getSelection()?.removeAllRanges();
       setChangesMenu(null);
       const panelRect = panelRef.current?.getBoundingClientRect();
       // Raw pointer position; the measured-clamp layout effect corrects it.
@@ -420,11 +419,6 @@ export function GitReviewStatusView(props: {
           selected && "border-l-emerald-500 bg-emerald-500/10",
           contextMenuOpen && "border-l-primary bg-primary/10 ring-1 ring-inset ring-primary/35",
         )}
-        onMouseDown={(event) => {
-          if (event.button === 2) {
-            window.getSelection()?.removeAllRanges();
-          }
-        }}
         onContextMenu={(event) => openChangeContextMenu(event, entry, section)}
       >
         <button

--- a/crates/agent-gui/test/chat/mention-composer-selection.test.mjs
+++ b/crates/agent-gui/test/chat/mention-composer-selection.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const sourceRoots = [
+  new URL("../../src/components/", import.meta.url),
+  new URL("../../../agent-gateway/web/src/components/", import.meta.url),
+];
+
+function source(root, relativePath) {
+  return readFileSync(new URL(relativePath, root), "utf8");
+}
+
+test("both composers restore the last editor selection before external mention insertion", () => {
+  for (const root of sourceRoots) {
+    const composer = source(root, "chat/MentionComposer.tsx");
+    assert.match(composer, /lastEditorSelectionRef = useRef<Range \| null>\(null\)/);
+    assert.match(composer, /document\.addEventListener\("selectionchange", rememberEditorSelection\)/);
+    assert.equal(
+      (composer.match(/focusEditorAtSavedSelection\(\);/g) ?? []).length,
+      5,
+    );
+  }
+});
+
+function extractFunction(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `missing function ${name}`);
+  const end = src.indexOf("\n}\n", start);
+  assert.notEqual(end, -1, `unterminated function ${name}`);
+  return src.slice(start, end + 3);
+}
+
+test("insertNodeAtCursor hops chip-inner boundaries and normalizes the caret anchor", () => {
+  const bodies = sourceRoots.map((root) =>
+    extractFunction(source(root, "chat/MentionComposer.tsx"), "insertNodeAtCursor"),
+  );
+  // Both frontends must keep the hardened implementation byte-identical.
+  assert.equal(bodies[0], bodies[1]);
+  const body = bodies[0];
+  // A saved selection restored before external insertion can sit inside a
+  // non-editable chip; the insert must hop outside instead of nesting.
+  assert.match(body, /closestComposerChipFromNode\(root, range\.startContainer\)/);
+  assert.match(body, /setStartAfter\(startChip\)/);
+  assert.match(body, /closestComposerChipFromNode\(root, range\.endContainer\)/);
+  assert.match(body, /setEndBefore\(endChip\)/);
+  // The caret anchor must go through the canonical normalizer so split-off
+  // text nodes are reused instead of leaving empty leftovers.
+  assert.match(body, /ensureCaretAnchorAfterChip\(node\)/);
+  assert.doesNotMatch(body, /range\.insertNode\(afterNode\)/);
+});
+
+test("right-dock context menus preserve composer selection on both frontends", () => {
+  for (const root of sourceRoots) {
+    for (const relativePath of [
+      "project-tools/file-tree/index.tsx",
+      "project-tools/git-review/StatusView.tsx",
+      "project-tools/git-review/HistoryView.tsx",
+    ]) {
+      const panel = source(root, relativePath);
+      assert.doesNotMatch(panel, /window\.getSelection\(\)\?\.removeAllRanges\(\)/);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

### fix(composer): external mention insertion caret handling (7bfc143)
- Right-dock context menus (file tree, git status/history) no longer clear the document selection on right-click; the composer remembers its last in-editor selection via `selectionchange`/blur and restores it before external chip insertion, so panel-inserted mentions land at the user's caret instead of the editor edge.
- Fixes the follow-up bug where Backspace after a panel insert left the caret inside a tag, after its label text: the restored range can carry boundaries inside a non-editable chip (WebKit drops click carets there; double-click selects the chip label and mouseup ejection only corrects collapsed carets), and `insertNodeAtCursor` only checked root containment, so the new chip nested inside the old one.
- Hardened `insertNodeAtCursor` (the single external-insertion choke point): hop the start boundary after the chip, shrink the end boundary before it, and normalize the caret anchor through `ensureCaretAnchorAfterChip`, which also reuses `splitText` leftovers instead of leaving empty text-node dead zones.
- Both frontends stay byte-mirrored; the new `mention-composer-selection.test.mjs` asserts the mirror and the hardening.

### Also riding on this branch
- refactor(settings): share one provider-grouped ModelPicker across model selects (6193a84)
- fix(memory): keep drawer select popups above the settings drawer backdrop (ad70d83)

## Testing
- `tsc --noEmit` clean on agent-gui and agent-gateway/web
- agent-gui chat tests: 390 pass; web tests: 368 pass
- Biome clean on touched files (warning count unchanged); `scripts/check-mirror.mjs` passes (87 files)