### PR TITLE
fix(docker): 修复 arm64 镜像内置 x86-64 二进制导致 ARM 服务器无法运行

### DIFF
--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -61,3 +61,25 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
+
+      # Guard against mislabeled variants: v0.1.0 through v1.1.8 advertised
+      # arm64 while shipping an x86-64 binary (TARGETARCH defaults in the
+      # Dockerfile shadowed the values buildx injects).
+      - name: Verify per-arch binaries
+        run: |
+          set -euo pipefail
+          image="$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')@${{ steps.push.outputs.digest }}"
+          for arch in amd64 arm64; do
+            case "$arch" in
+              amd64) want="x86-64" ;;
+              arm64) want="aarch64" ;;
+            esac
+            docker pull --platform "linux/$arch" "$image" >/dev/null
+            docker rm -f "verify-$arch" >/dev/null 2>&1 || true
+            docker create --platform "linux/$arch" --name "verify-$arch" "$image" >/dev/null
+            docker cp "verify-$arch:/usr/local/bin/liveagent-gateway" "/tmp/gateway-$arch"
+            docker rm -f "verify-$arch" >/dev/null
+            info="$(file -b "/tmp/gateway-$arch")"
+            echo "linux/$arch: $info"
+            echo "$info" | grep -q "$want" || { echo "::error::linux/$arch image contains a non-$arch gateway binary"; exit 1; }
+          done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:22.17.1-bookworm-slim AS webui
+FROM --platform=$BUILDPLATFORM node:22.17.1-bookworm-slim AS webui
 
 WORKDIR /src/crates/agent-gateway/web
 RUN npm install -g pnpm@10.32.1
@@ -11,10 +11,11 @@ RUN pnpm install --frozen-lockfile
 COPY crates/agent-gateway/web ./
 RUN pnpm build
 
-FROM golang:1.25-bookworm AS gateway-builder
+FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS gateway-builder
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+# Keep these ARGs bare: a default value shadows the per-platform values buildx injects.
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /src/crates/agent-gateway
 


### PR DESCRIPTION
## 问题

已发布的所有 gateway 镜像(v0.1.0 ~ v1.1.8)虽然 manifest 声明支持 `linux/arm64`,但 arm64 变体里装的实际是 **x86-64** 二进制,在 ARM 服务器上启动直接报 `exec format error`。

验证方式:分别下载 GHCR 上 `latest` 两个平台变体的最后一层并提取 `/usr/local/bin/liveagent-gateway`:

- amd64 变体:`ELF 64-bit LSB executable, x86-64`
- arm64 变体:`ELF 64-bit LSB executable, x86-64`(与 amd64 变体 **sha256 完全相同**,BuildID 一致)

## 根因

Dockerfile 中重新声明 buildx 自动注入的平台参数时带了默认值:

```dockerfile
ARG TARGETOS=linux
ARG TARGETARCH=amd64
```

stage 内带默认值的重声明会**遮蔽** buildx 按平台注入的值,导致两条构建腿的 `GOARCH` 都被钉死为 `amd64`。`FROM` 的平台解析本身是正常的(runtime 基础层两个变体各自正确),所以产出了"外壳 arm64、二进制 amd64"的镜像,`docker manifest inspect` 完全看不出异常。

## 修复

1. **Dockerfile**:去掉 `TARGETOS`/`TARGETARCH` 的默认值,让 buildx 注入的按平台值生效;同时把 webui 和 Go 构建阶段钉到 `--platform=$BUILDPLATFORM`,改为原生交叉编译——此前 arm64 腿的 `pnpm build` 和 `go build` 都跑在 QEMU 模拟下,纯浪费构建时间。本地 `make gateway-docker-build`(单平台 BuildKit 构建)行为不变,bare ARG 自动取宿主平台值。
2. **CI 防回归**:发布后新增校验步骤,按平台拉取刚推送的 digest,提取镜像内二进制并断言 ELF 架构与声明一致,不一致直接 fail。这个问题静默存在了 37 个 tag 没被发现,值得一道硬闸。

按需求不处理旧镜像/旧 tag;下一次打 tag 发布即产出真正的双架构镜像(注意 `workflow_dispatch` 重发旧 tag 会 checkout 旧代码,不含本修复)。

## 验证

本机无 docker 后端,未做本地构建;修复采用 Docker 官方文档的标准交叉编译模式,发布时由新增的 CI 校验步骤兜底验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)