### PR TITLE
fix(providers): route MiMo through chat completions

### DIFF
--- a/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
@@ -297,6 +297,18 @@ function inferCodexApi(requestFormat?: CodexRequestFormat, preferredApi?: CodexA
   return requestFormat ?? preferredApi ?? "openai-responses";
 }
 
+function isMiMoTarget(params: { baseUrl: string; upstreamBaseUrl?: string; modelId: string }) {
+  const modelId = params.modelId.trim().toLowerCase();
+  if (modelId.startsWith("mimo-")) return true;
+
+  try {
+    const baseUrl = new URL(params.upstreamBaseUrl?.trim() || params.baseUrl);
+    return baseUrl.hostname === "api.xiaomimimo.com";
+  } catch {
+    return false;
+  }
+}
+
 export function createModelFromConfig(
   providerId: ProviderId,
   modelId: string,
@@ -330,6 +342,10 @@ export function createModelFromConfig(
         upstreamBaseUrl,
         modelId,
       });
+    // MiMo only exposes its OpenAI-compatible Chat Completions endpoint.
+    const isMiMoCodex =
+      providerId === "codex" &&
+      isMiMoTarget({ baseUrl: normalizedBaseUrl, upstreamBaseUrl, modelId });
     // 正式 xai 供应商，或 Codex 直连 api.x.ai：固定 Responses（agentic 搜索等）。
     const isXaiTarget = isXaiProviderTarget({
       providerId,
@@ -339,7 +355,9 @@ export function createModelFromConfig(
       ? "openai-completions"
       : isXaiTarget
         ? "openai-responses"
-        : inferCodexApi(requestFormat, preferredApi);
+        : isMiMoCodex
+          ? "openai-completions"
+          : inferCodexApi(requestFormat, preferredApi);
     const responsesCompat =
       api === "openai-responses"
         ? resolveCodexOpenAIResponsesCompat({

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -428,6 +428,26 @@ test("custom Codex Chat Completions models infer reasoning-capable IDs", () => {
   assert.equal(model.compat.supportsStore, false);
 });
 
+test("MiMo models force Chat Completions without Responses storage", async () => {
+  const model = providers.createModelFromConfig(
+    "codex",
+    "mimo-v2.5-pro",
+    "https://token-plan-cn.xiaomimimo.com",
+    "openai-responses",
+  );
+
+  assert.equal(model.api, "openai-completions");
+  assert.equal(model.compat.supportsStore, false);
+
+  const options = providers.finalizeProviderStreamOptions({
+    providerId: "codex",
+    baseUrl: "https://token-plan-cn.xiaomimimo.com",
+    options: {},
+  });
+  const payload = await options.onPayload({ model: model.id, messages: [] }, model);
+  assert.equal(Object.hasOwn(payload, "store"), false);
+});
+
 test("custom Codex Chat Completions models behind proxy use upstream compat detection", () => {
   const model = providers.createModelFromConfig(
     "codex",


### PR DESCRIPTION
## 问题

MiMo 官方仅提供 OpenAI Chat Completions 接口，但 Codex 类型供应商默认使用 Responses API。即使用户配置的是 MiMo Token Plan，运行时仍会注入 `store: true`，被本地网关拒绝。

## 修复

- 识别 `mimo-*` 模型及 MiMo 官方 API 目标。
- 无论存量配置是否保存为 `openai-responses`，运行时统一切换到 `openai-completions`。
- 非 MiMo 模型和现有 OpenAI Responses 行为保持不变。

## 测试

- 新增 Token Plan Base URL + `openai-responses` 存量配置回归测试。
- GUI 前端测试 1223 项全部通过。
- GUI 生产构建通过。
- Biome lint 通过（仅存量 warning）。
- macOS 应用实测 MiMo 请求成功。