### PR TITLE
fix(chat): hide changed-files row actions on mobile so taps open the editor

### DIFF
--- a/crates/agent-gateway/web/src/components/chat/ChangedFilesCard.tsx
+++ b/crates/agent-gateway/web/src/components/chat/ChangedFilesCard.tsx
@@ -34,8 +34,10 @@ function splitPath(path: string): { dir: string; base: string } {
   return { dir: normalized.slice(0, index + 1), base: normalized.slice(index + 1) };
 }
 
+// 移动端（< md）隐藏行内两个动作按钮：opacity-0 的按钮在触屏上仍可被误触，
+// 且没有 hover 可以显形；此时点按文件名默认用代码编辑器打开。
 const ROW_ACTION_CLASS =
-  "flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 opacity-0 transition-all hover:bg-foreground/[0.07] hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none group-hover/changed-file:opacity-100";
+  "hidden h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 opacity-0 transition-all hover:bg-foreground/[0.07] hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none group-hover/changed-file:opacity-100 md:flex";
 
 const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFileEntry }) {
   const { t } = useLocale();


### PR DESCRIPTION
## 变更内容

WebUI 已编辑文件卡片（ChangedFilesCard）在移动端（< md / 768px）的交互修正：

- 每个文件行右侧的两个动作按钮（在文件树中定位、查看 diff）在移动端布局下彻底隐藏（`ROW_ACTION_CLASS` 由 `flex` 改为 `hidden md:flex`）。
- 此前这两个按钮是 `opacity-0` + hover 显形：触屏上不可见但仍占位、可被误触，且没有 hover 让它们显形。
- 隐藏后文件名按钮（`flex-1`）占满整行剩余宽度，移动端点按文件行即默认用代码编辑器打开该文件（已删除文件仍不可点，行为不变）。
- 桌面端 hover 显形行为与卡片头部 Review 按钮均不变。

## 范围说明

仅 web 端改动：agent-gui 是桌面应用不存在移动端布局，且该文件不在 mirror-manifest 强制镜像清单中，属合法平台差异。

## 验证

- web 端 biome check 通过；纯 class 字符串改动，无类型影响。