### PR TITLE
feat(tools): AskUserQuestion 切题增加方向感知的轻量滑入动画

### DIFF
--- a/crates/agent-gateway/web/src/components/chat/AskUserQuestionCard.tsx
+++ b/crates/agent-gateway/web/src/components/chat/AskUserQuestionCard.tsx
@@ -75,6 +75,8 @@ export function AskUserQuestionCard({
 }) {
   const { t } = useLocale();
   const [activeIndex, setActiveIndex] = useState(0);
+  // 切题方向（首次渲染为 null 不播动画）；keyed 内容区据此选滑入方向。
+  const [switchDirection, setSwitchDirection] = useState<"forward" | "backward" | null>(null);
   const [draftSelections, setDraftSelections] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const [errorText, setErrorText] = useState("");
@@ -99,6 +101,13 @@ export function AskUserQuestionCard({
   const answeredCount = questions.filter((question) => selections[question.id]).length;
   const allAnswered = answeredCount === questions.length;
 
+  // 带方向切题：内容区按 question.id 重挂载并向对应方向滑入。
+  const goToQuestion = (index: number) => {
+    if (index === safeActiveIndex || index < 0 || index >= questions.length) return;
+    setSwitchDirection(index > safeActiveIndex ? "forward" : "backward");
+    setActiveIndex(index);
+  };
+
   const selectOption = (questionId: string, label: string) => {
     if (!canInteract) return;
     setErrorText("");
@@ -109,7 +118,7 @@ export function AskUserQuestionCard({
         (question, index) => index !== safeActiveIndex && !next[question.id],
       );
       if (nextUnanswered >= 0 && next[questionId]) {
-        setActiveIndex(nextUnanswered);
+        goToQuestion(nextUnanswered);
       }
       return next;
     });
@@ -147,7 +156,7 @@ export function AskUserQuestionCard({
               <button
                 key={question.id}
                 type="button"
-                onClick={() => setActiveIndex(index)}
+                onClick={() => goToQuestion(index)}
                 className={cn(
                   "flex shrink-0 items-center gap-1 rounded-lg px-2.5 py-1 text-[calc(11px*var(--zone-font-scale,1))] font-medium leading-none transition-colors",
                   isActive
@@ -164,61 +173,75 @@ export function AskUserQuestionCard({
       ) : null}
 
       <div className="flex flex-col gap-2 px-3 py-2.5">
-        <div className="text-[calc(12.5px*var(--zone-font-scale,1))] font-medium leading-[1.55] text-foreground/90">
-          {activeQuestion.prompt}
-        </div>
+        {/* key 触发重挂载，切题时按方向播放轻量滑入动画。 */}
+        <div
+          key={activeQuestion.id}
+          className={cn(
+            "flex flex-col gap-2",
+            switchDirection === "forward" ? "ask-question-enter-forward" : "",
+            switchDirection === "backward" ? "ask-question-enter-backward" : "",
+          )}
+        >
+          <div className="text-[calc(12.5px*var(--zone-font-scale,1))] font-medium leading-[1.55] text-foreground/90">
+            {activeQuestion.prompt}
+          </div>
 
-        <div className="flex flex-col gap-1.5" role="radiogroup" aria-label={activeQuestion.prompt}>
-          {activeQuestion.options.map((option) => {
-            const isSelected = selections[activeQuestion.id] === option.label;
-            return (
-              <button
-                key={option.label}
-                type="button"
-                role="radio"
-                aria-checked={isSelected}
-                disabled={!canInteract}
-                onClick={() => selectOption(activeQuestion.id, option.label)}
-                className={cn(
-                  "group/option flex w-full items-start gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors",
-                  isSelected
-                    ? "border-primary/45 bg-primary/[0.06] dark:border-primary/40 dark:bg-primary/[0.1]"
-                    : "border-border/40 dark:border-white/[0.07]",
-                  canInteract && !isSelected
-                    ? "hover:border-border/70 hover:bg-foreground/[0.03] dark:hover:border-white/[0.14]"
-                    : "",
-                  !canInteract && !isSelected && (isSettled || cancelled) ? "opacity-55" : "",
-                  canInteract ? "cursor-pointer" : "cursor-default",
-                )}
-              >
-                <span
+          <div
+            className="flex flex-col gap-1.5"
+            role="radiogroup"
+            aria-label={activeQuestion.prompt}
+          >
+            {activeQuestion.options.map((option) => {
+              const isSelected = selections[activeQuestion.id] === option.label;
+              return (
+                <button
+                  key={option.label}
+                  type="button"
+                  role="radio"
+                  aria-checked={isSelected}
+                  disabled={!canInteract}
+                  onClick={() => selectOption(activeQuestion.id, option.label)}
                   className={cn(
-                    "mt-[3px] flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border transition-colors",
+                    "group/option flex w-full items-start gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors",
                     isSelected
-                      ? "border-primary bg-primary text-primary-foreground"
-                      : "border-muted-foreground/40 group-hover/option:border-muted-foreground/70",
+                      ? "border-primary/45 bg-primary/[0.06] dark:border-primary/40 dark:bg-primary/[0.1]"
+                      : "border-border/40 dark:border-white/[0.07]",
+                    canInteract && !isSelected
+                      ? "hover:border-border/70 hover:bg-foreground/[0.03] dark:hover:border-white/[0.14]"
+                      : "",
+                    !canInteract && !isSelected && (isSettled || cancelled) ? "opacity-55" : "",
+                    canInteract ? "cursor-pointer" : "cursor-default",
                   )}
                 >
-                  {isSelected ? <Check className="h-2.5 w-2.5" /> : null}
-                </span>
-                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <span className="flex flex-wrap items-center gap-1.5">
-                    <span className="text-[calc(12px*var(--zone-font-scale,1))] font-medium leading-[1.5] text-foreground/85">
-                      {option.label}
+                  <span
+                    className={cn(
+                      "mt-[3px] flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border transition-colors",
+                      isSelected
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-muted-foreground/40 group-hover/option:border-muted-foreground/70",
+                    )}
+                  >
+                    {isSelected ? <Check className="h-2.5 w-2.5" /> : null}
+                  </span>
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="flex flex-wrap items-center gap-1.5">
+                      <span className="text-[calc(12px*var(--zone-font-scale,1))] font-medium leading-[1.5] text-foreground/85">
+                        {option.label}
+                      </span>
+                      {option.recommended ? (
+                        <RecommendedTag label={t("chat.askUser.recommended")} />
+                      ) : null}
                     </span>
-                    {option.recommended ? (
-                      <RecommendedTag label={t("chat.askUser.recommended")} />
+                    {option.description ? (
+                      <span className="text-[calc(11px*var(--zone-font-scale,1))] leading-[1.55] text-muted-foreground/80">
+                        {option.description}
+                      </span>
                     ) : null}
                   </span>
-                  {option.description ? (
-                    <span className="text-[calc(11px*var(--zone-font-scale,1))] leading-[1.55] text-muted-foreground/80">
-                      {option.description}
-                    </span>
-                  ) : null}
-                </span>
-              </button>
-            );
-          })}
+                </button>
+              );
+            })}
+          </div>
         </div>
 
         {cancelled ? (

--- a/crates/agent-gateway/web/src/index.css
+++ b/crates/agent-gateway/web/src/index.css
@@ -1359,10 +1359,43 @@
     animation: toolExpandIn 0.22s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
+  /* AskUserQuestion 切题：按方向轻微滑入（forward 从右、backward 从左） */
+  @keyframes askQuestionSlideForward {
+    from {
+      opacity: 0;
+      transform: translateX(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @keyframes askQuestionSlideBackward {
+    from {
+      opacity: 0;
+      transform: translateX(-10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  .ask-question-enter-forward {
+    animation: askQuestionSlideForward 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .ask-question-enter-backward {
+    animation: askQuestionSlideBackward 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
   /* Respect reduced motion */
   @media (prefers-reduced-motion: reduce) {
     .tool-expand,
-    .lazy-collapse-reveal {
+    .lazy-collapse-reveal,
+    .ask-question-enter-forward,
+    .ask-question-enter-backward {
       animation: none !important;
     }
   }

--- a/crates/agent-gui/src/components/chat/AskUserQuestionCard.tsx
+++ b/crates/agent-gui/src/components/chat/AskUserQuestionCard.tsx
@@ -75,6 +75,8 @@ export function AskUserQuestionCard({
 }) {
   const { t } = useLocale();
   const [activeIndex, setActiveIndex] = useState(0);
+  // 切题方向（首次渲染为 null 不播动画）；keyed 内容区据此选滑入方向。
+  const [switchDirection, setSwitchDirection] = useState<"forward" | "backward" | null>(null);
   const [draftSelections, setDraftSelections] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const [errorText, setErrorText] = useState("");
@@ -99,6 +101,13 @@ export function AskUserQuestionCard({
   const answeredCount = questions.filter((question) => selections[question.id]).length;
   const allAnswered = answeredCount === questions.length;
 
+  // 带方向切题：内容区按 question.id 重挂载并向对应方向滑入。
+  const goToQuestion = (index: number) => {
+    if (index === safeActiveIndex || index < 0 || index >= questions.length) return;
+    setSwitchDirection(index > safeActiveIndex ? "forward" : "backward");
+    setActiveIndex(index);
+  };
+
   const selectOption = (questionId: string, label: string) => {
     if (!canInteract) return;
     setErrorText("");
@@ -109,7 +118,7 @@ export function AskUserQuestionCard({
         (question, index) => index !== safeActiveIndex && !next[question.id],
       );
       if (nextUnanswered >= 0 && next[questionId]) {
-        setActiveIndex(nextUnanswered);
+        goToQuestion(nextUnanswered);
       }
       return next;
     });
@@ -147,7 +156,7 @@ export function AskUserQuestionCard({
               <button
                 key={question.id}
                 type="button"
-                onClick={() => setActiveIndex(index)}
+                onClick={() => goToQuestion(index)}
                 className={cn(
                   "flex shrink-0 items-center gap-1 rounded-lg px-2.5 py-1 text-[calc(11px*var(--zone-font-scale,1))] font-medium leading-none transition-colors",
                   isActive
@@ -164,61 +173,75 @@ export function AskUserQuestionCard({
       ) : null}
 
       <div className="flex flex-col gap-2 px-3 py-2.5">
-        <div className="text-[calc(12.5px*var(--zone-font-scale,1))] font-medium leading-[1.55] text-foreground/90">
-          {activeQuestion.prompt}
-        </div>
+        {/* key 触发重挂载，切题时按方向播放轻量滑入动画。 */}
+        <div
+          key={activeQuestion.id}
+          className={cn(
+            "flex flex-col gap-2",
+            switchDirection === "forward" ? "ask-question-enter-forward" : "",
+            switchDirection === "backward" ? "ask-question-enter-backward" : "",
+          )}
+        >
+          <div className="text-[calc(12.5px*var(--zone-font-scale,1))] font-medium leading-[1.55] text-foreground/90">
+            {activeQuestion.prompt}
+          </div>
 
-        <div className="flex flex-col gap-1.5" role="radiogroup" aria-label={activeQuestion.prompt}>
-          {activeQuestion.options.map((option) => {
-            const isSelected = selections[activeQuestion.id] === option.label;
-            return (
-              <button
-                key={option.label}
-                type="button"
-                role="radio"
-                aria-checked={isSelected}
-                disabled={!canInteract}
-                onClick={() => selectOption(activeQuestion.id, option.label)}
-                className={cn(
-                  "group/option flex w-full items-start gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors",
-                  isSelected
-                    ? "border-primary/45 bg-primary/[0.06] dark:border-primary/40 dark:bg-primary/[0.1]"
-                    : "border-border/40 dark:border-white/[0.07]",
-                  canInteract && !isSelected
-                    ? "hover:border-border/70 hover:bg-foreground/[0.03] dark:hover:border-white/[0.14]"
-                    : "",
-                  !canInteract && !isSelected && (isSettled || cancelled) ? "opacity-55" : "",
-                  canInteract ? "cursor-pointer" : "cursor-default",
-                )}
-              >
-                <span
+          <div
+            className="flex flex-col gap-1.5"
+            role="radiogroup"
+            aria-label={activeQuestion.prompt}
+          >
+            {activeQuestion.options.map((option) => {
+              const isSelected = selections[activeQuestion.id] === option.label;
+              return (
+                <button
+                  key={option.label}
+                  type="button"
+                  role="radio"
+                  aria-checked={isSelected}
+                  disabled={!canInteract}
+                  onClick={() => selectOption(activeQuestion.id, option.label)}
                   className={cn(
-                    "mt-[3px] flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border transition-colors",
+                    "group/option flex w-full items-start gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors",
                     isSelected
-                      ? "border-primary bg-primary text-primary-foreground"
-                      : "border-muted-foreground/40 group-hover/option:border-muted-foreground/70",
+                      ? "border-primary/45 bg-primary/[0.06] dark:border-primary/40 dark:bg-primary/[0.1]"
+                      : "border-border/40 dark:border-white/[0.07]",
+                    canInteract && !isSelected
+                      ? "hover:border-border/70 hover:bg-foreground/[0.03] dark:hover:border-white/[0.14]"
+                      : "",
+                    !canInteract && !isSelected && (isSettled || cancelled) ? "opacity-55" : "",
+                    canInteract ? "cursor-pointer" : "cursor-default",
                   )}
                 >
-                  {isSelected ? <Check className="h-2.5 w-2.5" /> : null}
-                </span>
-                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <span className="flex flex-wrap items-center gap-1.5">
-                    <span className="text-[calc(12px*var(--zone-font-scale,1))] font-medium leading-[1.5] text-foreground/85">
-                      {option.label}
+                  <span
+                    className={cn(
+                      "mt-[3px] flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border transition-colors",
+                      isSelected
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-muted-foreground/40 group-hover/option:border-muted-foreground/70",
+                    )}
+                  >
+                    {isSelected ? <Check className="h-2.5 w-2.5" /> : null}
+                  </span>
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="flex flex-wrap items-center gap-1.5">
+                      <span className="text-[calc(12px*var(--zone-font-scale,1))] font-medium leading-[1.5] text-foreground/85">
+                        {option.label}
+                      </span>
+                      {option.recommended ? (
+                        <RecommendedTag label={t("chat.askUser.recommended")} />
+                      ) : null}
                     </span>
-                    {option.recommended ? (
-                      <RecommendedTag label={t("chat.askUser.recommended")} />
+                    {option.description ? (
+                      <span className="text-[calc(11px*var(--zone-font-scale,1))] leading-[1.55] text-muted-foreground/80">
+                        {option.description}
+                      </span>
                     ) : null}
                   </span>
-                  {option.description ? (
-                    <span className="text-[calc(11px*var(--zone-font-scale,1))] leading-[1.55] text-muted-foreground/80">
-                      {option.description}
-                    </span>
-                  ) : null}
-                </span>
-              </button>
-            );
-          })}
+                </button>
+              );
+            })}
+          </div>
         </div>
 
         {cancelled ? (

--- a/crates/agent-gui/src/index.css
+++ b/crates/agent-gui/src/index.css
@@ -1740,10 +1740,43 @@
     animation: toolExpandIn 0.22s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
+  /* AskUserQuestion 切题：按方向轻微滑入（forward 从右、backward 从左） */
+  @keyframes askQuestionSlideForward {
+    from {
+      opacity: 0;
+      transform: translateX(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @keyframes askQuestionSlideBackward {
+    from {
+      opacity: 0;
+      transform: translateX(-10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  .ask-question-enter-forward {
+    animation: askQuestionSlideForward 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .ask-question-enter-backward {
+    animation: askQuestionSlideBackward 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
   /* Respect reduced motion */
   @media (prefers-reduced-motion: reduce) {
     .tool-expand,
-    .lazy-collapse-reveal {
+    .lazy-collapse-reveal,
+    .ask-question-enter-forward,
+    .ask-question-enter-backward {
       animation: none !important;
     }
   }


### PR DESCRIPTION
## 概述

为 AskUserQuestion 卡片的多问题切换增加带方向感知的轻量滑入动画，增强交互体验。

## 改动

**组件 `AskUserQuestionCard.tsx`**（GUI 端修改后逐字节镜像到 web 端）：
- 新增 `switchDirection` 状态（`"forward" | "backward" | null`），初始为 `null`，首次渲染不播切题动画（避免与 `tool-expand` 入场动画叠加）
- 新增统一切题入口 `goToQuestion(index)`，tab 点击与「选完自动跳下一道未答题」两条路径都经由它记录切换方向
- 问题标题 + 选项组包在 `key={activeQuestion.id}` 容器中，切题时重挂载并按方向播放动画：向前从右滑入、向后从左滑入，配合淡入

**CSS（两端 `index.css` 手动镜像）**：
- 新增 `askQuestionSlideForward/Backward` keyframes 与对应类，动画参数对齐现有 `toolExpandIn`（0.22s，同缓动曲线）
- 仅使用 `opacity` + `transform`（合成层属性），10px 位移
- 新类已纳入现有 `prefers-reduced-motion: reduce` 覆盖

## 验证

- ✅ `scripts/check-mirror.mjs` 通过（91 个文件）
- ✅ 两端 `tsc --noEmit` 通过
- ✅ Biome 检查无新增告警（存量告警经 stash 对照确认为改动前已存在）