### PR TITLE
fix(proxy): extend app-proxy coverage and isolate local tunnel from env proxies

### DIFF
--- a/crates/agent-gateway/web/src/i18n/config.ts
+++ b/crates/agent-gateway/web/src/i18n/config.ts
@@ -1012,7 +1012,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.systemProxy": "应用代理",
     "settings.systemProxyEnable": "启用应用代理",
     "settings.systemProxyDesc":
-      "生效范围：桌面端本地命令环境变量（Bash / 后台任务 / 自动化脚本）、勾选“使用应用代理”的供应商请求、更新检查与技能下载。",
+      "生效范围：桌面端本地命令环境变量（Bash / 后台任务 / 自动化脚本）、勾选“使用应用代理”的供应商请求、Hook / Cron HTTP 任务、聊天图片加载、更新检查与技能下载。",
     "settings.systemProxyInvalid":
       "代理已启用，请填写有效的代理地址和端口；配置有效前相关请求将直接报错。",
     "settings.systemProxyEnableHint": "请先填写有效的代理地址和端口后再启用代理。",
@@ -2904,7 +2904,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.systemProxy": "App Proxy",
     "settings.systemProxyEnable": "Enable app proxy",
     "settings.systemProxyDesc":
-      "Applies to: local command environment on the desktop (Bash / background tasks / automation scripts), providers with “Use app proxy” checked, update checks and skill downloads.",
+      "Applies to: local command environment on the desktop (Bash / background tasks / automation scripts), providers with “Use app proxy” checked, Hook / Cron HTTP tasks, chat image loading, update checks and skill downloads.",
     "settings.systemProxyInvalid":
       "The proxy is enabled. Enter a valid host and port; affected requests fail until the configuration is valid.",
     "settings.systemProxyEnableHint":

--- a/crates/agent-gui/src-tauri/src/commands/app/custom_tools.rs
+++ b/crates/agent-gui/src-tauri/src/commands/app/custom_tools.rs
@@ -16,7 +16,10 @@ pub struct SystemHttpGetResponse {
 #[tauri::command]
 pub async fn system_http_get_test() -> Result<SystemHttpGetResponse, String> {
     tauri::async_runtime::spawn_blocking(|| {
-        let client = reqwest::blocking::Client::builder()
+        // 网络自检需反映应用真实出网路径：应用代理启用时经代理请求，
+        // 配置异常 fail fast；未启用则直连（忽略环境代理）。
+        let client = crate::services::system_proxy::blocking_client_builder()
+            .map_err(|e| format!("Failed to create the HTTP client: {e}"))?
             .timeout(Duration::from_secs(10))
             .build()
             .map_err(|e| format!("Failed to create the HTTP client: {e}"))?;

--- a/crates/agent-gui/src-tauri/src/commands/workspace/fs.rs
+++ b/crates/agent-gui/src-tauri/src/commands/workspace/fs.rs
@@ -2376,7 +2376,10 @@ fn read_url_image_source(source: &str) -> Result<ReadResponse, FsError> {
         }
     }
 
-    let client = reqwest::blocking::Client::builder()
+    // Image.url 供模型读取远程图片：与聊天图片反代同语义，应用代理启用时
+    // 经代理出网，代理配置异常时 fail fast，不静默直连。
+    let client = crate::services::system_proxy::blocking_client_builder()
+        .map_err(|e| FsError::Other(format!("Failed to create the HTTP client: {e}")))?
         .timeout(Duration::from_secs(IMAGE_SOURCE_HTTP_TIMEOUT_SECS))
         .build()
         .map_err(|e| FsError::Other(format!("Failed to create the HTTP client: {e}")))?;

--- a/crates/agent-gui/src-tauri/src/runtime/task_runner.rs
+++ b/crates/agent-gui/src-tauri/src/runtime/task_runner.rs
@@ -101,8 +101,13 @@ fn build_header_map(headers: &Option<BTreeMap<String, String>>) -> Result<Header
 
 /// `timeout_ms` bounds every request made by the returned client; `None`
 /// keeps the legacy 10s default used by hooks.
+///
+/// Hook / Cron HTTP 与其他应用出网点同策略：应用代理启用时经代理出网
+/// （环回地址豁免），配置异常 fail fast；未启用则直连并忽略环境代理，
+/// 避免 OS 级 HTTP(S)_PROXY 悄悄劫持自动化请求。
 pub(crate) fn build_http_client(timeout_ms: Option<u64>) -> Result<Client, String> {
-    Client::builder()
+    crate::services::system_proxy::blocking_client_builder()
+        .map_err(|e| format!("创建 Hook HTTP client 失败：{e}"))?
         .timeout(Duration::from_millis(
             timeout_ms.unwrap_or(DEFAULT_HTTP_TIMEOUT_MS).max(1),
         ))

--- a/crates/agent-gui/src-tauri/src/services/proxy.rs
+++ b/crates/agent-gui/src-tauri/src/services/proxy.rs
@@ -121,18 +121,25 @@ pub fn start_proxy_server() -> Result<Arc<ProxyServerState>, String> {
     Ok(state)
 }
 
-async fn handle_image_proxy(
-    State(state): State<Arc<ProxyServerState>>,
-    Query(query): Query<ImageProxyQuery>,
-    headers: HeaderMap,
-) -> Response {
+async fn handle_image_proxy(Query(query): Query<ImageProxyQuery>, headers: HeaderMap) -> Response {
     let target_url = match validate_image_proxy_url(&query.url) {
         Ok(url) => url,
         Err(message) => return error_response(StatusCode::BAD_REQUEST, &message, &headers),
     };
 
-    let image_request = state
-        .client
+    // 图片外链与商店链路同语义：恒随应用代理出网（未启用=直连，配置异常
+    // 502 fail fast）。<img> 请求无法携带自定义头，因此不走 per-request 开关。
+    let client = match crate::services::system_proxy::cached_client() {
+        Ok(client) => client,
+        Err(error) => {
+            return error_response(
+                StatusCode::BAD_GATEWAY,
+                &format!("App proxy unavailable: {error}"),
+                &headers,
+            );
+        }
+    };
+    let image_request = client
         .get(target_url.clone())
         .timeout(Duration::from_secs(IMAGE_PROXY_TIMEOUT_SECS));
 

--- a/crates/agent-gui/src-tauri/src/services/system_proxy.rs
+++ b/crates/agent-gui/src-tauri/src/services/system_proxy.rs
@@ -1,5 +1,6 @@
 //! 系统代理单一真源：设置保存/启动初始化时写入，shell env 注入与
-//! 各 reqwest 出网点（本地反代、更新检查、技能下载、MCP http/sse transport）按需读取。
+//! 各 reqwest 出网点（本地反代、图片反代、更新检查、技能下载、
+//! MCP http/sse transport、Hook / Cron HTTP、网络自检、Image.url 读取）按需读取。
 //! reqwest 侧与 shell env 共用 NO_PROXY_DEFAULT：环回地址永不走代理。
 //! 凭据绝不进入日志与错误信息（只输出 host:port）。
 

--- a/crates/agent-gui/src-tauri/src/services/tunnel/mod.rs
+++ b/crates/agent-gui/src-tauri/src/services/tunnel/mod.rs
@@ -536,7 +536,9 @@ async fn probe_tunnel_target(target_url: &str) -> TunnelHealthPayload {
         checked_at,
         rtt_ms: 0,
     };
+    // 探活目标与转发目标一致（本机/内网）：同样忽略环境代理，见 proxy.rs。
     let client = match reqwest::Client::builder()
+        .no_proxy()
         .redirect(reqwest::redirect::Policy::none())
         .timeout(TUNNEL_LOCAL_PROBE_TIMEOUT)
         .build()

--- a/crates/agent-gui/src-tauri/src/services/tunnel/proxy.rs
+++ b/crates/agent-gui/src-tauri/src/services/tunnel/proxy.rs
@@ -261,7 +261,10 @@ async fn run_tunnel_http_request(
         let method = reqwest::Method::from_bytes(method.trim().as_bytes())
             .map_err(|e| format!("invalid tunnel request method: {e}"))?;
         let body = reqwest::Body::wrap_stream(ReceiverStream::new(body_rx));
+        // 隧道目标恒为本机/内网服务：显式忽略环境代理，
+        // 防止 OS 级 HTTP(S)_PROXY 劫持本地转发导致隧道不可用。
         let client = reqwest::Client::builder()
+            .no_proxy()
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .map_err(|e| format!("failed to build local tunnel HTTP client: {e}"))?;

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -1084,7 +1084,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.systemProxy": "应用代理",
     "settings.systemProxyEnable": "启用应用代理",
     "settings.systemProxyDesc":
-      "生效范围：本地命令环境变量（Bash / 后台任务 / 自动化脚本）、勾选“使用应用代理”的供应商请求、更新检查与技能下载。",
+      "生效范围：本地命令环境变量（Bash / 后台任务 / 自动化脚本）、勾选“使用应用代理”的供应商请求、Hook / Cron HTTP 任务、聊天图片加载、更新检查与技能下载。",
     "settings.systemProxyInvalid":
       "代理已启用，请填写有效的代理地址和端口；配置有效前相关请求将直接报错。",
     "settings.systemProxyEnableHint": "请先填写有效的代理地址和端口后再启用代理。",
@@ -3062,7 +3062,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.systemProxy": "App Proxy",
     "settings.systemProxyEnable": "Enable app proxy",
     "settings.systemProxyDesc":
-      "Applies to: local command environment (Bash / background tasks / automation scripts), providers with “Use app proxy” checked, update checks and skill downloads.",
+      "Applies to: local command environment (Bash / background tasks / automation scripts), providers with “Use app proxy” checked, Hook / Cron HTTP tasks, chat image loading, update checks and skill downloads.",
     "settings.systemProxyInvalid":
       "The proxy is enabled. Enter a valid host and port; affected requests fail until the configuration is valid.",
     "settings.systemProxyEnableHint":


### PR DESCRIPTION
## 背景

排查设置中「应用代理」相关功能时发现：模型请求主链路（对话 / 标题生成 / 压缩 / Cron / Memory / 子代理 / 拉模型列表）对 `useSystemProxy` 的接线是完整一致的，但桌面端仍有若干出网点没有接入应用代理、或会被 OS 级环境变量代理意外劫持，在代理网络环境下会产生实际访问错误。

## 修复内容

**1. 图片反代 `/image-proxy` 从不走应用代理（`services/proxy.rs`）**
此前恒用启动时的 `no_proxy` 直连 client。在只有代理可出网的环境里，对话正常但聊天中的外链图片全部加载失败。`<img>` 请求无法携带自定义头，无法做 per-request 开关，故与商店（Hub）链路同语义：恒随应用代理出网，未启用=直连，配置异常 502 fail fast。

**2. Hook / Cron HTTP 任务未接入应用代理（`runtime/task_runner.rs`）**
`build_http_client` 此前用裸 `Client::builder()`：既不走应用代理，又会隐式跟随 OS 的 `HTTP(S)_PROXY` 环境变量（还没有环回豁免）。现改为共享 `system_proxy::blocking_client_builder()`，与 MCP / 更新检查 / 技能下载策略一致：启用走代理（环回豁免）、未启用直连、配置异常 fail fast。

**3. 网络自检 `system_http_get_test` 不反映真实出网路径（`commands/app/custom_tools.rs`）**
自检工具此前永远绕开应用代理，代理环境下测试结果与实际业务行为不符。现同样走 `system_proxy` 构建。

**4. `Image.url` 读取远程图片未走应用代理（`commands/workspace/fs.rs`）**
模型读取远程图片附件的路径，与聊天图片反代对齐。

**5. 隧道本地转发 / 探活可能被环境代理劫持（`services/tunnel/proxy.rs`、`services/tunnel/mod.rs`）**
隧道目标恒为本机 / 内网地址（`validate_tunnel_target_url` 强制），但 client 未 `.no_proxy()`：机器上设置过 `HTTP_PROXY` 且 `NO_PROXY` 不含 localhost 时，本地转发会被送进外部代理导致隧道不可用、探活误报。现显式忽略环境代理。

**6. i18n 生效范围描述更新（GUI + Gateway WebUI，中英文）**
补充「Hook / Cron HTTP 任务、聊天图片加载」。

## 不改变的行为

- 供应商模型请求仍为 per-provider 勾选「使用应用代理」的 opt-in 语义，未勾选保持直连；
- 应用代理未启用时，上述所有链路保持直连（忽略环境代理）；
- 配置异常一律 fail fast，绝不静默降级为直连。

## 测试

- `cargo check --manifest-path crates/agent-gui/src-tauri/Cargo.toml --tests` 通过（CI 同款门禁）
- `cargo fmt --check` 对本次改动文件无偏差
- GUI 前端 `pnpm test:frontend`：1066 通过 / 0 失败
- Gateway WebUI `pnpm test` + `pnpm lint`：367 通过 / 0 失败
- `node scripts/check-mirror.mjs`：87 个镜像文件一致