### PR TITLE
fix(updater): route update check/download/install through the app proxy

### DIFF
--- a/crates/agent-gui/src-tauri/src/commands/app/update.rs
+++ b/crates/agent-gui/src-tauri/src/commands/app/update.rs
@@ -452,6 +452,13 @@ fn build_updater(
         builder = builder.pubkey(public_key);
     }
 
+    // 更新下载/安装与 github_client() 的探测请求保持同一份应用代理配置；未启用时
+    // 显式 no_proxy()，避免插件内部 client 兜底读取 OS 代理环境变量。
+    builder = match crate::services::system_proxy::current_proxy_url()? {
+        Some(proxy_url) => builder.proxy(proxy_url),
+        None => builder.no_proxy(),
+    };
+
     builder
         .endpoints(vec![manifest_url])
         .map_err(|error| format!("invalid updater endpoint: {error}"))?

--- a/crates/agent-gui/src-tauri/src/services/system_proxy.rs
+++ b/crates/agent-gui/src-tauri/src/services/system_proxy.rs
@@ -282,6 +282,21 @@ pub fn blocking_client_builder() -> Result<reqwest::blocking::ClientBuilder, Str
     blocking_client_builder_for_mode(&current_snapshot().mode)
 }
 
+/// Resolved proxy URL for consumers that configure their own HTTP client rather
+/// than using `client_builder()`/`cached_client()` (e.g. `tauri-plugin-updater`,
+/// which only accepts a `Url` on its builder). `Ok(None)` means the app proxy is
+/// disabled — callers must still explicitly disable their own client's proxy in
+/// that case instead of leaving it to fall back to OS proxy env vars.
+pub fn current_proxy_url() -> Result<Option<reqwest::Url>, String> {
+    match current_snapshot().mode {
+        ProxyMode::Disabled => Ok(None),
+        ProxyMode::Invalid(error) => Err(error),
+        ProxyMode::Enabled(config) => reqwest::Url::parse(&config.proxy_url())
+            .map(Some)
+            .map_err(|_| format!("应用代理地址无效：{}", config.display_target())),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -402,5 +417,29 @@ mod tests {
         assert!(shell_proxy_envs_for_mode(&ProxyMode::Disabled)
             .expect("disabled proxy envs")
             .is_empty());
+    }
+
+    #[test]
+    fn current_proxy_url_reflects_mode() {
+        set_config(None);
+        assert_eq!(current_proxy_url().expect("disabled proxy url"), None);
+
+        set_config(Some(&json!({
+            "enabled": true, "type": "http", "host": "proxy.local", "port": 8080
+        })));
+        assert_eq!(
+            current_proxy_url()
+                .expect("enabled proxy url")
+                .map(|url| url.to_string()),
+            Some("http://proxy.local:8080/".to_string())
+        );
+
+        set_config(Some(&json!({
+            "enabled": true, "type": "http", "host": "bad host/@", "port": 8080
+        })));
+        assert!(current_proxy_url().is_err());
+
+        // reset so other tests in this module observe the default disabled state
+        set_config(None);
     }
 }


### PR DESCRIPTION
## Summary
- `github_client()` (manifest existence probe + release feed lookup) already routed through the app proxy, but `build_updater()` left `tauri-plugin-updater`'s own internal client untouched — the authoritative `updater.check()` and `update.download_and_install()` connected to GitHub directly, ignoring the app proxy setting (or silently picking up unrelated OS-level proxy env vars).
- Added `system_proxy::current_proxy_url()` to resolve the current app-proxy config into a `Url` for consumers that configure their own client (rather than reusing `client_builder()`), and wired it into `build_updater()`: `.proxy(url)` when enabled, `.no_proxy()` when disabled, matching the "single source of truth, no OS env leakage" behavior used elsewhere in `system_proxy.rs`.
- Since `UpdaterBuilder`'s `proxy`/`no_proxy` fields flow through to both `Updater::check()` and the resulting `Update::download_and_install()`, this one change covers the entire update flow (check, download, install).

## Test plan
- [x] `cargo test` for `services::system_proxy::tests::*` (8 tests, incl. new `current_proxy_url_reflects_mode`) and `commands::app_commands::update::tests::*` (5 tests) — all pass
- [x] `cargo check` / `cargo clippy` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)