### PR TITLE
fix(providers): send only each provider's standard api-key header

### DIFF
--- a/crates/agent-gateway/web/src/pages/settings/providerUtils.ts
+++ b/crates/agent-gateway/web/src/pages/settings/providerUtils.ts
@@ -83,23 +83,11 @@ export function buildProviderModelsUrl(
   return baseUrl.endsWith("/v1") ? `${baseUrl}/models` : `${baseUrl}/v1/models`;
 }
 
-function buildDefaultModelsHeaders(type: ProviderId, apiKey: string): Record<string, string> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  };
-  if (type === "gemini") {
-    headers["x-goog-api-key"] = apiKey;
-    return headers;
-  }
-  headers["x-api-key"] = apiKey;
-  if (type === "claude_code") {
-    headers["anthropic-version"] = ANTHROPIC_API_VERSION;
-  }
-  return headers;
-}
-
-function buildOfficialModelsHeaders(type: ProviderId, apiKey: string): Record<string, string> {
+// 每个供应商只带自家标准的 API Key 请求头：claude_code 用 x-api-key、
+// codex 用 Authorization Bearer、gemini 用 x-goog-api-key，绝不双头齐发。
+// default/official 两次尝试仅在 URL 上有差异（gemini v1 vs v1beta），
+// 请求头完全一致，重复的尝试由签名去重收敛。
+function buildModelsHeaders(type: ProviderId, apiKey: string): Record<string, string> {
   if (type === "gemini") {
     return {
       "Content-Type": "application/json",
@@ -135,8 +123,8 @@ export function buildProviderModelsAttempts(
   apiKey: string,
 ): ProviderModelsAttempt[] {
   const candidates: ProviderModelsAttempt[] = [
-    { kind: "default", headers: buildDefaultModelsHeaders(type, apiKey) },
-    { kind: "official", headers: buildOfficialModelsHeaders(type, apiKey) },
+    { kind: "default", headers: buildModelsHeaders(type, apiKey) },
+    { kind: "official", headers: buildModelsHeaders(type, apiKey) },
   ];
 
   const attempts: ProviderModelsAttempt[] = [];

--- a/crates/agent-gui/src-tauri/src/services/provider_models.rs
+++ b/crates/agent-gui/src-tauri/src/services/provider_models.rs
@@ -234,7 +234,7 @@ fn build_provider_models_attempts(
     let base_url = normalize_provider_base_url(provider_type, base_url)?;
     let candidates = [false, true].map(|official| ProviderModelsAttempt {
         url: build_provider_models_url(provider_type, &base_url, official),
-        headers: build_provider_models_headers(provider_type, api_key, official),
+        headers: build_provider_models_headers(provider_type, api_key),
     });
     let mut attempts = Vec::new();
     for candidate in candidates {
@@ -248,31 +248,25 @@ fn build_provider_models_attempts(
     Ok(attempts)
 }
 
+// 每个供应商只带自家标准的 API Key 请求头：claude_code 用 x-api-key、
+// codex 用 authorization Bearer、gemini 用 x-goog-api-key，绝不双头齐发。
+// official/default 两次尝试仅在 URL 上有差异（gemini v1 vs v1beta），
+// 请求头完全一致，重复的尝试由 build_provider_models_attempts 去重收敛。
 fn build_provider_models_headers(
     provider_type: &str,
     api_key: &str,
-    official: bool,
 ) -> Vec<(&'static str, String)> {
     let mut headers = vec![("content-type", "application/json".to_string())];
     match provider_type {
         "gemini" => {
             headers.push(("x-goog-api-key", api_key.to_string()));
-            if !official {
-                headers.push(("authorization", format!("Bearer {api_key}")));
-            }
         }
         "claude_code" => {
             headers.push(("x-api-key", api_key.to_string()));
             headers.push(("anthropic-version", ANTHROPIC_API_VERSION.to_string()));
-            if !official {
-                headers.push(("authorization", format!("Bearer {api_key}")));
-            }
         }
         _ => {
             headers.push(("authorization", format!("Bearer {api_key}")));
-            if !official {
-                headers.push(("x-api-key", api_key.to_string()));
-            }
         }
     }
     headers
@@ -341,12 +335,10 @@ mod tests {
             "key",
         )
         .expect("gemini attempts");
+        // 请求头不再随 official/default 变化，URL 相同的尝试会被去重收敛。
+        assert_eq!(gemini.len(), 1);
         assert_eq!(
             gemini[0].url.as_str(),
-            "https://relay.example.com/v1beta/models"
-        );
-        assert_eq!(
-            gemini[1].url.as_str(),
             "https://relay.example.com/v1beta/models"
         );
 
@@ -356,6 +348,7 @@ mod tests {
             "key",
         )
         .expect("codex attempts");
+        assert_eq!(codex.len(), 1);
         assert_eq!(codex[0].url.as_str(), "https://relay.example.com/v1/models");
     }
 
@@ -376,25 +369,45 @@ mod tests {
     #[test]
     fn provider_model_headers_exclude_inference_identity() {
         for provider_type in ["claude_code", "codex", "gemini"] {
-            for official in [false, true] {
-                let headers = build_provider_models_headers(provider_type, "key", official);
-                let names = headers
-                    .iter()
-                    .map(|(name, _)| name.to_ascii_lowercase())
-                    .collect::<Vec<_>>();
+            let headers = build_provider_models_headers(provider_type, "key");
+            let names = headers
+                .iter()
+                .map(|(name, _)| name.to_ascii_lowercase())
+                .collect::<Vec<_>>();
 
-                assert!(!names.iter().any(|name| name.starts_with("x-stainless-")));
-                for forbidden in [
-                    "x-app",
-                    "user-agent",
-                    "anthropic-beta",
-                    "anthropic-dangerous-direct-browser-access",
-                    "session_id",
-                    "conversation_id",
-                ] {
-                    assert!(!names.iter().any(|name| name == forbidden));
-                }
+            assert!(!names.iter().any(|name| name.starts_with("x-stainless-")));
+            for forbidden in [
+                "x-app",
+                "user-agent",
+                "anthropic-beta",
+                "anthropic-dangerous-direct-browser-access",
+                "session_id",
+                "conversation_id",
+            ] {
+                assert!(!names.iter().any(|name| name == forbidden));
             }
+        }
+    }
+
+    #[test]
+    fn provider_model_headers_carry_single_standard_auth_header() {
+        for (provider_type, expected) in [
+            ("claude_code", "x-api-key"),
+            ("codex", "authorization"),
+            ("gemini", "x-goog-api-key"),
+        ] {
+            let headers = build_provider_models_headers(provider_type, "key");
+            let auth_names = headers
+                .iter()
+                .map(|(name, _)| name.to_ascii_lowercase())
+                .filter(|name| {
+                    matches!(
+                        name.as_str(),
+                        "authorization" | "x-api-key" | "x-goog-api-key"
+                    )
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(auth_names, vec![expected.to_string()], "{provider_type}");
         }
     }
 

--- a/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
+++ b/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
@@ -709,7 +709,12 @@ export async function runAssistantWithTools(params: {
       params.providerId,
       params.runtime.baseUrl.trim(),
       mergeCustomHeaders(
-        buildProviderRequestHeaders(params.providerId, params.runtime.apiKey, params.sessionId),
+        buildProviderRequestHeaders(
+          params.providerId,
+          params.runtime.apiKey,
+          params.sessionId,
+          params.runtime.requestFormat,
+        ),
         params.runtime.customHeaders,
       ),
       { useSystemProxy: params.runtime.useSystemProxy === true },

--- a/crates/agent-gui/src/lib/providers/llm.ts
+++ b/crates/agent-gui/src/lib/providers/llm.ts
@@ -25,8 +25,9 @@ export {
   type ProviderPayloadMiddleware,
 } from "./runtime/payloadPipeline";
 export {
-  buildDualAuthHeaders,
+  buildAnthropicAuthHeaders,
   buildGeminiAuthHeaders,
+  buildOpenAIAuthHeaders,
   buildProviderRequestHeaders,
   buildProviderRequestMetadata,
   isValidCustomHeaderKey,

--- a/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
@@ -1,5 +1,10 @@
 import type { CacheRetention, SimpleStreamOptions } from "@earendil-works/pi-ai";
-import type { CodexRequestFormat, CustomProvider, ProviderId, ReasoningLevel } from "../../settings";
+import type {
+  CodexRequestFormat,
+  CustomProvider,
+  ProviderId,
+  ReasoningLevel,
+} from "../../settings";
 import { createUuid } from "../../shared/id";
 import {
   ANTHROPIC_DEFAULT_REQUEST_HEADERS,

--- a/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
@@ -1,5 +1,5 @@
 import type { CacheRetention, SimpleStreamOptions } from "@earendil-works/pi-ai";
-import type { CustomProvider, ProviderId, ReasoningLevel } from "../../settings";
+import type { CodexRequestFormat, CustomProvider, ProviderId, ReasoningLevel } from "../../settings";
 import { createUuid } from "../../shared/id";
 import {
   ANTHROPIC_DEFAULT_REQUEST_HEADERS,
@@ -13,10 +13,16 @@ import { normalizeSessionId } from "./common";
 
 export { isValidCustomHeaderKey } from "../customHeaders";
 
-export function buildDualAuthHeaders(apiKey: string): Record<string, string> {
+// 每个供应商只带自家标准的 API Key 请求头，绝不双头齐发。
+export function buildAnthropicAuthHeaders(apiKey: string): Record<string, string> {
+  return {
+    "x-api-key": apiKey,
+  };
+}
+
+export function buildOpenAIAuthHeaders(apiKey: string): Record<string, string> {
   return {
     Authorization: `Bearer ${apiKey}`,
-    "x-api-key": apiKey,
   };
 }
 
@@ -27,13 +33,16 @@ export function buildGeminiAuthHeaders(apiKey: string): Record<string, string> {
 }
 
 function buildProviderAuthHeaders(providerId: ProviderId, apiKey: string): Record<string, string> {
-  return providerId === "gemini" ? buildGeminiAuthHeaders(apiKey) : buildDualAuthHeaders(apiKey);
+  if (providerId === "gemini") return buildGeminiAuthHeaders(apiKey);
+  if (providerId === "claude_code") return buildAnthropicAuthHeaders(apiKey);
+  return buildOpenAIAuthHeaders(apiKey);
 }
 
 export function buildProviderRequestHeaders(
   providerId: ProviderId,
   apiKey: string,
   sessionId?: string,
+  requestFormat?: CodexRequestFormat,
 ): Record<string, string> {
   const authHeaders = buildProviderAuthHeaders(providerId, apiKey);
   if (providerId === "claude_code") {
@@ -44,6 +53,10 @@ export function buildProviderRequestHeaders(
     };
   }
   if (providerId === "codex") {
+    // 标准 Chat Completions 是无状态协议，只需 Authorization——
+    // codex_cli_rs UA 与 session_id/conversation_id 是 Responses（Codex CLI）
+    // 链路专属身份头，不得泄漏进 completions 格式的请求。
+    if (requestFormat === "openai-completions") return authHeaders;
     const requestSessionId = normalizeSessionId(sessionId) ?? createUuid();
     return {
       ...authHeaders,

--- a/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
@@ -148,7 +148,12 @@ export async function streamAssistantMessage(params: {
     params.providerId,
     params.runtime.baseUrl.trim(),
     mergeCustomHeaders(
-      buildProviderRequestHeaders(params.providerId, params.runtime.apiKey, params.sessionId),
+      buildProviderRequestHeaders(
+        params.providerId,
+        params.runtime.apiKey,
+        params.sessionId,
+        params.runtime.requestFormat,
+      ),
       params.runtime.customHeaders,
     ),
     { useSystemProxy: params.runtime.useSystemProxy === true },
@@ -343,7 +348,12 @@ export async function completeAssistantMessage(params: {
     params.providerId,
     params.runtime.baseUrl.trim(),
     mergeCustomHeaders(
-      buildProviderRequestHeaders(params.providerId, params.runtime.apiKey, params.sessionId),
+      buildProviderRequestHeaders(
+        params.providerId,
+        params.runtime.apiKey,
+        params.sessionId,
+        params.runtime.requestFormat,
+      ),
       params.runtime.customHeaders,
     ),
     { useSystemProxy: params.runtime.useSystemProxy === true },

--- a/crates/agent-gui/src/pages/settings/providerUtils.ts
+++ b/crates/agent-gui/src/pages/settings/providerUtils.ts
@@ -83,23 +83,11 @@ export function buildProviderModelsUrl(
   return baseUrl.endsWith("/v1") ? `${baseUrl}/models` : `${baseUrl}/v1/models`;
 }
 
-function buildDefaultModelsHeaders(type: ProviderId, apiKey: string): Record<string, string> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  };
-  if (type === "gemini") {
-    headers["x-goog-api-key"] = apiKey;
-    return headers;
-  }
-  headers["x-api-key"] = apiKey;
-  if (type === "claude_code") {
-    headers["anthropic-version"] = ANTHROPIC_API_VERSION;
-  }
-  return headers;
-}
-
-function buildOfficialModelsHeaders(type: ProviderId, apiKey: string): Record<string, string> {
+// 每个供应商只带自家标准的 API Key 请求头：claude_code 用 x-api-key、
+// codex 用 Authorization Bearer、gemini 用 x-goog-api-key，绝不双头齐发。
+// default/official 两次尝试仅在 URL 上有差异（gemini v1 vs v1beta），
+// 请求头完全一致，重复的尝试由签名去重收敛。
+function buildModelsHeaders(type: ProviderId, apiKey: string): Record<string, string> {
   if (type === "gemini") {
     return {
       "Content-Type": "application/json",
@@ -135,8 +123,8 @@ export function buildProviderModelsAttempts(
   apiKey: string,
 ): ProviderModelsAttempt[] {
   const candidates: ProviderModelsAttempt[] = [
-    { kind: "default", headers: buildDefaultModelsHeaders(type, apiKey) },
-    { kind: "official", headers: buildOfficialModelsHeaders(type, apiKey) },
+    { kind: "default", headers: buildModelsHeaders(type, apiKey) },
+    { kind: "official", headers: buildModelsHeaders(type, apiKey) },
   ];
 
   const attempts: ProviderModelsAttempt[] = [];

--- a/crates/agent-gui/test/chat/agent-runner.test.mjs
+++ b/crates/agent-gui/test/chat/agent-runner.test.mjs
@@ -242,16 +242,19 @@ const llmMock = {
   buildProviderRequestMetadata(_providerId, sessionId) {
     return sessionId ? { sessionId } : undefined;
   },
-  buildDualAuthHeaders(apiKey) {
+  buildAnthropicAuthHeaders(apiKey) {
+    return {
+      "x-api-key": apiKey,
+    };
+  },
+  buildOpenAIAuthHeaders(apiKey) {
     return {
       Authorization: `Bearer ${apiKey}`,
-      "x-api-key": apiKey,
     };
   },
   buildProviderRequestHeaders(_providerId, apiKey, _sessionId) {
     return {
       Authorization: `Bearer ${apiKey}`,
-      "x-api-key": apiKey,
     };
   },
   createModelFromConfig(providerId, modelId, baseUrl) {

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -66,8 +66,9 @@ test("llm facade preserves provider runtime exports", () => {
     "attachCodexResponsesStorage",
     "attachPayloadDebugLogging",
     "attachProviderNativeWebSearch",
-    "buildDualAuthHeaders",
+    "buildAnthropicAuthHeaders",
     "buildGeminiAuthHeaders",
+    "buildOpenAIAuthHeaders",
     "buildProviderRequestHeaders",
     "buildProviderRequestMetadata",
     "isValidCustomHeaderKey",
@@ -131,9 +132,11 @@ test("image proxy URL builder encodes the source URL", () => {
 });
 
 test("provider request helpers normalize auth, metadata, errors, and model values", () => {
-  assert.deepEqual(providers.buildDualAuthHeaders("secret"), {
-    Authorization: "Bearer secret",
+  assert.deepEqual(providers.buildAnthropicAuthHeaders("secret"), {
     "x-api-key": "secret",
+  });
+  assert.deepEqual(providers.buildOpenAIAuthHeaders("secret"), {
+    Authorization: "Bearer secret",
   });
   assert.deepEqual(providers.buildGeminiAuthHeaders("secret"), {
     "x-goog-api-key": "secret",
@@ -141,7 +144,6 @@ test("provider request helpers normalize auth, metadata, errors, and model value
   assert.deepEqual(
     providers.buildProviderRequestHeaders("claude_code", "secret", "conversation-1"),
     {
-      Authorization: "Bearer secret",
       "x-api-key": "secret",
       "x-app": "cli",
       "User-Agent": "claude-cli/2.1.71 (external, cli)",
@@ -164,11 +166,33 @@ test("provider request helpers normalize auth, metadata, errors, and model value
   );
   assert.deepEqual(providers.buildProviderRequestHeaders("codex", "secret", "conversation-1"), {
     Authorization: "Bearer secret",
-    "x-api-key": "secret",
     "User-Agent": "codex_cli_rs/0.72.0 (Ubuntu 24.4.0; x86_64) WindowsTerminal",
     session_id: "conversation-1",
     conversation_id: "conversation-1",
   });
+  // Responses 格式显式指定时保持 Codex CLI 身份头。
+  assert.deepEqual(
+    providers.buildProviderRequestHeaders("codex", "secret", "conversation-1", "openai-responses"),
+    {
+      Authorization: "Bearer secret",
+      "User-Agent": "codex_cli_rs/0.72.0 (Ubuntu 24.4.0; x86_64) WindowsTerminal",
+      session_id: "conversation-1",
+      conversation_id: "conversation-1",
+    },
+  );
+  // 标准 Chat Completions 是无状态协议：只带 Authorization，
+  // 不带 codex_cli_rs UA 与 session_id/conversation_id。
+  assert.deepEqual(
+    providers.buildProviderRequestHeaders(
+      "codex",
+      "secret",
+      "conversation-1",
+      "openai-completions",
+    ),
+    {
+      Authorization: "Bearer secret",
+    },
+  );
   assert.deepEqual(providers.buildProviderRequestHeaders("gemini", "secret", "conversation-1"), {
     "x-goog-api-key": "secret",
   });

--- a/crates/agent-gui/test/settings/provider-models-fetch.test.mjs
+++ b/crates/agent-gui/test/settings/provider-models-fetch.test.mjs
@@ -77,43 +77,45 @@ test("buildProviderModelsUrl defaults to /v1/models and falls back to official e
   );
 });
 
-test("buildProviderModelsAttempts orders default before official with provider headers", () => {
+test("buildProviderModelsAttempts carries only each provider's standard auth header", () => {
   const gemini = providerUtils.buildProviderModelsAttempts(
     "gemini",
     "https://relay.example.com",
     "test-key",
   );
+  // gemini 的 default/v1 与 official/v1beta URL 不同，保留两次尝试；请求头一致。
   assert.equal(gemini.length, 2);
   assert.deepEqual(
     gemini.map((attempt) => attempt.kind),
     ["default", "official"],
   );
-  assert.equal(gemini[0].headers.Authorization, "Bearer test-key");
-  assert.equal(gemini[0].headers["x-goog-api-key"], "test-key");
-  assert.equal(gemini[1].headers.Authorization, undefined);
-  assert.equal(gemini[1].headers["x-goog-api-key"], "test-key");
+  for (const attempt of gemini) {
+    assert.equal(attempt.headers.Authorization, undefined);
+    assert.equal(attempt.headers["x-api-key"], undefined);
+    assert.equal(attempt.headers["x-goog-api-key"], "test-key");
+  }
 
   const claude = providerUtils.buildProviderModelsAttempts(
     "claude_code",
     "https://relay.example.com",
     "test-key",
   );
-  assert.equal(claude.length, 2);
-  assert.equal(claude[0].headers.Authorization, "Bearer test-key");
+  // 请求头不再随 default/official 变化，URL 相同的尝试被签名去重收敛为一次。
+  assert.equal(claude.length, 1);
+  assert.equal(claude[0].headers.Authorization, undefined);
+  assert.equal(claude[0].headers["x-api-key"], "test-key");
+  assert.equal(claude[0].headers["x-goog-api-key"], undefined);
   assert.equal(claude[0].headers["anthropic-version"], "2023-06-01");
-  assert.equal(claude[1].headers.Authorization, undefined);
-  assert.equal(claude[1].headers["x-api-key"], "test-key");
-  assert.equal(claude[1].headers["anthropic-version"], "2023-06-01");
 
   const codex = providerUtils.buildProviderModelsAttempts(
     "codex",
     "https://relay.example.com",
     "test-key",
   );
-  assert.equal(codex.length, 2);
-  assert.equal(codex[0].headers["x-api-key"], "test-key");
-  assert.equal(codex[1].headers["x-api-key"], undefined);
-  assert.equal(codex[1].headers.Authorization, "Bearer test-key");
+  assert.equal(codex.length, 1);
+  assert.equal(codex[0].headers.Authorization, "Bearer test-key");
+  assert.equal(codex[0].headers["x-api-key"], undefined);
+  assert.equal(codex[0].headers["x-goog-api-key"], undefined);
 
   const inferenceOnlyHeaders = [
     "x-app",
@@ -251,22 +253,18 @@ test("fetchModelsFromApi surfaces the informative failure when every attempt fai
   );
 });
 
-test("fetchModelsFromApi retries claude_code with official anthropic headers", async () => {
+test("fetchModelsFromApi requests claude_code once with only the standard anthropic header", async () => {
   await withFetchStub(
-    (_url, callIndex) =>
-      callIndex === 1
-        ? jsonResponse(401, { error: "authorization header rejected" })
-        : jsonResponse(200, { data: [{ id: "claude-opus-4-8" }] }),
+    () => jsonResponse(200, { data: [{ id: "claude-opus-4-8" }] }),
     async (calls) => {
       const models = await providerUtils.fetchModelsFromApi(
         "claude_code",
         "https://relay.example.com",
         "test-key",
       );
-      assert.equal(calls.length, 2);
-      assert.equal(calls[0].options.headers.Authorization, "Bearer test-key");
-      assert.equal(calls[1].options.headers.Authorization, undefined);
-      assert.equal(calls[1].options.headers["x-api-key"], "test-key");
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].options.headers.Authorization, undefined);
+      assert.equal(calls[0].options.headers["x-api-key"], "test-key");
       assert.deepEqual(
         models.map((model) => model.id),
         ["claude-opus-4-8"],


### PR DESCRIPTION
## Summary
- Each provider now sends only its own standard API-key header — the dual-auth pattern (`Authorization` + `x-api-key` together) is removed:
  - `claude_code` → `x-api-key` only (OAuth keys unchanged: pi-ai injects `Authorization: Bearer` itself)
  - `codex` → `Authorization: Bearer` only
  - `gemini` → `x-goog-api-key` only
- Applied at all three header sources: chat runtime (`requestOptions.ts`), TS model listing (`providerUtils.ts`, gui + web mirror), and Rust model listing (`provider_models.rs`, `official` param dropped since headers no longer vary per attempt)
- Codex `openai-completions` requests no longer carry the Responses-only identity headers (`session_id` / `conversation_id` / `codex_cli_rs` user-agent) — standard Chat Completions is stateless and only expects `Authorization` ([API reference](https://developers.openai.com/api/reference/chat-completions/overview)); `buildProviderRequestHeaders` now takes the runtime `requestFormat` to gate them

## Test plan
- [x] GUI frontend suite: 1123 pass (`npm run test:frontend`)
- [x] Web suite: 374 pass (`npm test`)
- [x] Rust: `cargo test provider_model` 6 pass, `rustfmt --check` clean
- [x] `tsc --noEmit` clean on both gui and web