### PR TITLE
feat(composer): restyle pasted image attachments

### DIFF
--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -4785,6 +4785,7 @@ export default function GatewayApp() {
                       onChatRuntimeControlsChange={handleChatRuntimeControlsChange}
                       onPickReadableFiles={() => fileInputRef.current?.click()}
                       onPasteFiles={handleImportReadableFiles}
+                      onLoadUploadedImagePreview={handleLoadUploadedImagePreview}
                       loadHistoryPrompts={loadComposerHistoryPrompts}
                       pendingUploadedFiles={pendingUploadedFiles}
                       onRemovePendingUpload={(relativePath) => {

--- a/crates/agent-gateway/web/src/components/chat/ComposerAttachmentCard.tsx
+++ b/crates/agent-gateway/web/src/components/chat/ComposerAttachmentCard.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+import { X } from "../icons";
+
+export function ComposerAttachmentCard(props: {
+  fileName: string;
+  pathTitle: string;
+  imageSrc?: string | null;
+  isImageLoading?: boolean;
+  fallbackIcon: ReactNode;
+  disabled: boolean;
+  removeLabel: string;
+  onRemove: () => void;
+}) {
+  const {
+    fileName,
+    pathTitle,
+    imageSrc,
+    isImageLoading = false,
+    fallbackIcon,
+    disabled,
+    removeLabel,
+    onRemove,
+  } = props;
+
+  return (
+    <div
+      title={pathTitle}
+      className="group flex h-16 w-[min(26rem,100%)] shrink-0 items-center gap-2.5 rounded-xl border border-black/[0.075] bg-black/[0.035] p-2 pr-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.64)] transition-[border-color,background-color] hover:border-black/[0.11] hover:bg-black/[0.05] dark:border-white/[0.11] dark:bg-white/[0.065] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.055)] dark:hover:border-white/[0.16] dark:hover:bg-white/[0.09]"
+    >
+      <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-black/[0.045] text-muted-foreground dark:bg-white/[0.08]">
+        {imageSrc ? (
+          <img src={imageSrc} alt="" draggable={false} className="h-full w-full object-cover" />
+        ) : isImageLoading ? (
+          <span className="h-full w-full animate-pulse bg-black/[0.055] dark:bg-white/[0.09]" />
+        ) : (
+          fallbackIcon
+        )}
+      </div>
+
+      <span className="min-w-0 flex-1 truncate text-[calc(13px*var(--zone-font-scale,1))] font-medium leading-5 tracking-tight text-foreground/90">
+        {fileName}
+      </span>
+
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onRemove}
+        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground/75 outline-hidden transition-[background-color,color,scale] hover:bg-foreground/[0.07] hover:text-foreground active:scale-90 focus-visible:bg-foreground/[0.07] focus-visible:text-foreground disabled:pointer-events-none disabled:opacity-35"
+        aria-label={`${removeLabel} ${fileName}`}
+        title={removeLabel}
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/crates/agent-gateway/web/src/pages/chat/ChatComposerBar.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/ChatComposerBar.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { ComposerAttachmentCard } from "../../components/chat/ComposerAttachmentCard";
 import { getUploadedFileTypeIcon } from "../../components/chat/fileTypeIcons";
 import {
   MentionComposer,
@@ -35,7 +36,6 @@ import {
   Square,
   SquarePen,
   Trash2,
-  X,
 } from "../../components/icons";
 import { Button } from "../../components/ui/button";
 import {
@@ -46,7 +46,13 @@ import {
   SelectValue,
 } from "../../components/ui/select";
 import { useLocale } from "../../i18n";
-import { formatUploadedFileSize, type PendingUploadedFile } from "../../lib/chat/uploadedFiles";
+import type { PendingUploadedFile } from "../../lib/chat/uploadedFiles";
+import {
+  getUploadedImagePreviewCacheKey,
+  loadUploadedImagePreview,
+  readUploadedImagePreviewCache,
+  type UploadedImagePreviewLoader,
+} from "../../lib/chat/uploadedImagePreview";
 import type { GitClient } from "../../lib/git/types";
 import {
   type ChatRuntimeControls,
@@ -92,6 +98,81 @@ function RuntimeControlTooltip(props: { label: string; children: ReactNode }) {
         </Tooltip.Positioner>
       </Tooltip.Portal>
     </Tooltip.Root>
+  );
+}
+
+function useComposerUploadedImagePreview(
+  file: PendingUploadedFile,
+  workdir: string,
+  loader?: UploadedImagePreviewLoader,
+) {
+  const shouldPreviewImage =
+    file.kind === "image" && typeof file.absolutePath === "string" && file.absolutePath.trim();
+  const cacheKey = shouldPreviewImage ? getUploadedImagePreviewCacheKey(workdir, file) : "";
+  const [imageSrc, setImageSrc] = useState<string | null | undefined>(() => {
+    if (!cacheKey) return null;
+    return readUploadedImagePreviewCache(workdir, file);
+  });
+
+  useEffect(() => {
+    if (!cacheKey) {
+      setImageSrc(null);
+      return;
+    }
+
+    const cached = readUploadedImagePreviewCache(workdir, file);
+    if (cached !== undefined) {
+      setImageSrc(cached);
+      return;
+    }
+    if (!loader) {
+      setImageSrc(null);
+      return;
+    }
+
+    let cancelled = false;
+    setImageSrc(undefined);
+    void loadUploadedImagePreview({ workspaceRoot: workdir, file, loader }).then((value) => {
+      if (!cancelled) setImageSrc(value);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [cacheKey, file, loader, workdir]);
+
+  return {
+    imageSrc: imageSrc ?? null,
+    isLoading: Boolean(cacheKey && loader) && imageSrc === undefined,
+  };
+}
+
+function PendingComposerAttachment(props: {
+  file: PendingUploadedFile;
+  workdir: string;
+  disabled: boolean;
+  removeLabel: string;
+  imagePreviewLoader?: UploadedImagePreviewLoader;
+  onRemove: (relativePath: string) => void;
+}) {
+  const { file, workdir, disabled, removeLabel, imagePreviewLoader, onRemove } = props;
+  const { imageSrc, isLoading } = useComposerUploadedImagePreview(
+    file,
+    workdir,
+    imagePreviewLoader,
+  );
+  const TypeIcon = getUploadedFileTypeIcon(file);
+
+  return (
+    <ComposerAttachmentCard
+      fileName={file.fileName}
+      pathTitle={file.relativePath}
+      imageSrc={imageSrc}
+      isImageLoading={isLoading}
+      fallbackIcon={<TypeIcon className="h-4 w-4" />}
+      disabled={disabled}
+      removeLabel={removeLabel}
+      onRemove={() => onRemove(file.relativePath)}
+    />
   );
 }
 
@@ -147,6 +228,7 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
   onChatRuntimeControlsChange: (patch: Partial<ChatRuntimeControls>) => void;
   onPickReadableFiles: () => void;
   onPasteFiles: (files: File[]) => void;
+  onLoadUploadedImagePreview?: UploadedImagePreviewLoader;
   /** Prompts previously sent in this conversation for ↑/↓ recall. */
   loadHistoryPrompts?: () => readonly string[];
   pendingUploadedFiles: PendingUploadedFile[];
@@ -180,6 +262,7 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
     onChatRuntimeControlsChange,
     onPickReadableFiles,
     onPasteFiles,
+    onLoadUploadedImagePreview,
     loadHistoryPrompts,
     pendingUploadedFiles,
     onRemovePendingUpload,
@@ -516,44 +599,6 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
           isComposerExpanded && "flex min-h-0 flex-col justify-end",
         )}
       >
-        {/* Pending uploaded files — above the composer card */}
-        {pendingUploadedFiles.length > 0 && (
-          <div className="upload-file-list mb-2.5 flex gap-2 overflow-x-auto px-0.5 pb-1">
-            {pendingUploadedFiles.map((file) => {
-              const TypeIcon = getUploadedFileTypeIcon(file);
-              return (
-                <div
-                  key={file.relativePath}
-                  title={file.relativePath}
-                  className="group flex w-[calc(25%-6px)] min-w-[calc(25%-6px)] items-center gap-2 rounded-xl border border-white/45 bg-white/55 px-2.5 py-1.5 text-[calc(11px*var(--zone-font-scale,1))] shadow-[0_2px_8px_-2px_rgba(15,23,42,0.06)] backdrop-blur-2xl backdrop-saturate-150 transition-all hover:bg-white/75 hover:shadow-[0_4px_14px_-4px_rgba(15,23,42,0.10)] dark:border-white/10 dark:bg-white/[0.06] dark:hover:bg-white/[0.10]"
-                >
-                  <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-black/[0.04] dark:bg-white/[0.10]">
-                    <TypeIcon className="h-3.5 w-3.5" />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate text-[calc(12px*var(--zone-font-scale,1))] font-medium tracking-tight text-foreground/90">
-                      {file.fileName}
-                    </div>
-                    <div className="truncate text-[calc(10px*var(--zone-font-scale,1))] text-muted-foreground">
-                      {formatUploadedFileSize(file.sizeBytes)}
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    disabled={isInputDisabled}
-                    onClick={() => onRemovePendingUpload(file.relativePath)}
-                    className="shrink-0 rounded-full p-1 text-muted-foreground/70 opacity-0 transition-all hover:bg-foreground/5 hover:text-foreground group-hover:opacity-100 disabled:pointer-events-none"
-                    aria-label={`${t("chat.upload.removeFile")} ${file.fileName}`}
-                    title={t("chat.upload.removeFile")}
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-        )}
-
         {queuedTurns.length > 0 ? (
           <div
             ref={queuePanelRef}
@@ -727,6 +772,22 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
             className="pointer-events-none absolute inset-0 rounded-[24px] bg-gradient-to-b from-white/18 to-transparent opacity-70 dark:from-white/[0.04] dark:opacity-100"
           />
 
+          {pendingUploadedFiles.length > 0 ? (
+            <div className="upload-file-list relative z-10 flex shrink-0 gap-2 overflow-x-auto pb-1 pl-4 pr-12 pt-3.5">
+              {pendingUploadedFiles.map((file) => (
+                <PendingComposerAttachment
+                  key={`${file.relativePath}-${file.absolutePath ?? file.fileName}`}
+                  file={file}
+                  workdir={workdir}
+                  disabled={isInputDisabled}
+                  removeLabel={t("chat.upload.removeFile")}
+                  imagePreviewLoader={onLoadUploadedImagePreview}
+                  onRemove={onRemovePendingUpload}
+                />
+              ))}
+            </div>
+          ) : null}
+
           <button
             type="button"
             onClick={toggleComposerExpanded}
@@ -746,7 +807,11 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
               全程贴住卡片底边。min-h-0 只在展开态加——折叠态靠自动最小高度
               (= 编辑器钳制高) 撑起卡片的固有高度，加了会塌缩。 */}
           <div
-            className={cn("relative flex flex-1 px-4 pt-3.5", isComposerExpanded && "min-h-0")}
+            className={cn(
+              "relative flex flex-1 px-4",
+              pendingUploadedFiles.length > 0 ? "pt-2" : "pt-3.5",
+              isComposerExpanded && "min-h-0",
+            )}
             onFocusCapture={onPrepareChatRuntime}
           >
             <MentionComposer

--- a/crates/agent-gui/src/components/chat/ComposerAttachmentCard.tsx
+++ b/crates/agent-gui/src/components/chat/ComposerAttachmentCard.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+import { X } from "../icons";
+
+export function ComposerAttachmentCard(props: {
+  fileName: string;
+  pathTitle: string;
+  imageSrc?: string | null;
+  isImageLoading?: boolean;
+  fallbackIcon: ReactNode;
+  disabled: boolean;
+  removeLabel: string;
+  onRemove: () => void;
+}) {
+  const {
+    fileName,
+    pathTitle,
+    imageSrc,
+    isImageLoading = false,
+    fallbackIcon,
+    disabled,
+    removeLabel,
+    onRemove,
+  } = props;
+
+  return (
+    <div
+      title={pathTitle}
+      className="group flex h-16 w-[min(26rem,100%)] shrink-0 items-center gap-2.5 rounded-xl border border-black/[0.075] bg-black/[0.035] p-2 pr-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.64)] transition-[border-color,background-color] hover:border-black/[0.11] hover:bg-black/[0.05] dark:border-white/[0.11] dark:bg-white/[0.065] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.055)] dark:hover:border-white/[0.16] dark:hover:bg-white/[0.09]"
+    >
+      <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-black/[0.045] text-muted-foreground dark:bg-white/[0.08]">
+        {imageSrc ? (
+          <img src={imageSrc} alt="" draggable={false} className="h-full w-full object-cover" />
+        ) : isImageLoading ? (
+          <span className="h-full w-full animate-pulse bg-black/[0.055] dark:bg-white/[0.09]" />
+        ) : (
+          fallbackIcon
+        )}
+      </div>
+
+      <span className="min-w-0 flex-1 truncate text-[calc(13px*var(--zone-font-scale,1))] font-medium leading-5 tracking-tight text-foreground/90">
+        {fileName}
+      </span>
+
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onRemove}
+        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground/75 outline-hidden transition-[background-color,color,scale] hover:bg-foreground/[0.07] hover:text-foreground active:scale-90 focus-visible:bg-foreground/[0.07] focus-visible:text-foreground disabled:pointer-events-none disabled:opacity-35"
+        aria-label={`${removeLabel} ${fileName}`}
+        title={removeLabel}
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/crates/agent-gui/src/pages/chat/components/ChatComposerBar.tsx
+++ b/crates/agent-gui/src/pages/chat/components/ChatComposerBar.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { ComposerAttachmentCard } from "../../../components/chat/ComposerAttachmentCard";
 import { getUploadedFileTypeIcon } from "../../../components/chat/fileTypeIcons";
 import {
   MentionComposer,
@@ -35,7 +36,6 @@ import {
   Square,
   SquarePen,
   Trash2,
-  X,
 } from "../../../components/icons";
 import { Button } from "../../../components/ui/button";
 import {
@@ -46,10 +46,7 @@ import {
   SelectValue,
 } from "../../../components/ui/select";
 import { useLocale } from "../../../i18n";
-import {
-  formatUploadedFileSize,
-  type PendingUploadedFile,
-} from "../../../lib/chat/messages/uploadedFiles";
+import type { PendingUploadedFile } from "../../../lib/chat/messages/uploadedFiles";
 import type { GitClient } from "../../../lib/git/types";
 import {
   type ChatRuntimeControls,
@@ -58,6 +55,7 @@ import {
 } from "../../../lib/settings";
 import { cn } from "../../../lib/shared/utils";
 import type { WorkspaceActivityClient } from "../../../lib/workspace-activity/types";
+import { useUploadedImagePreview } from "../transcript/uploadedImagePreview";
 
 const REASONING_I18N_KEYS: Record<ReasoningLevel, string> = {
   off: "settings.reasoning.off",
@@ -95,6 +93,49 @@ function RuntimeControlTooltip(props: { label: string; children: ReactNode }) {
         </Tooltip.Positioner>
       </Tooltip.Portal>
     </Tooltip.Root>
+  );
+}
+
+let pendingComposerImagePreviewSequence = 0;
+const pendingComposerImagePreviewKeys = new WeakMap<PendingUploadedFile, string>();
+
+function getPendingComposerImagePreviewKey(file: PendingUploadedFile) {
+  const cached = pendingComposerImagePreviewKeys.get(file);
+  if (cached) return cached;
+  pendingComposerImagePreviewSequence += 1;
+  const next = String(pendingComposerImagePreviewSequence);
+  pendingComposerImagePreviewKeys.set(file, next);
+  return next;
+}
+
+function PendingComposerAttachment(props: {
+  file: PendingUploadedFile;
+  workdir: string;
+  disabled: boolean;
+  removeLabel: string;
+  onRemove: (relativePath: string) => void;
+}) {
+  const { file, workdir, disabled, removeLabel, onRemove } = props;
+  const shouldPreviewImage =
+    file.kind === "image" && typeof file.absolutePath === "string" && file.absolutePath.trim();
+  const { imageSrc, isLoading } = useUploadedImagePreview(
+    shouldPreviewImage ? file.absolutePath : undefined,
+    shouldPreviewImage ? workdir : undefined,
+    shouldPreviewImage ? getPendingComposerImagePreviewKey(file) : undefined,
+  );
+  const TypeIcon = getUploadedFileTypeIcon(file);
+
+  return (
+    <ComposerAttachmentCard
+      fileName={file.fileName}
+      pathTitle={file.relativePath}
+      imageSrc={imageSrc}
+      isImageLoading={isLoading}
+      fallbackIcon={<TypeIcon className="h-4 w-4" />}
+      disabled={disabled}
+      removeLabel={removeLabel}
+      onRemove={() => onRemove(file.relativePath)}
+    />
   );
 }
 
@@ -514,44 +555,6 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
           isComposerExpanded && "flex min-h-0 flex-col justify-end",
         )}
       >
-        {/* Pending uploaded files — above the composer card */}
-        {pendingUploadedFiles.length > 0 && (
-          <div className="upload-file-list mb-2.5 flex gap-2 overflow-x-auto px-0.5 pb-1">
-            {pendingUploadedFiles.map((file) => {
-              const TypeIcon = getUploadedFileTypeIcon(file);
-              return (
-                <div
-                  key={file.relativePath}
-                  title={file.relativePath}
-                  className="group flex w-[calc(25%-6px)] min-w-[calc(25%-6px)] items-center gap-2 rounded-xl border border-white/45 bg-white/55 px-2.5 py-1.5 text-[calc(11px*var(--zone-font-scale,1))] shadow-[0_2px_8px_-2px_rgba(15,23,42,0.06)] backdrop-blur-2xl backdrop-saturate-150 transition-all hover:bg-white/75 hover:shadow-[0_4px_14px_-4px_rgba(15,23,42,0.10)] dark:border-white/10 dark:bg-white/[0.06] dark:hover:bg-white/[0.10]"
-                >
-                  <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-black/[0.04] dark:bg-white/[0.10]">
-                    <TypeIcon className="h-3.5 w-3.5" />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate text-[calc(12px*var(--zone-font-scale,1))] font-medium tracking-tight text-foreground/90">
-                      {file.fileName}
-                    </div>
-                    <div className="truncate text-[calc(10px*var(--zone-font-scale,1))] text-muted-foreground">
-                      {formatUploadedFileSize(file.sizeBytes)}
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    disabled={isInputDisabled}
-                    onClick={() => onRemovePendingUpload(file.relativePath)}
-                    className="shrink-0 rounded-full p-1 text-muted-foreground/70 opacity-0 transition-all hover:bg-foreground/5 hover:text-foreground group-hover:opacity-100 disabled:pointer-events-none"
-                    aria-label={`${t("chat.upload.removeFile")} ${file.fileName}`}
-                    title={t("chat.upload.removeFile")}
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-        )}
-
         {queuedTurns.length > 0 ? (
           <div
             ref={queuePanelRef}
@@ -727,6 +730,21 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
             className="pointer-events-none absolute inset-0 rounded-[24px] bg-gradient-to-b from-white/18 to-transparent opacity-70 dark:from-white/[0.04] dark:opacity-100"
           />
 
+          {pendingUploadedFiles.length > 0 ? (
+            <div className="upload-file-list relative z-10 flex shrink-0 gap-2 overflow-x-auto pb-1 pl-4 pr-12 pt-3.5">
+              {pendingUploadedFiles.map((file) => (
+                <PendingComposerAttachment
+                  key={`${file.relativePath}-${file.absolutePath ?? file.fileName}`}
+                  file={file}
+                  workdir={workdir}
+                  disabled={isInputDisabled}
+                  removeLabel={t("chat.upload.removeFile")}
+                  onRemove={onRemovePendingUpload}
+                />
+              ))}
+            </div>
+          ) : null}
+
           <button
             type="button"
             onClick={toggleComposerExpanded}
@@ -745,7 +763,13 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
           {/* 常驻 flex-1：动画把卡片钳在中间高度时由本区吸收伸缩，工具栏才能
               全程贴住卡片底边。min-h-0 只在展开态加——折叠态靠自动最小高度
               (= 编辑器钳制高) 撑起卡片的固有高度，加了会塌缩。 */}
-          <div className={cn("relative flex flex-1 px-4 pt-3.5", isComposerExpanded && "min-h-0")}>
+          <div
+            className={cn(
+              "relative flex flex-1 px-4",
+              pendingUploadedFiles.length > 0 ? "pt-2" : "pt-3.5",
+              isComposerExpanded && "min-h-0",
+            )}
+          >
             <MentionComposer
               ref={composerRef}
               onSend={handleComposerSend}

--- a/crates/agent-gui/src/pages/chat/transcript/uploadedImagePreview.ts
+++ b/crates/agent-gui/src/pages/chat/transcript/uploadedImagePreview.ts
@@ -10,8 +10,14 @@ const uploadedImagePreviewCache = new Map<string, string>();
 const uploadedImagePreviewRequests = new Map<string, Promise<string | null>>();
 const UPLOADED_IMAGE_PREVIEW_CACHE_LIMIT = 64;
 
-function getUploadedImagePreviewCacheKey(workspaceRoot: string, absolutePath: string) {
-  return `${workspaceRoot}\n${absolutePath}`;
+function getUploadedImagePreviewCacheKey(
+  workspaceRoot: string,
+  absolutePath: string,
+  cacheVariant = "",
+) {
+  return cacheVariant
+    ? `${workspaceRoot}\n${absolutePath}\n${cacheVariant}`
+    : `${workspaceRoot}\n${absolutePath}`;
 }
 
 function readUploadedImagePreviewCache(cacheKey: string) {
@@ -33,9 +39,13 @@ function writeUploadedImagePreviewCache(cacheKey: string, value: string) {
   }
 }
 
-async function loadUploadedImagePreview(params: { workspaceRoot: string; absolutePath: string }) {
-  const { workspaceRoot, absolutePath } = params;
-  const cacheKey = getUploadedImagePreviewCacheKey(workspaceRoot, absolutePath);
+async function loadUploadedImagePreview(params: {
+  workspaceRoot: string;
+  absolutePath: string;
+  cacheVariant?: string;
+}) {
+  const { workspaceRoot, absolutePath, cacheVariant } = params;
+  const cacheKey = getUploadedImagePreviewCacheKey(workspaceRoot, absolutePath, cacheVariant);
   const cached = readUploadedImagePreviewCache(cacheKey);
   if (cached !== undefined) return cached;
 
@@ -67,12 +77,21 @@ async function loadUploadedImagePreview(params: { workspaceRoot: string; absolut
   return request;
 }
 
-export function useUploadedImagePreview(absolutePath?: string, workspaceRoot?: string) {
+export function useUploadedImagePreview(
+  absolutePath?: string,
+  workspaceRoot?: string,
+  cacheVariant?: string,
+) {
   const normalizedPath = typeof absolutePath === "string" ? absolutePath.trim() : "";
   const normalizedWorkspaceRoot = typeof workspaceRoot === "string" ? workspaceRoot.trim() : "";
+  const normalizedCacheVariant = typeof cacheVariant === "string" ? cacheVariant.trim() : "";
   const cacheKey =
     normalizedPath && normalizedWorkspaceRoot
-      ? getUploadedImagePreviewCacheKey(normalizedWorkspaceRoot, normalizedPath)
+      ? getUploadedImagePreviewCacheKey(
+          normalizedWorkspaceRoot,
+          normalizedPath,
+          normalizedCacheVariant,
+        )
       : "";
   const [imageSrc, setImageSrc] = useState<string | null | undefined>(() => {
     if (!cacheKey) return null;
@@ -96,6 +115,7 @@ export function useUploadedImagePreview(absolutePath?: string, workspaceRoot?: s
     void loadUploadedImagePreview({
       workspaceRoot: normalizedWorkspaceRoot,
       absolutePath: normalizedPath,
+      cacheVariant: normalizedCacheVariant,
     }).then((value) => {
       if (!cancelled) {
         setImageSrc(value);
@@ -104,7 +124,7 @@ export function useUploadedImagePreview(absolutePath?: string, workspaceRoot?: s
     return () => {
       cancelled = true;
     };
-  }, [cacheKey, normalizedPath, normalizedWorkspaceRoot]);
+  }, [cacheKey, normalizedCacheVariant, normalizedPath, normalizedWorkspaceRoot]);
 
   return {
     imageSrc: imageSrc ?? null,

--- a/scripts/mirror-manifest.json
+++ b/scripts/mirror-manifest.json
@@ -32,6 +32,7 @@
     "components/chat/promptHistory.ts",
     "components/chat/NotifyToast.tsx",
     "components/chat/fileTypeIcons.tsx",
+    "components/chat/ComposerAttachmentCard.tsx",
     "components/chat/AskUserQuestionCard.tsx",
     "lib/chat/askUserQuestion.ts",
     "components/Markdown.tsx",


### PR DESCRIPTION
## Summary

- move pending image attachments into the composer card to match the reference layout
- show a real thumbnail, truncated filename, and always-visible remove action
- keep multiple attachments horizontally scrollable and responsive in light/dark themes
- mirror the attachment card across the desktop GUI and Gateway WebUI
- refresh desktop previews when a same-path workspace image is selected again
- mark attachment thumbnails decorative to avoid duplicate screen-reader announcements

## Verification

- `node scripts/check-mirror.mjs`
- `git diff --check`
- Biome checks for all changed frontend files
- Desktop GUI TypeScript check and Vite production build
- Gateway WebUI TypeScript check and Vite production build
- `node --test test/chat/messages.test.mjs test/chat/conversation-state.test.mjs` (66 passed)
