### PR TITLE
fix(webui): keep assistant reply actions visible on touch devices

### DIFF
--- a/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
+++ b/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
@@ -1021,7 +1021,7 @@ const GatewayAssistantMessageActions = memo(function GatewayAssistantMessageActi
           {formatMessageTimestamp(row.timestamp)}
         </span>
         <div
-          className={`flex gap-0.5 transition-opacity group-focus-within/assistant:opacity-100 group-hover/assistant:opacity-100 ${isRowBranchPending ? "opacity-100" : "opacity-0"}`}
+          className={`flex gap-0.5 transition-opacity group-focus-within/assistant:opacity-100 group-hover/assistant:opacity-100 [@media(hover:none)]:opacity-100 ${isRowBranchPending ? "opacity-100" : "opacity-0"}`}
         >
           <button
             type="button"

--- a/crates/agent-gateway/web/src/index.css
+++ b/crates/agent-gateway/web/src/index.css
@@ -999,12 +999,20 @@
     }
   }
 
-  /* Mention composer placeholder */
+  /* Mention composer placeholder. left/right pin the box to the editor's own
+     padding box, and padding-right inherits its pr-8 (expand-button gutter) so
+     the placeholder wraps exactly like real typed text instead of running
+     under the button — the containing block's padding box already includes
+     that padding, so without this it overlaps regardless of which ancestor
+     is positioned. */
   .mention-composer.is-empty::before {
     content: attr(data-placeholder);
     color: hsl(var(--muted-foreground));
     pointer-events: none;
     position: absolute;
+    left: 0;
+    right: 0;
+    padding-right: inherit;
   }
 
   /* Composer typewriter: freshly typed characters fade in softly.


### PR DESCRIPTION
## Summary
- Copy/retry/branch buttons under an assistant reply were hover-only, making them undiscoverable on touch devices (no hover state).
- Added an `(hover: none)` media-query override so the actions stay fully visible on touch/mobile, while desktop keeps the existing hover-to-reveal behavior.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manually verify in a touch-emulated viewport (Chrome DevTools device toolbar) that the buttons are visible without hovering
- [ ] Manually verify desktop hover-to-reveal behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)