### PR TITLE
style(settings): move the shortcuts nav entry into the other group above about

### DIFF
--- a/crates/agent-gui/src/pages/SettingsPage.tsx
+++ b/crates/agent-gui/src/pages/SettingsPage.tsx
@@ -98,7 +98,6 @@ const NAV_GROUPS: NavGroup[] = [
       { id: "system", icon: <Settings2 className="h-3.5 w-3.5" /> },
       { id: "providers", icon: <Cpu className="h-3.5 w-3.5" /> },
       { id: "agents", icon: <BookOpen className="h-3.5 w-3.5" /> },
-      { id: "shortcuts", icon: <Keyboard className="h-3.5 w-3.5" /> },
     ],
   },
   {
@@ -124,7 +123,10 @@ const NAV_GROUPS: NavGroup[] = [
   },
   {
     labelKey: "settings.groupOther",
-    items: [{ id: "about", icon: <Info className="h-3.5 w-3.5" /> }],
+    items: [
+      { id: "shortcuts", icon: <Keyboard className="h-3.5 w-3.5" /> },
+      { id: "about", icon: <Info className="h-3.5 w-3.5" /> },
+    ],
   },
 ];
 


### PR DESCRIPTION
## Summary
- 将设置页导航中的「快捷键」入口从「通用」分组移动到「其他」分组，置于「关于」上方

## Test plan
- `tsc --noEmit` 通过
- biome check 无新增告警（现存 1 warning / 2 infos 为改动前已有）

🤖 Generated with [Claude Code](https://claude.com/claude-code)