### PR TITLE
fix(webui): translate reasoning level in composer select trigger

### DIFF
--- a/crates/agent-gateway/web/src/pages/chat/ChatComposerBar.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/ChatComposerBar.tsx
@@ -66,6 +66,10 @@ const REASONING_I18N_KEYS: Record<ReasoningLevel, string> = {
   max: "settings.reasoning.max",
 };
 
+function isReasoningLevel(value: unknown): value is ReasoningLevel {
+  return typeof value === "string" && Object.hasOwn(REASONING_I18N_KEYS, value);
+}
+
 function RuntimeControlTooltip(props: { label: string; children: ReactNode }) {
   return (
     <Tooltip.Root>
@@ -886,7 +890,15 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
                     >
                       <span className="flex min-w-0 items-center gap-1">
                         <Sparkle className="h-3.5 w-3.5 shrink-0 text-violet-500 transition-colors dark:text-violet-400" />
-                        <SelectValue />
+                        <SelectValue>
+                          {(value) =>
+                            t(
+                              REASONING_I18N_KEYS[
+                                isReasoningLevel(value) ? value : selectedReasoning
+                              ],
+                            )
+                          }
+                        </SelectValue>
                       </span>
                     </SelectTrigger>
                     <SelectContent className="sidebar-context-menu min-w-40 rounded-xl border-0">


### PR DESCRIPTION
## Summary

The thinking-effort dropdown under the WebUI composer always showed English (`high` / `medium` / …) regardless of locale. The locale files were fine — the WebUI `Select` component was migrated to Base UI, whose bare `<SelectValue />` renders the raw value string instead of the selected item's translated label, so the trigger bypassed i18n entirely.

## Changes

- Mirror the GUI composer's approach in `crates/agent-gateway/web/src/pages/chat/ChatComposerBar.tsx`: pass a children function to `<SelectValue>` that maps the raw value through `REASONING_I18N_KEYS` via `t()`.
- Add the same `isReasoningLevel` type guard used on the GUI side, falling back to `selectedReasoning` for unexpected values.

The dropdown list items were already translated; only the trigger needed the fix. The one remaining bare `<SelectValue />` in the WebUI (`httpRequestEditor.tsx`, HTTP methods) is unaffected since its value equals its label.

## Test plan

- `tsc --noEmit` passes for the web package
- `biome check` passes on the modified file
- Manual: with locale zh-CN, the composer trigger shows 低/中/高/最高 etc. and follows the selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)