### PR TITLE
fix(composer): keep the caret visible after Shift+Enter line breaks

### DIFF
--- a/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
@@ -1140,6 +1140,67 @@ function insertNodeAtCursor(root: HTMLElement, node: HTMLElement) {
   }
 }
 
+/** Measure the caret rect without corrupting the selection.
+ *
+ *  Range.getClientRects() covers most caret positions but is empty at line
+ *  boundaries (e.g. right after a Shift+Enter line break). The old fallback
+ *  used Range.insertNode() at the caret, which splits the underlying text
+ *  node; the caret then ended up inside the degenerate empty text node left
+ *  by the split, and WebKit stops painting a caret there entirely — the
+ *  cursor visibly vanished after every Shift+Enter. Instead, insert the
+ *  probe at the nearest node boundary (never splitting text nodes) and put
+ *  the selection back exactly where it was afterwards. */
+function measureComposerCaretRect(range: Range): DOMRect | null {
+  const rects = range.getClientRects();
+  if (rects.length > 0) {
+    return rects[0];
+  }
+
+  const { startContainer, startOffset } = range;
+  let parent: Node | null;
+  let before: Node | null;
+  if (startContainer.nodeType === Node.TEXT_NODE) {
+    const textNode = startContainer as Text;
+    parent = textNode.parentNode;
+    if (startOffset <= 0) {
+      before = textNode;
+    } else if (startOffset >= textNode.length) {
+      before = textNode.nextSibling;
+    } else {
+      // Mid-text carets always produce client rects; never risk a split.
+      return null;
+    }
+  } else {
+    parent = startContainer;
+    before = startContainer.childNodes[startOffset] ?? null;
+  }
+  if (!parent) {
+    return null;
+  }
+
+  const marker = document.createElement("span");
+  marker.textContent = "\u200B";
+  marker.style.display = "inline-block";
+  marker.style.width = "0";
+  marker.style.height = "1em";
+  marker.style.overflow = "hidden";
+  parent.insertBefore(marker, before);
+  const markerRect = marker.getBoundingClientRect();
+  marker.remove();
+
+  // Even a non-splitting insert/remove can drop or shift a WebKit selection;
+  // restore the caret to the exact position that was measured.
+  const sel = window.getSelection();
+  if (sel) {
+    try {
+      sel.collapse(startContainer, startOffset);
+    } catch {
+      // The container vanished mid-frame; leave the selection untouched.
+    }
+  }
+  return markerRect;
+}
+
 function scrollSelectionIntoComposerView(root: HTMLElement) {
   const sel = window.getSelection();
   if (!sel || sel.rangeCount === 0 || !sel.isCollapsed) {
@@ -1152,29 +1213,21 @@ function scrollSelectionIntoComposerView(root: HTMLElement) {
     return;
   }
 
-  const marker = document.createElement("span");
-  marker.textContent = "\u200B";
-  marker.style.display = "inline-block";
-  marker.style.width = "0";
-  marker.style.height = "1em";
-  marker.style.overflow = "hidden";
+  const caretRect = measureComposerCaretRect(range);
+  if (!caretRect) {
+    return;
+  }
 
-  const markerRange = range.cloneRange();
-  markerRange.insertNode(marker);
-
-  const markerRect = marker.getBoundingClientRect();
   const rootRect = root.getBoundingClientRect();
   const margin = 4;
-  const bottomOverflow = markerRect.bottom - (rootRect.bottom - margin);
-  const topOverflow = rootRect.top + margin - markerRect.top;
+  const bottomOverflow = caretRect.bottom - (rootRect.bottom - margin);
+  const topOverflow = rootRect.top + margin - caretRect.top;
 
   if (bottomOverflow > 0) {
     root.scrollTop += bottomOverflow;
   } else if (topOverflow > 0) {
     root.scrollTop -= topOverflow;
   }
-
-  marker.remove();
 }
 
 function scheduleComposerSelectionScroll(root: HTMLElement | null) {

--- a/crates/agent-gui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gui/src/components/chat/MentionComposer.tsx
@@ -1372,6 +1372,67 @@ function insertNodeAtCursor(root: HTMLElement, node: HTMLElement) {
   }
 }
 
+/** Measure the caret rect without corrupting the selection.
+ *
+ *  Range.getClientRects() covers most caret positions but is empty at line
+ *  boundaries (e.g. right after a Shift+Enter line break). The old fallback
+ *  used Range.insertNode() at the caret, which splits the underlying text
+ *  node; the caret then ended up inside the degenerate empty text node left
+ *  by the split, and WebKit stops painting a caret there entirely — the
+ *  cursor visibly vanished after every Shift+Enter. Instead, insert the
+ *  probe at the nearest node boundary (never splitting text nodes) and put
+ *  the selection back exactly where it was afterwards. */
+function measureComposerCaretRect(range: Range): DOMRect | null {
+  const rects = range.getClientRects();
+  if (rects.length > 0) {
+    return rects[0];
+  }
+
+  const { startContainer, startOffset } = range;
+  let parent: Node | null;
+  let before: Node | null;
+  if (startContainer.nodeType === Node.TEXT_NODE) {
+    const textNode = startContainer as Text;
+    parent = textNode.parentNode;
+    if (startOffset <= 0) {
+      before = textNode;
+    } else if (startOffset >= textNode.length) {
+      before = textNode.nextSibling;
+    } else {
+      // Mid-text carets always produce client rects; never risk a split.
+      return null;
+    }
+  } else {
+    parent = startContainer;
+    before = startContainer.childNodes[startOffset] ?? null;
+  }
+  if (!parent) {
+    return null;
+  }
+
+  const marker = document.createElement("span");
+  marker.textContent = "\u200B";
+  marker.style.display = "inline-block";
+  marker.style.width = "0";
+  marker.style.height = "1em";
+  marker.style.overflow = "hidden";
+  parent.insertBefore(marker, before);
+  const markerRect = marker.getBoundingClientRect();
+  marker.remove();
+
+  // Even a non-splitting insert/remove can drop or shift a WebKit selection;
+  // restore the caret to the exact position that was measured.
+  const sel = window.getSelection();
+  if (sel) {
+    try {
+      sel.collapse(startContainer, startOffset);
+    } catch {
+      // The container vanished mid-frame; leave the selection untouched.
+    }
+  }
+  return markerRect;
+}
+
 function scrollSelectionIntoComposerView(root: HTMLElement) {
   const sel = window.getSelection();
   if (!sel || sel.rangeCount === 0 || !sel.isCollapsed) {
@@ -1384,29 +1445,21 @@ function scrollSelectionIntoComposerView(root: HTMLElement) {
     return;
   }
 
-  const marker = document.createElement("span");
-  marker.textContent = "\u200B";
-  marker.style.display = "inline-block";
-  marker.style.width = "0";
-  marker.style.height = "1em";
-  marker.style.overflow = "hidden";
+  const caretRect = measureComposerCaretRect(range);
+  if (!caretRect) {
+    return;
+  }
 
-  const markerRange = range.cloneRange();
-  markerRange.insertNode(marker);
-
-  const markerRect = marker.getBoundingClientRect();
   const rootRect = root.getBoundingClientRect();
   const margin = 4;
-  const bottomOverflow = markerRect.bottom - (rootRect.bottom - margin);
-  const topOverflow = rootRect.top + margin - markerRect.top;
+  const bottomOverflow = caretRect.bottom - (rootRect.bottom - margin);
+  const topOverflow = rootRect.top + margin - caretRect.top;
 
   if (bottomOverflow > 0) {
     root.scrollTop += bottomOverflow;
   } else if (topOverflow > 0) {
     root.scrollTop -= topOverflow;
   }
-
-  marker.remove();
 }
 
 function scheduleComposerSelectionScroll(root: HTMLElement | null) {

--- a/crates/agent-gui/test/chat/mention-composer-selection.test.mjs
+++ b/crates/agent-gui/test/chat/mention-composer-selection.test.mjs
@@ -62,3 +62,27 @@ test("right-dock context menus preserve composer selection on both frontends", (
     }
   }
 });
+
+test("composer caret measurement never splits text nodes and restores the selection", () => {
+  const bodies = sourceRoots.map((root) =>
+    extractFunction(source(root, "chat/MentionComposer.tsx"), "measureComposerCaretRect"),
+  );
+  // Both frontends must keep the hardened implementation byte-identical.
+  assert.equal(bodies[0], bodies[1]);
+  const body = bodies[0];
+  // Range.insertNode() splits the text node under a line-boundary caret; the
+  // caret then lands inside the degenerate empty text node left by the split
+  // and WebKit stops painting it — the cursor vanished after Shift+Enter.
+  // The probe must be inserted at a node boundary instead, and the selection
+  // must be restored to the measured position afterwards.
+  assert.doesNotMatch(body, /insertNode\(/);
+  assert.match(body, /parent\.insertBefore\(marker, before\)/);
+  assert.match(body, /sel\.collapse\(startContainer, startOffset\)/);
+
+  const scrollBodies = sourceRoots.map((root) =>
+    extractFunction(source(root, "chat/MentionComposer.tsx"), "scrollSelectionIntoComposerView"),
+  );
+  assert.equal(scrollBodies[0], scrollBodies[1]);
+  assert.match(scrollBodies[0], /measureComposerCaretRect\(range\)/);
+  assert.doesNotMatch(scrollBodies[0], /cloneRange\(\)/);
+});


### PR DESCRIPTION
## Problem

在对话输入框中按 **Shift+Enter** 换行后，光标会消失（不再闪烁），直到输入下一个字符才恢复。桌面端（macOS WKWebView）必现。

## Root cause

`scrollSelectionIntoComposerView()` measures the caret by inserting a probe `<span>` with `Range.insertNode()` at the selection. Per the DOM spec, `insertNode` on a text-node position always calls `splitText()` — for the caret position left by `insertLineBreak` (offset 0 of the placeholder `"\n"` text node) this strands the selection inside a **degenerate empty text node** created by the split:

```
before:  ["hello\n", "\n"]           caret at ("\n", 0)   → caret painted
after:   ["hello\n", "", "\n"]       caret at ("", 0)     → WebKit paints no caret
```

WebKit refuses to paint a caret in an empty text node with no line box, so the cursor vanishes after every Shift+Enter. (Chromium tolerates the same degenerate state, which is why WebView2 users don't see it.)

## Fix

New `measureComposerCaretRect()` measures without corrupting the selection:

1. Prefer `Range.getClientRects()` — non-empty for mid-text carets, zero DOM mutation.
2. For line-boundary carets (empty rects), insert the probe at the nearest **node boundary** (`parent.insertBefore`), so text nodes are never split, then explicitly restore the selection to the measured position.

Applied identically to both frontends (`agent-gui` and `agent-gateway/web`, kept byte-identical per repo convention) plus a regression test asserting the measurement never uses `insertNode` and always restores the selection.

## Verification

Playwright harness driving real keyboard input against a faithful extraction of the composer (WebKit 26.5 + Chromium), asserting caret paint via screenshot blink-diff:

| Scenario | WebKit old | WebKit new | Chromium old | Chromium new |
|---|---|---|---|---|
| Shift+Enter at end of text | ❌ caret gone | ✅ | ✅ | ✅ |
| Shift+Enter on empty editor | ❌ caret gone | ✅ | ✅ | ✅ |
| Shift+Enter mid-text | ✅ | ✅ | ✅ | ✅ |
| 12-line overflow → caret scrolled into view | gap 6px | gap 4px | gap 5px | gap 5px |
| Text integrity after subsequent typing | ✅ | ✅ | ✅ | ✅ |

Scroll-into-view behaviour is preserved within 2px of the old implementation.

- `agent-gui`: `tsc` ✅ · biome ✅ (no new) · 1067/1067 tests ✅
- `agent-gateway/web`: `tsc` ✅ · biome ✅ (no new) · 367/367 tests ✅
