### PR TITLE
feat(providers): Grok/xAI provider, Responses compat, and reasoning.effort mapping

### DIFF
--- a/crates/agent-gateway/internal/handler/types.go
+++ b/crates/agent-gateway/internal/handler/types.go
@@ -98,13 +98,13 @@ func NormalizeChatSelectedModel(
 	}
 
 	switch selectedModel.ProviderType {
-	case "codex", "claude_code", "gemini":
+	case "codex", "claude_code", "gemini", "xai":
 		return selectedModel, nil
 	case "":
 		return nil, fmt.Errorf("selected_model.provider_type is required")
 	default:
 		return nil, fmt.Errorf(
-			"selected_model.provider_type must be codex, claude_code, or gemini",
+			"selected_model.provider_type must be codex, claude_code, gemini, or xai",
 		)
 	}
 }

--- a/crates/agent-gateway/internal/handler/types_test.go
+++ b/crates/agent-gateway/internal/handler/types_test.go
@@ -57,6 +57,36 @@ func TestNormalizeChatSelectedModelAcceptsGemini(t *testing.T) {
 	}
 }
 
+func TestNormalizeChatSelectedModelAcceptsXai(t *testing.T) {
+	t.Parallel()
+
+	got, err := NormalizeChatSelectedModel(&ChatSelectedModelBody{
+		CustomProviderID: " builtin-xai ",
+		Model:            " grok-4.5 ",
+		ProviderType:     " xai ",
+	})
+	if err != nil {
+		t.Fatalf("NormalizeChatSelectedModel() error = %v", err)
+	}
+	if got.CustomProviderID != "builtin-xai" ||
+		got.Model != "grok-4.5" ||
+		got.ProviderType != "xai" {
+		t.Fatalf("NormalizeChatSelectedModel() = %#v", got)
+	}
+}
+
+func TestNormalizeChatSelectedModelRejectsUnknownProviderType(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NormalizeChatSelectedModel(&ChatSelectedModelBody{
+		CustomProviderID: "provider",
+		Model:            "model",
+		ProviderType:     "grok",
+	}); err == nil {
+		t.Fatalf("NormalizeChatSelectedModel() expected error for unknown provider type")
+	}
+}
+
 func TestNormalizeChatRuntimeControlsDefaultsAndTrims(t *testing.T) {
 	t.Parallel()
 

--- a/crates/agent-gateway/test/webui/web-settings.test.mjs
+++ b/crates/agent-gateway/test/webui/web-settings.test.mjs
@@ -1575,3 +1575,12 @@ test("web right dock migrates the legacy tabs shape", () => {
   assert.deepEqual(project.tabOrder, ["sess-1", RIGHT_DOCK_TAB_IDS.fileTree]);
   assert.equal(project.activeTabId, "sess-1");
 });
+
+test("xai model limits use the pi-ai xai catalog without changing thinking detection", () => {
+  assert.equal(settings.getProviderModelDefaults("xai", "grok-4.5").contextWindow, 500_000);
+  assert.equal(settings.getProviderModelDefaults("xai", "grok-3").contextWindow, 131_072);
+  assert.equal(settings.getProviderModelDefaults("xai", "grok-unknown").contextWindow, 258_000);
+  // 思考档位检测刻意不吃 xai 目录（其 compat 反映 pi-ai completions 路径）：
+  // grok 仍按可推理的自定义模型给标准档位。
+  assert.ok(settings.getKnownModelThinkingLevels("xai", "grok-4.5").includes("high"));
+});

--- a/crates/agent-gateway/test/webui/web-settings.test.mjs
+++ b/crates/agent-gateway/test/webui/web-settings.test.mjs
@@ -1580,7 +1580,24 @@ test("xai model limits use the pi-ai xai catalog without changing thinking detec
   assert.equal(settings.getProviderModelDefaults("xai", "grok-4.5").contextWindow, 500_000);
   assert.equal(settings.getProviderModelDefaults("xai", "grok-3").contextWindow, 131_072);
   assert.equal(settings.getProviderModelDefaults("xai", "grok-unknown").contextWindow, 258_000);
-  // 思考档位检测刻意不吃 xai 目录（其 compat 反映 pi-ai completions 路径）：
-  // grok 仍按可推理的自定义模型给标准档位。
+  // 思考档位检测刻意不吃 xai 目录（其 compat 反映 pi-ai completions 路径），
+  // 而是无条件应用与桌面端同步的 XAI 档位映射。
   assert.ok(settings.getKnownModelThinkingLevels("xai", "grok-4.5").includes("high"));
+});
+
+test("xai thinking levels mirror the desktop XAI thinking map", () => {
+  // 与桌面端 modelFactory XAI_THINKING_LEVEL_MAP 对齐：档位含 xhigh、思考恒开。
+  // 否则 normalizeChatRuntimeControlsForProvider 的钳制会把桌面端设置的
+  // xhigh 在 web 侧压回 high，跨端行为分叉。
+  const levels = settings.getKnownModelThinkingLevels("xai", "grok-4.5");
+  assert.ok(levels.includes("xhigh"));
+  assert.ok(!levels.includes("off"));
+  assert.ok(!levels.includes("max"));
+  assert.equal(settings.isThinkingAlwaysOnForModel("xai", "grok-4.5"), true);
+  // 钳制路径：当前供应商为 xai 时 xhigh 不再被压回 high。
+  const clamped = settings.normalizeChatRuntimeControlsForProvider(
+    { reasoning: "xhigh", reasoningByProvider: { xai: "xhigh" } },
+    { providerId: "xai", modelId: "grok-4.5" },
+  );
+  assert.equal(clamped.reasoning, "xhigh");
 });

--- a/crates/agent-gateway/test/webui/web-settings.test.mjs
+++ b/crates/agent-gateway/test/webui/web-settings.test.mjs
@@ -293,6 +293,7 @@ test("web chat runtime controls default and follow model-aware reasoning support
       codex_openai_responses: "high",
       codex_openai_completions: "high",
       gemini: "high",
+      xai: "high",
     },
   });
 
@@ -425,6 +426,7 @@ test("web chat runtime controls default and follow model-aware reasoning support
         codex_openai_responses: "xhigh",
         codex_openai_completions: "xhigh",
         gemini: "high",
+        xai: "xhigh",
       },
     },
   );
@@ -448,7 +450,10 @@ test("web chat runtime controls default and follow model-aware reasoning support
         claude_code: "xhigh",
         codex_openai_responses: "xhigh",
         codex_openai_completions: "xhigh",
+        // gemini / xai 未在 reasoningByProvider 输入里显式给出，也未参与本次调用
+        // 的当前 provider key，因此只继承顶层 reasoning 原值，不做钳制。
         gemini: "xhigh",
+        xai: "xhigh",
       },
     },
   );
@@ -468,6 +473,7 @@ test("web chat runtime controls default and follow model-aware reasoning support
         codex_openai_responses: "xhigh",
         codex_openai_completions: "high",
         gemini: "high",
+        xai: "high",
       },
     },
   );

--- a/crates/agent-gateway/web/src/components/icons.tsx
+++ b/crates/agent-gateway/web/src/components/icons.tsx
@@ -454,6 +454,28 @@ export const AlertCircle = createIcon(AlertCircleSource);
 export const AlertTriangle = createIcon(AlertTriangleSource);
 export const ClaudeIcon = createIcon(ClaudeSource);
 export const GeminiIcon = createIcon(GeminiIconSource);
+/**
+ * Official xAI / Grok brand mark (from CC-Switch `src/icons/extracted/xai.svg`).
+ * Monochrome via currentColor so it tracks light/dark UI chrome.
+ */
+function GrokIconSource({ title, ...props }: SVGProps<SVGSVGElement> & { title?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1em"
+      fill="currentColor"
+      fillRule="evenodd"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+      aria-hidden={title ? undefined : true}
+    >
+      <title>{title ?? "Grok"}</title>
+      <path d="M6.469 8.776L16.512 23h-4.464L2.005 8.776H6.47zm-.004 7.9l2.233 3.164L6.467 23H2l4.465-6.324zM22 2.582V23h-3.659V7.764L22 2.582zM22 1l-9.952 14.095-2.233-3.163L17.533 1H22z" />
+    </svg>
+  );
+}
+export const GrokIcon = createIcon(GrokIconSource);
 export const Archive = createIcon(ArchiveSource);
 export const ArchiveRestore = createIcon(ArchiveRestoreSource);
 export const ArrowDownAZ = createIcon(ArrowDownAZSource);

--- a/crates/agent-gateway/web/src/lib/chat/uiMessages.ts
+++ b/crates/agent-gateway/web/src/lib/chat/uiMessages.ts
@@ -679,6 +679,7 @@ function isParentAgentToolCall(toolCall: ToolCall) {
   return toolCall.name === "Agent" && !isSubagentCardToolCall(toolCall);
 }
 
+// 与 agent-gui lib/providers/nativeWebSearch.ts 的同名判定保持一致（手动同步）。
 function isProviderNativeWebSearchToolName(toolName: string | undefined) {
   const normalized = toolName?.trim().toLowerCase() ?? "";
   return (
@@ -687,8 +688,13 @@ function isProviderNativeWebSearchToolName(toolName: string | undefined) {
     normalized === "web_search" ||
     normalized === "web_search_20250305" ||
     normalized === "web_search_20260209" ||
+    normalized === "web_search_20260318" ||
     normalized === "web_search_preview" ||
-    normalized.startsWith("web_search_call")
+    normalized.startsWith("web_search_call") ||
+    normalized === "x_search" ||
+    normalized === "x_keyword_search" ||
+    normalized === "x_semantic_search" ||
+    normalized.startsWith("x_search_call")
   );
 }
 

--- a/crates/agent-gateway/web/src/lib/providers/customHeaders.ts
+++ b/crates/agent-gateway/web/src/lib/providers/customHeaders.ts
@@ -55,6 +55,7 @@ const CUSTOM_HEADER_KEY_PRESETS: Record<CustomProvider["type"], readonly string[
   claude_code: ANTHROPIC_CUSTOM_HEADER_KEY_PRESETS,
   codex: CODEX_CUSTOM_HEADER_KEY_PRESETS,
   gemini: COMMON_CUSTOM_HEADER_KEY_PRESETS,
+  xai: COMMON_CUSTOM_HEADER_KEY_PRESETS,
 };
 
 export function getCustomHeaderKeyPresets(providerId: CustomProvider["type"]): readonly string[] {

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -1015,10 +1015,27 @@ function toKnownProvider(providerId: ProviderId): KnownProvider {
   return "anthropic";
 }
 
+// 仅限限额（contextWindow/maxOutputToken）回查的目录：xai 走 pi-ai 的 xai
+// 目录拿 grok 真实窗口（grok-4.5=500K、grok-3=131K、grok-code-fast-1=32K），
+// 不能落到 openai 目录查不到后吃统一兜底值。思考档位检测
+// （findKnownModelForThinking）刻意不用该目录——其 compat/reasoning 反映的是
+// pi-ai completions 路径，与 LiveAgent 强制 Responses + thinkingLevelMap 不符。
+function toLimitsCatalogProvider(providerId: ProviderId): KnownProvider {
+  return providerId === "xai" ? "xai" : toKnownProvider(providerId);
+}
+
 function findKnownModel(providerId: ProviderId, modelId: string | undefined) {
   const trimmedId = modelId?.trim();
   if (!trimmedId) return undefined;
   return getBuiltinModels(toKnownProvider(providerId)).find((model) => model.id === trimmedId);
+}
+
+function findKnownModelLimitsEntry(providerId: ProviderId, modelId: string | undefined) {
+  const trimmedId = modelId?.trim();
+  if (!trimmedId) return undefined;
+  return getBuiltinModels(toLimitsCatalogProvider(providerId)).find(
+    (model) => model.id === trimmedId,
+  );
 }
 
 // —— 以下 Anthropic id 规范化与启发式与桌面端 anthropicModels.ts/modelFactory.ts
@@ -1142,7 +1159,7 @@ function getKnownModelLimits(
           : Math.min(known.contextWindow, ANTHROPIC_STANDARD_CONTEXT_WINDOW);
     return { contextWindow, maxOutputToken: known.maxTokens };
   }
-  const known = findKnownModel(providerId, modelId);
+  const known = findKnownModelLimitsEntry(providerId, modelId);
   if (!known) return undefined;
   return { contextWindow: known.contextWindow, maxOutputToken: known.maxTokens };
 }

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -1164,13 +1164,27 @@ function getKnownModelLimits(
   return { contextWindow: known.contextWindow, maxOutputToken: known.maxTokens };
 }
 
-export function getKnownModelThinkingLevels(
-  providerId: ProviderId,
-  modelId: string | undefined,
-): ReasoningLevel[] {
-  const trimmedId = modelId?.trim();
-  if (!trimmedId) return [];
+// Grok / xAI 思考档：与桌面端 modelFactory 的 XAI_THINKING_LEVEL_MAP 手动同步
+// （off:null=思考恒开，max 不暴露）。桌面端对 xai 的所有模型（目录内外）一律
+// 盖这份映射，web 侧同样无条件应用，否则跨端钳制会把桌面设置的 xhigh 压回 high。
+const XAI_THINKING_LEVEL_MAP = {
+  off: null,
+  minimal: "low",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "xhigh",
+} as const;
+
+function resolveThinkingModel(providerId: ProviderId, trimmedId: string) {
+  if (providerId === "xai") {
+    return {
+      reasoning: true,
+      thinkingLevelMap: XAI_THINKING_LEVEL_MAP,
+    } as Parameters<typeof getSupportedThinkingLevels>[0];
+  }
   const known = findKnownModelForThinking(providerId, trimmedId);
+  if (known) return known;
   // 目录之外的自定义模型（deepseek/glm 等三方聚合）无法从 id 判断推理能力，
   // 与桌面端 modelFactory 自定义分支一致按可推理处理：标准档位，xhigh/max
   // 仍需目录 opt-in；deepseek 走 codex 时镜像桌面端 DeepSeek 适配层的 xhigh 档，
@@ -1181,12 +1195,19 @@ export function getKnownModelThinkingLevels(
       : toKnownProvider(providerId) === "anthropic"
         ? deriveAnthropicThinkingLevelMapForCustomModel(trimmedId)
         : undefined;
-  const model =
-    known ??
-    ({
-      reasoning: true,
-      ...(customThinkingLevelMap ? { thinkingLevelMap: customThinkingLevelMap } : {}),
-    } as Parameters<typeof getSupportedThinkingLevels>[0]);
+  return {
+    reasoning: true,
+    ...(customThinkingLevelMap ? { thinkingLevelMap: customThinkingLevelMap } : {}),
+  } as Parameters<typeof getSupportedThinkingLevels>[0];
+}
+
+export function getKnownModelThinkingLevels(
+  providerId: ProviderId,
+  modelId: string | undefined,
+): ReasoningLevel[] {
+  const trimmedId = modelId?.trim();
+  if (!trimmedId) return [];
+  const model = resolveThinkingModel(providerId, trimmedId);
   return getSupportedThinkingLevels(model).filter((level) => level !== "off");
 }
 
@@ -1199,6 +1220,11 @@ export function isThinkingAlwaysOnForModel(
 ): boolean {
   const trimmedId = modelId?.trim();
   if (!trimmedId) return false;
+  // xai 的映射 off:null 意味着思考恒开（与桌面端一致）；其余供应商目录
+  // 未命中时保持可关闭的兜底判定。
+  if (providerId === "xai") {
+    return !getSupportedThinkingLevels(resolveThinkingModel(providerId, trimmedId)).includes("off");
+  }
   const known = findKnownModelForThinking(providerId, trimmedId);
   return known ? !getSupportedThinkingLevels(known).includes("off") : false;
 }

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -9,7 +9,7 @@ import { normalizeApiKey, normalizeBaseUrl, normalizeModels } from "./normalize"
 
 export type { SystemToolId } from "../tools/systemToolOptions";
 
-export type ProviderId = "codex" | "claude_code" | "gemini";
+export type ProviderId = "codex" | "claude_code" | "gemini" | "xai";
 
 export type ExecutionMode = "text" | "tools" | "agent-dev";
 
@@ -205,7 +205,8 @@ export type ChatRuntimeReasoningProviderKey =
   | "claude_code"
   | "codex_openai_responses"
   | "codex_openai_completions"
-  | "gemini";
+  | "gemini"
+  | "xai";
 
 export type AgentPromptTemplate = {
   id: string;
@@ -331,6 +332,7 @@ export const DEFAULT_CHAT_RUNTIME_CONTROLS: ChatRuntimeControls = {
     codex_openai_responses: "high",
     codex_openai_completions: "high",
     gemini: "high",
+    xai: "high",
   },
 };
 
@@ -416,6 +418,21 @@ export function getBuiltinCustomProviders(): CustomProvider[] {
       models: [],
       activeModels: [],
       reasoning: "off",
+      promptCachingEnabled: false,
+      nativeWebSearchEnabled: true,
+      useSystemProxy: false,
+    },
+    {
+      id: "builtin-xai",
+      name: "Grok",
+      type: "xai",
+      baseUrl: "https://api.x.ai/v1",
+      apiKey: "",
+      customHeaders: [],
+      models: [],
+      activeModels: [],
+      requestFormat: "openai-responses",
+      reasoning: "high",
       promptCachingEnabled: false,
       nativeWebSearchEnabled: true,
       useSystemProxy: false,
@@ -760,6 +777,7 @@ const CHAT_RUNTIME_REASONING_PROVIDER_KEYS: ChatRuntimeReasoningProviderKey[] = 
   "codex_openai_responses",
   "codex_openai_completions",
   "gemini",
+  "xai",
 ];
 
 export function getChatRuntimeReasoningProviderKey(params: {
@@ -771,6 +789,9 @@ export function getChatRuntimeReasoningProviderKey(params: {
   }
   if (params.providerId === "gemini") {
     return "gemini";
+  }
+  if (params.providerId === "xai") {
+    return "xai";
   }
   if (params.providerId === "codex" && params.requestFormat === "openai-completions") {
     return "codex_openai_completions";
@@ -989,7 +1010,7 @@ export function normalizeRemoteSettings(input: unknown): RemoteSettings {
 }
 
 function toKnownProvider(providerId: ProviderId): KnownProvider {
-  if (providerId === "codex") return "openai";
+  if (providerId === "codex" || providerId === "xai") return "openai";
   if (providerId === "gemini") return "google";
   return "anthropic";
 }
@@ -1173,7 +1194,7 @@ export function getProviderModelDefaults(
   const known = getKnownModelLimits(providerId, modelId, baseUrl);
   if (known) return known;
 
-  if (providerId === "codex") {
+  if (providerId === "codex" || providerId === "xai") {
     return {
       contextWindow: DEFAULT_CODEX_CONTEXT_WINDOW,
       maxOutputToken: DEFAULT_CODEX_MAX_OUTPUT_TOKEN,
@@ -1339,6 +1360,7 @@ function normalizeProviderId(input: unknown): ProviderId {
   switch (input) {
     case "codex":
     case "gemini":
+    case "xai":
       return input;
     default:
       return "claude_code";
@@ -1349,6 +1371,7 @@ function normalizeProviderName(id: string, input: unknown): string {
   const name = typeof input === "string" && input.trim() ? input.trim() : "未命名供应商";
   if (id === "builtin-claude_code" && name === "Claude Code") return "Anthropic";
   if (id === "builtin-codex" && name === "Codex") return "OpenAI";
+  if (id === "builtin-xai" && (name === "xAI" || name === "XAI")) return "Grok";
   return name;
 }
 
@@ -1388,7 +1411,12 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
   const obj = (input && typeof input === "object" ? input : {}) as Record<string, unknown>;
   const type = normalizeProviderId(obj.type);
   const codexRouting =
-    type === "codex" ? normalizeCodexRouting(obj.baseUrl, obj.requestFormat) : undefined;
+    type === "codex" || type === "xai"
+      ? normalizeCodexRouting(
+          obj.baseUrl,
+          type === "xai" ? "openai-responses" : obj.requestFormat,
+        )
+      : undefined;
   const models = normalizeProviderModelConfigs(obj.models, type);
   const modelOrder = normalizeProviderModelOrder(obj.modelOrder, models);
   const validModelIds = new Set(models.map((model) => model.id));
@@ -1410,11 +1438,12 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
     activeModels: normalizeModels(normalizeStringArray(obj.activeModels)).filter((modelId) =>
       validModelIds.has(modelId),
     ),
-    requestFormat: codexRouting?.requestFormat,
+    requestFormat: type === "xai" ? "openai-responses" : codexRouting?.requestFormat,
     reasoning: normalizeReasoningLevel(obj.reasoning),
     // Anthropic/OpenAI 默认开启提示词缓存（OpenAI 侧体现为稳定的
-    // prompt_cache_key 路由提示）；Gemini 的隐式缓存由服务端自动处理。
-    promptCachingEnabled: type === "gemini" ? false : obj.promptCachingEnabled !== false,
+    // prompt_cache_key 路由提示）；Gemini / xAI 不使用 OpenAI 风格 prompt cache。
+    promptCachingEnabled:
+      type === "gemini" || type === "xai" ? false : obj.promptCachingEnabled !== false,
     ...(type === "claude_code" && obj.promptCacheRetention === "long"
       ? { promptCacheRetention: "long" as const }
       : {}),

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -1412,10 +1412,7 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
   const type = normalizeProviderId(obj.type);
   const codexRouting =
     type === "codex" || type === "xai"
-      ? normalizeCodexRouting(
-          obj.baseUrl,
-          type === "xai" ? "openai-responses" : obj.requestFormat,
-        )
+      ? normalizeCodexRouting(obj.baseUrl, type === "xai" ? "openai-responses" : obj.requestFormat)
       : undefined;
   const models = normalizeProviderModelConfigs(obj.models, type);
   const modelOrder = normalizeProviderModelOrder(obj.modelOrder, models);

--- a/crates/agent-gateway/web/src/pages/chat/ChatHeader.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/ChatHeader.tsx
@@ -6,6 +6,7 @@ import {
   ChevronDown,
   ClaudeIcon,
   GeminiIcon,
+  GrokIcon,
   Layers,
   MonitorSmartphone,
   Moon,
@@ -42,6 +43,7 @@ function ProviderBrandIcon({ type, className }: { type: ProviderId; className?: 
   const cls = cn("h-4 w-4 shrink-0", className);
   if (type === "claude_code") return <ClaudeIcon className={cls} />;
   if (type === "gemini") return <GeminiIcon className={cls} />;
+  if (type === "xai") return <GrokIcon className={cls} />;
   return <OpenaiChatgptIcon className={cn(cls, "fill-current dark:text-white")} />;
 }
 

--- a/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
@@ -7,6 +7,7 @@ import {
   EyeOff,
   GeminiIcon,
   Globe,
+  GrokIcon,
   List,
   OpenaiChatgptIcon,
   Pencil,
@@ -85,11 +86,12 @@ type ModelEditDraft = {
   costCacheRead: string;
   costCacheWrite: string;
 };
-const PROVIDER_TABS: ProviderId[] = ["claude_code", "codex", "gemini"];
+const PROVIDER_TABS: ProviderId[] = ["claude_code", "codex", "gemini", "xai"];
 const PROVIDER_LABELS: Record<ProviderId, string> = {
   claude_code: "Anthropic",
   codex: "OpenAI",
   gemini: "Gemini",
+  xai: "Grok",
 };
 
 function getProviderLabel(type: ProviderId) {
@@ -99,6 +101,7 @@ function getProviderLabel(type: ProviderId) {
 function ProviderBrandIcon({ type }: { type: ProviderId }) {
   if (type === "claude_code") return <ClaudeIcon height="1em" />;
   if (type === "gemini") return <GeminiIcon height="1em" />;
+  if (type === "xai") return <GrokIcon height="1em" />;
   return <OpenaiChatgptIcon height="1em" className="fill-current dark:text-white" />;
 }
 
@@ -235,7 +238,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
   );
   const [useSystemProxy, setUseSystemProxy] = useState(initialData?.useSystemProxy ?? false);
   const [promptCachingEnabled, setPromptCachingEnabled] = useState(
-    initialData?.promptCachingEnabled ?? providerType !== "gemini",
+    initialData?.promptCachingEnabled ?? (providerType !== "gemini" && providerType !== "xai"),
   );
   const [promptCacheRetention, setPromptCacheRetention] = useState<"short" | "long">(
     initialData?.promptCacheRetention === "long" ? "long" : "short",
@@ -561,12 +564,18 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
       models,
       modelOrder,
       activeModels: Array.from(activeModels),
-      requestFormat: providerType === "codex" ? requestFormat : undefined,
+      requestFormat:
+        providerType === "xai"
+          ? "openai-responses"
+          : providerType === "codex"
+            ? requestFormat
+            : undefined,
       reasoning:
         providerType === "gemini" && initialData?.reasoning === "xhigh"
           ? "high"
           : (initialData?.reasoning ?? "off"),
-      promptCachingEnabled: providerType === "gemini" ? false : promptCachingEnabled,
+      promptCachingEnabled:
+        providerType === "gemini" || providerType === "xai" ? false : promptCachingEnabled,
       promptCacheRetention:
         providerType === "claude_code" && promptCachingEnabled && promptCacheRetention === "long"
           ? "long"
@@ -1218,7 +1227,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                   />
                 </div>
 
-                {providerType !== "gemini" ? (
+                {providerType !== "gemini" && providerType !== "xai" ? (
                   <div
                     className={cn(
                       "mt-3 rounded-xl border bg-card px-4 py-3 transition-colors",

--- a/crates/agent-gateway/web/src/pages/settings/modelPicker.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/modelPicker.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown,
   ClaudeIcon,
   GeminiIcon,
+  GrokIcon,
   OpenaiChatgptIcon,
   Search,
   Sparkles,
@@ -36,6 +37,7 @@ function ProviderBrandIcon({ type, className }: { type?: ProviderId; className?:
   const cls = cn("h-4 w-4 shrink-0", className);
   if (type === "claude_code") return <ClaudeIcon className={cls} />;
   if (type === "gemini") return <GeminiIcon className={cls} />;
+  if (type === "xai") return <GrokIcon className={cls} />;
   return <OpenaiChatgptIcon className={cn(cls, "fill-current dark:text-white")} />;
 }
 

--- a/crates/agent-gateway/web/src/pages/settings/providerUtils.ts
+++ b/crates/agent-gateway/web/src/pages/settings/providerUtils.ts
@@ -26,13 +26,13 @@ export function formatTokenCount(value: number): string {
 function normalizeModelBaseUrl(type: ProviderId, baseUrl: string) {
   let normalizedUrl = normalizeBaseUrl(baseUrl);
 
-  if (type !== "codex" && type !== "gemini") {
+  if (type !== "codex" && type !== "xai" && type !== "gemini") {
     return normalizedUrl;
   }
 
   const lower = normalizedUrl.toLowerCase();
 
-  if (type === "codex") {
+  if (type === "codex" || type === "xai") {
     for (const suffix of CODEX_MODELS_SUFFIXES) {
       if (lower.endsWith(suffix)) {
         normalizedUrl = normalizedUrl.slice(0, -suffix.length);

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/ccs_import.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/ccs_import.rs
@@ -124,7 +124,12 @@ fn list_ccswitch_liveagent_providers_from_db(
         .prepare(
             "SELECT id, app_type, name, settings_config
              FROM providers
-             WHERE app_type IN ('codex', 'claude', 'claude-code', 'claude_code', 'gemini')
+             WHERE app_type IN (
+               'codex',
+               'claude', 'claude-code', 'claude_code',
+               'gemini',
+               'grokbuild', 'grok-build', 'grok_build', 'grok', 'xai'
+             )
              ORDER BY
                CASE app_type
                  WHEN 'claude' THEN 0
@@ -132,7 +137,12 @@ fn list_ccswitch_liveagent_providers_from_db(
                  WHEN 'claude_code' THEN 0
                  WHEN 'codex' THEN 1
                  WHEN 'gemini' THEN 2
-                 ELSE 3
+                 WHEN 'grokbuild' THEN 3
+                 WHEN 'grok-build' THEN 3
+                 WHEN 'grok_build' THEN 3
+                 WHEN 'grok' THEN 3
+                 WHEN 'xai' THEN 3
+                 ELSE 4
                END,
                COALESCE(sort_index, 999999), created_at ASC, id ASC",
         )
@@ -178,7 +188,10 @@ fn ccs_provider_from_value(
         name: strip_ccswitch_suffix(name).to_string(),
         base_url,
         api_key,
-        request_format: if provider_type == "codex" && ccs_is_chat_protocol(config) {
+        request_format: if provider_type == "xai" {
+            // Grok / xAI 在 LiveAgent 固定 Responses。
+            "openai-responses".to_string()
+        } else if provider_type == "codex" && ccs_is_chat_protocol(config) {
             "openai-completions".to_string()
         } else {
             "openai-responses".to_string()
@@ -192,6 +205,8 @@ fn ccs_provider_type_from_app_type(app_type: &str) -> Option<&'static str> {
         "codex" => Some("codex"),
         "claude" | "claude-code" | "claude_code" => Some("claude_code"),
         "gemini" => Some("gemini"),
+        // CC-Switch Grok Build 应用桶（与上游 AppType::GrokBuild 别名对齐）。
+        "grokbuild" | "grok-build" | "grok_build" | "grok" | "xai" => Some("xai"),
         _ => None,
     }
 }
@@ -225,6 +240,18 @@ fn ccs_extract_models(provider_type: &str, config: &Value) -> Vec<String> {
                 }
             }
         }
+        "xai" => {
+            // Grok Build：settings_config.config 为 TOML，[models].default 与
+            // [model."<id>"].model 为模型 id。
+            if let Some(config_text) = config.get("config").and_then(Value::as_str) {
+                if let Some(model) = ccs_extract_toml_string_value(config_text, "default") {
+                    push_model(model);
+                }
+                if let Some(model) = ccs_extract_toml_string_value(config_text, "model") {
+                    push_model(model);
+                }
+            }
+        }
         _ => {}
     }
 
@@ -254,6 +281,19 @@ fn ccs_extract_base_url(provider_type: &str, config: &Value) -> Option<String> {
         "gemini" => ccs_string_at_path(config, &["env", "GEMINI_BASE_URL"])
             .or_else(|| ccs_string_at_path(config, &["env", "GOOGLE_GEMINI_BASE_URL"]))
             .or_else(|| ccs_string_at_path(config, &["config", "base_url"])),
+        "xai" => ccs_string_at(config, &["base_url", "baseURL"])
+            .or_else(|| {
+                config
+                    .get("config")
+                    .and_then(|value| ccs_string_at(value, &["base_url", "baseURL"]))
+            })
+            .or_else(|| {
+                // Grok Build：config 字段是完整 TOML 文本。
+                config
+                    .get("config")
+                    .and_then(Value::as_str)
+                    .and_then(|text| ccs_extract_toml_string_value(text, "base_url"))
+            }),
         _ => ccs_string_at(config, &["base_url", "baseURL"])
             .or_else(|| {
                 config
@@ -276,6 +316,29 @@ fn ccs_extract_api_key(provider_type: &str, config: &Value) -> Option<String> {
             .or_else(|| ccs_string_at_path(config, &["env", "ANTHROPIC_API_KEY"])),
         "gemini" => ccs_string_at_path(config, &["env", "GEMINI_API_KEY"])
             .or_else(|| ccs_string_at_path(config, &["env", "GOOGLE_API_KEY"])),
+        "xai" => config
+            .pointer("/env/OPENAI_API_KEY")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .or_else(|| {
+                config
+                    .pointer("/auth/OPENAI_API_KEY")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .or_else(|| ccs_string_at(config, &["apiKey", "api_key"]))
+            .or_else(|| {
+                config
+                    .get("config")
+                    .and_then(|value| ccs_string_at(value, &["apiKey", "api_key"]))
+            })
+            .or_else(|| {
+                // Grok Build TOML：api_key = "..."
+                config
+                    .get("config")
+                    .and_then(Value::as_str)
+                    .and_then(|text| ccs_extract_toml_string_value(text, "api_key"))
+            }),
         _ => config
             .pointer("/env/OPENAI_API_KEY")
             .and_then(Value::as_str)

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
@@ -1405,4 +1405,54 @@ mod tests {
             .iter()
             .any(|item| item.provider_type == "claude_code"));
     }
+
+    #[test]
+    fn ccs_maps_grokbuild_app_type_to_xai() {
+        assert_eq!(
+            ccs_provider_type_from_app_type("grokbuild"),
+            Some("xai")
+        );
+        assert_eq!(ccs_provider_type_from_app_type("grok"), Some("xai"));
+        assert_eq!(ccs_provider_type_from_app_type("xai"), Some("xai"));
+        assert_eq!(ccs_provider_type_from_app_type("Grok-Build"), Some("xai"));
+    }
+
+    #[test]
+    fn ccs_imports_grokbuild_toml_config_fields() {
+        // 与 CC-Switch Grok Build 写入 providers.settings_config 的形状对齐：
+        // config 是 TOML 文本，含 [models].default 与 [model."<id>"] 表。
+        let config = json!({
+            "config": "[models]\ndefault = \"grok-4.5\"\n\n[model]\n[model.\"grok-4.5\"]\nmodel = \"grok-4.5\"\nbase_url = \"https://api.x.ai/v1\"\nname = \"packy\"\napi_backend = \"responses\"\ncontext_window = 500000\napi_key = \"sk-test-key\"\n"
+        });
+        let item = ccs_provider_from_value(
+            "d262e762-test",
+            "grokbuild",
+            "PackyCode",
+            &config,
+        )
+        .expect("grokbuild provider should import");
+
+        assert_eq!(item.provider_type, "xai");
+        assert_eq!(item.app_type, "grokbuild");
+        assert_eq!(item.base_url, "https://api.x.ai/v1");
+        assert_eq!(item.api_key, "sk-test-key");
+        assert_eq!(item.request_format, "openai-responses");
+        assert!(item.models.iter().any(|m| m == "grok-4.5"));
+    }
+
+    #[test]
+    fn ccs_imports_empty_official_grokbuild_seed() {
+        let config = json!({ "config": "" });
+        let item = ccs_provider_from_value(
+            "grokbuild-official",
+            "grokbuild",
+            "Grok Official",
+            &config,
+        )
+        .expect("official grok seed should still map");
+        assert_eq!(item.provider_type, "xai");
+        assert_eq!(item.base_url, "");
+        assert_eq!(item.api_key, "");
+        assert_eq!(item.request_format, "openai-responses");
+    }
 }

--- a/crates/agent-gui/src-tauri/src/services/provider_models.rs
+++ b/crates/agent-gui/src-tauri/src/services/provider_models.rs
@@ -151,7 +151,7 @@ async fn read_limited_response(response: reqwest::Response) -> Result<Vec<u8>, S
 }
 
 fn normalize_provider_base_url(provider_type: &str, raw: &str) -> Result<Url, String> {
-    if !matches!(provider_type, "claude_code" | "codex" | "gemini") {
+    if !matches!(provider_type, "claude_code" | "codex" | "gemini" | "xai") {
         return Err("不支持的供应商类型".to_string());
     }
     let mut url = Url::parse(raw.trim()).map_err(|_| "Base URL 必须是绝对 URL".to_string())?;
@@ -167,7 +167,7 @@ fn normalize_provider_base_url(provider_type: &str, raw: &str) -> Result<Url, St
     }
 
     let mut path = url.path().trim_end_matches('/').to_string();
-    if provider_type == "codex" {
+    if provider_type == "codex" || provider_type == "xai" {
         let lower = path.to_ascii_lowercase();
         if let Some(suffix) = CODEX_MODELS_SUFFIXES
             .iter()
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     fn provider_model_headers_exclude_inference_identity() {
-        for provider_type in ["claude_code", "codex", "gemini"] {
+        for provider_type in ["claude_code", "codex", "gemini", "xai"] {
             let headers = build_provider_models_headers(provider_type, "key");
             let names = headers
                 .iter()
@@ -395,6 +395,7 @@ mod tests {
             ("claude_code", "x-api-key"),
             ("codex", "authorization"),
             ("gemini", "x-goog-api-key"),
+            ("xai", "authorization"),
         ] {
             let headers = build_provider_models_headers(provider_type, "key");
             let auth_names = headers

--- a/crates/agent-gui/src/components/icons.tsx
+++ b/crates/agent-gui/src/components/icons.tsx
@@ -456,6 +456,28 @@ function GeminiIconSource({ title, ...props }: SVGProps<SVGSVGElement> & { title
 export const AlertTriangle = createIcon(AlertTriangleSource);
 export const ClaudeIcon = createIcon(ClaudeSource);
 export const GeminiIcon = createIcon(GeminiIconSource);
+/**
+ * Official xAI / Grok brand mark (from CC-Switch `src/icons/extracted/xai.svg`).
+ * Monochrome via currentColor so it tracks light/dark UI chrome.
+ */
+function GrokIconSource({ title, ...props }: SVGProps<SVGSVGElement> & { title?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1em"
+      fill="currentColor"
+      fillRule="evenodd"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+      aria-hidden={title ? undefined : true}
+    >
+      <title>{title ?? "Grok"}</title>
+      <path d="M6.469 8.776L16.512 23h-4.464L2.005 8.776H6.47zm-.004 7.9l2.233 3.164L6.467 23H2l4.465-6.324zM22 2.582V23h-3.659V7.764L22 2.582zM22 1l-9.952 14.095-2.233-3.163L17.533 1H22z" />
+    </svg>
+  );
+}
+export const GrokIcon = createIcon(GrokIconSource);
 export const Archive = createIcon(ArchiveSource);
 export const ArchiveRestore = createIcon(ArchiveRestoreSource);
 export const ArrowDownAZ = createIcon(ArrowDownAZSource);

--- a/crates/agent-gui/src/lib/providers/customHeaders.ts
+++ b/crates/agent-gui/src/lib/providers/customHeaders.ts
@@ -55,6 +55,7 @@ const CUSTOM_HEADER_KEY_PRESETS: Record<CustomProvider["type"], readonly string[
   claude_code: ANTHROPIC_CUSTOM_HEADER_KEY_PRESETS,
   codex: CODEX_CUSTOM_HEADER_KEY_PRESETS,
   gemini: COMMON_CUSTOM_HEADER_KEY_PRESETS,
+  xai: COMMON_CUSTOM_HEADER_KEY_PRESETS,
 };
 
 export function getCustomHeaderKeyPresets(providerId: CustomProvider["type"]): readonly string[] {

--- a/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
+++ b/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
@@ -315,6 +315,10 @@ type SearchEventParser = {
 // ---------------------------------------------------------------------------
 // OpenAI Responses: web_search_call lifecycle events + url_citation annotations.
 // Every event carries a complete, self-contained payload — no cross-event state.
+// xAI (api.x.ai) reuses the same wire shape but reports server-side search via
+// its own item types: x_search_call(_output) items, plus custom_tool_call items
+// named x_keyword_search / x_semantic_search. Result sources arrive on
+// action.sources when the request includes web_search_call.action.sources.
 // ---------------------------------------------------------------------------
 
 function mapOpenAIWebSearchCallStatus(rawStatus: string, isDoneEvent: boolean): HostedSearchStatus {
@@ -324,32 +328,101 @@ function mapOpenAIWebSearchCallStatus(rawStatus: string, isDoneEvent: boolean): 
   return isDoneEvent ? "completed" : "searching";
 }
 
+function extractResponsesSourceList(raw: unknown): HostedSearchSource[] {
+  if (!Array.isArray(raw)) return [];
+  const sources: HostedSearchSource[] = [];
+  for (const entry of raw) {
+    if (typeof entry === "string") {
+      const url = entry.trim();
+      if (url && isHttpUrl(url)) sources.push({ url, sourceType: "source" });
+      continue;
+    }
+    if (!isRecord(entry)) continue;
+    const url = readString(entry.url ?? entry.uri);
+    if (!url || !isHttpUrl(url)) continue;
+    const title = readString(entry.title);
+    sources.push({ url, ...(title ? { title } : {}), sourceType: "source" });
+  }
+  return sources;
+}
+
+function isXaiSearchCallItemType(itemType: string) {
+  return itemType === "x_search_call" || itemType === "x_search_call_output";
+}
+
+function isXaiCustomSearchToolName(name: string) {
+  const normalized = name.trim().toLowerCase();
+  return normalized === "x_keyword_search" || normalized === "x_semantic_search";
+}
+
+function readXaiCustomSearchQuery(item: Record<string, unknown>) {
+  const raw = readRawString(item.input) || readRawString(item.arguments);
+  const parsed = maybeParseJson(raw);
+  return isRecord(parsed) ? readString(parsed.query) : "";
+}
+
+const RESPONSES_SEARCH_CALL_LIFECYCLE_PREFIXES = [
+  "response.web_search_call.",
+  "response.x_search_call.",
+] as const;
+
 function parseOpenAIResponsesSearchEvent(raw: unknown): HostedSearchUpdate[] {
   if (!isRecord(raw)) return [];
   const type = readString(raw.type);
 
   if (type === "response.output_item.added" || type === "response.output_item.done") {
     const item = isRecord(raw.item) ? raw.item : {};
-    if (readString(item.type) !== "web_search_call") return [];
-    const action = isRecord(item.action) ? item.action : {};
-    const query = readString(action.query);
-    const id = readString(item.id) || readString(item.call_id);
-    return [
-      {
-        ...(id ? { id } : {}),
-        provider: "codex",
-        status: mapOpenAIWebSearchCallStatus(readString(item.status), type.endsWith(".done")),
-        queries: query ? [query] : [],
-        sources: [],
-      },
-    ];
+    const itemType = readString(item.type);
+    const isDoneEvent = type.endsWith(".done");
+
+    if (itemType === "web_search_call" || isXaiSearchCallItemType(itemType)) {
+      const action = isRecord(item.action) ? item.action : {};
+      const query = readString(action.query);
+      const id =
+        readString(item.id) || readString(item.call_id) || readString(item.x_search_call_id);
+      return [
+        {
+          ...(id ? { id } : {}),
+          provider: "codex",
+          status: mapOpenAIWebSearchCallStatus(
+            readString(item.status),
+            isDoneEvent || itemType.endsWith("_output"),
+          ),
+          queries: query ? [query] : [],
+          sources: [
+            ...extractResponsesSourceList(action.sources),
+            ...extractResponsesSourceList(item.sources),
+          ],
+        },
+      ];
+    }
+
+    if (itemType === "custom_tool_call" && isXaiCustomSearchToolName(readString(item.name))) {
+      const query = readXaiCustomSearchQuery(item);
+      const id = readString(item.id) || readString(item.call_id) || readString(item.item_id);
+      return [
+        {
+          ...(id ? { id } : {}),
+          provider: "codex",
+          status: mapOpenAIWebSearchCallStatus(readString(item.status), isDoneEvent),
+          queries: query ? [query] : [],
+          sources: [],
+        },
+      ];
+    }
+
+    return [];
   }
 
-  // Defensive coverage for the dedicated response.web_search_call.* lifecycle
-  // events (in_progress/searching/completed) some OpenAI-compatible gateways
-  // emit alongside (or instead of) output_item add/done.
-  if (type.startsWith("response.web_search_call.")) {
-    const suffix = type.slice("response.web_search_call.".length).toLowerCase();
+  // Defensive coverage for the dedicated response.web_search_call.* /
+  // response.x_search_call.* lifecycle events (in_progress/searching/completed)
+  // some OpenAI-compatible gateways emit alongside (or instead of) output_item
+  // add/done.
+  const lifecyclePrefix = RESPONSES_SEARCH_CALL_LIFECYCLE_PREFIXES.find((prefix) =>
+    type.startsWith(prefix),
+  );
+  if (lifecyclePrefix) {
+    const suffix = type.slice(lifecyclePrefix.length).toLowerCase();
     const id = readString(raw.item_id) || readString(raw.output_item_id);
     return [
       {

--- a/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
+++ b/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
@@ -142,8 +142,10 @@ function requestBodyMatchesProbe(probe: FetchProbe, body: unknown) {
   if (!probe.sessionId) return true;
   if (!isRecord(body)) return false;
 
-  if (probe.providerId === "codex") {
+  if (probe.providerId === "codex" || probe.providerId === "xai") {
     const promptCacheKey = readString(body.prompt_cache_key);
+    // xAI Responses 会剥离 prompt_cache_key；有 requestId 头时已在上游匹配。
+    if (!promptCacheKey && probe.providerId === "xai") return true;
     return promptCacheKey === probe.sessionId;
   }
 
@@ -650,7 +652,9 @@ function createGeminiSearchEventParser(): SearchEventParser {
 }
 
 function createHostedSearchEventParser(providerId: ProviderId): SearchEventParser {
-  if (providerId === "codex") return createOpenAIResponsesSearchEventParser();
+  if (providerId === "codex" || providerId === "xai") {
+    return createOpenAIResponsesSearchEventParser();
+  }
   if (providerId === "claude_code") return createAnthropicSearchEventParser();
   if (providerId === "gemini") return createGeminiSearchEventParser();
   return { parse: () => [] };

--- a/crates/agent-gui/src/lib/providers/nativeResponsesAttachments.ts
+++ b/crates/agent-gui/src/lib/providers/nativeResponsesAttachments.ts
@@ -856,7 +856,7 @@ export function attachOpenAIResponsesNativeAttachments<
   },
 ): TOptions {
   if (
-    params.providerId !== "codex" ||
+    (params.providerId !== "codex" && params.providerId !== "xai") ||
     !params.context ||
     !isOpenAIResponsesModel(params.model) ||
     !params.workdir?.trim()

--- a/crates/agent-gui/src/lib/providers/nativeWebSearch.ts
+++ b/crates/agent-gui/src/lib/providers/nativeWebSearch.ts
@@ -24,7 +24,11 @@ export function isProviderNativeWebSearchToolName(toolName: string | undefined) 
     normalized === "web_search_20260209" ||
     normalized === "web_search_20260318" ||
     normalized === "web_search_preview" ||
-    normalized.startsWith("web_search_call")
+    normalized.startsWith("web_search_call") ||
+    normalized === "x_search" ||
+    normalized === "x_keyword_search" ||
+    normalized === "x_semantic_search" ||
+    normalized.startsWith("x_search_call")
   );
 }
 

--- a/crates/agent-gui/src/lib/providers/nativeWebSearch.ts
+++ b/crates/agent-gui/src/lib/providers/nativeWebSearch.ts
@@ -165,6 +165,7 @@ export function providerSupportsNativeWebSearch(
 
   return (
     (providerId === "codex" && api === "openai-responses") ||
+    (providerId === "xai" && api === "openai-responses") ||
     (providerId === "claude_code" && api === "anthropic-messages") ||
     (providerId === "gemini" && api === "google-generative-ai")
   );

--- a/crates/agent-gui/src/lib/providers/runtime/codexPromptCache.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/codexPromptCache.ts
@@ -22,6 +22,7 @@ export function attachCodexPromptCacheKey(
   providerId: ProviderId,
   options: StreamOptionsEx,
 ): StreamOptionsEx {
+  // xai 不使用 OpenAI prompt_cache_key 路由；仅 Codex 需要。
   if (providerId !== "codex") return options;
   if (options.cacheRetention === "none") return options;
   const sessionId = normalizeSessionId(options.sessionId);

--- a/crates/agent-gui/src/lib/providers/runtime/codexStorage.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/codexStorage.ts
@@ -8,6 +8,7 @@ export function attachCodexResponsesStorage(
 ): StreamOptionsEx {
   const previousOnPayload = options.onPayload;
 
+  // xai 走 xaiResponsesPayloadCompat 处理 store；此处仅 Codex 官方 Responses。
   if (providerId !== "codex") {
     return options;
   }

--- a/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
@@ -19,6 +19,7 @@ import {
   isDeepSeekCodexTarget,
   resolveDeepSeekOpenAICompletionsOverrides,
 } from "../deepSeekProviderAdapter";
+import { isXaiDirectBaseUrl } from "./xaiResponsesPayload";
 
 const CODEX_RESPONSES_SUFFIX = "/responses";
 const CODEX_RESPONSE_SUFFIX = "/response";
@@ -318,7 +319,14 @@ export function createModelFromConfig(
       upstreamBaseUrl,
       modelId,
     });
-    const api = isDeepSeekCodex ? "openai-completions" : inferCodexApi(requestFormat, preferredApi);
+    // xAI 直连仅在 Responses 端点提供服务端 agentic 搜索等原生工具，
+    // 无论请求格式配置为何一律按 openai-responses 发送。
+    const isXaiDirect = isXaiDirectBaseUrl(upstreamBaseUrl?.trim() || baseUrl);
+    const api = isDeepSeekCodex
+      ? "openai-completions"
+      : isXaiDirect
+        ? "openai-responses"
+        : inferCodexApi(requestFormat, preferredApi);
     const responsesCompat =
       api === "openai-responses"
         ? resolveCodexOpenAIResponsesCompat({

--- a/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
@@ -19,7 +19,17 @@ import {
   isDeepSeekCodexTarget,
   resolveDeepSeekOpenAICompletionsOverrides,
 } from "../deepSeekProviderAdapter";
-import { isXaiDirectBaseUrl } from "./xaiResponsesPayload";
+import { isXaiProviderTarget } from "./xaiResponsesPayload";
+
+/** Grok / xAI 思考档：UI 标准档 → 官方 effort；max 不暴露，off 对多数模型不可用。 */
+const XAI_THINKING_LEVEL_MAP: NonNullable<Model<"openai-responses">["thinkingLevelMap"]> = {
+  off: null,
+  minimal: "low",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "xhigh",
+};
 
 const CODEX_RESPONSES_SUFFIX = "/responses";
 const CODEX_RESPONSE_SUFFIX = "/response";
@@ -311,20 +321,24 @@ export function createModelFromConfig(
   const zeroCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
   const customModelCost = configuredCost ?? zeroCost;
 
-  if (providerId === "codex") {
+  if (providerId === "codex" || providerId === "xai") {
     const { baseUrl: normalizedBaseUrl, preferredApi } = normalizeCodexBaseUrl(baseUrl);
-    const isDeepSeekCodex = isDeepSeekCodexTarget({
+    const isDeepSeekCodex =
+      providerId === "codex" &&
+      isDeepSeekCodexTarget({
+        providerId,
+        baseUrl: normalizedBaseUrl,
+        upstreamBaseUrl,
+        modelId,
+      });
+    // 正式 xai 供应商，或 Codex 直连 api.x.ai：固定 Responses（agentic 搜索等）。
+    const isXaiTarget = isXaiProviderTarget({
       providerId,
-      baseUrl: normalizedBaseUrl,
-      upstreamBaseUrl,
-      modelId,
+      baseUrl: upstreamBaseUrl?.trim() || baseUrl,
     });
-    // xAI 直连仅在 Responses 端点提供服务端 agentic 搜索等原生工具，
-    // 无论请求格式配置为何一律按 openai-responses 发送。
-    const isXaiDirect = isXaiDirectBaseUrl(upstreamBaseUrl?.trim() || baseUrl);
     const api = isDeepSeekCodex
       ? "openai-completions"
-      : isXaiDirect
+      : isXaiTarget
         ? "openai-responses"
         : inferCodexApi(requestFormat, preferredApi);
     const responsesCompat =
@@ -342,6 +356,7 @@ export function createModelFromConfig(
           contextWindow,
           maxTokens,
           ...(configuredCost ? { cost: configuredCost } : {}),
+          ...(isXaiTarget ? { thinkingLevelMap: { ...XAI_THINKING_LEVEL_MAP } } : {}),
           ...(responsesCompat
             ? {
                 compat: {
@@ -375,6 +390,9 @@ export function createModelFromConfig(
       contextWindow,
       maxTokens,
     };
+    if (isXaiTarget) {
+      custom.thinkingLevelMap = { ...XAI_THINKING_LEVEL_MAP };
+    }
     if (api === "openai-responses" && responsesCompat) {
       custom.compat = responsesCompat;
     } else if (api === "openai-completions") {

--- a/crates/agent-gui/src/lib/providers/runtime/nativeSearchPayload.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/nativeSearchPayload.ts
@@ -165,7 +165,7 @@ export function attachProviderNativeWebSearch(
         return nextPayload;
       }
 
-      if (providerId === "codex") {
+      if (providerId === "codex" || providerId === "xai") {
         if (model.api === "openai-completions") {
           return appendOpenAIChatCompletionsNativeWebSearch(nextPayload, {
             baseUrl: params?.baseUrl,

--- a/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
@@ -16,6 +16,7 @@ import { attachGeminiThoughtSignatureGuard } from "./geminiToolPayload";
 import { attachProviderNativeWebSearch } from "./nativeSearchPayload";
 import { attachOpenAICompletionsFinishReasonCompatibility } from "./openAICompletionsStream";
 import type { StreamOptionsEx } from "./types";
+import { attachXaiResponsesPayloadCompat } from "./xaiResponsesPayload";
 
 export type ProviderPayloadMiddleware = (
   options: StreamOptionsEx,
@@ -101,6 +102,11 @@ const finalizePayloadMiddlewares = composePayloadMiddlewares([
     }),
   (options, params) =>
     attachProviderNativeWebSearch(params.providerId, options, params.nativeWebSearch, {
+      baseUrl: params.baseUrl,
+    }),
+  (options, params) =>
+    attachXaiResponsesPayloadCompat(options, {
+      providerId: params.providerId,
       baseUrl: params.baseUrl,
     }),
   (options, params) => {

--- a/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
@@ -70,6 +70,7 @@ export function buildProviderRequestHeaders(
       [CODEX_CONVERSATION_ID_HEADER]: requestSessionId,
     };
   }
+  // xai 与其它 OpenAI 兼容端：仅 Bearer，不带 Codex CLI 身份头。
   return authHeaders;
 }
 

--- a/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
@@ -95,7 +95,7 @@ function buildTextOnlyStreamOptions(params: {
     ),
     metadata: buildProviderRequestMetadata(params.providerId, sessionId),
     reasoning:
-      (params.providerId === "codex" &&
+      ((params.providerId === "codex" || params.providerId === "xai") &&
         (params.model.api === "openai-responses" || params.model.api === "openai-completions")) ||
       (params.providerId === "claude_code" && params.model.api === "anthropic-messages") ||
       (params.providerId === "gemini" && params.model.api === "google-generative-ai")

--- a/crates/agent-gui/src/lib/providers/runtime/xaiResponsesPayload.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/xaiResponsesPayload.ts
@@ -1,0 +1,112 @@
+import type { ProviderId } from "../../settings";
+import { isRecord } from "./common";
+import type { StreamOptionsEx } from "./types";
+
+// xAI Responses 端点严格校验请求体：OpenAI 专属的存储/缓存/推理档位与系统
+// 元数据字段（store、prompt_cache_*、reasoning、instructions、metadata 等）
+// 不被接受，直连 api.x.ai 时必须整组剥离，仅保留 Responses 协议的公共字段。
+const XAI_UNSUPPORTED_RESPONSES_PAYLOAD_KEYS = [
+  "background",
+  "instructions",
+  "metadata",
+  "prompt",
+  "prompt_cache_key",
+  "prompt_cache_retention",
+  "reasoning",
+  "service_tier",
+  "store",
+  "stream_options",
+  "text",
+] as const;
+
+export function isXaiDirectBaseUrl(baseUrl: string | undefined): boolean {
+  const trimmed = baseUrl?.trim() ?? "";
+  if (!trimmed) return false;
+  const candidate = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
+  try {
+    return new URL(candidate).hostname.toLowerCase() === "api.x.ai";
+  } catch {
+    return false;
+  }
+}
+
+// grok 的服务端工具（web_search / x_search / code_interpreter）只有显式
+// include 才会回传搜索来源与执行输出；reasoning.encrypted_content 则是
+// store 关闭时跨轮回放推理项的前提，始终请求。
+function xaiResponsesIncludeValues(tools: unknown): string[] {
+  const values = ["reasoning.encrypted_content"];
+  if (!Array.isArray(tools)) return values;
+  for (const tool of tools) {
+    if (!isRecord(tool) || typeof tool.type !== "string") continue;
+    switch (tool.type.trim()) {
+      case "web_search":
+        values.push("web_search_call.action.sources");
+        break;
+      case "file_search":
+        values.push("file_search_call.results");
+        break;
+      case "code_interpreter":
+        values.push("code_interpreter_call.outputs");
+        break;
+    }
+  }
+  return values;
+}
+
+function mergeUniqueIncludeValues(defaults: string[], existing: unknown): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  const push = (value: unknown) => {
+    if (typeof value !== "string") return;
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    result.push(trimmed);
+  };
+  for (const value of defaults) push(value);
+  if (Array.isArray(existing)) {
+    for (const value of existing) push(value);
+  }
+  return result;
+}
+
+export function attachXaiResponsesPayloadCompat(
+  options: StreamOptionsEx,
+  params: {
+    providerId: ProviderId;
+    baseUrl?: string;
+  },
+): StreamOptionsEx {
+  if (params.providerId !== "codex" || !isXaiDirectBaseUrl(params.baseUrl)) {
+    return options;
+  }
+
+  const previousOnPayload = options.onPayload;
+  return {
+    ...options,
+    onPayload: async (payload, model) => {
+      let nextPayload = payload;
+
+      if (previousOnPayload) {
+        const overridden = await previousOnPayload(nextPayload, model);
+        if (overridden !== undefined) {
+          nextPayload = overridden;
+        }
+      }
+
+      if (model.api !== "openai-responses" || !isRecord(nextPayload)) {
+        return nextPayload;
+      }
+
+      const sanitized: Record<string, unknown> = { ...nextPayload };
+      for (const key of XAI_UNSUPPORTED_RESPONSES_PAYLOAD_KEYS) {
+        delete sanitized[key];
+      }
+      sanitized.include = mergeUniqueIncludeValues(
+        xaiResponsesIncludeValues(sanitized.tools),
+        nextPayload.include,
+      );
+      return sanitized;
+    },
+  };
+}

--- a/crates/agent-gui/src/lib/providers/runtime/xaiResponsesPayload.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/xaiResponsesPayload.ts
@@ -2,9 +2,9 @@ import type { ProviderId } from "../../settings";
 import { isRecord } from "./common";
 import type { StreamOptionsEx } from "./types";
 
-// xAI Responses 端点严格校验请求体：OpenAI 专属的存储/缓存/推理档位与系统
-// 元数据字段（store、prompt_cache_*、reasoning、instructions、metadata 等）
-// 不被接受，直连 api.x.ai 时必须整组剥离，仅保留 Responses 协议的公共字段。
+// xAI Responses 端点严格校验请求体：OpenAI 专属的存储/缓存/系统元数据字段
+// （store、prompt_cache_*、instructions、metadata 等）不被接受。
+// reasoning 保留，但会规范化为 xAI 支持的 effort 档位（无 summary）。
 const XAI_UNSUPPORTED_RESPONSES_PAYLOAD_KEYS = [
   "background",
   "instructions",
@@ -12,12 +12,40 @@ const XAI_UNSUPPORTED_RESPONSES_PAYLOAD_KEYS = [
   "prompt",
   "prompt_cache_key",
   "prompt_cache_retention",
-  "reasoning",
   "service_tier",
   "store",
   "stream_options",
   "text",
 ] as const;
+
+/** UI / OpenAI 风格 effort → xAI 官方 effort（low|medium|high|xhigh|none）。 */
+export function mapUiEffortToXaiEffort(
+  effort: string | undefined,
+  modelId?: string,
+): "none" | "low" | "medium" | "high" | "xhigh" | undefined {
+  const normalized = effort?.trim().toLowerCase() ?? "";
+  if (!normalized) return undefined;
+
+  const id = modelId?.trim().toLowerCase() ?? "";
+  const supportsNone = id.includes("grok-4.3") || id.includes("grok-3");
+
+  switch (normalized) {
+    case "off":
+    case "none":
+      return supportsNone ? "none" : undefined;
+    case "minimal":
+      return "low";
+    case "low":
+    case "medium":
+    case "high":
+    case "xhigh":
+      return normalized;
+    case "max":
+      return "high";
+    default:
+      return undefined;
+  }
+}
 
 export function isXaiDirectBaseUrl(baseUrl: string | undefined): boolean {
   const trimmed = baseUrl?.trim() ?? "";
@@ -28,6 +56,13 @@ export function isXaiDirectBaseUrl(baseUrl: string | undefined): boolean {
   } catch {
     return false;
   }
+}
+
+export function isXaiProviderTarget(params: {
+  providerId: ProviderId;
+  baseUrl?: string;
+}): boolean {
+  return params.providerId === "xai" || isXaiDirectBaseUrl(params.baseUrl);
 }
 
 // grok 的服务端工具（web_search / x_search / code_interpreter）只有显式
@@ -70,6 +105,24 @@ function mergeUniqueIncludeValues(defaults: string[], existing: unknown): string
   return result;
 }
 
+function readPayloadEffort(reasoning: unknown): string | undefined {
+  if (!isRecord(reasoning)) return undefined;
+  return typeof reasoning.effort === "string" ? reasoning.effort : undefined;
+}
+
+function applyXaiReasoningField(
+  sanitized: Record<string, unknown>,
+  previousReasoning: unknown,
+  modelId: string | undefined,
+) {
+  const mapped = mapUiEffortToXaiEffort(readPayloadEffort(previousReasoning), modelId);
+  if (mapped) {
+    sanitized.reasoning = { effort: mapped };
+  } else {
+    delete sanitized.reasoning;
+  }
+}
+
 export function attachXaiResponsesPayloadCompat(
   options: StreamOptionsEx,
   params: {
@@ -77,7 +130,11 @@ export function attachXaiResponsesPayloadCompat(
     baseUrl?: string;
   },
 ): StreamOptionsEx {
-  if (params.providerId !== "codex" || !isXaiDirectBaseUrl(params.baseUrl)) {
+  // 正式 xai 供应商，或 Codex 直连 api.x.ai 的兼容路径。
+  if (params.providerId !== "xai" && params.providerId !== "codex") {
+    return options;
+  }
+  if (params.providerId === "codex" && !isXaiDirectBaseUrl(params.baseUrl)) {
     return options;
   }
 
@@ -98,10 +155,12 @@ export function attachXaiResponsesPayloadCompat(
         return nextPayload;
       }
 
+      const previousReasoning = nextPayload.reasoning;
       const sanitized: Record<string, unknown> = { ...nextPayload };
       for (const key of XAI_UNSUPPORTED_RESPONSES_PAYLOAD_KEYS) {
         delete sanitized[key];
       }
+      applyXaiReasoningField(sanitized, previousReasoning, model.id);
       sanitized.include = mergeUniqueIncludeValues(
         xaiResponsesIncludeValues(sanitized.tools),
         nextPayload.include,

--- a/crates/agent-gui/src/lib/providers/runtime/xaiResponsesPayload.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/xaiResponsesPayload.ts
@@ -58,10 +58,7 @@ export function isXaiDirectBaseUrl(baseUrl: string | undefined): boolean {
   }
 }
 
-export function isXaiProviderTarget(params: {
-  providerId: ProviderId;
-  baseUrl?: string;
-}): boolean {
+export function isXaiProviderTarget(params: { providerId: ProviderId; baseUrl?: string }): boolean {
   return params.providerId === "xai" || isXaiDirectBaseUrl(params.baseUrl);
 }
 

--- a/crates/agent-gui/src/lib/settings/index.ts
+++ b/crates/agent-gui/src/lib/settings/index.ts
@@ -21,7 +21,7 @@ import { normalizeApiKey, normalizeBaseUrl, normalizeModels } from "./normalize"
 export type { SystemToolId } from "../tools/systemToolOptions";
 export { isThinkingAlwaysOnForModel };
 
-export type ProviderId = "codex" | "claude_code" | "gemini";
+export type ProviderId = "codex" | "claude_code" | "gemini" | "xai";
 
 export type ExecutionMode = "text" | "tools" | "agent-dev";
 
@@ -221,7 +221,8 @@ export type ChatRuntimeReasoningProviderKey =
   | "claude_code"
   | "codex_openai_responses"
   | "codex_openai_completions"
-  | "gemini";
+  | "gemini"
+  | "xai";
 
 export type AgentPromptTemplate = {
   id: string;
@@ -355,6 +356,7 @@ export const DEFAULT_CHAT_RUNTIME_CONTROLS: ChatRuntimeControls = {
     codex_openai_responses: "high",
     codex_openai_completions: "high",
     gemini: "high",
+    xai: "high",
   },
 };
 
@@ -440,6 +442,21 @@ export function getBuiltinCustomProviders(): CustomProvider[] {
       models: [],
       activeModels: [],
       reasoning: "off",
+      promptCachingEnabled: false,
+      nativeWebSearchEnabled: true,
+      useSystemProxy: false,
+    },
+    {
+      id: "builtin-xai",
+      name: "Grok",
+      type: "xai",
+      baseUrl: "https://api.x.ai/v1",
+      apiKey: "",
+      customHeaders: [],
+      models: [],
+      activeModels: [],
+      requestFormat: "openai-responses",
+      reasoning: "high",
       promptCachingEnabled: false,
       nativeWebSearchEnabled: true,
       useSystemProxy: false,
@@ -781,6 +798,7 @@ const CHAT_RUNTIME_REASONING_PROVIDER_KEYS: ChatRuntimeReasoningProviderKey[] = 
   "codex_openai_responses",
   "codex_openai_completions",
   "gemini",
+  "xai",
 ];
 
 export function getChatRuntimeReasoningProviderKey(params: {
@@ -792,6 +810,9 @@ export function getChatRuntimeReasoningProviderKey(params: {
   }
   if (params.providerId === "gemini") {
     return "gemini";
+  }
+  if (params.providerId === "xai") {
+    return "xai";
   }
   if (params.providerId === "codex" && params.requestFormat === "openai-completions") {
     return "codex_openai_completions";
@@ -1022,7 +1043,7 @@ export function normalizeRemoteSettings(input: unknown): RemoteSettings {
 }
 
 function toKnownProvider(providerId: ProviderId): KnownProvider {
-  if (providerId === "codex") return "openai";
+  if (providerId === "codex" || providerId === "xai") return "openai";
   if (providerId === "gemini") return "google";
   return "anthropic";
 }
@@ -1054,7 +1075,7 @@ export function getProviderModelDefaults(
   const known = getKnownModelLimits(providerId, modelId, baseUrl);
   if (known) return known;
 
-  if (providerId === "codex") {
+  if (providerId === "codex" || providerId === "xai") {
     return {
       contextWindow: DEFAULT_CODEX_CONTEXT_WINDOW,
       maxOutputToken: DEFAULT_CODEX_MAX_OUTPUT_TOKEN,
@@ -1203,6 +1224,7 @@ function normalizeProviderId(input: unknown): ProviderId {
   switch (input) {
     case "codex":
     case "gemini":
+    case "xai":
       return input;
     default:
       return "claude_code";
@@ -1213,6 +1235,7 @@ function normalizeProviderName(id: string, input: unknown): string {
   const name = typeof input === "string" && input.trim() ? input.trim() : "未命名供应商";
   if (id === "builtin-claude_code" && name === "Claude Code") return "Anthropic";
   if (id === "builtin-codex" && name === "Codex") return "OpenAI";
+  if (id === "builtin-xai" && (name === "xAI" || name === "XAI")) return "Grok";
   return name;
 }
 
@@ -1252,7 +1275,13 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
   const obj = (input && typeof input === "object" ? input : {}) as Record<string, unknown>;
   const type = normalizeProviderId(obj.type);
   const codexRouting =
-    type === "codex" ? normalizeCodexRouting(obj.baseUrl, obj.requestFormat) : undefined;
+    type === "codex" || type === "xai"
+      ? normalizeCodexRouting(
+          obj.baseUrl,
+          // xAI / Grok 固定走 Responses；忽略历史配置中的 completions。
+          type === "xai" ? "openai-responses" : obj.requestFormat,
+        )
+      : undefined;
   const models = normalizeProviderModelConfigs(obj.models, type);
   const modelOrder = normalizeProviderModelOrder(obj.modelOrder, models);
   const validModelIds = new Set(models.map((model) => model.id));
@@ -1274,11 +1303,12 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
     activeModels: normalizeModels(normalizeStringArray(obj.activeModels)).filter((modelId) =>
       validModelIds.has(modelId),
     ),
-    requestFormat: codexRouting?.requestFormat,
+    requestFormat: type === "xai" ? "openai-responses" : codexRouting?.requestFormat,
     reasoning: normalizeReasoningLevel(obj.reasoning),
     // Anthropic/OpenAI 默认开启提示词缓存（OpenAI 侧体现为稳定的
-    // prompt_cache_key 路由提示）；Gemini 的隐式缓存由服务端自动处理。
-    promptCachingEnabled: type === "gemini" ? false : obj.promptCachingEnabled !== false,
+    // prompt_cache_key 路由提示）；Gemini / xAI 不使用 OpenAI 风格 prompt cache。
+    promptCachingEnabled:
+      type === "gemini" || type === "xai" ? false : obj.promptCachingEnabled !== false,
     ...(type === "claude_code" && obj.promptCacheRetention === "long"
       ? { promptCacheRetention: "long" as const }
       : {}),

--- a/crates/agent-gui/src/lib/settings/index.ts
+++ b/crates/agent-gui/src/lib/settings/index.ts
@@ -1043,7 +1043,11 @@ export function normalizeRemoteSettings(input: unknown): RemoteSettings {
 }
 
 function toKnownProvider(providerId: ProviderId): KnownProvider {
-  if (providerId === "codex" || providerId === "xai") return "openai";
+  if (providerId === "codex") return "openai";
+  // pi-ai 自带 xai 目录（grok 真实窗口差异极大：grok-4.5=500K、grok-3=131K、
+  // grok-code-fast-1=32K），限额回查必须走它，不能落到 openai 目录查不到后
+  // 吃统一兜底值。
+  if (providerId === "xai") return "xai";
   if (providerId === "gemini") return "google";
   return "anthropic";
 }

--- a/crates/agent-gui/src/lib/tools/bashTimeoutPolicy.ts
+++ b/crates/agent-gui/src/lib/tools/bashTimeoutPolicy.ts
@@ -33,6 +33,12 @@ const BASH_TIMEOUT_POLICIES: Record<ProviderId, BashTimeoutPolicy> = {
     defaultTimeoutMs: CODEX_BASH_DEFAULT_TIMEOUT_MS,
     maxTimeoutMs: CODEX_BASH_MAX_TIMEOUT_MS,
   },
+  xai: {
+    providerId: "xai",
+    providerLabel: "Grok",
+    defaultTimeoutMs: CODEX_BASH_DEFAULT_TIMEOUT_MS,
+    maxTimeoutMs: CODEX_BASH_MAX_TIMEOUT_MS,
+  },
 };
 
 export function resolveBashTimeoutPolicy(providerId: ProviderId): BashTimeoutPolicy {

--- a/crates/agent-gui/src/pages/chat/components/ChatHeader.tsx
+++ b/crates/agent-gui/src/pages/chat/components/ChatHeader.tsx
@@ -6,6 +6,7 @@ import {
   ChevronDown,
   ClaudeIcon,
   GeminiIcon,
+  GrokIcon,
   Layers,
   MonitorSmartphone,
   Moon,
@@ -43,6 +44,7 @@ function ProviderBrandIcon({ type, className }: { type: ProviderId; className?: 
   const cls = cn("h-4 w-4 shrink-0", className);
   if (type === "claude_code") return <ClaudeIcon className={cls} />;
   if (type === "gemini") return <GeminiIcon className={cls} />;
+  if (type === "xai") return <GrokIcon className={cls} />;
   return <OpenaiChatgptIcon className={cn(cls, "fill-current dark:text-white")} />;
 }
 

--- a/crates/agent-gui/src/pages/chat/gateway/gatewayBridgeTypes.ts
+++ b/crates/agent-gui/src/pages/chat/gateway/gatewayBridgeTypes.ts
@@ -105,7 +105,12 @@ export type GatewayBridgeRuntimeRefs = {
 
 export function normalizeGatewayProviderType(value: string): ProviderId | null {
   const normalized = value.trim();
-  if (normalized === "codex" || normalized === "claude_code" || normalized === "gemini") {
+  if (
+    normalized === "codex" ||
+    normalized === "claude_code" ||
+    normalized === "gemini" ||
+    normalized === "xai"
+  ) {
     return normalized;
   }
   return null;

--- a/crates/agent-gui/src/pages/settings/CherryStudioImportModal.tsx
+++ b/crates/agent-gui/src/pages/settings/CherryStudioImportModal.tsx
@@ -5,6 +5,7 @@ import {
   ClaudeIcon,
   FolderOpen,
   GeminiIcon,
+  GrokIcon,
   OpenaiChatgptIcon,
   RefreshCw,
   Settings,
@@ -56,17 +57,19 @@ type CherryStudioImportModalProps = {
   onConfirm: (items: CherryProviderImportItem[]) => void;
 };
 
-const PROVIDER_ORDER: ProviderId[] = ["claude_code", "codex", "gemini"];
+const PROVIDER_ORDER: ProviderId[] = ["claude_code", "codex", "gemini", "xai"];
 
 const PROVIDER_LABELS: Record<ProviderId, string> = {
   claude_code: "Anthropic",
   codex: "OpenAI",
   gemini: "Gemini",
+  xai: "Grok",
 };
 
 function ProviderTypeIcon({ type }: { type: ProviderId }) {
   if (type === "claude_code") return <ClaudeIcon height="1em" />;
   if (type === "gemini") return <GeminiIcon height="1em" />;
+  if (type === "xai") return <GrokIcon height="1em" />;
   return <OpenaiChatgptIcon height="1em" className="fill-current dark:text-white" />;
 }
 

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -1891,8 +1891,7 @@ function providerFromCherry(
           : undefined,
     reasoning: existing?.reasoning ?? "off",
     promptCachingEnabled:
-      existing?.promptCachingEnabled ??
-      (providerType !== "gemini" && providerType !== "xai"),
+      existing?.promptCachingEnabled ?? (providerType !== "gemini" && providerType !== "xai"),
     nativeWebSearchEnabled: existing?.nativeWebSearchEnabled ?? true,
     useSystemProxy: existing?.useSystemProxy ?? false,
   };

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -13,6 +13,7 @@ import {
   EyeOff,
   GeminiIcon,
   Globe,
+  GrokIcon,
   Key,
   List,
   Loader2,
@@ -122,11 +123,12 @@ type CcsProvidersResponse = {
   providers: CcsProviderImportItem[];
 };
 
-const PROVIDER_TABS: ProviderId[] = ["claude_code", "codex", "gemini"];
+const PROVIDER_TABS: ProviderId[] = ["claude_code", "codex", "gemini", "xai"];
 const PROVIDER_LABELS: Record<ProviderId, string> = {
   claude_code: "Anthropic",
   codex: "OpenAI",
   gemini: "Gemini",
+  xai: "Grok",
 };
 
 function getProviderLabel(type: ProviderId) {
@@ -136,6 +138,7 @@ function getProviderLabel(type: ProviderId) {
 function ProviderBrandIcon({ type }: { type: ProviderId }) {
   if (type === "claude_code") return <ClaudeIcon height="1em" />;
   if (type === "gemini") return <GeminiIcon height="1em" />;
+  if (type === "xai") return <GrokIcon height="1em" />;
   return <OpenaiChatgptIcon height="1em" className="fill-current dark:text-white" />;
 }
 
@@ -618,12 +621,18 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
       models,
       modelOrder,
       activeModels: Array.from(activeModels),
-      requestFormat: providerType === "codex" ? requestFormat : undefined,
+      requestFormat:
+        providerType === "xai"
+          ? "openai-responses"
+          : providerType === "codex"
+            ? requestFormat
+            : undefined,
       reasoning:
         providerType === "gemini" && initialData?.reasoning === "xhigh"
           ? "high"
           : (initialData?.reasoning ?? "off"),
-      promptCachingEnabled: providerType === "gemini" ? false : promptCachingEnabled,
+      promptCachingEnabled:
+        providerType === "gemini" || providerType === "xai" ? false : promptCachingEnabled,
       promptCacheRetention:
         providerType === "claude_code" && promptCachingEnabled && promptCacheRetention === "long"
           ? "long"
@@ -1271,7 +1280,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                   />
                 </div>
 
-                {providerType !== "gemini" ? (
+                {providerType !== "gemini" && providerType !== "xai" ? (
                   <div
                     className={cn(
                       "mt-3 rounded-xl border bg-card px-4 py-3 transition-colors",
@@ -1805,13 +1814,15 @@ function providerFromCcs(item: CcsProviderImportItem, existingIds: Set<string>):
     models,
     activeModels: models.map((model) => model.id),
     requestFormat:
-      providerType === "codex"
-        ? item.requestFormat === "openai-completions"
-          ? "openai-completions"
-          : "openai-responses"
-        : undefined,
+      providerType === "xai"
+        ? "openai-responses"
+        : providerType === "codex"
+          ? item.requestFormat === "openai-completions"
+            ? "openai-completions"
+            : "openai-responses"
+          : undefined,
     reasoning: "off",
-    promptCachingEnabled: providerType !== "gemini",
+    promptCachingEnabled: providerType !== "gemini" && providerType !== "xai",
     nativeWebSearchEnabled: true,
     useSystemProxy: false,
   };
@@ -1871,13 +1882,17 @@ function providerFromCherry(
     models,
     activeModels: existing?.activeModels ?? [],
     requestFormat:
-      providerType === "codex"
-        ? item.requestFormat === "openai-completions"
-          ? "openai-completions"
-          : "openai-responses"
-        : undefined,
+      providerType === "xai"
+        ? "openai-responses"
+        : providerType === "codex"
+          ? item.requestFormat === "openai-completions"
+            ? "openai-completions"
+            : "openai-responses"
+          : undefined,
     reasoning: existing?.reasoning ?? "off",
-    promptCachingEnabled: existing?.promptCachingEnabled ?? providerType !== "gemini",
+    promptCachingEnabled:
+      existing?.promptCachingEnabled ??
+      (providerType !== "gemini" && providerType !== "xai"),
     nativeWebSearchEnabled: existing?.nativeWebSearchEnabled ?? true,
     useSystemProxy: existing?.useSystemProxy ?? false,
   };

--- a/crates/agent-gui/src/pages/settings/modelPicker.tsx
+++ b/crates/agent-gui/src/pages/settings/modelPicker.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown,
   ClaudeIcon,
   GeminiIcon,
+  GrokIcon,
   OpenaiChatgptIcon,
   Search,
   Sparkles,
@@ -36,6 +37,7 @@ function ProviderBrandIcon({ type, className }: { type?: ProviderId; className?:
   const cls = cn("h-4 w-4 shrink-0", className);
   if (type === "claude_code") return <ClaudeIcon className={cls} />;
   if (type === "gemini") return <GeminiIcon className={cls} />;
+  if (type === "xai") return <GrokIcon className={cls} />;
   return <OpenaiChatgptIcon className={cn(cls, "fill-current dark:text-white")} />;
 }
 

--- a/crates/agent-gui/src/pages/settings/providerUtils.ts
+++ b/crates/agent-gui/src/pages/settings/providerUtils.ts
@@ -26,13 +26,13 @@ export function formatTokenCount(value: number): string {
 function normalizeModelBaseUrl(type: ProviderId, baseUrl: string) {
   let normalizedUrl = normalizeBaseUrl(baseUrl);
 
-  if (type !== "codex" && type !== "gemini") {
+  if (type !== "codex" && type !== "xai" && type !== "gemini") {
     return normalizedUrl;
   }
 
   const lower = normalizedUrl.toLowerCase();
 
-  if (type === "codex") {
+  if (type === "codex" || type === "xai") {
     for (const suffix of CODEX_MODELS_SUFFIXES) {
       if (lower.endsWith(suffix)) {
         normalizedUrl = normalizedUrl.slice(0, -suffix.length);

--- a/crates/agent-gui/test/providers/hosted-search-events.test.mjs
+++ b/crates/agent-gui/test/providers/hosted-search-events.test.mjs
@@ -380,3 +380,152 @@ test("hosted search aggregation extracts OpenAI url_citation annotations and mar
     [{ url: "https://example.com/openai", sourceType: "citation" }],
   );
 });
+
+test("codex aggregator tracks xAI x_search_call items and extracts action sources", () => {
+  const aggregator = hostedSearchEvents.createHostedSearchEventAggregator({
+    providerId: "codex",
+  });
+
+  aggregator.accept({
+    type: "response.output_item.added",
+    item: {
+      type: "x_search_call",
+      id: "xs-1",
+      status: "in_progress",
+      action: { query: "武汉今天的天气" },
+    },
+  });
+
+  let block = aggregator.getBlocks().find((candidate) => candidate.id === "xs-1");
+  assert.equal(block.status, "searching");
+  assert.deepEqual(block.queries, ["武汉今天的天气"]);
+
+  aggregator.accept({
+    type: "response.output_item.done",
+    item: {
+      type: "x_search_call",
+      id: "xs-1",
+      status: "completed",
+      action: {
+        query: "武汉今天的天气",
+        sources: [{ url: "https://example.com/weather", title: "Weather" }, "https://example.com/extra"],
+      },
+    },
+  });
+
+  block = aggregator.getBlocks().find((candidate) => candidate.id === "xs-1");
+  assert.equal(block.status, "completed");
+  assert.deepEqual(
+    block.sources.map((source) => ({ url: source.url, title: source.title })),
+    [
+      { url: "https://example.com/weather", title: "Weather" },
+      { url: "https://example.com/extra", title: undefined },
+    ],
+  );
+});
+
+test("codex aggregator treats xAI custom_tool_call search items as hosted search activity", () => {
+  const aggregator = hostedSearchEvents.createHostedSearchEventAggregator({
+    providerId: "codex",
+  });
+
+  aggregator.accept({
+    type: "response.output_item.added",
+    item: {
+      type: "custom_tool_call",
+      id: "ct-1",
+      name: "x_keyword_search",
+      status: "in_progress",
+      input: JSON.stringify({ query: "grok news" }),
+    },
+  });
+
+  let block = aggregator.getBlocks().find((candidate) => candidate.id === "ct-1");
+  assert.equal(block.status, "searching");
+  assert.deepEqual(block.queries, ["grok news"]);
+
+  aggregator.accept({
+    type: "response.output_item.done",
+    item: {
+      type: "custom_tool_call",
+      id: "ct-1",
+      name: "x_keyword_search",
+      status: "completed",
+      input: JSON.stringify({ query: "grok news" }),
+    },
+  });
+
+  block = aggregator.getBlocks().find((candidate) => candidate.id === "ct-1");
+  assert.equal(block.status, "completed");
+
+  aggregator.accept({
+    type: "response.output_item.added",
+    item: {
+      type: "custom_tool_call",
+      id: "ct-2",
+      name: "x_semantic_search",
+      status: "in_progress",
+      arguments: JSON.stringify({ query: "semantic query" }),
+    },
+  });
+
+  block = aggregator.getBlocks().find((candidate) => candidate.id === "ct-2");
+  assert.equal(block.status, "searching");
+  assert.deepEqual(block.queries, ["semantic query"]);
+
+  aggregator.accept({
+    type: "response.output_item.added",
+    item: {
+      type: "custom_tool_call",
+      id: "ct-3",
+      name: "unrelated_custom_tool",
+      status: "in_progress",
+      input: JSON.stringify({ query: "not a search" }),
+    },
+  });
+  assert.equal(
+    aggregator.getBlocks().find((candidate) => candidate.id === "ct-3"),
+    undefined,
+  );
+});
+
+test("codex aggregator extracts web_search_call action sources delivered via include", () => {
+  const aggregator = hostedSearchEvents.createHostedSearchEventAggregator({
+    providerId: "codex",
+  });
+
+  aggregator.accept({
+    type: "response.output_item.done",
+    item: {
+      type: "web_search_call",
+      id: "ws-1",
+      status: "completed",
+      action: {
+        query: "today news",
+        sources: [{ url: "https://example.com/news", title: "News" }],
+      },
+    },
+  });
+
+  const block = aggregator.getBlocks().find((candidate) => candidate.id === "ws-1");
+  assert.equal(block.status, "completed");
+  assert.deepEqual(block.queries, ["today news"]);
+  assert.deepEqual(
+    block.sources.map((source) => ({ url: source.url, title: source.title })),
+    [{ url: "https://example.com/news", title: "News" }],
+  );
+});
+
+test("codex aggregator maps response.x_search_call lifecycle events onto block status", () => {
+  const aggregator = hostedSearchEvents.createHostedSearchEventAggregator({
+    providerId: "codex",
+  });
+
+  aggregator.accept({ type: "response.x_search_call.searching", item_id: "xs-9" });
+  let block = aggregator.getBlocks().find((candidate) => candidate.id === "xs-9");
+  assert.equal(block.status, "searching");
+
+  aggregator.accept({ type: "response.x_search_call.completed", item_id: "xs-9" });
+  block = aggregator.getBlocks().find((candidate) => candidate.id === "xs-9");
+  assert.equal(block.status, "completed");
+});

--- a/crates/agent-gui/test/providers/model-factory-xai.test.mjs
+++ b/crates/agent-gui/test/providers/model-factory-xai.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const { createModelFromConfig } = loader.loadModule("src/lib/providers/runtime/modelFactory.ts");
+
+test("xAI direct base URLs are forced onto the openai-responses API even when completions is requested", () => {
+  const model = createModelFromConfig(
+    "codex",
+    "grok-4.5",
+    "https://api.x.ai/v1",
+    "openai-completions",
+  );
+  assert.equal(model.api, "openai-responses");
+  assert.equal(model.id, "grok-4.5");
+});
+
+test("xAI direct detection uses the upstream base URL when requests are proxied", () => {
+  const model = createModelFromConfig(
+    "codex",
+    "grok-4.5",
+    "http://127.0.0.1:18080/proxy/codex",
+    "openai-completions",
+    undefined,
+    "https://api.x.ai/v1",
+  );
+  assert.equal(model.api, "openai-responses");
+});
+
+test("xAI chat-completions style base URLs also normalize onto the responses API", () => {
+  const model = createModelFromConfig(
+    "codex",
+    "grok-4.5",
+    "https://api.x.ai/v1/chat/completions",
+  );
+  assert.equal(model.api, "openai-responses");
+});
+
+test("non-xAI relays keep the requested completions API", () => {
+  const model = createModelFromConfig(
+    "codex",
+    "grok-4.5",
+    "https://relay.example.com/v1",
+    "openai-completions",
+  );
+  assert.equal(model.api, "openai-completions");
+});
+
+test("xAI direct default request format remains openai-responses", () => {
+  const model = createModelFromConfig("codex", "grok-4.5", "https://api.x.ai/v1");
+  assert.equal(model.api, "openai-responses");
+  assert.equal(model.reasoning, true);
+});

--- a/crates/agent-gui/test/providers/model-factory-xai.test.mjs
+++ b/crates/agent-gui/test/providers/model-factory-xai.test.mjs
@@ -17,6 +17,19 @@ test("xAI direct base URLs are forced onto the openai-responses API even when co
   assert.equal(model.id, "grok-4.5");
 });
 
+test("formal xai provider type always uses openai-responses", () => {
+  const model = createModelFromConfig(
+    "xai",
+    "grok-4.5",
+    "https://api.x.ai/v1",
+    "openai-completions",
+  );
+  assert.equal(model.api, "openai-responses");
+  assert.equal(model.thinkingLevelMap?.minimal, "low");
+  assert.equal(model.thinkingLevelMap?.high, "high");
+  assert.equal(model.thinkingLevelMap?.off, null);
+});
+
 test("xAI direct detection uses the upstream base URL when requests are proxied", () => {
   const model = createModelFromConfig(
     "codex",

--- a/crates/agent-gui/test/providers/native-web-search.test.mjs
+++ b/crates/agent-gui/test/providers/native-web-search.test.mjs
@@ -84,3 +84,14 @@ test("isProviderNativeWebSearchToolName matches every hidden tool name, case-ins
   assert.equal(isProviderNativeWebSearchToolName("unrelated_tool"), false);
   assert.equal(isProviderNativeWebSearchToolName(undefined), false);
 });
+
+test("isProviderNativeWebSearchToolName recognizes xAI server-side search tool names", () => {
+  assert.equal(isProviderNativeWebSearchToolName("x_search"), true);
+  assert.equal(isProviderNativeWebSearchToolName("x_keyword_search"), true);
+  assert.equal(isProviderNativeWebSearchToolName("x_semantic_search"), true);
+  assert.equal(isProviderNativeWebSearchToolName("X_Keyword_Search"), true);
+  assert.equal(isProviderNativeWebSearchToolName("x_search_call"), true);
+  assert.equal(isProviderNativeWebSearchToolName("x_search_call_output"), true);
+  assert.equal(isProviderNativeWebSearchToolName("x_searcher"), false);
+  assert.equal(isProviderNativeWebSearchToolName("x_unrelated_tool"), false);
+});

--- a/crates/agent-gui/test/providers/xai-responses-payload.test.mjs
+++ b/crates/agent-gui/test/providers/xai-responses-payload.test.mjs
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const { attachXaiResponsesPayloadCompat, isXaiDirectBaseUrl } = loader.loadModule(
+  "src/lib/providers/runtime/xaiResponsesPayload.ts",
+);
+const { finalizeProviderStreamOptions } = loader.loadModule(
+  "src/lib/providers/runtime/payloadPipeline.ts",
+);
+
+function createXaiResponsesModel(overrides = {}) {
+  return {
+    id: "grok-4.5",
+    name: "grok-4.5",
+    api: "openai-responses",
+    provider: "openai",
+    baseUrl: "http://127.0.0.1:18080/proxy/codex",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 131_072,
+    maxTokens: 8_192,
+    ...overrides,
+  };
+}
+
+test("isXaiDirectBaseUrl only matches the api.x.ai host", () => {
+  assert.equal(isXaiDirectBaseUrl("https://api.x.ai/v1"), true);
+  assert.equal(isXaiDirectBaseUrl("https://api.x.ai"), true);
+  assert.equal(isXaiDirectBaseUrl("https://API.X.AI/v1/"), true);
+  assert.equal(isXaiDirectBaseUrl("api.x.ai/v1"), true);
+  assert.equal(isXaiDirectBaseUrl("https://relay.example.com/api.x.ai/v1"), false);
+  assert.equal(isXaiDirectBaseUrl("https://api.x.ai.evil.example.com/v1"), false);
+  assert.equal(isXaiDirectBaseUrl("https://api.openai.com/v1"), false);
+  assert.equal(isXaiDirectBaseUrl(""), false);
+  assert.equal(isXaiDirectBaseUrl(undefined), false);
+});
+
+test("xAI responses compat strips unsupported payload fields and adds the encrypted reasoning include", async () => {
+  const options = attachXaiResponsesPayloadCompat(
+    {},
+    { providerId: "codex", baseUrl: "https://api.x.ai/v1" },
+  );
+  const payload = await options.onPayload(
+    {
+      model: "grok-4.5",
+      input: [],
+      stream: true,
+      store: true,
+      background: false,
+      prompt_cache_key: "session-1",
+      prompt_cache_retention: "24h",
+      reasoning: { effort: "none" },
+      metadata: { trace: "ok" },
+      instructions: "custom instructions",
+      prompt: { id: "pmpt_123" },
+      service_tier: "auto",
+      stream_options: { include_obfuscation: true },
+      text: { verbosity: "low" },
+      temperature: 0.7,
+      max_output_tokens: 8_192,
+      tools: [{ type: "function", name: "Bash" }],
+    },
+    createXaiResponsesModel(),
+  );
+
+  for (const key of [
+    "store",
+    "background",
+    "prompt_cache_key",
+    "prompt_cache_retention",
+    "reasoning",
+    "metadata",
+    "instructions",
+    "prompt",
+    "service_tier",
+    "stream_options",
+    "text",
+  ]) {
+    assert.equal(Object.hasOwn(payload, key), false, `expected ${key} to be stripped`);
+  }
+  assert.deepEqual(payload.include, ["reasoning.encrypted_content"]);
+  assert.equal(payload.model, "grok-4.5");
+  assert.equal(payload.stream, true);
+  assert.equal(payload.temperature, 0.7);
+  assert.equal(payload.max_output_tokens, 8_192);
+  assert.deepEqual(payload.tools, [{ type: "function", name: "Bash" }]);
+});
+
+test("xAI responses compat maps hosted tool types to include values and keeps custom includes", async () => {
+  const options = attachXaiResponsesPayloadCompat(
+    {},
+    { providerId: "codex", baseUrl: "https://api.x.ai/v1" },
+  );
+  const payload = await options.onPayload(
+    {
+      model: "grok-4.5",
+      input: [],
+      stream: true,
+      include: ["custom.include"],
+      tools: [{ type: "x_search" }, { type: "web_search" }, { type: "code_interpreter" }],
+    },
+    createXaiResponsesModel(),
+  );
+
+  assert.deepEqual(payload.include, [
+    "reasoning.encrypted_content",
+    "web_search_call.action.sources",
+    "code_interpreter_call.outputs",
+    "custom.include",
+  ]);
+  assert.deepEqual(payload.tools, [
+    { type: "x_search" },
+    { type: "web_search" },
+    { type: "code_interpreter" },
+  ]);
+});
+
+test("xAI responses compat is a no-op for non-xAI targets and non-codex providers", () => {
+  const options = {};
+  assert.equal(
+    attachXaiResponsesPayloadCompat(options, {
+      providerId: "codex",
+      baseUrl: "https://api.openai.com/v1",
+    }),
+    options,
+  );
+  assert.equal(
+    attachXaiResponsesPayloadCompat(options, {
+      providerId: "claude_code",
+      baseUrl: "https://api.x.ai/v1",
+    }),
+    options,
+  );
+});
+
+test("xAI responses compat leaves openai-completions payloads untouched", async () => {
+  const options = attachXaiResponsesPayloadCompat(
+    {},
+    { providerId: "codex", baseUrl: "https://api.x.ai/v1" },
+  );
+  const original = {
+    model: "grok-4.5",
+    messages: [],
+    stream: true,
+    reasoning_effort: "low",
+  };
+  const payload = await options.onPayload(
+    original,
+    createXaiResponsesModel({ api: "openai-completions" }),
+  );
+  assert.deepEqual(payload, original);
+});
+
+test("payload pipeline turns an xAI web-search request into a sanitized hosted-tool payload", async () => {
+  const options = finalizeProviderStreamOptions({
+    providerId: "codex",
+    baseUrl: "https://api.x.ai/v1",
+    options: {},
+    nativeWebSearch: true,
+  });
+  const payload = await options.onPayload(
+    {
+      model: "grok-4.5",
+      input: [],
+      stream: true,
+      store: false,
+      prompt_cache_key: "session-1",
+      reasoning: { effort: "none" },
+      tools: [{ type: "function", name: "Bash" }],
+    },
+    createXaiResponsesModel(),
+  );
+
+  assert.equal(Object.hasOwn(payload, "store"), false);
+  assert.equal(Object.hasOwn(payload, "prompt_cache_key"), false);
+  assert.equal(Object.hasOwn(payload, "reasoning"), false);
+  assert.deepEqual(payload.include, [
+    "reasoning.encrypted_content",
+    "web_search_call.action.sources",
+  ]);
+  assert.deepEqual(
+    payload.tools.map((tool) => tool.type),
+    ["function", "web_search"],
+  );
+});
+
+test("payload pipeline keeps the OpenAI responses storage behaviour for non-xAI targets", async () => {
+  const options = finalizeProviderStreamOptions({
+    providerId: "codex",
+    baseUrl: "https://api.openai.com/v1",
+    options: {},
+    nativeWebSearch: false,
+  });
+  const payload = await options.onPayload(
+    { model: "gpt-5.2", input: [], stream: true },
+    createXaiResponsesModel({ id: "gpt-5.2", name: "gpt-5.2" }),
+  );
+  assert.equal(payload.store, true);
+  assert.equal(Object.hasOwn(payload, "include"), false);
+});

--- a/crates/agent-gui/test/providers/xai-responses-payload.test.mjs
+++ b/crates/agent-gui/test/providers/xai-responses-payload.test.mjs
@@ -4,9 +4,12 @@ import test from "node:test";
 import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 
 const loader = createTsModuleLoader();
-const { attachXaiResponsesPayloadCompat, isXaiDirectBaseUrl } = loader.loadModule(
-  "src/lib/providers/runtime/xaiResponsesPayload.ts",
-);
+const {
+  attachXaiResponsesPayloadCompat,
+  isXaiDirectBaseUrl,
+  isXaiProviderTarget,
+  mapUiEffortToXaiEffort,
+} = loader.loadModule("src/lib/providers/runtime/xaiResponsesPayload.ts");
 const { finalizeProviderStreamOptions } = loader.loadModule(
   "src/lib/providers/runtime/payloadPipeline.ts",
 );
@@ -39,7 +42,32 @@ test("isXaiDirectBaseUrl only matches the api.x.ai host", () => {
   assert.equal(isXaiDirectBaseUrl(undefined), false);
 });
 
-test("xAI responses compat strips unsupported payload fields and adds the encrypted reasoning include", async () => {
+test("isXaiProviderTarget matches the formal xai provider type", () => {
+  assert.equal(isXaiProviderTarget({ providerId: "xai", baseUrl: "https://relay.example.com/v1" }), true);
+  assert.equal(
+    isXaiProviderTarget({ providerId: "codex", baseUrl: "https://api.x.ai/v1" }),
+    true,
+  );
+  assert.equal(
+    isXaiProviderTarget({ providerId: "codex", baseUrl: "https://api.openai.com/v1" }),
+    false,
+  );
+});
+
+test("mapUiEffortToXaiEffort maps LiveAgent levels onto official Grok efforts", () => {
+  assert.equal(mapUiEffortToXaiEffort("minimal", "grok-4.5"), "low");
+  assert.equal(mapUiEffortToXaiEffort("low", "grok-4.5"), "low");
+  assert.equal(mapUiEffortToXaiEffort("medium", "grok-4.5"), "medium");
+  assert.equal(mapUiEffortToXaiEffort("high", "grok-4.5"), "high");
+  assert.equal(mapUiEffortToXaiEffort("xhigh", "grok-4.5"), "xhigh");
+  assert.equal(mapUiEffortToXaiEffort("max", "grok-4.5"), "high");
+  assert.equal(mapUiEffortToXaiEffort("off", "grok-4.5"), undefined);
+  assert.equal(mapUiEffortToXaiEffort("none", "grok-4.5"), undefined);
+  assert.equal(mapUiEffortToXaiEffort("none", "grok-4.3"), "none");
+  assert.equal(mapUiEffortToXaiEffort("off", "grok-4.3"), "none");
+});
+
+test("xAI responses compat strips unsupported fields and keeps mapped reasoning effort", async () => {
   const options = attachXaiResponsesPayloadCompat(
     {},
     { providerId: "codex", baseUrl: "https://api.x.ai/v1" },
@@ -53,7 +81,7 @@ test("xAI responses compat strips unsupported payload fields and adds the encryp
       background: false,
       prompt_cache_key: "session-1",
       prompt_cache_retention: "24h",
-      reasoning: { effort: "none" },
+      reasoning: { effort: "minimal", summary: "auto" },
       metadata: { trace: "ok" },
       instructions: "custom instructions",
       prompt: { id: "pmpt_123" },
@@ -72,7 +100,6 @@ test("xAI responses compat strips unsupported payload fields and adds the encryp
     "background",
     "prompt_cache_key",
     "prompt_cache_retention",
-    "reasoning",
     "metadata",
     "instructions",
     "prompt",
@@ -82,12 +109,33 @@ test("xAI responses compat strips unsupported payload fields and adds the encryp
   ]) {
     assert.equal(Object.hasOwn(payload, key), false, `expected ${key} to be stripped`);
   }
+  assert.deepEqual(payload.reasoning, { effort: "low" });
   assert.deepEqual(payload.include, ["reasoning.encrypted_content"]);
   assert.equal(payload.model, "grok-4.5");
   assert.equal(payload.stream, true);
   assert.equal(payload.temperature, 0.7);
   assert.equal(payload.max_output_tokens, 8_192);
   assert.deepEqual(payload.tools, [{ type: "function", name: "Bash" }]);
+});
+
+test("formal xai provider type also applies responses compat", async () => {
+  const options = attachXaiResponsesPayloadCompat(
+    {},
+    { providerId: "xai", baseUrl: "https://relay.example.com/v1" },
+  );
+  const payload = await options.onPayload(
+    {
+      model: "grok-4.5",
+      input: [],
+      stream: true,
+      store: true,
+      reasoning: { effort: "high", summary: "auto" },
+    },
+    createXaiResponsesModel(),
+  );
+  assert.equal(Object.hasOwn(payload, "store"), false);
+  assert.deepEqual(payload.reasoning, { effort: "high" });
+  assert.deepEqual(payload.include, ["reasoning.encrypted_content"]);
 });
 
 test("xAI responses compat maps hosted tool types to include values and keeps custom includes", async () => {
@@ -119,7 +167,7 @@ test("xAI responses compat maps hosted tool types to include values and keeps cu
   ]);
 });
 
-test("xAI responses compat is a no-op for non-xAI targets and non-codex providers", () => {
+test("xAI responses compat is a no-op for non-xAI targets and non-openai providers", () => {
   const options = {};
   assert.equal(
     attachXaiResponsesPayloadCompat(options, {
@@ -157,7 +205,7 @@ test("xAI responses compat leaves openai-completions payloads untouched", async 
 
 test("payload pipeline turns an xAI web-search request into a sanitized hosted-tool payload", async () => {
   const options = finalizeProviderStreamOptions({
-    providerId: "codex",
+    providerId: "xai",
     baseUrl: "https://api.x.ai/v1",
     options: {},
     nativeWebSearch: true,
@@ -169,7 +217,7 @@ test("payload pipeline turns an xAI web-search request into a sanitized hosted-t
       stream: true,
       store: false,
       prompt_cache_key: "session-1",
-      reasoning: { effort: "none" },
+      reasoning: { effort: "high" },
       tools: [{ type: "function", name: "Bash" }],
     },
     createXaiResponsesModel(),
@@ -177,7 +225,7 @@ test("payload pipeline turns an xAI web-search request into a sanitized hosted-t
 
   assert.equal(Object.hasOwn(payload, "store"), false);
   assert.equal(Object.hasOwn(payload, "prompt_cache_key"), false);
-  assert.equal(Object.hasOwn(payload, "reasoning"), false);
+  assert.deepEqual(payload.reasoning, { effort: "high" });
   assert.deepEqual(payload.include, [
     "reasoning.encrypted_content",
     "web_search_call.action.sources",

--- a/crates/agent-gui/test/settings/normalization.test.mjs
+++ b/crates/agent-gui/test/settings/normalization.test.mjs
@@ -344,6 +344,7 @@ test("chat runtime controls default and follow provider model reasoning support"
       codex_openai_responses: "high",
       codex_openai_completions: "high",
       gemini: "high",
+      xai: "high",
     },
   });
 
@@ -470,6 +471,7 @@ test("chat runtime controls default and follow provider model reasoning support"
         codex_openai_responses: "xhigh",
         codex_openai_completions: "xhigh",
         gemini: "high",
+        xai: "xhigh",
       },
     },
   );
@@ -498,9 +500,10 @@ test("chat runtime controls default and follow provider model reasoning support"
         claude_code: "xhigh",
         codex_openai_responses: "xhigh",
         codex_openai_completions: "xhigh",
-        // gemini 未在 reasoningByProvider 输入里显式给出，也未参与本次调用
+        // gemini / xai 未在 reasoningByProvider 输入里显式给出，也未参与本次调用
         // 的当前 provider key，因此只继承顶层 reasoning 原值，不做钳制。
         gemini: "xhigh",
+        xai: "xhigh",
       },
     },
   );
@@ -525,6 +528,7 @@ test("chat runtime controls default and follow provider model reasoning support"
         codex_openai_responses: "xhigh",
         codex_openai_completions: "high",
         gemini: "high",
+        xai: "high",
       },
     },
   );
@@ -581,6 +585,7 @@ test("chat runtime controls default and follow provider model reasoning support"
       codex_openai_responses: "high",
       codex_openai_completions: "high",
       gemini: "high",
+      xai: "high",
     },
   });
 });

--- a/crates/agent-gui/test/settings/normalization.test.mjs
+++ b/crates/agent-gui/test/settings/normalization.test.mjs
@@ -2332,3 +2332,11 @@ test("gateway sync merge keeps system proxy password against redacted payloads",
   assert.equal(mergedHost.system.systemProxy.port, 1080);
   assert.equal(mergedHost.system.systemProxy.password, "secret");
 });
+
+test("xai provider model defaults come from the pi-ai xai catalog", () => {
+  assert.equal(settings.getProviderModelDefaults("xai", "grok-4.5").contextWindow, 500_000);
+  assert.equal(settings.getProviderModelDefaults("xai", "grok-3").contextWindow, 131_072);
+  assert.equal(settings.getProviderModelDefaults("xai", "grok-code-fast-1").contextWindow, 32_768);
+  // 目录未收录的模型仍吃 Codex 系兜底窗口。
+  assert.equal(settings.getProviderModelDefaults("xai", "grok-unknown").contextWindow, 258_000);
+});


### PR DESCRIPTION
## Summary
- Add direct `api.x.ai` Responses compatibility for Codex/OpenAI-compatible providers, plus a first-class **Grok (`xai`)** provider type in desktop GUI and WebUI.
- Force `openai-responses` for xAI (formal `xai` type or direct `api.x.ai` base URL), strip OpenAI-only request fields, keep/map UI thinking levels to `reasoning.effort` (`minimal?low`, etc.), and request `include` for encrypted reasoning + hosted search sources.
- Parse xAI hosted search lifecycle (`x_search_call`, `x_keyword_search` / `x_semantic_search`, `response.x_search_call.*`).
- Import CC-Switch `grokbuild` providers into LiveAgent `xai`, use the official Grok/xAI brand icon, and extend model list fetch / native search / gateway provider typing.

## Test plan
- [x] Unit tests: xai-responses-payload, model-factory-xai, hosted-search-events, native-web-search, settings normalization
- [x] Rust unit tests: `ccs_imports_grokbuild_*` / `ccs_maps_grokbuild_app_type_to_xai`
- [x] `pnpm exec tsc --noEmit` (agent-gui)
- [x] Windows Tauri release binary builds (`liveagent.exe`)
- [x] agent-dev debug jsonl: UI `minimal` ? payload `reasoning.effort: "low"`
- [x] Manual: Grok tab ? API key ? `grok-4.5`, switch low/medium/high and confirm behavior / debug payload
- [x] Manual: Settings ? import from CC-Switch shows `grokbuild` rows under Grok
- [x] Manual: non-xAI OpenAI relays still use completions when configured that way