### PR TITLE
fix: WebUI stream-loss truncation and touch/no-hover UI visibility

### DIFF
--- a/crates/agent-gateway/internal/session/conversation_ingress.go
+++ b/crates/agent-gateway/internal/session/conversation_ingress.go
@@ -44,20 +44,7 @@ func (m *Manager) ingestChatEvent(requestID string, event *gatewayv1.ChatEvent) 
 		eventType = chatwire.EventTypeName(event.GetType())
 	}
 
-	switch event.GetType() {
-	case gatewayv1.ChatEvent_DONE:
-		delete(payload, "type")
-		delete(payload, "seq")
-		s.runFinishedLocked(stream, runID, "completed", "", "", payload, now)
-		return
-	case gatewayv1.ChatEvent_ERROR:
-		message, _ := payload["message"].(string)
-		delete(payload, "type")
-		delete(payload, "seq")
-		delete(payload, "message")
-		s.runFinishedLocked(stream, runID, "failed", "", strings.TrimSpace(message), payload, now)
-		return
-	case gatewayv1.ChatEvent_USER_MESSAGE:
+	if event.GetType() == gatewayv1.ChatEvent_USER_MESSAGE {
 		if record := s.runs[runID]; record != nil && record.userMessageSeeded {
 			// The gateway already appended this run's user_message at accept
 			// time; swallow the agent echo so the message appears once.
@@ -72,6 +59,21 @@ func (m *Manager) ingestChatEvent(requestID string, event *gatewayv1.ChatEvent) 
 			// Late straggler after a genuine or duplicate terminal; drop it.
 			return
 		}
+	}
+
+	switch event.GetType() {
+	case gatewayv1.ChatEvent_DONE:
+		delete(payload, "type")
+		delete(payload, "seq")
+		s.runFinishedLocked(stream, runID, "completed", "", "", payload, now)
+		return
+	case gatewayv1.ChatEvent_ERROR:
+		message, _ := payload["message"].(string)
+		delete(payload, "type")
+		delete(payload, "seq")
+		delete(payload, "message")
+		s.runFinishedLocked(stream, runID, "failed", "", strings.TrimSpace(message), payload, now)
+		return
 	}
 
 	if event.GetType() == gatewayv1.ChatEvent_USER_MESSAGE {
@@ -161,16 +163,22 @@ func (m *Manager) ingestChatControl(requestID string, control *gatewayv1.ChatCon
 		// A reconnect republish may re-anchor a run this store wrongly gave up
 		// on (inferred loss); resurrect before the started no-ops against the
 		// finished set.
-		if stream.runFinishedRecently(runID) {
-			s.resurrectRunLocked(stream, runID)
+		if stream.runFinishedRecently(runID) && !s.resurrectRunLocked(stream, runID) {
+			return
 		}
 		s.runStartedLocked(stream, runID, "", now)
 	case "completed", "failed", "cancelled":
+		inferredLoss := controlType == "failed" && isInferredRunLossCode(errorCode)
+		if stream.runFinishedRecently(runID) {
+			if inferredLoss || !s.resurrectRunLocked(stream, runID) {
+				return
+			}
+		}
 		// The desktop ledger flushes inferred losses (desktop_run_lost & co)
 		// through this same channel. For the conversation's active run, ignore
 		// such a verdict while the run's own events are fresh or it was
 		// already falsified once — genuine terminals always pass.
-		if controlType == "failed" && isInferredRunLossCode(errorCode) &&
+		if inferredLoss &&
 			stream.activity != nil && stream.activity.RunID == runID {
 			record := s.runs[runID]
 			eventsFresh := !stream.lastEventAt.IsZero() &&
@@ -251,20 +259,20 @@ func (m *Manager) ingestRuntimeSnapshot(snapshot *gatewayv1.ChatRuntimeSnapshot)
 	streamWasUnknown := existingStream == nil || (existingStream.lastSeq == 0 && existingStream.activity == nil)
 	stream := s.streamLocked(conversationID, now)
 	s.noteAgentEpochLocked(stream, epoch)
+	if stream.runFinishedRecently(runID) {
+		// Both running and terminal snapshots are authoritative runtime
+		// evidence. A terminal snapshot must be able to correct an earlier
+		// inferred loss even when no token arrived between the two verdicts.
+		if !s.resurrectRunLocked(stream, runID) {
+			return
+		}
+	}
 
 	switch state {
 	case "completed", "failed", "cancelled":
 		s.runFinishedLocked(stream, runID, state, "", "", nil, now)
 		return
 	}
-	if stream.runFinishedRecently(runID) {
-		// A running snapshot proves the desktop still executes a run this
-		// store wrongly inferred as lost — reopen it.
-		if !s.resurrectRunLocked(stream, runID) {
-			return
-		}
-	}
-
 	next := &RunSnapshot{
 		RunID:                  runID,
 		Revision:               snapshot.GetRevision(),

--- a/crates/agent-gateway/internal/session/conversation_ingress.go
+++ b/crates/agent-gateway/internal/session/conversation_ingress.go
@@ -66,8 +66,12 @@ func (m *Manager) ingestChatEvent(requestID string, event *gatewayv1.ChatEvent) 
 	}
 
 	if stream.runFinishedRecently(runID) {
-		// Late straggler after a forced or duplicate terminal; drop it.
-		return
+		// A live event for a run whose terminal was merely inferred proves the
+		// inference wrong — reopen the run instead of dropping its stream.
+		if !s.resurrectRunLocked(stream, runID) {
+			// Late straggler after a genuine or duplicate terminal; drop it.
+			return
+		}
 	}
 
 	if event.GetType() == gatewayv1.ChatEvent_USER_MESSAGE {
@@ -154,8 +158,27 @@ func (m *Manager) ingestChatControl(requestID string, control *gatewayv1.ChatCon
 
 	switch controlType {
 	case "started":
+		// A reconnect republish may re-anchor a run this store wrongly gave up
+		// on (inferred loss); resurrect before the started no-ops against the
+		// finished set.
+		if stream.runFinishedRecently(runID) {
+			s.resurrectRunLocked(stream, runID)
+		}
 		s.runStartedLocked(stream, runID, "", now)
 	case "completed", "failed", "cancelled":
+		// The desktop ledger flushes inferred losses (desktop_run_lost & co)
+		// through this same channel. For the conversation's active run, ignore
+		// such a verdict while the run's own events are fresh or it was
+		// already falsified once — genuine terminals always pass.
+		if controlType == "failed" && isInferredRunLossCode(errorCode) &&
+			stream.activity != nil && stream.activity.RunID == runID {
+			record := s.runs[runID]
+			eventsFresh := !stream.lastEventAt.IsZero() &&
+				now.Sub(stream.lastEventAt) < s.runReportLostTimeout
+			if eventsFresh || (record != nil && record.revived) {
+				return
+			}
+		}
 		s.runFinishedLocked(stream, runID, controlType, errorCode, message, nil, now)
 	case "queued_in_gui":
 		s.markRunQueuedInGUILocked(stream, runID, now)
@@ -235,7 +258,11 @@ func (m *Manager) ingestRuntimeSnapshot(snapshot *gatewayv1.ChatRuntimeSnapshot)
 		return
 	}
 	if stream.runFinishedRecently(runID) {
-		return
+		// A running snapshot proves the desktop still executes a run this
+		// store wrongly inferred as lost — reopen it.
+		if !s.resurrectRunLocked(stream, runID) {
+			return
+		}
 	}
 
 	next := &RunSnapshot{

--- a/crates/agent-gateway/internal/session/conversation_stream.go
+++ b/crates/agent-gateway/internal/session/conversation_stream.go
@@ -180,6 +180,27 @@ type chatRunRecord struct {
 	// the agent's ref-bearing user_message, so a reconnect replay of the same
 	// event cannot seed a second truncation.
 	rebaseSeeded bool
+	// lostInferred marks a run whose terminal was inferred from missing
+	// liveness reports (desktop_run_lost and friends) rather than delivered by
+	// the run itself. Such a terminal is falsifiable: fresh events for the run
+	// prove it wrong and resurrect the run instead of being dropped as
+	// stragglers.
+	lostInferred bool
+	// revived marks a run resurrected after a wrong inferred terminal; further
+	// inferred-loss signals for it are ignored (the desktop-side ledger may
+	// keep repeating the stale verdict) until a genuine terminal arrives.
+	revived bool
+}
+
+// isInferredRunLossCode reports whether an error code represents a liveness
+// inference (nobody vouched for the run) instead of an outcome the run itself
+// produced. Inferred terminals must stay reversible: the run may well be alive.
+func isInferredRunLossCode(errorCode string) bool {
+	switch errorCode {
+	case "desktop_run_lost", "stale_run", "agent_offline", "desktop_runtime_lease_expired":
+		return true
+	}
+	return false
 }
 
 // chatCommandDedupeRecord is the process-local idempotency key for WebUI chat
@@ -645,8 +666,16 @@ func (s *conversationStreamStore) runFinishedLocked(
 			payload[key] = value
 		}
 	}
-	if record := s.runs[runID]; record != nil && record.clientRequestID != "" {
+	record := s.runRecordLocked(runID, stream.conversationID)
+	if record.clientRequestID != "" {
 		payload["client_request_id"] = record.clientRequestID
+	}
+	// Inferred terminals (nobody vouched for the run) stay falsifiable: a
+	// later event for the run resurrects it instead of being dropped. Genuine
+	// terminals settle the run for good.
+	record.lostInferred = status == "failed" && isInferredRunLossCode(errorCode)
+	if !record.lostInferred {
+		record.revived = false
 	}
 	s.appendEventLocked(stream, runID, StreamEventRunFinished, payload, now)
 	stream.finishedRuns = append(stream.finishedRuns, runID)
@@ -664,6 +693,41 @@ func (s *conversationStreamStore) runFinishedLocked(
 		stream.snapshotDirty = false
 		s.publishActivityLocked(stream, now)
 	}
+}
+
+// resurrectRunLocked reopens a run that was force-finished by a liveness
+// inference: fresh agent traffic for the run proves the inference wrong. The
+// run leaves the finished set (so runStartedLocked re-registers it), is
+// flagged to ignore repeats of the stale verdict, and the stream is marked
+// snapshot-hungry so subscribers rebuild the tail that was dropped while the
+// run was considered dead. Refuses when another run owns the conversation —
+// then the late events really are stragglers.
+func (s *conversationStreamStore) resurrectRunLocked(
+	stream *conversationStream,
+	runID string,
+) bool {
+	record := s.runs[runID]
+	if record == nil || !record.lostInferred {
+		return false
+	}
+	if stream.activity != nil {
+		return false
+	}
+	kept := stream.finishedRuns[:0]
+	for _, finished := range stream.finishedRuns {
+		if finished != runID {
+			kept = append(kept, finished)
+		}
+	}
+	stream.finishedRuns = kept
+	record.lostInferred = false
+	record.revived = true
+	// The events dropped between the wrong terminal and this resurrection are
+	// unrecoverable from the log; late joiners and current subscribers rebuild
+	// from the next runtime snapshot.
+	stream.runNeedsSnapshot = true
+	stream.snapshotDirty = true
+	return true
 }
 
 // markRunQueuedLocked records that a run's command is pending in the gateway
@@ -1123,17 +1187,37 @@ func (s *conversationStreamStore) onRuntimeStatus(event *gatewayv1.RuntimeStatus
 			stream.activity.UpdatedAt = now
 			continue
 		}
+		record := s.runs[runID]
+		revived := record != nil && record.revived
+		eventsFresh := !stream.lastEventAt.IsZero() &&
+			now.Sub(stream.lastEventAt) < s.runReportLostTimeout
 		if report, ok := finished[runID]; ok {
 			state := report.GetState()
 			errorCode := report.GetErrorCode()
+			// Judged on the report's own fields: a ledger-swept loss is an
+			// inference, while an unknown state is still a desktop-asserted
+			// terminal (normalized below) and stays adopted verbatim.
+			inferred := state == "failed" && isInferredRunLossCode(errorCode)
 			switch state {
 			case "completed", "failed", "cancelled":
 			default:
 				state = "failed"
 				errorCode = "desktop_run_lost"
 			}
-			s.runFinishedLocked(stream, runID, state, errorCode, report.GetMessage(),
-				map[string]any{"reason": "desktop_reported"}, now)
+			// A loss the desktop merely inferred (its ledger starved while the
+			// run's events still flow through this relay, or the verdict was
+			// already falsified once) is not adopted — genuine terminals the
+			// run itself produced always are.
+			if !inferred || (!eventsFresh && !revived) {
+				s.runFinishedLocked(stream, runID, state, errorCode, report.GetMessage(),
+					map[string]any{"reason": "desktop_reported"}, now)
+				continue
+			}
+		}
+		if revived {
+			// Resurrected after a wrong loss verdict: liveness inferences no
+			// longer end this run; the reaper's stale-run timeout is the
+			// backstop for a genuinely dead one.
 			continue
 		}
 		// Stream events vouch too: never finalize a run whose events are still

--- a/crates/agent-gateway/internal/session/conversation_stream_reconcile_test.go
+++ b/crates/agent-gateway/internal/session/conversation_stream_reconcile_test.go
@@ -225,6 +225,76 @@ func TestChatEventResurrectsInferredLostRun(t *testing.T) {
 	}
 }
 
+func TestAuthoritativeTerminalCorrectsInferredLostRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		finish     func(*Manager)
+		wantStatus string
+	}{
+		{
+			name: "done event",
+			finish: func(m *Manager) {
+				m.ingestChatEvent("run-1", doneEvent("conv-1"))
+			},
+			wantStatus: "completed",
+		},
+		{
+			name: "error event",
+			finish: func(m *Manager) {
+				m.ingestChatEvent("run-1", &gatewayv1.ChatEvent{
+					Type:           gatewayv1.ChatEvent_ERROR,
+					ConversationId: "conv-1",
+					Data:           `{"message":"provider failed"}`,
+				})
+			},
+			wantStatus: "failed",
+		},
+		{
+			name: "completed control",
+			finish: func(m *Manager) {
+				m.ingestChatControl("run-1", completedControl("run-1", "conv-1"))
+			},
+			wantStatus: "completed",
+		},
+		{
+			name: "terminal snapshot",
+			finish: func(m *Manager) {
+				m.ingestRuntimeSnapshot(&gatewayv1.ChatRuntimeSnapshot{
+					RunId:          "run-1",
+					ConversationId: "conv-1",
+					State:          "completed",
+				})
+			},
+			wantStatus: "completed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := NewManager()
+			m.ingestChatControl("run-1", startedControl("run-1", "conv-1"))
+			m.convStreams.onRuntimeStatus(runsReport(nil, nil), time.Now().Add(16*time.Second))
+
+			test.finish(m)
+
+			last := lastEvent(t, m, "conv-1")
+			if last.Type != StreamEventRunFinished || last.Payload["status"] != test.wantStatus {
+				t.Fatalf("corrected terminal = %s %#v, want run_finished/%s", last.Type, last.Payload, test.wantStatus)
+			}
+			if last.Payload["error_code"] == "desktop_run_lost" {
+				t.Fatalf("authoritative terminal retained inferred loss: %#v", last.Payload)
+			}
+			record := m.convStreams.runs["run-1"]
+			if record == nil || record.lostInferred || record.revived {
+				t.Fatalf("terminal run flags not settled: %#v", record)
+			}
+			if activities := m.ActiveConversationActivities(); len(activities) != 0 {
+				t.Fatalf("authoritative terminal left activity behind: %#v", activities)
+			}
+		})
+	}
+}
+
 // Stragglers after a genuine terminal stay dropped — resurrection applies only
 // to inferred losses.
 func TestGenuineTerminalStragglersStayDropped(t *testing.T) {

--- a/crates/agent-gateway/internal/session/conversation_stream_reconcile_test.go
+++ b/crates/agent-gateway/internal/session/conversation_stream_reconcile_test.go
@@ -111,6 +111,151 @@ func TestRunReportFinalizesLostRunAfterGrace(t *testing.T) {
 	}
 }
 
+// A loss the desktop merely inferred (ledger sweep starved while the webview
+// was throttled) must not kill a run whose events still flow through the
+// relay; once the events go quiet past the grace window it is adopted.
+func TestInferredLossNotAdoptedWhileEventsFlow(t *testing.T) {
+	m := NewManager()
+	m.ingestChatControl("run-1", startedControl("run-1", "conv-1"))
+	m.ingestChatEvent("run-1", tokenEvent("conv-1", "hello"))
+
+	lost := runReport("run-1", "conv-1", "failed")
+	lost.ErrorCode = "desktop_run_lost"
+	lost.Message = "The desktop runtime stopped reporting this run."
+	report := runsReport(nil, []*gatewayv1.ChatRunReport{lost})
+
+	m.convStreams.onRuntimeStatus(report, time.Now())
+	if activities := m.ActiveConversationActivities(); len(activities) != 1 {
+		t.Fatalf("inferred loss adopted despite fresh events, activities=%d", len(activities))
+	}
+
+	m.convStreams.onRuntimeStatus(report, time.Now().Add(16*time.Second))
+	if activities := m.ActiveConversationActivities(); len(activities) != 0 {
+		t.Fatalf("inferred loss not adopted after events went quiet, activities=%d", len(activities))
+	}
+	last := lastEvent(t, m, "conv-1")
+	if last.Type != StreamEventRunFinished || last.Payload["error_code"] != "desktop_run_lost" {
+		t.Fatalf("quiet-adopted tail = %s %#v, want failed/desktop_run_lost", last.Type, last.Payload)
+	}
+}
+
+// The desktop ledger flushes inferred losses as failed control events too; the
+// conversation's active run ignores that verdict while its events are fresh. A
+// genuine failure the run produced always terminates it.
+func TestInferredFailedControlIgnoredWhileEventsFlow(t *testing.T) {
+	m := NewManager()
+	m.ingestChatControl("run-1", startedControl("run-1", "conv-1"))
+	m.ingestChatEvent("run-1", tokenEvent("conv-1", "hello"))
+
+	m.ingestChatControl("run-1", &gatewayv1.ChatControlEvent{
+		RequestId:      "run-1",
+		ConversationId: "conv-1",
+		Type:           "failed",
+		ErrorCode:      "desktop_run_lost",
+		Message:        "The desktop runtime stopped reporting this run.",
+	})
+	if activities := m.ActiveConversationActivities(); len(activities) != 1 {
+		t.Fatalf("inferred failed control killed a streaming run, activities=%d", len(activities))
+	}
+
+	m.ingestChatControl("run-1", &gatewayv1.ChatControlEvent{
+		RequestId:      "run-1",
+		ConversationId: "conv-1",
+		Type:           "failed",
+		ErrorCode:      "provider_error",
+		Message:        "boom",
+	})
+	if activities := m.ActiveConversationActivities(); len(activities) != 0 {
+		t.Fatalf("genuine failure must terminate the run, activities=%d", len(activities))
+	}
+}
+
+// A wrongly-lost run resurrects when its events resume: the finished set
+// releases it, activity returns, the stream is marked snapshot-hungry so
+// subscribers rebuild the tail, and repeats of the stale verdict are ignored
+// until the genuine terminal arrives.
+func TestChatEventResurrectsInferredLostRun(t *testing.T) {
+	m := NewManager()
+	m.ingestChatControl("run-1", startedControl("run-1", "conv-1"))
+	m.convStreams.onRuntimeStatus(runsReport(nil, nil), time.Now().Add(16*time.Second))
+	if activities := m.ActiveConversationActivities(); len(activities) != 0 {
+		t.Fatalf("precondition: run not finalized as lost, activities=%d", len(activities))
+	}
+
+	m.ingestChatEvent("run-1", tokenEvent("conv-1", "still alive"))
+
+	activities := m.ActiveConversationActivities()
+	if len(activities) != 1 || activities[0].RunID != "run-1" {
+		t.Fatalf("run not resurrected by its own event, activities=%#v", activities)
+	}
+	stream := m.convStreams.streams["conv-1"]
+	if stream == nil || !stream.snapshotDirty || !stream.runNeedsSnapshot {
+		t.Fatalf("resurrection must mark the stream snapshot-hungry")
+	}
+	sub := m.SubscribeConversationStream("conv-1", 0, "")
+	sub.Cleanup()
+	if len(sub.Events) < 2 {
+		t.Fatalf("expected restart + token events, got %d", len(sub.Events))
+	}
+	tail := sub.Events[len(sub.Events)-2:]
+	if tail[0].Type != StreamEventRunStarted || tail[1].Type != "token" {
+		t.Fatalf("resurrection tail = %s,%s, want run_started,token", tail[0].Type, tail[1].Type)
+	}
+
+	// The desktop ledger may keep repeating the stale verdict; a revived run
+	// ignores it (the reaper stays the backstop for a genuinely dead run).
+	lost := runReport("run-1", "conv-1", "failed")
+	lost.ErrorCode = "desktop_run_lost"
+	m.convStreams.onRuntimeStatus(
+		runsReport(nil, []*gatewayv1.ChatRunReport{lost}),
+		time.Now().Add(time.Hour),
+	)
+	if activities := m.ActiveConversationActivities(); len(activities) != 1 {
+		t.Fatalf("revived run must ignore stale loss verdicts, activities=%d", len(activities))
+	}
+
+	// The genuine terminal still settles it.
+	m.ingestChatEvent("run-1", doneEvent("conv-1"))
+	if activities := m.ActiveConversationActivities(); len(activities) != 0 {
+		t.Fatalf("genuine done must settle a revived run, activities=%d", len(activities))
+	}
+	last := lastEvent(t, m, "conv-1")
+	if last.Type != StreamEventRunFinished || last.Payload["status"] != "completed" {
+		t.Fatalf("final tail = %s %#v, want run_finished/completed", last.Type, last.Payload)
+	}
+}
+
+// Stragglers after a genuine terminal stay dropped — resurrection applies only
+// to inferred losses.
+func TestGenuineTerminalStragglersStayDropped(t *testing.T) {
+	m := NewManager()
+	m.ingestChatControl("run-1", startedControl("run-1", "conv-1"))
+	m.ingestChatEvent("run-1", doneEvent("conv-1"))
+	m.ingestChatEvent("run-1", tokenEvent("conv-1", "late"))
+
+	if activities := m.ActiveConversationActivities(); len(activities) != 0 {
+		t.Fatalf("straggler resurrected a completed run, activities=%d", len(activities))
+	}
+	last := lastEvent(t, m, "conv-1")
+	if last.Type != StreamEventRunFinished {
+		t.Fatalf("tail after straggler = %s, want run_finished", last.Type)
+	}
+}
+
+// A reconnect republish of "started" re-anchors a run this store wrongly gave
+// up on.
+func TestStartedControlResurrectsInferredLostRun(t *testing.T) {
+	m := NewManager()
+	m.ingestChatControl("run-1", startedControl("run-1", "conv-1"))
+	m.convStreams.onRuntimeStatus(runsReport(nil, nil), time.Now().Add(16*time.Second))
+
+	m.ingestChatControl("run-1", startedControl("run-1", "conv-1"))
+	activities := m.ActiveConversationActivities()
+	if len(activities) != 1 || activities[0].RunID != "run-1" {
+		t.Fatalf("started republish must resurrect the lost run, activities=%#v", activities)
+	}
+}
+
 // Queued runs belong to the accepted-command startup watchdog; the desktop may
 // not know them yet, so reconcile never finalizes them.
 func TestRunReportSkipsQueuedRuns(t *testing.T) {

--- a/crates/agent-gateway/test/webui/conversation-stream-client.test.mjs
+++ b/crates/agent-gateway/test/webui/conversation-stream-client.test.mjs
@@ -87,7 +87,7 @@ test("subscribes with resume cursor and re-subscribes after reconnect", async ()
   assert.equal(transport.calls.length, 1);
   assert.equal(transport.calls[0].type, "chat.subscribe");
   assert.equal(transport.calls[0].payload.after_seq, 0);
-  assert.equal(transport.calls[0].options.timeoutMs, 5_000);
+  assert.equal(transport.calls[0].options.timeoutMs, 30_000);
   assert.equal(seen.syncs.length, 1);
 
   // Live events advance the cursor.

--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -205,6 +205,9 @@ import type { ModelProviderSource, OverlayState, SendChatFn, SendChatOptions } f
 import { UserMenu } from "./UserMenu";
 import { WorkspaceOverlayHost } from "./WorkspaceOverlayHost";
 
+const STALE_HISTORY_RETRY_INITIAL_DELAY_MS = 1_000;
+const STALE_HISTORY_RETRY_MAX_DELAY_MS = 30_000;
+
 // Two-phase open: schedule the quiet full hydration at browser idle time,
 // with a hard timeout so it still runs on busy pages (mirrors the GUI helper
 // semantics).
@@ -1662,6 +1665,61 @@ export default function GatewayApp() {
     displayedConversationBusy,
     displayedConversationId,
     refreshDisplayedConversationHistorySnapshot,
+  ]);
+
+  // Inferred liveness failures can settle before the desktop's final history
+  // write. History upserts are intentionally lossy broadcasts under WebSocket
+  // backpressure, so a stale displayed turn cannot rely on that one signal:
+  // keep retrying the quiet enrich at a bounded cadence until history adopts
+  // the authoritative persisted reply or the conversation becomes busy again.
+  useEffect(() => {
+    const conversationIdValue = displayedConversationId.trim();
+    if (
+      !api ||
+      !conversationIdValue ||
+      displayedConversationBusy ||
+      !displayedTranscript.needsHistoryRefresh
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    let timerId: number | null = null;
+    let retryDelayMs = STALE_HISTORY_RETRY_INITIAL_DELAY_MS;
+    const retry = async () => {
+      await refreshDisplayedConversationHistorySnapshot(conversationIdValue, api);
+      if (cancelled) {
+        return;
+      }
+      const stillStale =
+        transcriptStoreRegistry.peek(conversationIdValue)?.getSnapshot().needsHistoryRefresh ===
+        true;
+      if (!stillStale || isConversationBusy(conversationIdValue)) {
+        return;
+      }
+      retryDelayMs = Math.min(retryDelayMs * 2, STALE_HISTORY_RETRY_MAX_DELAY_MS);
+      timerId = window.setTimeout(() => {
+        void retry();
+      }, retryDelayMs);
+    };
+
+    timerId = window.setTimeout(() => {
+      void retry();
+    }, retryDelayMs);
+    return () => {
+      cancelled = true;
+      if (timerId !== null) {
+        window.clearTimeout(timerId);
+      }
+    };
+  }, [
+    api,
+    displayedConversationBusy,
+    displayedConversationId,
+    displayedTranscript.needsHistoryRefresh,
+    isConversationBusy,
+    refreshDisplayedConversationHistorySnapshot,
+    transcriptStoreRegistry,
   ]);
 
   // The upsert-while-idle backstop: the desktop reports run completion before

--- a/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
+++ b/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
@@ -915,7 +915,7 @@ const GatewayUserMessageRowBody = memo(function GatewayUserMessageRowBody(props:
       />
       <div className="chat-user-bubble-actions mt-1 flex items-center justify-end gap-1.5">
         {!readOnly ? (
-          <div className="flex gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+          <div className="flex gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100">
             <button
               type="button"
               className="chat-user-bubble-action rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"

--- a/crates/agent-gateway/web/src/components/chat/ChatHistorySidebar.tsx
+++ b/crates/agent-gateway/web/src/components/chat/ChatHistorySidebar.tsx
@@ -2018,7 +2018,7 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
             <>
               <div
                 ref={projectsHeaderRef}
-                className="group/workspace-header flex items-center justify-between px-2 pb-1 pt-2"
+                className="flex items-center justify-between px-2 pb-1 pt-2"
               >
                 <button
                   type="button"
@@ -2038,10 +2038,7 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className={cn(
-                    PROJECT_ICON_BUTTON_CLASS,
-                    "pointer-events-none opacity-0 transition-opacity hover:!bg-transparent group-hover/workspace-header:pointer-events-auto group-hover/workspace-header:opacity-100 focus-visible:opacity-100",
-                  )}
+                  className={cn(PROJECT_ICON_BUTTON_CLASS, "hover:!bg-transparent")}
                   title={t("chat.workspaceCreate")}
                   aria-label={t("chat.workspaceCreate")}
                   onClick={handleCreateProject}

--- a/crates/agent-gateway/web/src/components/chat/ChatHistorySidebar.tsx
+++ b/crates/agent-gateway/web/src/components/chat/ChatHistorySidebar.tsx
@@ -626,7 +626,14 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
               className={cn(
                 "relative flex items-center justify-end overflow-hidden transition-[max-width,opacity] duration-200 ease-out",
                 isRunning
-                  ? "max-w-7 opacity-100 group-hover/item:max-w-16 group-focus-within/item:max-w-16"
+                  ? // Mobile rows render no inline action buttons, so this flex
+                    // box has zero content width AND zero height — max-w alone
+                    // leaves the absolutely-positioned spinner fully clipped by
+                    // overflow-hidden. Reserve the spinner slot explicitly
+                    // (both axes) and skip the hover/focus swap.
+                    isMobileMenuLayout
+                    ? "h-7 w-7 opacity-100"
+                    : "max-w-7 opacity-100 group-hover/item:max-w-16 group-focus-within/item:max-w-16"
                   : "max-w-0 opacity-0 group-hover/item:max-w-16 group-hover/item:opacity-100 group-focus-within/item:max-w-16 group-focus-within/item:opacity-100",
                 menuOpen && "max-w-16 opacity-100",
               )}
@@ -638,8 +645,12 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
                   title={t("chat.statusRunningReply")}
                   className={cn(
                     "pointer-events-none absolute right-1.5 flex h-4 w-4 items-center justify-center text-muted-foreground transition-opacity duration-200",
-                    "opacity-100 group-hover/item:opacity-0 group-focus-within/item:opacity-0",
-                    menuOpen && "opacity-0",
+                    isMobileMenuLayout
+                      ? "opacity-100"
+                      : [
+                          "opacity-100 group-hover/item:opacity-0 group-focus-within/item:opacity-0",
+                          menuOpen && "opacity-0",
+                        ],
                   )}
                 >
                   <Loader2 className="h-4 w-4 animate-spin" />

--- a/crates/agent-gateway/web/src/lib/chat/stream/conversationStreamClient.ts
+++ b/crates/agent-gateway/web/src/lib/chat/stream/conversationStreamClient.ts
@@ -32,7 +32,7 @@ type Registration = {
 };
 
 const MAX_PENDING_EVENTS = 512;
-const SUBSCRIBE_REQUEST_TIMEOUT_MS = 5_000;
+const SUBSCRIBE_REQUEST_TIMEOUT_MS = 30_000;
 const SYNC_RETRY_INITIAL_DELAY_MS = 250;
 // Persistent failures (deleted conversation, permanent server-side rejects)
 // retry forever but back off far enough to stay negligible; transient

--- a/crates/agent-gateway/web/src/lib/chat/stream/useConversationChat.ts
+++ b/crates/agent-gateway/web/src/lib/chat/stream/useConversationChat.ts
@@ -72,6 +72,7 @@ const EMPTY_TRANSCRIPT: TranscriptSnapshot = {
   toolStatus: null,
   toolStatusIsCompaction: false,
   retryAttempts: [],
+  needsHistoryRefresh: false,
   foldRevision: 0,
   revision: 0,
 };

--- a/crates/agent-gateway/web/src/lib/chat/transcript/historyAlignment.ts
+++ b/crates/agent-gateway/web/src/lib/chat/transcript/historyAlignment.ts
@@ -102,7 +102,12 @@ function enrichTurnFromHistory(turn: Turn, historyTurn: HistoryTurn): Turn {
     historyTurn.entries.length > 0 &&
     next.phase === "settled"
   ) {
-    return { ...next, entries: historyTurn.entries, contentStale: false };
+    return {
+      ...next,
+      entries: historyTurn.entries,
+      contentStale: false,
+      inferredLossErrorEntryId: undefined,
+    };
   }
 
   const historyToolCalls = historyTurn.entries.filter(

--- a/crates/agent-gateway/web/src/lib/chat/transcript/transcriptStore.ts
+++ b/crates/agent-gateway/web/src/lib/chat/transcript/transcriptStore.ts
@@ -95,6 +95,7 @@ const EMPTY_SNAPSHOT: TranscriptSnapshot = {
   toolStatus: null,
   toolStatusIsCompaction: false,
   retryAttempts: EMPTY_RETRY_ATTEMPTS,
+  needsHistoryRefresh: false,
   foldRevision: 0,
   revision: 0,
 };
@@ -347,6 +348,7 @@ export function createTranscriptStore(options?: {
       toolStatus,
       toolStatusIsCompaction,
       retryAttempts,
+      needsHistoryRefresh: turns.some((turn) => turn.contentStale === true),
       foldRevision,
       revision: snapshot.revision + 1,
     };
@@ -571,6 +573,9 @@ export function createTranscriptStore(options?: {
     }
     let next = adoptRun(turn, runId);
     next = rebuildTurnFromSnapshot(next, parsed);
+    if (next.inferredLossErrorEntryId) {
+      next = { ...next, inferredLossErrorEntryId: undefined };
+    }
     if (next.phase !== "streaming" || next.folded) {
       next = { ...next, phase: "streaming", folded: false };
     }
@@ -606,16 +611,42 @@ export function createTranscriptStore(options?: {
       reason?: string;
       error_code?: string;
     };
+    const inferredLoss =
+      payload.status === "failed" && isInferredRunLossErrorCode(payload.error_code);
     let turn = findTurnByRunId(runId) ?? findStreamingTurn();
+    if (turn && !inferredLoss && turn.inferredLossErrorEntryId) {
+      const previousTurn = turn;
+      const correctedTurn = {
+        ...previousTurn,
+        entries: previousTurn.entries.filter(
+          (entry) => entry.id !== previousTurn.inferredLossErrorEntryId,
+        ),
+        inferredLossErrorEntryId: undefined,
+      };
+      replaceTurn(previousTurn, correctedTurn);
+      turn = correctedTurn;
+    }
     if (payload.status === "failed" && payload.message && payload.reason !== "superseded") {
       if (!turn) {
         turn = createTurn({ key: `run:${runId || `finished-${readEventSeq(event)}`}`, runId });
         turns = [...turns, turn];
       }
-      const withError = applyEventToTurn(turn, {
+      const previousEntryIds = new Set(turn.entries.map((entry) => entry.id));
+      let withError = applyEventToTurn(turn, {
         type: "error",
         message: payload.message,
       } as ChatEvent);
+      if (inferredLoss) {
+        const inferredErrorEntry = withError.entries.find(
+          (entry) => !previousEntryIds.has(entry.id),
+        );
+        if (inferredErrorEntry) {
+          withError = {
+            ...withError,
+            inferredLossErrorEntryId: inferredErrorEntry.id,
+          };
+        }
+      }
       replaceTurn(turn, withError);
       turn = withError;
     }
@@ -624,8 +655,6 @@ export function createTranscriptStore(options?: {
     // trusted as the full content: mark it stale so the post-persist history
     // refresh may adopt the real reply (enrichTurnFromHistory). A gateway
     // resurrection rebuilds from the runtime snapshot and clears the mark.
-    const inferredLoss =
-      payload.status === "failed" && isInferredRunLossErrorCode(payload.error_code);
     if (turn && (turn.phase !== "settled" || (inferredLoss && turn.contentStale !== true))) {
       replaceTurn(turn, {
         ...turn,
@@ -717,10 +746,15 @@ export function createTranscriptStore(options?: {
           turns = [...turns, turn];
         }
         const bound = adoptRun(turn, runId);
+        const entries = bound.inferredLossErrorEntryId
+          ? bound.entries.filter((entry) => entry.id !== bound.inferredLossErrorEntryId)
+          : bound.entries;
         replaceTurn(turn, {
           ...bound,
+          entries,
           phase: "streaming",
           folded: false,
+          inferredLossErrorEntryId: undefined,
         });
         activeRun = {
           runId,

--- a/crates/agent-gateway/web/src/lib/chat/transcript/transcriptStore.ts
+++ b/crates/agent-gateway/web/src/lib/chat/transcript/transcriptStore.ts
@@ -137,6 +137,18 @@ function readEventClientRequestId(event: ConversationStreamEvent): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+// Terminals carrying these codes were inferred from missing liveness reports
+// (gateway reconcile / desktop ledger sweep) rather than produced by the run
+// itself — the run may still be streaming and the settled content incomplete.
+function isInferredRunLossErrorCode(errorCode: unknown): boolean {
+  return (
+    errorCode === "desktop_run_lost" ||
+    errorCode === "stale_run" ||
+    errorCode === "agent_offline" ||
+    errorCode === "desktop_runtime_lease_expired"
+  );
+}
+
 // Assistant-side content carriers (everything applyDelta folds into a turn's
 // entries, except the slot-guarded user_message). Lifecycle events —
 // run_started/run_finished/run_queued/rebased/snapshot/tool_status — are not
@@ -588,7 +600,12 @@ export function createTranscriptStore(options?: {
       }
       return;
     }
-    const payload = event as { status?: string; message?: string; reason?: string };
+    const payload = event as {
+      status?: string;
+      message?: string;
+      reason?: string;
+      error_code?: string;
+    };
     let turn = findTurnByRunId(runId) ?? findStreamingTurn();
     if (payload.status === "failed" && payload.message && payload.reason !== "superseded") {
       if (!turn) {
@@ -602,8 +619,19 @@ export function createTranscriptStore(options?: {
       replaceTurn(turn, withError);
       turn = withError;
     }
-    if (turn && turn.phase !== "settled") {
-      replaceTurn(turn, { ...turn, phase: "settled" });
+    // A failure inferred from missing liveness reports (desktop_run_lost &
+    // co) may have cut the stream mid-reply, so the streamed copy cannot be
+    // trusted as the full content: mark it stale so the post-persist history
+    // refresh may adopt the real reply (enrichTurnFromHistory). A gateway
+    // resurrection rebuilds from the runtime snapshot and clears the mark.
+    const inferredLoss =
+      payload.status === "failed" && isInferredRunLossErrorCode(payload.error_code);
+    if (turn && (turn.phase !== "settled" || (inferredLoss && turn.contentStale !== true))) {
+      replaceTurn(turn, {
+        ...turn,
+        phase: "settled",
+        contentStale: inferredLoss ? true : turn.contentStale,
+      });
     }
     activeRun = null;
     setToolStatus(null, false);

--- a/crates/agent-gateway/web/src/lib/chat/transcript/types.ts
+++ b/crates/agent-gateway/web/src/lib/chat/transcript/types.ts
@@ -46,6 +46,9 @@ export type Turn = {
   // carrying assistant content adopts wholesale (enrichTurnFromHistory)
   // instead of the usual payload-only upgrade.
   contentStale?: boolean;
+  // Error entry appended for a falsifiable liveness verdict. A same-run
+  // resurrection removes this exact entry before streaming resumes.
+  inferredLossErrorEntryId?: string;
 };
 
 export type TranscriptRowOrigin = "history" | "stream";
@@ -111,6 +114,9 @@ export type TranscriptSnapshot = {
   // Live run's stream-retry history (cleared at run boundaries and whenever
   // the desktop starts a fresh network attempt).
   retryAttempts: readonly RetryAttemptRecord[];
+  // At least one settled streamed turn may be incomplete and should keep
+  // retrying the quiet history enrich while the conversation is idle.
+  needsHistoryRefresh: boolean;
   // Bumped whenever turns fold into the virtualized region.
   foldRevision: number;
   revision: number;

--- a/crates/agent-gateway/web/src/pages/settings/AgentsSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/AgentsSection.tsx
@@ -184,7 +184,7 @@ export function AgentsSection(props: SettingsSectionProps) {
                         title={template.enabled ? t("settings.disable") : t("settings.enable")}
                         onToggle={() => handleToggleEnabled(template.id)}
                       />
-                      <div className="settings-hover-actions ml-1 flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+                      <div className="settings-hover-actions ml-1 flex items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
                         <Button
                           variant="ghost"
                           size="icon"

--- a/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
@@ -1173,7 +1173,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                                   else focusCustomHeader(index + 1, "key");
                                 }}
                               />
-                              <div className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 max-[720px]:opacity-100">
+                              <div className="settings-hover-actions absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 max-[720px]:opacity-100">
                                 <Button
                                   type="button"
                                   variant="ghost"
@@ -1484,7 +1484,7 @@ function ProviderList(props: {
                     {provider.activeModels.length} {t("settings.activeModels")}
                   </div>
                 </div>
-                <div className="settings-card-actions settings-hover-actions flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                <div className="settings-card-actions settings-hover-actions flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
                   <Button
                     variant="ghost"
                     size="icon"

--- a/crates/agent-gateway/web/src/styles.css
+++ b/crates/agent-gateway/web/src/styles.css
@@ -3188,6 +3188,17 @@ html[data-liveagent-webui="gateway"]
   }
 }
 
+/* Tailwind v4 gates every hover:/group-hover: utility behind
+ * @media (hover: hover), so on devices whose primary pointer cannot hover
+ * (tablets, touch-primary 2-in-1s) the reveal rule never exists.
+ * Hover-revealed settings action clusters must stay visible there. */
+@media (hover: none), (pointer: coarse) {
+  html[data-liveagent-webui="gateway"] .settings-card-actions,
+  html[data-liveagent-webui="gateway"] .settings-hover-actions {
+    opacity: 1 !important;
+  }
+}
+
 @media (max-width: 640px) {
   .login-shell {
     padding: 10px;

--- a/crates/agent-gateway/web/test/transcript-store.test.mjs
+++ b/crates/agent-gateway/web/test/transcript-store.test.mjs
@@ -175,6 +175,7 @@ test("inferred desktop_run_lost marks the streamed copy stale so enrich adopts t
   );
   store.flush();
   assert.equal(store.getSnapshot().activeRun, null);
+  assert.equal(store.getSnapshot().needsHistoryRefresh, true);
 
   // The run actually kept going on the desktop and persisted the full reply;
   // the truncated streamed copy must not be treated as authoritative.
@@ -189,6 +190,7 @@ test("inferred desktop_run_lost marks the streamed copy stale so enrich adopts t
   const text = allRows(store.getSnapshot()).map(rowText).join("\n");
   assert.match(text, /partial plus the rest of the reply/, "persisted reply adopted");
   assert.doesNotMatch(text, /stopped reporting/, "inferred error entry replaced by real content");
+  assert.equal(store.getSnapshot().needsHistoryRefresh, false);
 });
 
 test("a genuine failure keeps the streamed copy authoritative under enrich", () => {
@@ -237,10 +239,39 @@ test("a resurrected run reopens its truncated turn in place and finishes normall
   const liveText = allRows(live).map(rowText).join("\n");
   assert.match(liveText, /part one/);
   assert.match(liveText, /part two/);
+  assert.doesNotMatch(liveText, /stopped reporting/, "resurrection removes the inferred error");
+  assert.equal(live.needsHistoryRefresh, true, "persisted history still owns final convergence");
 
   store.applyEvent(runFinished("run-1", 7));
   store.flush();
   assert.equal(store.getSnapshot().activeRun, null, "genuine completion settles the revived run");
+});
+
+test("an authoritative terminal replaces an inferred loss without leaving its error", () => {
+  const store = createTranscriptStore();
+  store.applyEvent(userMessage("run-1", 1, "hello"));
+  store.applyEvent(runStarted("run-1", 2));
+  store.applyEvent(token("run-1", 3, "partial"));
+  store.applyEvent(
+    runFinished("run-1", 4, "failed", {
+      error_code: "desktop_run_lost",
+      message: "The desktop runtime stopped reporting this run.",
+    }),
+  );
+  store.flush();
+
+  store.applyEvent(
+    runFinished("run-1", 5, "failed", {
+      error_code: "provider_error",
+      message: "provider failed",
+    }),
+  );
+  store.flush();
+  const snapshot = store.getSnapshot();
+  const text = allRows(snapshot).map(rowText).join("\n");
+  assert.match(text, /provider failed/);
+  assert.doesNotMatch(text, /stopped reporting/);
+  assert.equal(snapshot.needsHistoryRefresh, true, "history still owns final tail convergence");
 });
 
 test("run_queued removes the turn entirely", () => {

--- a/crates/agent-gateway/web/test/transcript-store.test.mjs
+++ b/crates/agent-gateway/web/test/transcript-store.test.mjs
@@ -162,6 +162,87 @@ test("failed run appends an error entry and clears busy", () => {
   assert.match(text, /model exploded/);
 });
 
+test("inferred desktop_run_lost marks the streamed copy stale so enrich adopts the persisted reply", () => {
+  const store = createTranscriptStore();
+  store.applyEvent(userMessage("run-1", 1, "hello"));
+  store.applyEvent(runStarted("run-1", 2));
+  store.applyEvent(token("run-1", 3, "partial"));
+  store.applyEvent(
+    runFinished("run-1", 4, "failed", {
+      error_code: "desktop_run_lost",
+      message: "The desktop runtime stopped reporting this run.",
+    }),
+  );
+  store.flush();
+  assert.equal(store.getSnapshot().activeRun, null);
+
+  // The run actually kept going on the desktop and persisted the full reply;
+  // the truncated streamed copy must not be treated as authoritative.
+  store.applyHistorySnapshot(
+    [
+      { id: "hu:m1", kind: "user", text: "hello", attachments: [], messageRef: messageRef("m1") },
+      { id: "ht:hu:m1>0", kind: "assistant", text: "partial plus the rest of the reply", round: 1 },
+    ],
+    { mode: "enrich" },
+  );
+  store.flush();
+  const text = allRows(store.getSnapshot()).map(rowText).join("\n");
+  assert.match(text, /partial plus the rest of the reply/, "persisted reply adopted");
+  assert.doesNotMatch(text, /stopped reporting/, "inferred error entry replaced by real content");
+});
+
+test("a genuine failure keeps the streamed copy authoritative under enrich", () => {
+  const store = createTranscriptStore();
+  store.applyEvent(userMessage("run-1", 1, "hello"));
+  store.applyEvent(runStarted("run-1", 2));
+  store.applyEvent(token("run-1", 3, "streamed reply"));
+  store.applyEvent(runFinished("run-1", 4, "failed", { message: "model exploded" }));
+  store.flush();
+
+  store.applyHistorySnapshot(
+    [
+      { id: "hu:m1", kind: "user", text: "hello", attachments: [], messageRef: messageRef("m1") },
+      { id: "ht:hu:m1>0", kind: "assistant", text: "some other persisted text", round: 1 },
+    ],
+    { mode: "enrich" },
+  );
+  store.flush();
+  const text = allRows(store.getSnapshot()).map(rowText).join("\n");
+  assert.match(text, /streamed reply/, "streamed content kept");
+  assert.doesNotMatch(text, /some other persisted text/, "no wholesale adoption without contentStale");
+});
+
+test("a resurrected run reopens its truncated turn in place and finishes normally", () => {
+  const store = createTranscriptStore();
+  store.applyEvent(userMessage("run-1", 1, "hello"));
+  store.applyEvent(runStarted("run-1", 2));
+  store.applyEvent(token("run-1", 3, "part one "));
+  store.applyEvent(
+    runFinished("run-1", 4, "failed", {
+      error_code: "desktop_run_lost",
+      message: "The desktop runtime stopped reporting this run.",
+    }),
+  );
+  store.flush();
+  assert.equal(store.getSnapshot().activeRun, null);
+
+  // The gateway falsified the loss verdict: the same run restarts and keeps
+  // streaming into the same turn.
+  store.applyEvent(runStarted("run-1", 5));
+  store.applyEvent(token("run-1", 6, "part two"));
+  store.flush();
+  const live = store.getSnapshot();
+  assertUniqueKeys(live);
+  assert.equal(live.activeRun?.runId, "run-1", "activity restored");
+  const liveText = allRows(live).map(rowText).join("\n");
+  assert.match(liveText, /part one/);
+  assert.match(liveText, /part two/);
+
+  store.applyEvent(runFinished("run-1", 7));
+  store.flush();
+  assert.equal(store.getSnapshot().activeRun, null, "genuine completion settles the revived run");
+});
+
 test("run_queued removes the turn entirely", () => {
   const store = createTranscriptStore();
   store.addOptimisticUserEntry({ clientRequestId: "client-1", text: "park me" });

--- a/crates/agent-gui/src-tauri/src/services/chat_run_ledger.rs
+++ b/crates/agent-gui/src-tauri/src/services/chat_run_ledger.rs
@@ -253,6 +253,21 @@ impl ChatRunLedger {
         recent
     }
 
+    // Liveness stand-in for runs whose only refresher is a throttled webview
+    // timer: while the webview is known to be merely stalled (its runtime
+    // status record is recent but its DOM timers are not firing), the caller
+    // refreshes every live entry so a long event-silent run is not demoted to
+    // desktop_run_lost by the TTL sweep below. Never resurrects terminals.
+    pub fn refresh_running(&mut self, now: Instant, now_ms: i64) {
+        for entry in self.entries.values_mut() {
+            if entry.state.is_terminal() {
+                continue;
+            }
+            entry.touched_at = now;
+            entry.updated_at_ms = now_ms;
+        }
+    }
+
     pub fn sweep(&mut self, now: Instant, now_ms: i64) -> Vec<ChatRunLedgerEntry> {
         let mut demoted: Vec<ChatRunLedgerEntry> = Vec::new();
         for entry in self.entries.values_mut() {
@@ -377,6 +392,41 @@ mod tests {
             ledger.active_reports(t0 + Duration::from_secs(400)).len(),
             1
         );
+    }
+
+    #[test]
+    fn refresh_running_keeps_live_entries_out_of_sweep() {
+        let mut ledger = test_ledger();
+        let t0 = Instant::now();
+        ledger.mark_running("run-1", "conversation-1", t0, 1_000);
+        ledger.mark_terminal(
+            "run-2",
+            "conversation-2",
+            ChatRunLedgerState::Completed,
+            "",
+            "",
+            t0,
+            1_000,
+        );
+
+        // Untouched past the TTL, but refreshed by the webview-stall grace.
+        let t1 = t0 + Duration::from_secs(301);
+        ledger.refresh_running(t1, 2_000);
+        assert!(ledger.sweep(t1, 2_000).is_empty());
+        assert_eq!(ledger.active_reports(t1).len(), 1);
+        // Terminal entries are never resurrected by the refresh.
+        assert_eq!(ledger.recent_terminal_reports().len(), 1);
+        assert_eq!(
+            ledger.recent_terminal_reports()[0].state,
+            ChatRunLedgerState::Completed
+        );
+
+        // Without further refreshes the normal TTL judgment resumes.
+        let t2 = t1 + Duration::from_secs(301);
+        let demoted = ledger.sweep(t2, 3_000);
+        assert_eq!(demoted.len(), 1);
+        assert_eq!(demoted[0].run_id, "run-1");
+        assert_eq!(demoted[0].error_code, DESKTOP_RUN_LOST_ERROR_CODE);
     }
 
     #[test]

--- a/crates/agent-gui/src-tauri/src/services/gateway/chat_inbox.rs
+++ b/crates/agent-gui/src-tauri/src/services/gateway/chat_inbox.rs
@@ -937,15 +937,25 @@ impl GatewayController {
     // nothing about the run. Beyond the max age the webview is treated as gone
     // and the normal TTL judgment resumes, keeping terminal delivery for
     // genuinely lost runs guaranteed.
+    pub(super) fn webview_status_report_stalled_but_alive_at(
+        record: Option<&RuntimeStatusRepublishRecord>,
+        now: Instant,
+    ) -> bool {
+        let Some(record) = record else {
+            return false;
+        };
+        if record.active_run_count == 0 {
+            return false;
+        }
+        let age = now.saturating_duration_since(record.updated_at);
+        age > GATEWAY_WEBVIEW_REPORT_FRESH_WINDOW && age <= GATEWAY_RUNTIME_STATUS_REPUBLISH_MAX_AGE
+    }
+
     fn webview_status_report_stalled_but_alive(&self) -> bool {
         let Ok(slot) = self.runtime_status_republish.lock() else {
             return false;
         };
-        let Some(record) = slot.as_ref() else {
-            return false;
-        };
-        let age = Instant::now().saturating_duration_since(record.updated_at);
-        age > GATEWAY_WEBVIEW_REPORT_FRESH_WINDOW && age <= GATEWAY_RUNTIME_STATUS_REPUBLISH_MAX_AGE
+        Self::webview_status_report_stalled_but_alive_at(slot.as_ref(), Instant::now())
     }
 
     pub(crate) async fn flush_unsent_chat_run_terminals(&self) -> Result<(), String> {

--- a/crates/agent-gui/src-tauri/src/services/gateway/chat_inbox.rs
+++ b/crates/agent-gui/src-tauri/src/services/gateway/chat_inbox.rs
@@ -929,16 +929,43 @@ impl GatewayController {
         })
     }
 
+    // A record that is stale relative to the webview's 2s heartbeat cadence
+    // but still within the republish max age means the webview is alive yet
+    // throttled (hidden/occluded window): its DOM timers — including the 60s
+    // run-snapshot keepalive that normally refreshes the ledger through long
+    // silent tool calls — are not firing, so an untouched ledger entry proves
+    // nothing about the run. Beyond the max age the webview is treated as gone
+    // and the normal TTL judgment resumes, keeping terminal delivery for
+    // genuinely lost runs guaranteed.
+    fn webview_status_report_stalled_but_alive(&self) -> bool {
+        let Ok(slot) = self.runtime_status_republish.lock() else {
+            return false;
+        };
+        let Some(record) = slot.as_ref() else {
+            return false;
+        };
+        let age = Instant::now().saturating_duration_since(record.updated_at);
+        age > GATEWAY_WEBVIEW_REPORT_FRESH_WINDOW && age <= GATEWAY_RUNTIME_STATUS_REPUBLISH_MAX_AGE
+    }
+
     pub(crate) async fn flush_unsent_chat_run_terminals(&self) -> Result<(), String> {
         if !self.status().online {
             return Ok(());
         }
+        let webview_stalled_but_alive = self.webview_status_report_stalled_but_alive();
         let unsent = {
             let (now, now_ms) = chat_run_ledger_now();
             let mut ledger = self
                 .chat_run_ledger
                 .lock()
                 .map_err(|_| "gateway chat run ledger lock poisoned".to_string())?;
+            // While the webview is merely throttled its keepalive cannot vouch
+            // for long-silent runs; stand in for it so the sweep below (and the
+            // gateway's active_runs reconcile fed by active_reports) never
+            // declares a live run desktop_run_lost during a stall.
+            if webview_stalled_but_alive {
+                ledger.refresh_running(now, now_ms);
+            }
             // Sweep first: runs demoted by the TTL become unsent terminals and
             // are picked up by this very flush.
             ledger.sweep(now, now_ms);

--- a/crates/agent-gui/src-tauri/src/services/gateway/mod.rs
+++ b/crates/agent-gui/src-tauri/src/services/gateway/mod.rs
@@ -112,6 +112,11 @@ pub(crate) const GATEWAY_CHAT_LEASE_SWEEP_INTERVAL: Duration = Duration::from_se
 // throttled) or has said "suspended".
 pub(crate) const GATEWAY_RUNTIME_STATUS_REPUBLISH_INTERVAL: Duration = Duration::from_secs(5);
 pub(crate) const GATEWAY_RUNTIME_STATUS_REPUBLISH_MAX_AGE: Duration = Duration::from_secs(10 * 60);
+// A healthy webview stamps the republish record every ~2s; a gap beyond this
+// window means its DOM timers are throttled (hidden/occluded window), so run
+// keepalives are not firing either and ledger staleness proves nothing about
+// the runs themselves.
+pub(crate) const GATEWAY_WEBVIEW_REPORT_FRESH_WINDOW: Duration = Duration::from_secs(6);
 pub(crate) const GATEWAY_CHAT_RUNTIME_WAKE_REQUEST_PREFIX: &str = "chat-runtime-wake-";
 pub(crate) const GATEWAY_CHAT_RUNTIME_WAKE_EVENT: &str = "gateway:chat-runtime-wake";
 pub(crate) const GATEWAY_CONNECTION_NUDGE_COOLDOWN: Duration = Duration::from_secs(1);

--- a/crates/agent-gui/src-tauri/src/services/gateway/tests.rs
+++ b/crates/agent-gui/src-tauri/src/services/gateway/tests.rs
@@ -8,7 +8,7 @@ use super::{
     GatewayChatRuntimeSnapshot, GatewayController, GatewayStatusSnapshot, RemoteChatInboxRecord,
     GATEWAY_CHAT_LEASE_MS, GATEWAY_CHAT_RUNNING_LEASE_MS, GATEWAY_RECONNECT_MAX,
     GATEWAY_RECONNECT_MIN, GATEWAY_RECONNECT_STABLE_AFTER,
-    GATEWAY_RUNTIME_STATUS_REPUBLISH_MAX_AGE,
+    GATEWAY_RUNTIME_STATUS_REPUBLISH_MAX_AGE, GATEWAY_WEBVIEW_REPORT_FRESH_WINDOW,
 };
 use crate::commands::settings::RemoteSettingsPayload;
 use serde_json::{json, Value};
@@ -908,5 +908,42 @@ fn runtime_status_republish_payload_expires_after_max_age() {
     assert_eq!(
         GatewayController::runtime_status_republish_payload(None, now),
         None
+    );
+}
+
+#[test]
+fn stalled_webview_status_refreshes_running_ledger_only_inside_grace_window() {
+    let now = Instant::now();
+    let record =
+        GatewayController::next_runtime_status_republish_record("worker-1", "busy", false, 1, now)
+            .expect("busy record");
+
+    assert!(
+        !GatewayController::webview_status_report_stalled_but_alive_at(
+            Some(&record),
+            now + GATEWAY_WEBVIEW_REPORT_FRESH_WINDOW,
+        )
+    );
+    assert!(
+        GatewayController::webview_status_report_stalled_but_alive_at(
+            Some(&record),
+            now + GATEWAY_WEBVIEW_REPORT_FRESH_WINDOW + Duration::from_secs(1),
+        )
+    );
+    assert!(
+        !GatewayController::webview_status_report_stalled_but_alive_at(
+            Some(&record),
+            now + GATEWAY_RUNTIME_STATUS_REPUBLISH_MAX_AGE + Duration::from_secs(1),
+        )
+    );
+    assert!(!GatewayController::webview_status_report_stalled_but_alive_at(None, now,));
+    let idle_record =
+        GatewayController::next_runtime_status_republish_record("worker-1", "ready", false, 0, now)
+            .expect("idle record");
+    assert!(
+        !GatewayController::webview_status_report_stalled_but_alive_at(
+            Some(&idle_record),
+            now + GATEWAY_WEBVIEW_REPORT_FRESH_WINDOW + Duration::from_secs(1),
+        )
     );
 }

--- a/crates/agent-gui/src/components/chat/ChatHistorySidebar.tsx
+++ b/crates/agent-gui/src/components/chat/ChatHistorySidebar.tsx
@@ -1521,7 +1521,7 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
             <>
               <div
                 ref={projectsHeaderRef}
-                className="group/workspace-header flex items-center justify-between px-2 pb-1 pt-2"
+                className="flex items-center justify-between px-2 pb-1 pt-2"
               >
                 <button
                   type="button"
@@ -1540,10 +1540,7 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className={cn(
-                    PROJECT_ICON_BUTTON_CLASS,
-                    "pointer-events-none opacity-0 transition-opacity hover:!bg-transparent group-hover/workspace-header:pointer-events-auto group-hover/workspace-header:opacity-100 focus-visible:opacity-100",
-                  )}
+                  className={cn(PROJECT_ICON_BUTTON_CLASS, "hover:!bg-transparent")}
                   title={t("chat.workspaceCreate")}
                   aria-label={t("chat.workspaceCreate")}
                   onClick={() => onCreateProject?.()}

--- a/crates/agent-gui/src/index.css
+++ b/crates/agent-gui/src/index.css
@@ -2408,6 +2408,16 @@
   }
 }
 
+/* Tailwind v4 gates every hover:/group-hover: utility behind
+ * @media (hover: hover), so on devices whose primary pointer cannot hover
+ * (touch-primary 2-in-1s, some pen/touch webviews) the reveal rule never
+ * exists. Hover-revealed action clusters must stay visible there. */
+@media (hover: none) {
+  .settings-hover-actions {
+    opacity: 1 !important;
+  }
+}
+
 /*
  * Streamdown mermaid / table fullscreen fix — macOS WebKit (Tauri WKWebView)
  *

--- a/crates/agent-gui/src/lib/chat/conversation/run/gatewayBridgeEvents.ts
+++ b/crates/agent-gui/src/lib/chat/conversation/run/gatewayBridgeEvents.ts
@@ -37,6 +37,7 @@ type GatewayBridgeEventControllerParams = {
     event: Record<string, unknown>,
     options?: { workerId?: string },
   ) => GatewayBridgeSendResult;
+  flushEvents?: (requestId: string) => Promise<void>;
   resolveErrorConversationId?: () => string;
 };
 
@@ -56,7 +57,7 @@ export type GatewayBridgeEventController = {
   queueRetryAttempts: (attempts: readonly RetryAttemptRecord[]) => void;
   queueCheckpoint: (state: ConversationViewState) => void;
   emitError: (message: string, conversationIdOverride?: string) => void;
-  close: () => void;
+  close: () => Promise<void>;
   hasForwardedText: () => boolean;
   isClosed: () => boolean;
 };
@@ -66,6 +67,7 @@ export function createGatewayBridgeEventController(
 ): GatewayBridgeEventController {
   let forwardedText = false;
   let streamClosed = false;
+  let closePromise: Promise<void> | null = null;
   let lastToolStatusKey = "";
   let lastToolStatus: string | null = null;
   let lastToolStatusIsCompaction = false;
@@ -197,6 +199,8 @@ export function createGatewayBridgeEventController(
     },
     close() {
       streamClosed = true;
+      closePromise ??= params.flushEvents?.(params.requestId) ?? Promise.resolve();
+      return closePromise;
     },
     hasForwardedText() {
       return forwardedText;

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -432,7 +432,8 @@ export function ChatPage(props: ChatPageProps) {
   } = useLiveTranscriptController({
     currentConversationId,
   });
-  const { queueGatewayBridgeEventForRequest } = useGatewayBridgeBatcher();
+  const { queueGatewayBridgeEventForRequest, flushGatewayBridgeEventsForRequest } =
+    useGatewayBridgeBatcher();
   const {
     currentConversationIdRef,
     conversationRuntimeCacheRef,
@@ -1249,6 +1250,7 @@ export function ChatPage(props: ChatPageProps) {
     updateToolStatus,
     updateRetryAttempts,
     queueGatewayBridgeEventForRequest,
+    flushGatewayBridgeEventsForRequest,
     activeGatewayRuntimeRunsRef,
     queueGatewayRuntimeSnapshot,
     queueGatewayRuntimeSnapshotForRun,

--- a/crates/agent-gui/src/pages/chat/gateway/useGatewayBridgeBatcher.ts
+++ b/crates/agent-gui/src/pages/chat/gateway/useGatewayBridgeBatcher.ts
@@ -322,6 +322,14 @@ export function useGatewayBridgeBatcher() {
     }
   }, [flushGatewayBridgeEventBatchForRequest]);
 
+  const flushGatewayBridgeEventsForRequest = useCallback(
+    async (requestId: string) => {
+      flushGatewayBridgeEventBatchesForRequest(requestId);
+      await gatewayEventChainRef.current.catch(() => undefined);
+    },
+    [flushGatewayBridgeEventBatchesForRequest],
+  );
+
   useEffect(
     () => () => {
       for (const pending of pendingGatewayBridgeEventBatchesRef.current.values()) {
@@ -355,6 +363,7 @@ export function useGatewayBridgeBatcher() {
 
   return {
     queueGatewayBridgeEventForRequest,
+    flushGatewayBridgeEventsForRequest,
     flushPendingGatewayBridgeEvents,
   };
 }

--- a/crates/agent-gui/src/pages/chat/gateway/useGatewayRuntimeSnapshots.ts
+++ b/crates/agent-gui/src/pages/chat/gateway/useGatewayRuntimeSnapshots.ts
@@ -171,13 +171,13 @@ export function useGatewayRuntimeSnapshots(params: UseGatewayRuntimeSnapshotsPar
   ) {
     const targetConversationId = conversationId.trim();
     if (!targetConversationId) {
-      return;
+      return Promise.resolve();
     }
     const run = activeGatewayRuntimeRunsRef.current.get(targetConversationId);
     if (!run) {
-      return;
+      return Promise.resolve();
     }
-    void queueGatewayRuntimeSnapshotForRun(run, { state, force: true }).finally(() => {
+    return queueGatewayRuntimeSnapshotForRun(run, { state, force: true }).finally(() => {
       if (activeGatewayRuntimeRunsRef.current.get(targetConversationId) === run) {
         activeGatewayRuntimeRunsRef.current.delete(targetConversationId);
       }

--- a/crates/agent-gui/src/pages/chat/runtime/useSendChatTurn.ts
+++ b/crates/agent-gui/src/pages/chat/runtime/useSendChatTurn.ts
@@ -145,6 +145,7 @@ type UseSendChatTurnParams = {
   updateToolStatus: LiveTranscriptController["updateToolStatus"];
   updateRetryAttempts: LiveTranscriptController["updateRetryAttempts"];
   queueGatewayBridgeEventForRequest: GatewayBridgeBatcher["queueGatewayBridgeEventForRequest"];
+  flushGatewayBridgeEventsForRequest: GatewayBridgeBatcher["flushGatewayBridgeEventsForRequest"];
   activeGatewayRuntimeRunsRef: GatewayRuntimeSnapshots["activeGatewayRuntimeRunsRef"];
   queueGatewayRuntimeSnapshot: GatewayRuntimeSnapshots["queueGatewayRuntimeSnapshot"];
   queueGatewayRuntimeSnapshotForRun: GatewayRuntimeSnapshots["queueGatewayRuntimeSnapshotForRun"];
@@ -210,6 +211,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
     updateToolStatus,
     updateRetryAttempts,
     queueGatewayBridgeEventForRequest,
+    flushGatewayBridgeEventsForRequest,
     activeGatewayRuntimeRunsRef,
     queueGatewayRuntimeSnapshot,
     queueGatewayRuntimeSnapshotForRun,
@@ -235,6 +237,12 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
     params: Parameters<typeof persistConversation>[0],
   ) {
     return await persistConversation(params);
+  }
+
+  async function waitForTerminalHistoryPersist(persistPromise: Promise<boolean> | null) {
+    if (persistPromise) {
+      await persistPromise.catch(() => false);
+    }
   }
 
   const enableManagedSkills = useCallback(
@@ -318,6 +326,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         void queueGatewayRuntimeSnapshot(conversationId);
         return result;
       },
+      flushEvents: flushGatewayBridgeEventsForRequest,
       resolveErrorConversationId: () =>
         gatewayBridgeRequest?.conversationId ?? currentConversationIdRef.current,
     });
@@ -351,7 +360,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
       if (gatewayBridgeRequest) {
         const message = "Conversation is already sending.";
         gatewayBridgeEvents.emitError(message, conversationId);
-        gatewayBridgeEvents.close();
+        await gatewayBridgeEvents.close();
       }
       return false;
     }
@@ -476,7 +485,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         setConversationErrorState(message);
         setErrorMessage(message);
         gatewayBridgeEvents.emitError(message, conversationId);
-        gatewayBridgeEvents.close();
+        await gatewayBridgeEvents.close();
         return false;
       } finally {
         isImportingPastedTextRef.current = false;
@@ -489,7 +498,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
       if (gatewayBridgeRequest) {
         const message = "Message is required.";
         gatewayBridgeEvents.emitError(message, conversationId);
-        gatewayBridgeEvents.close();
+        await gatewayBridgeEvents.close();
       }
       return false;
     }
@@ -650,14 +659,15 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         scrollFollowRef.current?.stickToBottom();
       }
     }
-    function markConversationRunStopped(state: GatewayRuntimeSnapshotState = "completed") {
+    async function markConversationRunStopped(state: GatewayRuntimeSnapshotState = "completed") {
       if (!conversationRunStarted) {
         return;
       }
       setConversationAbortController(conversationId, null);
       setConversationSendingState(conversationId, false);
+      await gatewayBridgeEvents.close();
       if (gatewayRunStarted) {
-        finishActiveGatewayRuntimeRun(conversationId, state);
+        await finishActiveGatewayRuntimeRun(conversationId, state);
       }
     }
     let localGatewayRunStarted = false;
@@ -731,8 +741,8 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         const message = asErrorMessage(error, "启动远程对话运行失败");
         setConversationErrorState(message);
         gatewayBridgeEvents.emitError(message, conversationId);
-        gatewayBridgeEvents.close();
-        markConversationRunStopped("failed");
+        await gatewayBridgeEvents.close();
+        await markConversationRunStopped("failed");
         restoreComposerOnStartFailure();
         return false;
       }
@@ -760,8 +770,8 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         const message = "历史记录保存失败，已取消回滚与重发。";
         setConversationErrorState(message);
         gatewayBridgeEvents.emitError(message, conversationId);
-        gatewayBridgeEvents.close();
-        markConversationRunStopped("failed");
+        await gatewayBridgeEvents.close();
+        await markConversationRunStopped("failed");
         restoreComposerOnStartFailure();
         return true;
       }
@@ -771,8 +781,8 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         const message = asErrorMessage(error, "回滚历史失败");
         setConversationErrorState(message);
         gatewayBridgeEvents.emitError(message, conversationId);
-        gatewayBridgeEvents.close();
-        markConversationRunStopped("failed");
+        await gatewayBridgeEvents.close();
+        await markConversationRunStopped("failed");
         restoreComposerOnStartFailure();
         return true;
       }
@@ -950,8 +960,8 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         const message = `找不到以下 Skills：${missing.join(", ")}（请先重新扫描固定 Skills 目录）`;
         setConversationErrorState(message);
         gatewayBridgeEvents.emitError(message, conversationId);
-        gatewayBridgeEvents.close();
-        markConversationRunStopped("failed");
+        await gatewayBridgeEvents.close();
+        await markConversationRunStopped("failed");
         restoreComposerOnStartFailure();
         return true;
       }
@@ -1013,6 +1023,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
     });
 
     let abortedConversationCommitted = false;
+    let terminalHistoryPersistPromise: Promise<boolean> | null = null;
     let persistableAgentProgress: {
       completedThroughRound: number;
       suppressedToolTrace: SuppressedToolTraceSnapshot[];
@@ -1042,7 +1053,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         ...prev,
         state: finalState,
       }));
-      void persistConversationWithHistorySync({
+      terminalHistoryPersistPromise = persistConversationWithHistorySync({
         conversationId,
         sessionId,
         providerId,
@@ -1083,7 +1094,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         state: finalState,
         errorMessage: null,
       }));
-      void persistConversationWithHistorySync({
+      terminalHistoryPersistPromise = persistConversationWithHistorySync({
         conversationId,
         sessionId,
         providerId,
@@ -1247,8 +1258,6 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
       const remoteErrorMessage = aborted
         ? "Cancelled"
         : (err instanceof Error ? err.message : String(err)) || "Request failed";
-      gatewayBridgeEvents.emitError(remoteErrorMessage, conversationId);
-      gatewayBridgeEvents.close();
       if (aborted) {
         hookScope.cancel();
         const rolledBack = await compaction.handleTurnAbort();
@@ -1259,6 +1268,9 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         const msg = err instanceof Error ? err.message : String(err);
         commitErroredConversation(msg || "Request failed");
       }
+      await waitForTerminalHistoryPersist(terminalHistoryPersistPromise);
+      gatewayBridgeEvents.emitError(remoteErrorMessage, conversationId);
+      await gatewayBridgeEvents.close();
       if (shouldCreatePendingHistoryItem && !abortedConversationCommitted) {
         sidebarStore.removeLocal(conversationId);
       }
@@ -1270,7 +1282,8 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
       hookLifecycle.endAgent();
       hookScope.close();
       clearAbortSnapshot(transcriptStore);
-      markConversationRunStopped(gatewayRuntimeFinalState);
+      await waitForTerminalHistoryPersist(terminalHistoryPersistPromise);
+      await markConversationRunStopped(gatewayRuntimeFinalState);
       pruneIdleConversationCaches([conversationId]);
       requestQueuedChatTurnProcessing(conversationId);
     }

--- a/crates/agent-gui/src/pages/chat/turns/runAgentConversationTurn.ts
+++ b/crates/agent-gui/src/pages/chat/turns/runAgentConversationTurn.ts
@@ -1136,7 +1136,7 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
     ...prev,
     state: completedState,
   }));
-  void persistConversationWithHistorySync({
+  await persistConversationWithHistorySync({
     conversationId,
     sessionId,
     providerId,
@@ -1151,7 +1151,7 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
     type: "done",
     conversation_id: conversationId,
   });
-  gatewayBridgeEvents.close();
+  await gatewayBridgeEvents.close();
   if (!showSilentMemoryExtraction && shouldRunMemoryExtraction) {
     void runPostTurnMemoryExtraction();
   }

--- a/crates/agent-gui/src/pages/chat/turns/runTextConversationTurn.ts
+++ b/crates/agent-gui/src/pages/chat/turns/runTextConversationTurn.ts
@@ -400,7 +400,7 @@ export async function runTextConversationTurn(params: RunTextConversationTurnPar
   }));
   hookLifecycle.ensureMessageEnded();
   hookLifecycle.endAgent();
-  void persistConversationWithHistorySync({
+  await persistConversationWithHistorySync({
     conversationId,
     sessionId,
     providerId,
@@ -415,7 +415,7 @@ export async function runTextConversationTurn(params: RunTextConversationTurnPar
     type: "done",
     conversation_id: conversationId,
   });
-  gatewayBridgeEvents.close();
+  await gatewayBridgeEvents.close();
   if (shouldRunMemoryExtraction) {
     const currentMemoryExtractionModel: MemoryExtractionModelConfig = {
       providerId,

--- a/crates/agent-gui/src/pages/settings/AgentsSection.tsx
+++ b/crates/agent-gui/src/pages/settings/AgentsSection.tsx
@@ -184,7 +184,7 @@ export function AgentsSection(props: SettingsSectionProps) {
                         title={template.enabled ? t("settings.disable") : t("settings.enable")}
                         onToggle={() => handleToggleEnabled(template.id)}
                       />
-                      <div className="ml-1 flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+                      <div className="settings-hover-actions ml-1 flex items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
                         <Button
                           variant="ghost"
                           size="icon"

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -1223,7 +1223,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                                   else focusCustomHeader(index + 1, "key");
                                 }}
                               />
-                              <div className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 max-[720px]:opacity-100">
+                              <div className="settings-hover-actions absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 max-[720px]:opacity-100">
                                 <Button
                                   type="button"
                                   variant="ghost"
@@ -2140,7 +2140,7 @@ function ProviderList(props: {
                     {provider.activeModels.length} {t("settings.activeModels")}
                   </div>
                 </div>
-                <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                <div className="settings-hover-actions flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
                   <Button
                     variant="ghost"
                     size="icon"

--- a/crates/agent-gui/test/chat/gateway-bridge-events.test.mjs
+++ b/crates/agent-gui/test/chat/gateway-bridge-events.test.mjs
@@ -21,6 +21,7 @@ function createController(options = {}) {
       }
       sent.push(item);
     },
+    flushEvents: options.flushEvents,
     resolveErrorConversationId: options.resolveErrorConversationId,
   });
   return { controller, sent };
@@ -221,6 +222,40 @@ test("gateway bridge close blocks normal events but allows forced title updates"
       },
     ],
   );
+});
+
+test("gateway bridge close waits for the transport drain and stays idempotent", async () => {
+  let releaseDrain;
+  let drainCalls = 0;
+  const drain = new Promise((resolve) => {
+    releaseDrain = resolve;
+  });
+  const { controller } = createController({
+    flushEvents: async (requestId) => {
+      drainCalls += 1;
+      assert.equal(requestId, "request-1");
+      await drain;
+    },
+  });
+
+  controller.queueToken("tail");
+  const firstClose = controller.close();
+  const secondClose = controller.close();
+  assert.equal(firstClose, secondClose);
+  assert.equal(controller.isClosed(), true);
+  assert.equal(drainCalls, 1);
+
+  let settled = false;
+  void firstClose.then(() => {
+    settled = true;
+  });
+  await Promise.resolve();
+  assert.equal(settled, false, "close must remain pending until queued events drain");
+
+  releaseDrain();
+  await firstClose;
+  assert.equal(settled, true);
+  assert.equal(drainCalls, 1);
 });
 
 test("gateway bridge checkpoint emits compaction summary payload", () => {


### PR DESCRIPTION
## Summary

Two groups of fixes on this branch.

### WebUI stream truncation (original branch scope)
- **stop false `desktop_run_lost` from truncating live WebUI streams** (4e6dd6a): a run whose events went quiet while the GUI webview was hidden lost its ledger keepalive; the sweeper demoted it to `desktop_run_lost`, the gateway adopted the verdict, and the straggler guard dropped the rest of the stream. Layered fix across desktop flush-loop keepalive, gateway adoption rules (fresh events veto inferred loss, revivable force-finish), and WebUI settle logic.
- **make WebUI stream completion lossless** (26f2561): desktop now awaits persist before emitting done, so the gateway replay can never race ahead of storage.

### Touch / no-hover device visibility (follow-ups found on mobile & touch hardware)
- **mobile sidebar running spinner** (854e931): the history-row reveal box takes both width and height from inline buttons that mobile doesn't render, so `overflow-hidden` clipped the absolute spinner on both axes. Reserve the slot explicitly (`h-7 w-7`) and skip the hover/focus swap on mobile. Verified per-pixel in headless Chrome against the built CSS (0 painted spinner pixels before, visible arc after).
- **user-bubble copy/edit actions on touch** (c774544): add the `[@media(hover:none)]:opacity-100` escape the assistant actions row already uses.
- **workspace create button always visible** (e8682f5): the "+" in the workspace section header was hover-revealed and undiscoverable; show it permanently in both GUI and WebUI sidebars.
- **settings hover-action clusters on no-hover devices** (89801e9): Tailwind v4 wraps every `hover:`/`group-hover:` utility in `@media (hover: hover)`, so on touch-primary devices the reveal rules don't exist and `opacity-0` clusters (provider edit/delete, agent templates, custom headers) were permanently invisible. Add capability-based `(hover: none)` escapes in both frontends' CSS, tag the affected clusters with `settings-hover-actions`, and add `focus-within` reveals for keyboard reachability. Verified by emulating a no-hover device (strip `(hover:hover)` blocks / unwrap `(hover:none)` blocks from built CSS) in headless Chrome: cluster opacity 0 → 1.

## Testing
- `tsc --noEmit` clean in both `agent-gui` and `agent-gateway/web`
- GUI frontend suite 1124 pass, WebUI suite 378 pass
- biome: no new findings (existing warnings verified pre-existing via stash comparison)
- Built CSS inspected for compiled escape rules; headless-Chrome pixel/computed-style verification for the spinner and settings clusters