### PR TITLE
fix: nested @ file mention lookup and store link button labels

### DIFF
--- a/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
@@ -192,6 +192,7 @@ export interface MentionComposerProps {
 
 const MAX_SUGGESTIONS = 30;
 const MENTION_INDEX_MAX_RESULTS = 5000;
+const MENTION_REFETCH_DEBOUNCE_MS = 150;
 const MENTION_TAG_ATTR = "data-mention-path";
 const MENTION_KIND_ATTR = "data-mention-kind";
 const SKILL_MENTION_NAME_ATTR = "data-skill-name";
@@ -449,6 +450,28 @@ function editorSelectionRange(root: HTMLElement) {
 
 function normalizeMentionQuery(query: string) {
   return removeCaretAnchors(query).trim().replace(/\\/g, "/").toLowerCase();
+}
+
+type MentionFetchSnapshot = {
+  trigger: MentionContext["trigger"];
+  query: string;
+  truncated: boolean;
+};
+
+// A cached snapshot answers narrower queries client-side only when the backend
+// returned every match for the query it was fetched with. A truncated snapshot
+// can be missing matches for any other query, so extending the query must go
+// back to the backend instead of narrowing locally.
+export function mentionSnapshotCoversQuery(
+  fetched: MentionFetchSnapshot | null,
+  trigger: MentionContext["trigger"],
+  normalizedQuery: string,
+): boolean {
+  if (!fetched) return true;
+  if (fetched.trigger !== trigger) return false;
+  if (!normalizedQuery.startsWith(fetched.query)) return false;
+  if (!fetched.truncated) return true;
+  return normalizedQuery === fetched.query;
 }
 
 function normalizeLargePastePreview(text: string) {
@@ -1921,22 +1944,31 @@ export const MentionComposer = memo(
     const mentionSessionRequestSeqRef = useRef(0);
     const mentionActiveRef = useRef(false);
     const mentionSessionQueryRef = useRef("");
-    const mentionFetchRef = useRef<{ trigger: MentionContext["trigger"]; query: string } | null>(
-      null,
-    );
+    const mentionFetchRef = useRef<MentionFetchSnapshot | null>(null);
+    const mentionRefetchTimerRef = useRef<number | null>(null);
+    const [mentionRefetchPending, setMentionRefetchPending] = useState(false);
 
     // ---- Mention state ----
     const [mentionCtx, setMentionCtx] = useState<MentionContext | null>(null);
     const [highlightIdx, setHighlightIdx] = useState(0);
 
+    const cancelMentionRefetch = useCallback(() => {
+      if (mentionRefetchTimerRef.current !== null) {
+        window.clearTimeout(mentionRefetchTimerRef.current);
+        mentionRefetchTimerRef.current = null;
+      }
+      setMentionRefetchPending(false);
+    }, []);
+
     const resetMentionSession = useCallback(() => {
       mentionSessionRequestSeqRef.current += 1;
       mentionSessionQueryRef.current = "";
       mentionFetchRef.current = null;
+      cancelMentionRefetch();
       setMentionSessionEntries([]);
       setMentionSessionLoading(false);
       setMentionSessionError(null);
-    }, []);
+    }, [cancelMentionRefetch]);
 
     const closeMentionSession = useCallback(() => {
       mentionActiveRef.current = false;
@@ -1946,12 +1978,23 @@ export const MentionComposer = memo(
     }, [resetMentionSession]);
 
     const startMentionSession = useCallback(
-      (ctx: MentionContext) => {
+      (ctx: MentionContext, opts?: { keepEntries?: boolean }) => {
+        cancelMentionRefetch();
         const requestSeq = ++mentionSessionRequestSeqRef.current;
+        const isFileFetch = ctx.trigger === "file" && Boolean(normalizedWorkdir);
         mentionSessionQueryRef.current = ctx.query;
-        mentionFetchRef.current = { trigger: ctx.trigger, query: normalizeMentionQuery(ctx.query) };
-        setMentionSessionEntries([]);
-        setMentionSessionLoading(ctx.trigger === "file" && Boolean(normalizedWorkdir));
+        mentionFetchRef.current = {
+          trigger: ctx.trigger,
+          query: normalizeMentionQuery(ctx.query),
+          // Pessimistic while the fetch is in flight so keystrokes racing the
+          // response keep refetching; the response corrects it. Skill and
+          // workdir-less sessions never fetch, so their snapshot is complete.
+          truncated: isFileFetch,
+        };
+        if (!opts?.keepEntries) {
+          setMentionSessionEntries([]);
+        }
+        setMentionSessionLoading(isFileFetch);
         setMentionSessionError(null);
 
         if (ctx.trigger === "skill") {
@@ -1969,6 +2012,9 @@ export const MentionComposer = memo(
           .then((resp) => {
             if (requestSeq !== mentionSessionRequestSeqRef.current) return;
             setMentionSessionEntries(resp.entries);
+            if (mentionFetchRef.current) {
+              mentionFetchRef.current = { ...mentionFetchRef.current, truncated: resp.truncated };
+            }
           })
           .catch(() => {
             if (requestSeq !== mentionSessionRequestSeqRef.current) return;
@@ -1980,7 +2026,22 @@ export const MentionComposer = memo(
             setMentionSessionLoading(false);
           });
       },
-      [normalizedWorkdir],
+      [cancelMentionRefetch, normalizedWorkdir],
+    );
+
+    const scheduleMentionRefetch = useCallback(
+      (ctx: MentionContext) => {
+        if (mentionRefetchTimerRef.current !== null) {
+          window.clearTimeout(mentionRefetchTimerRef.current);
+        }
+        setMentionRefetchPending(true);
+        mentionRefetchTimerRef.current = window.setTimeout(() => {
+          mentionRefetchTimerRef.current = null;
+          setMentionRefetchPending(false);
+          startMentionSession(ctx, { keepEntries: true });
+        }, MENTION_REFETCH_DEBOUNCE_MS);
+      },
+      [startMentionSession],
     );
 
     const mentionSessionSearchIndex = useMemo<MentionSearchEntry[]>(
@@ -1999,6 +2060,9 @@ export const MentionComposer = memo(
     useEffect(() => {
       return () => {
         mentionSessionRequestSeqRef.current += 1;
+        if (mentionRefetchTimerRef.current !== null) {
+          window.clearTimeout(mentionRefetchTimerRef.current);
+        }
         if (busyReleaseTimerRef.current !== null) {
           window.clearTimeout(busyReleaseTimerRef.current);
         }
@@ -2053,7 +2117,7 @@ export const MentionComposer = memo(
       });
     }, [suggestions.length]);
 
-    const popupLoading = mentionSessionLoading;
+    const popupLoading = mentionSessionLoading || mentionRefetchPending;
     const popupError = suggestions.length === 0 ? mentionSessionError : null;
     const popupEmptyLabel =
       mentionCtx?.trigger === "skill"
@@ -2259,14 +2323,16 @@ export const MentionComposer = memo(
         if (ctx.query === mentionSessionQueryRef.current) return;
         mentionSessionQueryRef.current = ctx.query;
         setHighlightIdx(0);
-        // The backend filters entries by the query used at fetch time, so the
-        // cached snapshot only narrows further; refetch once that breaks.
+        // The cached snapshot only answers the new query when it was complete
+        // for the fetched one; anything else goes back to the backend. File
+        // refetches are debounced so fast typing does not walk a large
+        // workspace once per keystroke.
         const fetched = mentionFetchRef.current;
-        if (
-          fetched &&
-          (fetched.trigger !== ctx.trigger ||
-            !normalizeMentionQuery(ctx.query).startsWith(fetched.query))
-        ) {
+        if (mentionSnapshotCoversQuery(fetched, ctx.trigger, normalizeMentionQuery(ctx.query))) {
+          cancelMentionRefetch();
+        } else if (fetched?.trigger === "file" && ctx.trigger === "file") {
+          scheduleMentionRefetch(ctx);
+        } else {
           startMentionSession(ctx);
         }
       };
@@ -2277,7 +2343,13 @@ export const MentionComposer = memo(
         if (!nextEl || document.activeElement !== nextEl) return;
         applyContext(detectMention(nextEl, enabledSkills.length > 0));
       });
-    }, [closeMentionSession, enabledSkills.length, startMentionSession]);
+    }, [
+      cancelMentionRefetch,
+      closeMentionSession,
+      enabledSkills.length,
+      scheduleMentionRefetch,
+      startMentionSession,
+    ]);
 
     useImperativeHandle(
       ref,

--- a/crates/agent-gateway/web/src/pages/mcp-hub/McpRegistryBrowser.tsx
+++ b/crates/agent-gateway/web/src/pages/mcp-hub/McpRegistryBrowser.tsx
@@ -1213,13 +1213,11 @@ function McpRegistryPreviewDrawer(props: {
               className="h-9 flex-1 gap-1.5 rounded-xl border-border/50 bg-background/70"
               render={
                 <a href={primaryLink} target="_blank" rel="noreferrer">
-                  <span className="sr-only">{t("mcpHub.storeOpenExternal")}</span>
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  {t("mcpHub.storeOpenExternal")}
                 </a>
               }
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-              {t("mcpHub.storeOpenExternal")}
-            </Button>
+            />
           ) : null}
           <Button
             type="button"

--- a/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
@@ -4354,13 +4354,11 @@ function SkillsStorePreviewDrawer(props: {
               className="h-9 flex-1 gap-1.5 rounded-xl border-border/50 bg-background/70"
               render={
                 <a href={link} target="_blank" rel="noreferrer">
-                  <span className="sr-only">{t("settings.skillsStoreOpenInClawHub")}</span>
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  {t("settings.skillsStoreOpenInClawHub")}
                 </a>
               }
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-              {t("settings.skillsStoreOpenInClawHub")}
-            </Button>
+            />
           ) : null}
           <Button
             type="button"

--- a/crates/agent-gui/src-tauri/src/commands/workspace/fs.rs
+++ b/crates/agent-gui/src-tauri/src/commands/workspace/fs.rs
@@ -4471,11 +4471,11 @@ pub fn fs_mention_list_sync(
     let wd = canonicalize_workdir(&workdir).map_err(|e| e.to_string())?;
     let max_results = max_results.unwrap_or(DEFAULT_MENTION_MAX_RESULTS).max(1);
     let query = normalize_mention_query(query);
-    let candidate_limit = if query.is_empty() {
-        max_results
-    } else {
-        QUERY_MENTION_CANDIDATE_LIMIT.max(max_results)
-    };
+    // Collect more candidates than requested even for an empty query: the
+    // walker yields depth-first, so capping at max_results would drop shallow
+    // entries whenever an early directory is large enough to fill the cap on
+    // its own. Ranking picks the shallowest entries out of the larger pool.
+    let candidate_limit = QUERY_MENTION_CANDIDATE_LIMIT.max(max_results);
 
     let visibility = requested_visibility(show_hidden, false);
     let normally_visible = visibility
@@ -4508,10 +4508,7 @@ pub fn fs_mention_list_sync(
 
         if entries.len() >= candidate_limit {
             truncated = true;
-            if query.is_empty() {
-                break;
-            }
-            continue;
+            break;
         }
 
         entries.push(MentionFileEntry {
@@ -4523,9 +4520,7 @@ pub fn fs_mention_list_sync(
         });
     }
 
-    entries.sort_by(|a, b| {
-        mention_sort_key(&a.path, &a.kind, &query).cmp(&mention_sort_key(&b.path, &b.kind, &query))
-    });
+    entries.sort_by_cached_key(|entry| mention_sort_key(&entry.path, &entry.kind, &query));
     if entries.len() > max_results {
         entries.truncate(max_results);
         truncated = true;
@@ -5653,6 +5648,51 @@ mod tests {
         assert_eq!(paths.first(), Some(&"src/needle.ts"));
         assert!(paths.contains(&"src/deep/other-needle.ts"));
         assert!(!paths.contains(&"src/unrelated.ts"));
+
+        let _ = fs::remove_dir_all(workdir);
+    }
+
+    #[test]
+    fn mention_list_truncation_keeps_shallow_entries_and_queries_reach_dropped_files() {
+        let workdir = unique_test_workdir("mention-truncated");
+        // The walker yields "aaa/deep" before the shallow sibling, so a
+        // walk-order cap would fill up on filler files alone.
+        fs::create_dir_all(workdir.join("aaa/deep")).expect("create dirs");
+        for index in 0..30 {
+            fs::write(workdir.join(format!("aaa/deep/filler-{index:02}.txt")), "")
+                .expect("write filler");
+        }
+        fs::write(workdir.join("aaa/deep/target-needle.ts"), "").expect("write needle");
+        fs::write(workdir.join("zzz-shallow.ts"), "").expect("write shallow");
+
+        let response = fs_mention_list_sync(workdir.display().to_string(), Some(5), None, None)
+            .expect("mention list should succeed");
+        assert!(response.truncated);
+        assert_eq!(response.entries.len(), 5);
+        let paths = response
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect::<Vec<_>>();
+        assert!(
+            paths.contains(&"zzz-shallow.ts"),
+            "shallow entry must survive truncation: {paths:?}"
+        );
+
+        // Files dropped from the truncated snapshot must stay reachable by
+        // query; the composer relies on this when it refetches while typing.
+        let queried = fs_mention_list_sync(
+            workdir.display().to_string(),
+            Some(5),
+            Some("target-needle".to_string()),
+            None,
+        )
+        .expect("mention query should succeed");
+        assert_eq!(
+            queried.entries.first().map(|entry| entry.path.as_str()),
+            Some("aaa/deep/target-needle.ts")
+        );
+        assert!(!queried.truncated);
 
         let _ = fs::remove_dir_all(workdir);
     }

--- a/crates/agent-gui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gui/src/components/chat/MentionComposer.tsx
@@ -199,6 +199,7 @@ export interface MentionComposerProps {
 
 const MAX_SUGGESTIONS = 30;
 const MENTION_INDEX_MAX_RESULTS = 5000;
+const MENTION_REFETCH_DEBOUNCE_MS = 150;
 const MENTION_TAG_ATTR = "data-mention-path";
 const MENTION_KIND_ATTR = "data-mention-kind";
 const SKILL_MENTION_NAME_ATTR = "data-skill-name";
@@ -602,6 +603,28 @@ function clampComposerContextMenuPosition(x: number, y: number) {
 
 function normalizeMentionQuery(query: string) {
   return removeCaretAnchors(query).trim().replace(/\\/g, "/").toLowerCase();
+}
+
+type MentionFetchSnapshot = {
+  trigger: MentionContext["trigger"];
+  query: string;
+  truncated: boolean;
+};
+
+// A cached snapshot answers narrower queries client-side only when the backend
+// returned every match for the query it was fetched with. A truncated snapshot
+// can be missing matches for any other query, so extending the query must go
+// back to the backend instead of narrowing locally.
+export function mentionSnapshotCoversQuery(
+  fetched: MentionFetchSnapshot | null,
+  trigger: MentionContext["trigger"],
+  normalizedQuery: string,
+): boolean {
+  if (!fetched) return true;
+  if (fetched.trigger !== trigger) return false;
+  if (!normalizedQuery.startsWith(fetched.query)) return false;
+  if (!fetched.truncated) return true;
+  return normalizedQuery === fetched.query;
 }
 
 function normalizeLargePastePreview(text: string) {
@@ -2163,22 +2186,31 @@ export const MentionComposer = memo(
     const mentionSessionRequestSeqRef = useRef(0);
     const mentionActiveRef = useRef(false);
     const mentionSessionQueryRef = useRef("");
-    const mentionFetchRef = useRef<{ trigger: MentionContext["trigger"]; query: string } | null>(
-      null,
-    );
+    const mentionFetchRef = useRef<MentionFetchSnapshot | null>(null);
+    const mentionRefetchTimerRef = useRef<number | null>(null);
+    const [mentionRefetchPending, setMentionRefetchPending] = useState(false);
 
     // ---- Mention state ----
     const [mentionCtx, setMentionCtx] = useState<MentionContext | null>(null);
     const [highlightIdx, setHighlightIdx] = useState(0);
 
+    const cancelMentionRefetch = useCallback(() => {
+      if (mentionRefetchTimerRef.current !== null) {
+        window.clearTimeout(mentionRefetchTimerRef.current);
+        mentionRefetchTimerRef.current = null;
+      }
+      setMentionRefetchPending(false);
+    }, []);
+
     const resetMentionSession = useCallback(() => {
       mentionSessionRequestSeqRef.current += 1;
       mentionSessionQueryRef.current = "";
       mentionFetchRef.current = null;
+      cancelMentionRefetch();
       setMentionSessionEntries([]);
       setMentionSessionLoading(false);
       setMentionSessionError(null);
-    }, []);
+    }, [cancelMentionRefetch]);
 
     const closeMentionSession = useCallback(() => {
       mentionActiveRef.current = false;
@@ -2188,12 +2220,23 @@ export const MentionComposer = memo(
     }, [resetMentionSession]);
 
     const startMentionSession = useCallback(
-      (ctx: MentionContext) => {
+      (ctx: MentionContext, opts?: { keepEntries?: boolean }) => {
+        cancelMentionRefetch();
         const requestSeq = ++mentionSessionRequestSeqRef.current;
+        const isFileFetch = ctx.trigger === "file" && Boolean(normalizedWorkdir);
         mentionSessionQueryRef.current = ctx.query;
-        mentionFetchRef.current = { trigger: ctx.trigger, query: normalizeMentionQuery(ctx.query) };
-        setMentionSessionEntries([]);
-        setMentionSessionLoading(ctx.trigger === "file" && Boolean(normalizedWorkdir));
+        mentionFetchRef.current = {
+          trigger: ctx.trigger,
+          query: normalizeMentionQuery(ctx.query),
+          // Pessimistic while the fetch is in flight so keystrokes racing the
+          // response keep refetching; the response corrects it. Skill and
+          // workdir-less sessions never fetch, so their snapshot is complete.
+          truncated: isFileFetch,
+        };
+        if (!opts?.keepEntries) {
+          setMentionSessionEntries([]);
+        }
+        setMentionSessionLoading(isFileFetch);
         setMentionSessionError(null);
 
         if (ctx.trigger === "skill") {
@@ -2211,6 +2254,9 @@ export const MentionComposer = memo(
           .then((resp) => {
             if (requestSeq !== mentionSessionRequestSeqRef.current) return;
             setMentionSessionEntries(resp.entries);
+            if (mentionFetchRef.current) {
+              mentionFetchRef.current = { ...mentionFetchRef.current, truncated: resp.truncated };
+            }
           })
           .catch(() => {
             if (requestSeq !== mentionSessionRequestSeqRef.current) return;
@@ -2222,7 +2268,22 @@ export const MentionComposer = memo(
             setMentionSessionLoading(false);
           });
       },
-      [normalizedWorkdir],
+      [cancelMentionRefetch, normalizedWorkdir],
+    );
+
+    const scheduleMentionRefetch = useCallback(
+      (ctx: MentionContext) => {
+        if (mentionRefetchTimerRef.current !== null) {
+          window.clearTimeout(mentionRefetchTimerRef.current);
+        }
+        setMentionRefetchPending(true);
+        mentionRefetchTimerRef.current = window.setTimeout(() => {
+          mentionRefetchTimerRef.current = null;
+          setMentionRefetchPending(false);
+          startMentionSession(ctx, { keepEntries: true });
+        }, MENTION_REFETCH_DEBOUNCE_MS);
+      },
+      [startMentionSession],
     );
 
     const mentionSessionSearchIndex = useMemo<MentionSearchEntry[]>(
@@ -2241,6 +2302,9 @@ export const MentionComposer = memo(
     useEffect(() => {
       return () => {
         mentionSessionRequestSeqRef.current += 1;
+        if (mentionRefetchTimerRef.current !== null) {
+          window.clearTimeout(mentionRefetchTimerRef.current);
+        }
         if (busyReleaseTimerRef.current !== null) {
           window.clearTimeout(busyReleaseTimerRef.current);
         }
@@ -2335,7 +2399,7 @@ export const MentionComposer = memo(
       });
     }, [suggestions.length]);
 
-    const popupLoading = mentionSessionLoading;
+    const popupLoading = mentionSessionLoading || mentionRefetchPending;
     const popupError = suggestions.length === 0 ? mentionSessionError : null;
     const popupEmptyLabel =
       mentionCtx?.trigger === "skill"
@@ -2541,14 +2605,16 @@ export const MentionComposer = memo(
         if (ctx.query === mentionSessionQueryRef.current) return;
         mentionSessionQueryRef.current = ctx.query;
         setHighlightIdx(0);
-        // The backend filters entries by the query used at fetch time, so the
-        // cached snapshot only narrows further; refetch once that breaks.
+        // The cached snapshot only answers the new query when it was complete
+        // for the fetched one; anything else goes back to the backend. File
+        // refetches are debounced so fast typing does not walk a large
+        // workspace once per keystroke.
         const fetched = mentionFetchRef.current;
-        if (
-          fetched &&
-          (fetched.trigger !== ctx.trigger ||
-            !normalizeMentionQuery(ctx.query).startsWith(fetched.query))
-        ) {
+        if (mentionSnapshotCoversQuery(fetched, ctx.trigger, normalizeMentionQuery(ctx.query))) {
+          cancelMentionRefetch();
+        } else if (fetched?.trigger === "file" && ctx.trigger === "file") {
+          scheduleMentionRefetch(ctx);
+        } else {
           startMentionSession(ctx);
         }
       };
@@ -2559,7 +2625,13 @@ export const MentionComposer = memo(
         if (!nextEl || document.activeElement !== nextEl) return;
         applyContext(detectMention(nextEl, enabledSkills.length > 0));
       });
-    }, [closeMentionSession, enabledSkills.length, startMentionSession]);
+    }, [
+      cancelMentionRefetch,
+      closeMentionSession,
+      enabledSkills.length,
+      scheduleMentionRefetch,
+      startMentionSession,
+    ]);
 
     useImperativeHandle(
       ref,

--- a/crates/agent-gui/src/pages/mcp-hub/McpRegistryBrowser.tsx
+++ b/crates/agent-gui/src/pages/mcp-hub/McpRegistryBrowser.tsx
@@ -1215,13 +1215,11 @@ function McpRegistryPreviewDrawer(props: {
               className="h-9 flex-1 gap-1.5 rounded-xl border-border/50 bg-background/70"
               render={
                 <a href={primaryLink} target="_blank" rel="noreferrer">
-                  <span className="sr-only">{t("mcpHub.storeOpenExternal")}</span>
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  {t("mcpHub.storeOpenExternal")}
                 </a>
               }
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-              {t("mcpHub.storeOpenExternal")}
-            </Button>
+            />
           ) : null}
           <Button
             type="button"

--- a/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
@@ -4587,13 +4587,11 @@ function SkillsStorePreviewDrawer(props: {
               className="h-9 flex-1 gap-1.5 rounded-xl border-border/50 bg-background/70"
               render={
                 <a href={link} target="_blank" rel="noreferrer">
-                  <span className="sr-only">{t("settings.skillsStoreOpenInClawHub")}</span>
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  {t("settings.skillsStoreOpenInClawHub")}
                 </a>
               }
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-              {t("settings.skillsStoreOpenInClawHub")}
-            </Button>
+            />
           ) : null}
           <Button
             type="button"

--- a/crates/agent-gui/test/chat/mention-refetch.test.mjs
+++ b/crates/agent-gui/test/chat/mention-refetch.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const sourceRoots = [
+  new URL("../../src/components/chat/", import.meta.url),
+  new URL("../../../agent-gateway/web/src/components/chat/", import.meta.url),
+];
+
+function source(root) {
+  return readFileSync(new URL("MentionComposer.tsx", root), "utf8");
+}
+
+function extractFunction(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `missing function ${name}`);
+  const end = src.indexOf("\n}\n", start);
+  assert.notEqual(end, -1, `unterminated function ${name}`);
+  return src.slice(start, end + 3);
+}
+
+function loadCoversQuery(src) {
+  const body = extractFunction(src, "mentionSnapshotCoversQuery").replace(
+    /\(\s*fetched[^)]*\)\s*:\s*boolean/s,
+    "(fetched, trigger, normalizedQuery)",
+  );
+  return new Function(`${body}; return mentionSnapshotCoversQuery;`)();
+}
+
+test("both composers share the snapshot-coverage decision byte-identically", () => {
+  const bodies = sourceRoots.map((root) =>
+    extractFunction(source(root), "mentionSnapshotCoversQuery"),
+  );
+  assert.equal(bodies[0], bodies[1]);
+});
+
+test("a truncated snapshot never claims to cover an extended query", () => {
+  for (const root of sourceRoots) {
+    const coversQuery = loadCoversQuery(source(root));
+
+    // Complete snapshots narrow client-side, exactly as before.
+    const complete = { trigger: "file", query: "", truncated: false };
+    assert.equal(coversQuery(complete, "file", ""), true);
+    assert.equal(coversQuery(complete, "file", "src/app"), true);
+    assert.equal(coversQuery(complete, "skill", "src/app"), false);
+
+    // The big-workspace regression: an empty-query snapshot capped by the
+    // backend must refetch for every non-empty query instead of filtering
+    // the incomplete cache.
+    const truncated = { trigger: "file", query: "", truncated: true };
+    assert.equal(coversQuery(truncated, "file", ""), true);
+    assert.equal(coversQuery(truncated, "file", "s"), false);
+    assert.equal(coversQuery(truncated, "file", "settings.rs"), false);
+
+    // Query edits that stop extending the fetched query always refetch.
+    const scoped = { trigger: "file", query: "src/", truncated: false };
+    assert.equal(coversQuery(scoped, "file", "src/main"), true);
+    assert.equal(coversQuery(scoped, "file", "sr"), false);
+
+    // No snapshot yet means nothing to refetch against.
+    assert.equal(coversQuery(null, "file", "anything"), true);
+  }
+});
+
+test("both composers wire truncation tracking and debounced refetches", () => {
+  for (const root of sourceRoots) {
+    const composer = source(root);
+    // The fetch snapshot starts pessimistic and is corrected by the response.
+    assert.match(composer, /truncated: isFileFetch,/);
+    assert.match(
+      composer,
+      /mentionFetchRef\.current = \{ \.\.\.mentionFetchRef\.current, truncated: resp\.truncated \}/,
+    );
+    // Query-driven file refetches are debounced and keep the current entries
+    // so the popup does not flash empty between keystrokes.
+    assert.match(composer, /const MENTION_REFETCH_DEBOUNCE_MS = 150;/);
+    assert.match(composer, /startMentionSession\(ctx, \{ keepEntries: true \}\)/);
+    // While a refetch is pending the popup reports loading instead of a
+    // premature "no matching files".
+    assert.match(
+      composer,
+      /const popupLoading = mentionSessionLoading \|\| mentionRefetchPending;/,
+    );
+  }
+});


### PR DESCRIPTION
## 概述

修复 #249 报告的两个问题：

### 1. @ 引用多层嵌套目录下的文件时搜索不到

大仓库中文件索引快照被截断（上限 20k 条）时，前端仍在本地窄化过滤，导致深层嵌套路径的文件永远不出现在候选里。修复后由 `mentionSnapshotCoversQuery` 单一裁决快照是否覆盖当前查询，不覆盖则重新请求后端检索：

- 截断快照禁止本地窄化，fetch 在途按悲观 truncated 处理
- 150ms 防抖 + `keepEntries` 避免列表闪烁，pending 状态并入 popupLoading
- Rust 端空 query 也走 20k 候选池按路径浅度排序，保证浅层条目优先
- 新增 mention-refetch 测试并强制 GUI/WebUI 两端逐字节一致

### 2. MCP 商店 / Skills 商店详情页“打开外部链接”按钮无任何文字

两端 Button 均为 Base UI `useRender`，`render` 元素自带的 children 会覆盖 Button 自身 children。原代码给 `<a>` 塞了一个 sr-only span（为通过 biome `useAnchorContent` 规则），结果把图标和可见文字整体覆盖成隐藏文本，按钮视觉空白。

修复：把图标 + 文字移入 render 的 `<a>` 元素内部、Button 不留 children（与 ChatHistorySidebar 既有 render 用法一致）。共修复 4 处：GUI/WebUI 的 `McpRegistryBrowser.tsx` 与 `SkillsHubPage.tsx` 详情抽屉。

## 验证

- 两端 `biome check` 通过（原 GUI 端 2 个 `useAnchorContent` error 随修复消除）
- 两端 `tsc --noEmit` 无错误
- mention-refetch 单测覆盖截断快照重取逻辑

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)