### PR TITLE
fix(models): resolve catalog limits for models configured under a foreign provider

### DIFF
--- a/crates/agent-gateway/web/src/lib/models/modelCatalog.ts
+++ b/crates/agent-gateway/web/src/lib/models/modelCatalog.ts
@@ -95,6 +95,53 @@ export function findCatalogModel(
   return undefined;
 }
 
+// 中转聚合常把 A 家模型挂在 B 家供应商类型下（如 Anthropic 兼容中转供 grok），
+// 供应商作用域查不到时按 id 跨供应商回查，避免真实限额被本供应商兜底值顶掉。
+// 目录 id 无跨供应商重名（目录不变量测试锁死）；候选链放外层——更精确的 id
+// 形态优先于供应商声明序。
+const CATALOG_PROVIDER_IDS = Object.keys(MODEL_CATALOG) as CatalogProviderId[];
+
+export function findCatalogModelAcrossProviders(
+  modelId: string | undefined,
+): CatalogModelEntry | undefined {
+  const trimmedId = modelId?.trim();
+  if (!trimmedId) return undefined;
+  for (const candidate of normalizeModelIdCandidates(trimmedId)) {
+    for (const catalogProvider of CATALOG_PROVIDER_IDS) {
+      const entry = getCatalogIndex(catalogProvider).get(candidate);
+      if (entry) return entry;
+    }
+  }
+  return undefined;
+}
+
+export function resolveModelLimitsAcrossProviders(
+  modelId: string | undefined,
+): ModelLimits | undefined {
+  const entry = findCatalogModelAcrossProviders(modelId);
+  if (!entry) return undefined;
+  return { contextWindow: entry.contextWindow, maxOutputToken: entry.maxOutputToken };
+}
+
+// 跨供应商回查上线前，别家模型挂在本供应商下会以本供应商兜底值落库。存量
+// 恰为兜底对、且模型只在其他供应商目录命中时视为坏默认值替换为目录真实限额；
+// 两值有一处偏离兜底对即视为用户显式配置，原样保留。
+export function repairStaleCrossProviderLimits(
+  providerId: CatalogAppProviderId,
+  modelId: string,
+  limits: ModelLimits,
+): ModelLimits {
+  const fallback = PROVIDER_FALLBACK_LIMITS[providerId];
+  if (
+    limits.contextWindow !== fallback.contextWindow ||
+    limits.maxOutputToken !== fallback.maxOutputToken
+  ) {
+    return limits;
+  }
+  if (findCatalogModel(providerId, modelId)) return limits;
+  return resolveModelLimitsAcrossProviders(modelId) ?? limits;
+}
+
 export function resolveModelLimits(
   providerId: CatalogAppProviderId,
   modelId: string | undefined,

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -8,7 +8,9 @@ import {
   getProviderFallbackLimits,
   normalizeModelIdCandidates,
   normalizeModelLimits,
+  repairStaleCrossProviderLimits,
   resolveModelLimits,
+  resolveModelLimitsAcrossProviders,
 } from "../models/modelCatalog";
 import { createUuid } from "../shared/id";
 import { mergeAlwaysEnabledSkillNames } from "../skills/builtin";
@@ -1230,6 +1232,12 @@ export function getProviderModelDefaults(
     };
   }
 
+  // 中转聚合把别家模型挂在本供应商下（如 Anthropic 兼容中转供 grok）：按 id
+  // 跨供应商回查真实限额，避免吃错本供应商兜底值。Anthropic 的 1M/adaptive
+  // 窗口策略只约束目录内的 Anthropic 模型，跨供应商命中直接透传目录值。
+  const crossProvider = resolveModelLimitsAcrossProviders(modelId);
+  if (crossProvider) return crossProvider;
+
   return getProviderFallbackLimits(providerId);
 }
 
@@ -1277,7 +1285,9 @@ export function normalizeProviderModelConfig(
   };
   // 退化限额（输出吃满窗口）可能来自坏目录数据落库期或手工配置，读侧统一修复；
   // 规则与目录生成期同源（normalizeModelLimits），对所有供应商一视同仁。
-  const limits = normalizeModelLimits(storedLimits);
+  // 跨供应商回查上线前落库的别家模型吃过本供应商兜底值，同样读侧修复，
+  // 不需要用户删除重加（识别与替换规则见 repairStaleCrossProviderLimits）。
+  const limits = repairStaleCrossProviderLimits(providerId, id, normalizeModelLimits(storedLimits));
   return {
     id,
     ...(ownedBy ? { ownedBy } : {}),

--- a/crates/agent-gui/src/lib/models/modelCatalog.ts
+++ b/crates/agent-gui/src/lib/models/modelCatalog.ts
@@ -95,6 +95,53 @@ export function findCatalogModel(
   return undefined;
 }
 
+// 中转聚合常把 A 家模型挂在 B 家供应商类型下（如 Anthropic 兼容中转供 grok），
+// 供应商作用域查不到时按 id 跨供应商回查，避免真实限额被本供应商兜底值顶掉。
+// 目录 id 无跨供应商重名（目录不变量测试锁死）；候选链放外层——更精确的 id
+// 形态优先于供应商声明序。
+const CATALOG_PROVIDER_IDS = Object.keys(MODEL_CATALOG) as CatalogProviderId[];
+
+export function findCatalogModelAcrossProviders(
+  modelId: string | undefined,
+): CatalogModelEntry | undefined {
+  const trimmedId = modelId?.trim();
+  if (!trimmedId) return undefined;
+  for (const candidate of normalizeModelIdCandidates(trimmedId)) {
+    for (const catalogProvider of CATALOG_PROVIDER_IDS) {
+      const entry = getCatalogIndex(catalogProvider).get(candidate);
+      if (entry) return entry;
+    }
+  }
+  return undefined;
+}
+
+export function resolveModelLimitsAcrossProviders(
+  modelId: string | undefined,
+): ModelLimits | undefined {
+  const entry = findCatalogModelAcrossProviders(modelId);
+  if (!entry) return undefined;
+  return { contextWindow: entry.contextWindow, maxOutputToken: entry.maxOutputToken };
+}
+
+// 跨供应商回查上线前，别家模型挂在本供应商下会以本供应商兜底值落库。存量
+// 恰为兜底对、且模型只在其他供应商目录命中时视为坏默认值替换为目录真实限额；
+// 两值有一处偏离兜底对即视为用户显式配置，原样保留。
+export function repairStaleCrossProviderLimits(
+  providerId: CatalogAppProviderId,
+  modelId: string,
+  limits: ModelLimits,
+): ModelLimits {
+  const fallback = PROVIDER_FALLBACK_LIMITS[providerId];
+  if (
+    limits.contextWindow !== fallback.contextWindow ||
+    limits.maxOutputToken !== fallback.maxOutputToken
+  ) {
+    return limits;
+  }
+  if (findCatalogModel(providerId, modelId)) return limits;
+  return resolveModelLimitsAcrossProviders(modelId) ?? limits;
+}
+
 export function resolveModelLimits(
   providerId: CatalogAppProviderId,
   modelId: string | undefined,

--- a/crates/agent-gui/src/lib/settings/index.ts
+++ b/crates/agent-gui/src/lib/settings/index.ts
@@ -3,7 +3,9 @@ import { DEFAULT_LOCALE, type Locale, normalizeLocale } from "../../i18n/config"
 import {
   getProviderFallbackLimits,
   normalizeModelLimits,
+  repairStaleCrossProviderLimits,
   resolveModelLimits,
+  resolveModelLimitsAcrossProviders,
 } from "../models/modelCatalog";
 import {
   ANTHROPIC_LONG_CONTEXT_WINDOW,
@@ -1078,6 +1080,12 @@ export function getProviderModelDefaults(
     };
   }
 
+  // 中转聚合把别家模型挂在本供应商下（如 Anthropic 兼容中转供 grok）：按 id
+  // 跨供应商回查真实限额，避免吃错本供应商兜底值。Anthropic 的 1M/adaptive
+  // 窗口策略只约束目录内的 Anthropic 模型，跨供应商命中直接透传目录值。
+  const crossProvider = resolveModelLimitsAcrossProviders(modelId);
+  if (crossProvider) return crossProvider;
+
   return getProviderFallbackLimits(providerId);
 }
 
@@ -1125,7 +1133,9 @@ export function normalizeProviderModelConfig(
   };
   // 退化限额（输出吃满窗口）可能来自坏目录数据落库期或手工配置，读侧统一修复；
   // 规则与目录生成期同源（normalizeModelLimits），对所有供应商一视同仁。
-  const limits = normalizeModelLimits(storedLimits);
+  // 跨供应商回查上线前落库的别家模型吃过本供应商兜底值，同样读侧修复，
+  // 不需要用户删除重加（识别与替换规则见 repairStaleCrossProviderLimits）。
+  const limits = repairStaleCrossProviderLimits(providerId, id, normalizeModelLimits(storedLimits));
   return {
     id,
     ...(ownedBy ? { ownedBy } : {}),

--- a/crates/agent-gui/test/models/model-catalog.test.mjs
+++ b/crates/agent-gui/test/models/model-catalog.test.mjs
@@ -11,6 +11,12 @@ const PROVIDERS = ["anthropic", "google", "openai", "xai"];
 const MIN_MODELS_PER_PROVIDER = { anthropic: 8, google: 15, openai: 20, xai: 3 };
 
 test("generated catalog upholds the data invariants", () => {
+  // 跨供应商回查（findCatalogModelAcrossProviders）依赖 id 全目录唯一，
+  // 否则同名模型在不同供应商下会产生歧义命中。
+  const allIds = PROVIDERS.flatMap((providerId) =>
+    catalog.MODEL_CATALOG[providerId].map((entry) => entry.id),
+  );
+  assert.equal(new Set(allIds).size, allIds.length, "ids must be unique across providers");
   for (const providerId of PROVIDERS) {
     const entries = catalog.MODEL_CATALOG[providerId];
     assert.ok(
@@ -81,6 +87,57 @@ test("findCatalogModel resolves exact and decorated ids across providers", () =>
   assert.equal(catalog.findCatalogModel("codex", "model-not-in-catalog"), undefined);
   assert.equal(catalog.findCatalogModel("gemini", ""), undefined);
   assert.equal(catalog.findCatalogModel("gemini", undefined), undefined);
+});
+
+test("cross-provider lookup resolves models configured under a foreign provider", () => {
+  // 中转聚合场景：别家模型挂在本供应商类型下时按 id 全目录回查。
+  assert.equal(catalog.findCatalogModelAcrossProviders("grok-4.5")?.id, "grok-4.5");
+  // 候选链（大小写、@版本、[1m]、日期后缀）对跨供应商回查同样生效。
+  assert.equal(catalog.findCatalogModelAcrossProviders("GROK-4.5@prod")?.id, "grok-4.5");
+  assert.equal(catalog.findCatalogModelAcrossProviders("model-not-in-catalog"), undefined);
+  assert.equal(catalog.findCatalogModelAcrossProviders(""), undefined);
+  assert.equal(catalog.findCatalogModelAcrossProviders(undefined), undefined);
+  assert.deepEqual(catalog.resolveModelLimitsAcrossProviders("grok-4.5"), {
+    contextWindow: 500_000,
+    maxOutputToken: 32_000,
+  });
+  assert.equal(catalog.resolveModelLimitsAcrossProviders("model-not-in-catalog"), undefined);
+});
+
+test("repairStaleCrossProviderLimits replaces only stale provider-fallback pairs", () => {
+  // grok-4.5 挂在 anthropic 类型下、存量恰为 claude_code 兜底对：判为跨供应商
+  // 回查上线前落库的坏默认值，替换为目录真实限额。
+  assert.deepEqual(
+    catalog.repairStaleCrossProviderLimits("claude_code", "grok-4.5", {
+      contextWindow: 200_000,
+      maxOutputToken: 32_000,
+    }),
+    { contextWindow: 500_000, maxOutputToken: 32_000 },
+  );
+  // 任一值偏离兜底对 = 用户显式配置，原样保留。
+  assert.deepEqual(
+    catalog.repairStaleCrossProviderLimits("claude_code", "grok-4.5", {
+      contextWindow: 200_000,
+      maxOutputToken: 31_000,
+    }),
+    { contextWindow: 200_000, maxOutputToken: 31_000 },
+  );
+  // 本供应商目录可命中的模型绝不跨供应商替换（claude-opus-4-1 真实限额恰为兜底对）。
+  assert.deepEqual(
+    catalog.repairStaleCrossProviderLimits("claude_code", "claude-opus-4-1", {
+      contextWindow: 200_000,
+      maxOutputToken: 32_000,
+    }),
+    { contextWindow: 200_000, maxOutputToken: 32_000 },
+  );
+  // 全目录未收录：兜底对本来就是正确默认值，保持不动。
+  assert.deepEqual(
+    catalog.repairStaleCrossProviderLimits("xai", "relay-custom-model", {
+      contextWindow: 258_000,
+      maxOutputToken: 142_000,
+    }),
+    { contextWindow: 258_000, maxOutputToken: 142_000 },
+  );
 });
 
 test("resolveModelLimits returns repaired catalog limits and undefined on miss", () => {

--- a/crates/agent-gui/test/settings/normalization.test.mjs
+++ b/crates/agent-gui/test/settings/normalization.test.mjs
@@ -2401,6 +2401,66 @@ test("degenerate catalog limits (output == context window) are clamped in the sn
   assert.equal(grok43.maxOutputToken, 30_000);
 });
 
+test("cross-provider models resolve real catalog limits instead of provider fallback", () => {
+  // 中转聚合把别家模型挂在本供应商类型下：grok-4.5 配在 anthropic 下也要
+  // 显示真实限额（500K/32K），而不是 claude_code 兜底 200K/32K。
+  const grokUnderAnthropic = settings.getProviderModelDefaults("claude_code", "grok-4.5");
+  assert.equal(grokUnderAnthropic.contextWindow, 500_000);
+  assert.equal(grokUnderAnthropic.maxOutputToken, 32_000);
+  // 反向同理：claude 模型挂在 OpenAI 兼容供应商下读 anthropic 目录。
+  const claudeUnderCodex = settings.getProviderModelDefaults("codex", "claude-opus-4-5");
+  assert.equal(claudeUnderCodex.contextWindow, 200_000);
+  assert.equal(claudeUnderCodex.maxOutputToken, 64_000);
+  const geminiUnderXai = settings.getProviderModelDefaults("xai", "gemini-2.5-pro");
+  assert.equal(geminiUnderXai.contextWindow, 1_048_576);
+  assert.equal(geminiUnderXai.maxOutputToken, 65_536);
+  // 装饰 id 的候选链对跨供应商回查同样生效。
+  assert.equal(
+    settings.getProviderModelDefaults("claude_code", "GROK-4.5@prod").contextWindow,
+    500_000,
+  );
+  // 全目录未收录的模型仍吃本供应商兜底值。
+  assert.equal(
+    settings.getProviderModelDefaults("claude_code", "some-custom-model").contextWindow,
+    200_000,
+  );
+  // Anthropic 形态的未知 id（[1m]/adaptive 启发式）优先级高于跨供应商回查：
+  // [1m] 是用户对部署窗口的显式声明。
+  assert.equal(
+    settings.getProviderModelDefaults("claude_code", "grok-4.5[1m]").contextWindow,
+    1_000_000,
+  );
+});
+
+test("stale fallback limits persisted for cross-provider models are repaired on read", () => {
+  // 跨供应商回查上线前，grok-4.5 挂 anthropic 下会以 200K/32K 兜底对落库：
+  // 读侧识别并替换为目录真实限额，不需要用户删除重加。
+  const repaired = settings.normalizeProviderModelConfig(
+    { id: "grok-4.5", contextWindow: 200_000, maxOutputToken: 32_000 },
+    "claude_code",
+  );
+  assert.equal(repaired.contextWindow, 500_000);
+  assert.equal(repaired.maxOutputToken, 32_000);
+  // 任一值偏离兜底对 = 用户显式配置，原样保留。
+  const custom = settings.normalizeProviderModelConfig(
+    { id: "grok-4.5", contextWindow: 200_000, maxOutputToken: 30_000 },
+    "claude_code",
+  );
+  assert.equal(custom.contextWindow, 200_000);
+  assert.equal(custom.maxOutputToken, 30_000);
+  // 本供应商目录内的模型不受存量修复影响（claude-opus-4-1 真实限额恰为兜底对）。
+  const native = settings.normalizeProviderModelConfig(
+    { id: "claude-opus-4-1", contextWindow: 200_000, maxOutputToken: 32_000 },
+    "claude_code",
+  );
+  assert.equal(native.contextWindow, 200_000);
+  assert.equal(native.maxOutputToken, 32_000);
+  // 新增（无存量限额）直接拿跨供应商默认值。
+  const fresh = settings.normalizeProviderModelConfig("grok-4.5", "claude_code");
+  assert.equal(fresh.contextWindow, 500_000);
+  assert.equal(fresh.maxOutputToken, 32_000);
+});
+
 test("persisted degenerate limits are repaired at normalize time for every provider", () => {
   // 坏目录数据落库期间加入的模型：读侧修复，不需要用户重新添加。
   const repaired = settings.normalizeProviderModelConfig(


### PR DESCRIPTION
## 问题

各供应商原生目录下的模型限额显示正确，但把 A 家模型配置到 B 家供应商类型下（中转聚合的常见用法）时元数据错误。最典型的例子：grok-4.5 在 xai 供应商下显示正确的 500K/32K，配到 Anthropic 兼容供应商下却显示 claude_code 兜底值 200K/32K。

根因：目录查找 `getProviderModelDefaults` 只在本供应商类型对应的目录分区里检索，跨供应商配置必然 miss 并落到本供应商兜底限额。

## 修复

**`lib/models/modelCatalog.ts`（镜像文件，两端字节一致）**
- 新增 `findCatalogModelAcrossProviders` / `resolveModelLimitsAcrossProviders`：按模型 id 跨全部目录分区回查，装饰 id 候选链（大小写、`@版本`、`[1m]`、日期后缀）同样生效；目录 id 全局唯一已由不变量测试锁死，回查无歧义。
- 新增 `repairStaleCrossProviderLimits`：修复本 fix 之前已落库的坏默认值——存量恰等于本供应商兜底对、且模型只在别家目录分区可命中时替换为真实限额；任一值偏离兜底对即视为用户显式配置，原样保留。

**两端 `lib/settings/index.ts`（GUI 与 WebUI 手动同步）**
- `getProviderModelDefaults` 查找顺序：本供应商目录命中 → claude_code 的 `[1m]`/adaptive 启发式 → **跨供应商回查（新增）** → 供应商兜底。启发式优先于回查是刻意的：`[1m]` 后缀是用户对部署窗口的显式声明；Anthropic 的 1M/adaptive 窗口策略只约束目录内的 Anthropic 模型，跨供应商命中直接透传目录值。
- `normalizeProviderModelConfig` 读侧接入存量修复：已存在的错误配置打开设置即自动修正，无需删除重加。

## 行为确认

- grok-4.5 配在 anthropic 下：200K/32K → 500K/32K，与 xai 原生下一致；claude 模型配在 codex/xai 下、gemini 模型配在别家下同理。
- 原生供应商下的模型、全目录未收录的自定义模型、anthropic `[1m]`/adaptive 启发式与窗口钳制：行为全部不变（anthropic-long-context 测试零改动通过）。
- 已知副作用（接受）：grok-4.5 挂 anthropic 中转后窗口默认 500K > 200K，请求会携带 `context-1m` beta 头——与用户手动配置 500K 的既有行为一致。

## 测试

- 新增用例：目录 id 全局唯一不变量、跨供应商回查（含装饰 id 与 miss 路径）、`repairStaleCrossProviderLimits` 四种边界、`getProviderModelDefaults` 三个方向的跨供应商解析与优先级、读侧存量修复。
- GUI `test:frontend` 1222 通过、Web `npm test` 413 通过、两端 `tsc --noEmit` 与 biome 干净、`scripts/check-mirror.mjs` 104 个文件全部一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)