### PR TITLE
ci: 修复发布 workflow 按架构校验步骤的 digest 冲突

### DIFF
--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -68,15 +68,22 @@ jobs:
       - name: Verify per-arch binaries
         run: |
           set -euo pipefail
-          image="$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')@${{ steps.push.outputs.digest }}"
+          repo="$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
+          index="$repo@${{ steps.push.outputs.digest }}"
           for arch in amd64 arm64; do
             case "$arch" in
               amd64) want="x86-64" ;;
               arm64) want="aarch64" ;;
             esac
-            docker pull --platform "linux/$arch" "$image" >/dev/null
+            # Pull each variant by its own manifest digest. Pulling the shared
+            # index digest with --platform binds repo@digest to one platform,
+            # so the second arch fails with "cannot overwrite digest".
+            digest="$(docker buildx imagetools inspect --raw "$index" \
+              | jq -r --arg arch "$arch" '.manifests[] | select(.platform.os == "linux" and .platform.architecture == $arch) | .digest')"
+            test -n "$digest" || { echo "::error::pushed index has no linux/$arch manifest"; exit 1; }
+            docker pull "$repo@$digest" >/dev/null
             docker rm -f "verify-$arch" >/dev/null 2>&1 || true
-            docker create --platform "linux/$arch" --name "verify-$arch" "$image" >/dev/null
+            docker create --name "verify-$arch" "$repo@$digest" >/dev/null
             docker cp "verify-$arch:/usr/local/bin/liveagent-gateway" "/tmp/gateway-$arch"
             docker rm -f "verify-$arch" >/dev/null
             info="$(file -b "/tmp/gateway-$arch")"


### PR DESCRIPTION
## 问题

v1.1.9 发布 run 在 "Verify per-arch binaries" 步骤失败(https://github.com/Stack-Cairn/LiveAgent/actions/runs/29980591762):amd64 校验通过后,arm64 的 `docker pull --platform` 报 `cannot overwrite digest`。

根因:对同一个 `repo@<index digest>` 引用先后用 `--platform` 拉两个平台变体,经典镜像存储只允许该 digest 引用绑定一个镜像,第二次拉取直接拒绝。

**v1.1.9 镜像本身没有问题**——我已从 GHCR 手动提取 arm64 变体的二进制验证,是真正的 `ELF ARM aarch64`(#240 的 Dockerfile 修复已生效)。坏的只是校验脚本自己。

## 修复

改为先用 `docker buildx imagetools inspect --raw` 从刚推送的 index 解析出每个平台**各自的 manifest digest**,再按该独立 digest 拉取和创建容器:

- 两个平台各自的 digest 引用互不冲突,从结构上消除这类问题;
- `docker create` 不再需要 `--platform`(单平台 manifest 无歧义);
- 若 index 缺某个平台的 manifest,显式报错而不是静默跳过。

jq 过滤逻辑已用 v1.1.9 线上真实 index JSON 验证,amd64/arm64 各返回唯一 digest。

## 附带说明

同批失败的 main CI "Gateway Docker Smoke"(runs/29980527009)是 `setup-buildx` 从 Docker Hub 拉 `moby/buildkit` 引导镜像超时的瞬态故障,与代码无关,已触发重跑。

v1.1.9 那个红色 run 无法原地变绿(重跑会用 tag 上的旧脚本),但镜像已人工验证可用;本修复自下一个 tag 起生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)