### PR TITLE
fix(providers): read event.currentTarget before deferred setState in model editor

### DIFF
--- a/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
@@ -833,16 +833,12 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                                           "ring-1 ring-inset ring-destructive focus-visible:ring-destructive",
                                       )}
                                       value={editingModel.contextWindow}
-                                      onChange={(event) =>
+                                      onChange={(event) => {
+                                        const value = event.currentTarget.value;
                                         setEditingModel((prev) =>
-                                          prev
-                                            ? {
-                                                ...prev,
-                                                contextWindow: event.currentTarget.value,
-                                              }
-                                            : prev,
-                                        )
-                                      }
+                                          prev ? { ...prev, contextWindow: value } : prev,
+                                        );
+                                      }}
                                     />
                                   </div>
                                   <div className="space-y-1.5">
@@ -857,16 +853,12 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                                           "ring-1 ring-inset ring-destructive focus-visible:ring-destructive",
                                       )}
                                       value={editingModel.maxOutputToken}
-                                      onChange={(event) =>
+                                      onChange={(event) => {
+                                        const value = event.currentTarget.value;
                                         setEditingModel((prev) =>
-                                          prev
-                                            ? {
-                                                ...prev,
-                                                maxOutputToken: event.currentTarget.value,
-                                              }
-                                            : prev,
-                                        )
-                                      }
+                                          prev ? { ...prev, maxOutputToken: value } : prev,
+                                        );
+                                      }}
                                     />
                                   </div>
                                 </div>
@@ -901,16 +893,12 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                                             "ring-1 ring-inset ring-destructive focus-visible:ring-destructive",
                                         )}
                                         value={editingModel[field]}
-                                        onChange={(event) =>
+                                        onChange={(event) => {
+                                          const value = event.currentTarget.value;
                                           setEditingModel((prev) =>
-                                            prev
-                                              ? {
-                                                  ...prev,
-                                                  [field]: event.currentTarget.value,
-                                                }
-                                              : prev,
-                                          )
-                                        }
+                                            prev ? { ...prev, [field]: value } : prev,
+                                          );
+                                        }}
                                       />
                                     </div>
                                   ))}

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -883,16 +883,12 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                                           "ring-1 ring-inset ring-destructive focus-visible:ring-destructive",
                                       )}
                                       value={editingModel.contextWindow}
-                                      onChange={(event) =>
+                                      onChange={(event) => {
+                                        const value = event.currentTarget.value;
                                         setEditingModel((prev) =>
-                                          prev
-                                            ? {
-                                                ...prev,
-                                                contextWindow: event.currentTarget.value,
-                                              }
-                                            : prev,
-                                        )
-                                      }
+                                          prev ? { ...prev, contextWindow: value } : prev,
+                                        );
+                                      }}
                                     />
                                   </div>
                                   <div className="space-y-1.5">
@@ -907,16 +903,12 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                                           "ring-1 ring-inset ring-destructive focus-visible:ring-destructive",
                                       )}
                                       value={editingModel.maxOutputToken}
-                                      onChange={(event) =>
+                                      onChange={(event) => {
+                                        const value = event.currentTarget.value;
                                         setEditingModel((prev) =>
-                                          prev
-                                            ? {
-                                                ...prev,
-                                                maxOutputToken: event.currentTarget.value,
-                                              }
-                                            : prev,
-                                        )
-                                      }
+                                          prev ? { ...prev, maxOutputToken: value } : prev,
+                                        );
+                                      }}
                                     />
                                   </div>
                                 </div>
@@ -951,16 +943,12 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                                             "ring-1 ring-inset ring-destructive focus-visible:ring-destructive",
                                         )}
                                         value={editingModel[field]}
-                                        onChange={(event) =>
+                                        onChange={(event) => {
+                                          const value = event.currentTarget.value;
                                           setEditingModel((prev) =>
-                                            prev
-                                              ? {
-                                                  ...prev,
-                                                  [field]: event.currentTarget.value,
-                                                }
-                                              : prev,
-                                          )
-                                        }
+                                            prev ? { ...prev, [field]: value } : prev,
+                                          );
+                                        }}
                                       />
                                     </div>
                                   ))}


### PR DESCRIPTION
## Summary
- Editing a model's contextWindow/maxOutputToken/other fields in the provider modal could crash: React nulls `event.currentTarget` before an async `setState` updater callback runs, so reading it inside `setEditingModel((prev) => ...)` was unsafe.
- Capture the field value synchronously into a local variable before the deferred updater, in both agent-gateway/web and agent-gui (mirrored files).

## Test plan
- [x] Open provider settings, edit a custom model, and update contextWindow/maxOutputToken/other fields without a crash (both WebUI and GUI)