### PR TITLE
fix(skills): repair non-portable ClawHub skill names instead of rejecting

### DIFF
--- a/crates/agent-gui/src-tauri/src/services/skills/install.rs
+++ b/crates/agent-gui/src-tauri/src/services/skills/install.rs
@@ -303,6 +303,20 @@ fn is_clawhub_download_source(source: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Reads a query parameter from a ClawHub download URL, so installs driven by
+/// a bare `/api/v1/download` source (no explicit payload slug) still resolve
+/// their registry identity.
+pub(crate) fn clawhub_download_query_param(source: &str, name: &str) -> Option<String> {
+    if !is_clawhub_download_source(source) {
+        return None;
+    }
+    let url = reqwest::Url::parse(source).ok()?;
+    url.query_pairs().find_map(|(key, value)| {
+        let value = value.trim();
+        (key == name && !value.is_empty()).then(|| value.to_string())
+    })
+}
+
 fn registry_skill_slug(value: &str) -> &str {
     value
         .trim()
@@ -373,9 +387,16 @@ fn rewrite_skill_metadata_name(metadata_file: &Path, normalized_name: &str) -> R
         .map_err(|e| format!("Failed to update {}: {e}", metadata_file.display()))
 }
 
+/// ClawHub keeps the routable slug and the catalog display name separate, so
+/// registry packages legally carry human-readable frontmatter names (for
+/// example "Self-Improving + Proactive Agent") that violate the Agent Skills
+/// naming rule and have no derivation relationship with the slug. For a
+/// single-skill ClawHub download we repair the staged copy instead of
+/// rejecting it: prefer the registry slug as the portable name, and fall back
+/// to the normalized frontmatter name when no usable slug is available.
 pub(crate) fn normalize_clawhub_candidate_name(
     candidate: &Path,
-    slug: &str,
+    slug: Option<&str>,
 ) -> Result<Option<SkillNameCompatibilityTransform>, String> {
     let metadata_file = metadata_file_for(candidate).ok_or_else(|| {
         format!(
@@ -391,31 +412,44 @@ pub(crate) fn normalize_clawhub_candidate_name(
         return Ok(None);
     }
 
-    let normalized_name = normalize_skill_name(&original_name);
-    let expected_name = registry_skill_slug(slug);
-    if normalized_name != expected_name || sanitize_skill_name(expected_name).is_err() {
+    let normalized_from_name = normalize_skill_name(&original_name);
+    let target_name = slug
+        .map(registry_skill_slug)
+        .filter(|value| sanitize_skill_name(value).is_ok())
+        .or_else(|| {
+            sanitize_skill_name(&normalized_from_name)
+                .is_ok()
+                .then_some(normalized_from_name.as_str())
+        });
+    let Some(target_name) = target_name else {
         return Ok(None);
-    }
+    };
 
-    rewrite_skill_metadata_name(&metadata_file, expected_name)?;
+    rewrite_skill_metadata_name(&metadata_file, target_name)?;
     Ok(Some(SkillNameCompatibilityTransform {
         original_name,
-        normalized_name,
+        normalized_name: target_name.to_string(),
     }))
 }
 
 fn build_skill_source_metadata(
     payload: &serde_json::Map<String, Value>,
+    registry_slug: Option<&str>,
     compatibility: Option<&SkillNameCompatibilityTransform>,
 ) -> Result<Option<Vec<u8>>, String> {
-    let Some(slug) = object_string(payload, "slug") else {
+    let Some(slug) = registry_slug else {
         return Ok(None);
     };
     let metadata = serde_json::json!({
         "registry": "clawhub",
         "slug": slug,
         "ownerHandle": object_string(payload, "ownerHandle")
-            .or_else(|| object_string(payload, "owner")),
+            .map(ToOwned::to_owned)
+            .or_else(|| object_string(payload, "owner").map(ToOwned::to_owned))
+            .or_else(|| {
+                object_string(payload, "source")
+                    .and_then(|source| clawhub_download_query_param(source, "ownerHandle"))
+            }),
         "version": object_string(payload, "version"),
         "publishedAt": payload.get("publishedAt").and_then(Value::as_u64),
         "originalName": compatibility.map(|value| value.original_name.as_str()),
@@ -498,7 +532,11 @@ where
         return Err("name can only be used when exactly one skill is installed".to_string());
     }
     let normalize_clawhub_name = candidates.len() == 1 && is_clawhub_download_source(source);
-    let registry_slug = object_string(payload, "slug").map(ToOwned::to_owned);
+    // Payload slug first (clawhub_install / store install path), then the
+    // download URL query, so bare `source`-only installs keep the same repair.
+    let registry_slug = object_string(payload, "slug")
+        .map(ToOwned::to_owned)
+        .or_else(|| clawhub_download_query_param(source, "slug"));
 
     let mut results = Vec::new();
     for candidate in candidates {
@@ -506,11 +544,7 @@ where
             return Err(INSTALL_CANCELLED_ERROR.to_string());
         }
         let compatibility = if normalize_clawhub_name {
-            registry_slug
-                .as_deref()
-                .map(|slug| normalize_clawhub_candidate_name(&candidate, slug))
-                .transpose()?
-                .flatten()
+            normalize_clawhub_candidate_name(&candidate, registry_slug.as_deref())?
         } else {
             None
         };
@@ -527,7 +561,8 @@ where
         }
         let metadata = read_skill_metadata_from_dir(&candidate)?;
         let skill_name = name_override.as_deref().unwrap_or(&metadata.name);
-        let source_meta = build_skill_source_metadata(payload, compatibility.as_ref())?;
+        let source_meta =
+            build_skill_source_metadata(payload, registry_slug.as_deref(), compatibility.as_ref())?;
         ensure_not_builtin_skill_management_target(root, skill_name, "install")?;
         on_progress(SkillInstallProgressUpdate {
             phase: "installing",

--- a/crates/agent-gui/src-tauri/src/services/skills/tests.rs
+++ b/crates/agent-gui/src-tauri/src/services/skills/tests.rs
@@ -583,7 +583,7 @@ fn clawhub_candidate_normalizes_nonportable_name_when_it_matches_slug() {
     )
     .expect("write skill");
 
-    let transform = normalize_clawhub_candidate_name(&candidate, "skillscan")
+    let transform = normalize_clawhub_candidate_name(&candidate, Some("skillscan"))
         .expect("normalize candidate")
         .expect("compatibility transform");
     let metadata = read_skill_metadata_from_dir(&candidate).expect("read normalized metadata");
@@ -597,21 +597,104 @@ fn clawhub_candidate_normalizes_nonportable_name_when_it_matches_slug() {
 }
 
 #[test]
-fn clawhub_candidate_does_not_normalize_name_that_does_not_match_slug() {
+fn clawhub_candidate_prefers_registry_slug_when_name_does_not_match_it() {
+    // Real registry shape: ClawHub keeps slug and display name separate, so
+    // "Self-Improving + Proactive Agent" is published under slug
+    // "self-improving" with no derivation relationship between the two.
     let tmp = TempDir::new("liveagent-clawhub-name-mismatch-test").expect("temp dir");
     let candidate = tmp.path().join("candidate");
     fs::create_dir_all(&candidate).expect("create candidate");
     fs::write(
         candidate.join("SKILL.md"),
-        "---\nname: DifferentName\ndescription: Mismatch\n---\n",
+        "---\nname: Self-Improving + Proactive Agent\nslug: self-improving\ndescription: Self-reflection loops\n---\n",
+    )
+    .expect("write skill");
+
+    let transform = normalize_clawhub_candidate_name(&candidate, Some("self-improving"))
+        .expect("normalize candidate")
+        .expect("compatibility transform");
+    let metadata = read_skill_metadata_from_dir(&candidate).expect("read normalized metadata");
+
+    assert_eq!(transform.original_name, "Self-Improving + Proactive Agent");
+    assert_eq!(transform.normalized_name, "self-improving");
+    assert_eq!(metadata.name, "self-improving");
+}
+
+#[test]
+fn clawhub_candidate_falls_back_to_normalized_name_without_usable_slug() {
+    let tmp = TempDir::new("liveagent-clawhub-name-fallback-test").expect("temp dir");
+    let candidate = tmp.path().join("candidate");
+    fs::create_dir_all(&candidate).expect("create candidate");
+    fs::write(
+        candidate.join("SKILL.md"),
+        "---\nname: Self-Improving Proactive Agent\ndescription: Merged variant\n---\n",
+    )
+    .expect("write skill");
+
+    let transform = normalize_clawhub_candidate_name(&candidate, None)
+        .expect("normalize candidate")
+        .expect("compatibility transform");
+    let metadata = read_skill_metadata_from_dir(&candidate).expect("read normalized metadata");
+
+    assert_eq!(transform.normalized_name, "self-improving-proactive-agent");
+    assert_eq!(metadata.name, "self-improving-proactive-agent");
+}
+
+#[test]
+fn clawhub_candidate_keeps_portable_name_untouched_even_when_it_differs_from_slug() {
+    let tmp = TempDir::new("liveagent-clawhub-name-portable-test").expect("temp dir");
+    let candidate = tmp.path().join("candidate");
+    fs::create_dir_all(&candidate).expect("create candidate");
+    fs::write(
+        candidate.join("SKILL.md"),
+        "---\nname: already-portable\ndescription: Valid name\n---\n",
+    )
+    .expect("write skill");
+
+    let transform = normalize_clawhub_candidate_name(&candidate, Some("some-other-slug"))
+        .expect("inspect candidate");
+    let metadata = read_skill_metadata_from_dir(&candidate).expect("read metadata");
+
+    assert_eq!(transform, None);
+    assert_eq!(metadata.name, "already-portable");
+}
+
+#[test]
+fn clawhub_candidate_rejects_when_neither_slug_nor_name_is_usable() {
+    let tmp = TempDir::new("liveagent-clawhub-name-unusable-test").expect("temp dir");
+    let candidate = tmp.path().join("candidate");
+    fs::create_dir_all(&candidate).expect("create candidate");
+    fs::write(
+        candidate.join("SKILL.md"),
+        "---\nname: \"###\"\ndescription: Unusable\n---\n",
     )
     .expect("write skill");
 
     let transform =
-        normalize_clawhub_candidate_name(&candidate, "skillscan").expect("inspect candidate");
+        normalize_clawhub_candidate_name(&candidate, Some("CON")).expect("inspect candidate");
 
     assert_eq!(transform, None);
     assert!(read_skill_metadata_from_dir(&candidate).is_err());
+}
+
+#[test]
+fn clawhub_download_query_param_reads_slug_and_owner_from_source_url() {
+    let source =
+        "https://clawhub.ai/api/v1/download?slug=self-improving&tag=latest&ownerHandle=ivangdavila";
+
+    assert_eq!(
+        clawhub_download_query_param(source, "slug").as_deref(),
+        Some("self-improving")
+    );
+    assert_eq!(
+        clawhub_download_query_param(source, "ownerHandle").as_deref(),
+        Some("ivangdavila")
+    );
+    assert_eq!(clawhub_download_query_param(source, "version"), None);
+    assert_eq!(
+        clawhub_download_query_param("https://example.com/api/v1/download?slug=x", "slug"),
+        None
+    );
 }
 
 #[test]

--- a/docs/features/skills-and-mcp.md
+++ b/docs/features/skills-and-mcp.md
@@ -42,8 +42,8 @@
 | Store identity | ClawHub Skill 以 `ownerHandle + slug` 作为唯一身份；React key、安装任务、已安装状态和 `_meta.json` 回读不得只按 slug 合并。 |
 | list 缺 owner | `/api/v1/skills` 条目缺少发布者时，详情/安装前通过精确搜索按 `updatedAt`、version、downloads 等字段懒解析 owner；无法唯一匹配时明确失败，不盲选发布者。 |
 | 下载/详情 | 所有已解析的详情和 `/api/v1/download` 请求都携带 `ownerHandle`，避免重名 slug 返回 HTTP 409。 |
-| 非便携名称 | 仍严格执行 Agent Skills 小写名称规范；只有 ClawHub 单 Skill 包的非法名称归一化后与 registry slug 完全一致时，才改写临时副本并把原名、规范名和转换类型写入 `_meta.json`。 |
-| 原始内容 | 名称兼容转换只发生在下载临时目录，不修改注册表下载包；其他名称不匹配继续按严格校验拒绝。 |
+| 非便携名称 | 仍严格执行 Agent Skills 小写名称规范；ClawHub 官方语义是 slug 与目录显示名分离、互不派生，因此单 Skill 包的非法 `name` 一律修复而非拒绝：优先改写为 registry slug（payload 缺 slug 时从下载 URL query 兜底解析），slug 不可用时回退为规范化后的 `name`；原名、规范名和转换类型写入 `_meta.json`。 |
+| 原始内容 | 名称兼容转换只发生在下载临时目录，不修改注册表下载包；合法 `name` 即便与 slug 不同也保持原样；slug 与规范化 `name` 都不可用（如 Windows 保留名）时仍按严格校验拒绝。 |
 
 ## Skills 选择与 Prompt 注入
 


### PR DESCRIPTION
## 问题

从 Skills 商店安装 ClawHub 上的热门 skill（如 `ivangdavila/self-improving`，即 "Self-Improving + Proactive Agent"，20.5 万下载）会报错：

```
Skill name 'Self-Improving Proactive Agent' must use lowercase letters, digits, and hyphens only
```

## 根因

ClawHub 官方语义（OpenClaw skill-format 文档）是**可路由 slug 与目录显示名分离、互不派生**：发布者可自选 slug，frontmatter `name:` 保留人类可读标题不被静默改写。经实际拉包验证：

| slug | frontmatter name | 旧守卫结果 |
|---|---|---|
| `self-improving` | `Self-Improving + Proactive Agent` | ❌ 报错 |
| `kj-self-improving-proactive` | `Self-Improving Proactive Agent` | ❌ 报错 |
| `self-improving-proactive-agent` | `Self-Improving Proactive Agent` | ✅ 恰好能装 |

而 `normalize_clawhub_candidate_name` 的旧守卫要求 `normalize(name) == registry slug` 才肯改写临时副本，这个前提与注册表契约相悖——不满足时直接掉进 `sanitize_skill_name` 硬校验报错。

## 修复

- **守卫重写**（`install.rs`）：单 Skill ClawHub 包的非法 `name` 一律修复而非拒绝——优先改写为 registry slug；slug 不可用时回退为规范化后的 `name`；两者都不可用（如 Windows 保留名）才维持严格拒绝。合法 `name` 即便与 slug 不同也不动。
- **slug 兜底解析**：payload 不带 `slug`、只有裸 `/api/v1/download` source 时（如聊天内 SkillsManager `action=install`），从下载 URL query 解析 slug，修复行为与商店链路一致。`_meta.json` 的 `slug`/`ownerHandle` 溯源同步受益。
- 名称转换仍只发生在下载临时目录（stage-then-swap），不修改注册表原始包；原名/规范名/转换类型照旧写入 `_meta.json`。

## 测试

- `cargo test --lib`：533 全过（skills 模块 58，其中新增/改写 ClawHub 守卫用例 5 个 + URL query 解析用例 1 个，覆盖真实注册表场景 name≠slug、无 slug 回退、合法名不动、双不可用拒绝）
- 改动文件 `rustfmt --check` clean；clippy 无新增告警
- 文档 `docs/features/skills-and-mcp.md` ClawHub 兼容边界表已同步

## 影响面

仅 Rust 后端（GUI/WebUI 共用），前端零改动。`agent-gateway` 侧 TS 镜像不涉及此逻辑。