### PR TITLE
feat(chat): add resizable transcript width

### DIFF
--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -4677,9 +4677,7 @@ export default function GatewayApp() {
                             : "调整对话正文宽度"
                         }
                         resetLabel={
-                          settings.locale === "en-US"
-                            ? "Double-click to reset"
-                            : "双击恢复默认宽度"
+                          settings.locale === "en-US" ? "Double-click to reset" : "双击恢复默认宽度"
                         }
                       />
                       {displayedTranscriptRowCount > 0 && !conversationOpenState.showOverlay ? (

--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -89,6 +89,7 @@ import {
   type SelectedModel,
   setSelectedModel,
   updateChatRuntimeControlsForProvider,
+  updateChatTranscriptWidth,
   updateCustomSettings,
   updateRightDockFileTreeState,
   updateRightDockProjectState,
@@ -147,6 +148,10 @@ import {
 } from "@/lib/sidebar/webSidebarBackend";
 import { findWorkspaceProject, mergeWorkspaceProjectsWithHistory } from "@/lib/workspaceProjects";
 import { FloorNavRail } from "@/pages/chat/transcript/FloorNavRail";
+import {
+  CHAT_TRANSCRIPT_WIDTH_CSS_VAR,
+  TranscriptWidthControls,
+} from "@/pages/chat/transcript/TranscriptWidthControls";
 import { WorkspaceCloneModal } from "@/pages/chat/WorkspaceCloneModal";
 import {
   type WorkspaceCloneTask,
@@ -341,6 +346,7 @@ export default function GatewayApp() {
     null,
   );
   const [transcriptViewport, setTranscriptViewport] = useState<HTMLDivElement | null>(null);
+  const transcriptStageRef = useRef<HTMLElement | null>(null);
   const { handle: transcriptFollow, following: transcriptFollowing } = useScrollFollow({
     viewport: transcriptViewport,
     listenerRoot: transcriptScrollAreaRoot,
@@ -4043,6 +4049,12 @@ export default function GatewayApp() {
   );
   // RightDockPanel is memo'd: every callback handed to it must be stable or
   // the memo boundary is void (see the panel-side context useMemo).
+  const handleChatTranscriptWidthChange = useCallback(
+    (nextWidth: number) => {
+      setSettings((prev) => updateChatTranscriptWidth(prev, nextWidth));
+    },
+    [setSettings],
+  );
   const handleRightDockWidthChange = useCallback(
     (nextWidth: number) => {
       setSettings((prev) => updateRightDockWidth(prev, nextWidth));
@@ -4602,7 +4614,15 @@ export default function GatewayApp() {
                     <div className="gateway-banner-error">{chatError}</div>
                   ) : null}
 
-                  <section className="gateway-transcript-stage">
+                  <section
+                    ref={transcriptStageRef}
+                    className="gateway-transcript-stage"
+                    style={
+                      {
+                        [CHAT_TRANSCRIPT_WIDTH_CSS_VAR]: `${settings.customSettings.chatTranscript.width}px`,
+                      } as CSSProperties
+                    }
+                  >
                     <div className="gateway-transcript-scroll-shell">
                       <ScrollArea
                         ref={setTranscriptScrollAreaRoot}
@@ -4615,6 +4635,7 @@ export default function GatewayApp() {
                             rows={transcriptRows}
                             liveStartIndex={transcriptLiveStartIndex}
                             activeTurnKey={displayedTranscript.activeTurnKey}
+                            contentWidth={settings.customSettings.chatTranscript.width}
                             isViewportFollowing={transcriptFollow.isFollowing}
                             navRef={transcriptNavRef}
                             onAnchorUserRowChange={setActiveFloorKey}
@@ -4646,6 +4667,21 @@ export default function GatewayApp() {
                           />
                         </ChangedFilesActionsProvider>
                       </ScrollArea>
+                      <TranscriptWidthControls
+                        hostRef={transcriptStageRef}
+                        width={settings.customSettings.chatTranscript.width}
+                        onWidthChange={handleChatTranscriptWidthChange}
+                        resizeLabel={
+                          settings.locale === "en-US"
+                            ? "Resize conversation content"
+                            : "调整对话正文宽度"
+                        }
+                        resetLabel={
+                          settings.locale === "en-US"
+                            ? "Double-click to reset"
+                            : "双击恢复默认宽度"
+                        }
+                      />
                       {displayedTranscriptRowCount > 0 && !conversationOpenState.showOverlay ? (
                         <FloorNavRail
                           conversationId={displayedConversationId}

--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -4617,6 +4617,10 @@ export default function GatewayApp() {
                   <section
                     ref={transcriptStageRef}
                     className="gateway-transcript-stage"
+                    // Preferred (persisted) width, so a fresh mount paints at
+                    // the user's width instead of the default.
+                    // TranscriptWidthControls narrows this same variable to
+                    // the stage in a layout effect — see its header.
                     style={
                       {
                         [CHAT_TRANSCRIPT_WIDTH_CSS_VAR]: `${settings.customSettings.chatTranscript.width}px`,

--- a/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
+++ b/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
@@ -39,7 +39,10 @@ import { DEFAULT_CHAT_TRANSCRIPT_WIDTH } from "@/lib/settings";
 import { cn } from "@/lib/shared/utils";
 import { extractLiveRange } from "@/lib/transcript-virtual/liveRangeExtractor";
 import { createLiveRowScrollAdjustPolicy } from "@/lib/transcript-virtual/liveScrollAdjustPolicy";
-import { createTranscriptMeasurementsLru } from "@/lib/transcript-virtual/measurementsLru";
+import {
+  buildTranscriptLayoutKey,
+  createTranscriptMeasurementsLru,
+} from "@/lib/transcript-virtual/measurementsLru";
 import {
   CHECKPOINT_ROW_ESTIMATE_PX,
   estimateAssistantRowHeight,
@@ -1324,7 +1327,7 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
       (conversationId && scrollViewport
         ? transcriptMeasurementsLru.restore(
             conversationId,
-            `${scrollViewport.clientWidth}:${contentWidth}`,
+            buildTranscriptLayoutKey(scrollViewport.clientWidth, contentWidth),
           )
         : null) ?? [],
   );
@@ -1515,7 +1518,7 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
     if (!conversationId || !scrollViewport) return;
     transcriptMeasurementsLru.save(
       conversationId,
-      `${scrollViewport.clientWidth}:${contentWidth}`,
+      buildTranscriptLayoutKey(scrollViewport.clientWidth, contentWidth),
       transcriptVirtualizer.takeSnapshot(),
     );
   };

--- a/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
+++ b/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
@@ -35,6 +35,7 @@ import {
   UserMessageContent,
 } from "@/lib/chat/userMessageContent";
 import type { GitClient } from "@/lib/git/types";
+import { DEFAULT_CHAT_TRANSCRIPT_WIDTH } from "@/lib/settings";
 import { cn } from "@/lib/shared/utils";
 import { extractLiveRange } from "@/lib/transcript-virtual/liveRangeExtractor";
 import { createLiveRowScrollAdjustPolicy } from "@/lib/transcript-virtual/liveScrollAdjustPolicy";
@@ -83,6 +84,7 @@ type GatewayTranscriptProps = {
   liveStartIndex?: number;
   // Key of the actively streaming turn (caret / live structural state).
   activeTurnKey?: string | null;
+  contentWidth?: number;
   // Whether the scroll-follow engine is attached to the bottom; gates the
   // virtualizer's resize-compensation carve-out for live-row growth.
   isViewportFollowing?: () => boolean;
@@ -1160,6 +1162,7 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
   rows: readonly TranscriptRow[];
   liveStartIndex: number;
   activeTurnKey?: string | null;
+  contentWidth: number;
   scrollViewport: HTMLDivElement | null;
   isViewportFollowing?: () => boolean;
   navRef?: MutableRefObject<GatewayTranscriptNavHandle | null>;
@@ -1192,6 +1195,7 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
     rows,
     liveStartIndex,
     activeTurnKey,
+    contentWidth,
     scrollViewport,
     isViewportFollowing,
     navRef,
@@ -1318,7 +1322,10 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
   const [initialMeasurementsCache] = useState(
     () =>
       (conversationId && scrollViewport
-        ? transcriptMeasurementsLru.restore(conversationId, scrollViewport.clientWidth)
+        ? transcriptMeasurementsLru.restore(
+            conversationId,
+            `${scrollViewport.clientWidth}:${contentWidth}`,
+          )
         : null) ?? [],
   );
 
@@ -1357,6 +1364,12 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
       getLiveStartIndex: () => forceMountStartRef.current,
       isFollowing: () => isViewportFollowing?.() ?? false,
     });
+
+  // Every mounted row is already tracked by the virtualizer's ResizeObserver,
+  // which updates its measured height as the centered transcript reflows.
+  // Do not call measure() on width commits: it clears those fresh measurements
+  // after the DOM has already resized, so estimate-based row positions can
+  // overlap without another resize event to repopulate the cache.
 
   // 楼层跳转：scrollToIndex(align:"start") 后连续几帧重对齐——目标行远处的
   // 估高行在滚动后被真实测量，落点会漂移；对准同一 index 是收敛操作，不会
@@ -1502,7 +1515,7 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
     if (!conversationId || !scrollViewport) return;
     transcriptMeasurementsLru.save(
       conversationId,
-      scrollViewport.clientWidth,
+      `${scrollViewport.clientWidth}:${contentWidth}`,
       transcriptVirtualizer.takeSnapshot(),
     );
   };
@@ -1717,6 +1730,7 @@ export function GatewayTranscript({
   rows,
   liveStartIndex = -1,
   activeTurnKey = null,
+  contentWidth = DEFAULT_CHAT_TRANSCRIPT_WIDTH,
   isViewportFollowing,
   navRef,
   onAnchorUserRowChange,
@@ -1802,6 +1816,7 @@ export function GatewayTranscript({
           rows={rows}
           liveStartIndex={liveStartIndex}
           activeTurnKey={activeTurnKey}
+          contentWidth={contentWidth}
           scrollViewport={transcriptScrollViewport}
           isViewportFollowing={isViewportFollowing}
           navRef={navRef}

--- a/crates/agent-gateway/web/src/lib/chat-scroll/scrollFollowCore.ts
+++ b/crates/agent-gateway/web/src/lib/chat-scroll/scrollFollowCore.ts
@@ -60,6 +60,13 @@ export const DIRECTION_SLOP_PX = 1;
 // can never read as "dragged away from the bottom".
 export const POINTER_DRAG_SLOP_PX = 4;
 
+// Elements carrying this attribute keep their arrow/Home/End keys to
+// themselves: the transcript width handles resize on those keys, which must
+// not also read as a scroll intent and detach bottom-follow. useScrollFollow
+// builds its selector from this constant, so widget code and the follow engine
+// cannot drift onto different attribute names.
+export const SCROLL_FOLLOW_IGNORE_KEYS_ATTRIBUTE = "data-scroll-follow-ignore-keys";
+
 // Attach-side gesture latch. Armed only by toward-bottom wheel/touch/key input
 // and extended by chained downward scroll events (touchscreen momentum carries
 // no input events); it can extend an active latch but never create one.

--- a/crates/agent-gateway/web/src/lib/chat-scroll/useScrollFollow.ts
+++ b/crates/agent-gateway/web/src/lib/chat-scroll/useScrollFollow.ts
@@ -15,7 +15,7 @@ import {
 // not change follow state, and nested elements under it don't consume wheels.
 const SCROLLABLE_OVERFLOW_MIN_PX = 4;
 
-function isEditableEventTarget(target: EventTarget | null) {
+function shouldIgnoreScrollKeyTarget(target: EventTarget | null) {
   if (!(target instanceof HTMLElement)) {
     return false;
   }
@@ -23,12 +23,13 @@ function isEditableEventTarget(target: EventTarget | null) {
     target.isContentEditable ||
     target instanceof HTMLInputElement ||
     target instanceof HTMLTextAreaElement ||
-    target instanceof HTMLSelectElement
+    target instanceof HTMLSelectElement ||
+    target.closest("[data-scroll-follow-ignore-keys]") !== null
   );
 }
 
 function isHistoryScrollKey(event: KeyboardEvent) {
-  if (isEditableEventTarget(event.target)) {
+  if (shouldIgnoreScrollKeyTarget(event.target)) {
     return false;
   }
   return (
@@ -40,7 +41,7 @@ function isHistoryScrollKey(event: KeyboardEvent) {
 }
 
 function isFollowScrollKey(event: KeyboardEvent) {
-  if (isEditableEventTarget(event.target)) {
+  if (shouldIgnoreScrollKeyTarget(event.target)) {
     return false;
   }
   return (

--- a/crates/agent-gateway/web/src/lib/chat-scroll/useScrollFollow.ts
+++ b/crates/agent-gateway/web/src/lib/chat-scroll/useScrollFollow.ts
@@ -9,6 +9,7 @@ import {
   isDominantVerticalWheel,
   POINTER_DRAG_SLOP_PX,
   reduceFollowEvent,
+  SCROLL_FOLLOW_IGNORE_KEYS_ATTRIBUTE,
 } from "./scrollFollowCore";
 
 // Below this the element cannot meaningfully scroll; wheel/touch on it must
@@ -24,7 +25,7 @@ function shouldIgnoreScrollKeyTarget(target: EventTarget | null) {
     target instanceof HTMLInputElement ||
     target instanceof HTMLTextAreaElement ||
     target instanceof HTMLSelectElement ||
-    target.closest("[data-scroll-follow-ignore-keys]") !== null
+    target.closest(`[${SCROLL_FOLLOW_IGNORE_KEYS_ATTRIBUTE}]`) !== null
   );
 }
 

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -15,6 +15,11 @@ import {
 import { createUuid } from "../shared/id";
 import { mergeAlwaysEnabledSkillNames } from "../skills/builtin";
 import { SYSTEM_TOOL_OPTIONS, type SystemToolId } from "../tools/systemToolOptions";
+import {
+  DEFAULT_CHAT_TRANSCRIPT_WIDTH,
+  MAX_CHAT_TRANSCRIPT_WIDTH,
+  MIN_CHAT_TRANSCRIPT_WIDTH,
+} from "../transcript-width/transcriptWidthModel";
 import { normalizeApiKey, normalizeBaseUrl, normalizeModels } from "./normalize";
 
 export { normalizeFontFamily } from "../fontFamily";
@@ -134,9 +139,9 @@ export type FontScaleSettings = {
   rightDock: number;
 };
 
-export const DEFAULT_CHAT_TRANSCRIPT_WIDTH = 768;
-export const MIN_CHAT_TRANSCRIPT_WIDTH = 560;
-export const MAX_CHAT_TRANSCRIPT_WIDTH = 1200;
+// Bounds live with the geometry that enforces them; re-exported here so
+// settings consumers keep a single import site.
+export { DEFAULT_CHAT_TRANSCRIPT_WIDTH, MAX_CHAT_TRANSCRIPT_WIDTH, MIN_CHAT_TRANSCRIPT_WIDTH };
 
 export type ChatTranscriptSettings = {
   width: number;

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -134,9 +134,18 @@ export type FontScaleSettings = {
   rightDock: number;
 };
 
+export const DEFAULT_CHAT_TRANSCRIPT_WIDTH = 768;
+export const MIN_CHAT_TRANSCRIPT_WIDTH = 560;
+export const MAX_CHAT_TRANSCRIPT_WIDTH = 1200;
+
+export type ChatTranscriptSettings = {
+  width: number;
+};
+
 export type CustomSettings = {
   conversationTitleModel?: SelectedModel;
   chatSidebar: ChatSidebarSettings;
+  chatTranscript: ChatTranscriptSettings;
   rightDock: RightDockSettings;
   // Empty strings select the built-in font stacks for their respective UI zones.
   interfaceFontFamily: string;
@@ -2134,6 +2143,18 @@ export function normalizeFontScaleSettings(input: unknown): FontScaleSettings {
   };
 }
 
+export function normalizeChatTranscriptSettings(input: unknown): ChatTranscriptSettings {
+  const obj = (input && typeof input === "object" ? input : {}) as Record<string, unknown>;
+  return {
+    width: normalizeIntegerInRange(
+      obj.width,
+      MIN_CHAT_TRANSCRIPT_WIDTH,
+      MAX_CHAT_TRANSCRIPT_WIDTH,
+      DEFAULT_CHAT_TRANSCRIPT_WIDTH,
+    ),
+  };
+}
+
 export function normalizeCustomSettings(
   input: unknown,
   customProviders: CustomProvider[],
@@ -2151,6 +2172,7 @@ export function normalizeCustomSettings(
       projectsCollapsed: chatSidebar.projectsCollapsed === true,
       recentCollapsed: chatSidebar.recentCollapsed === true,
     },
+    chatTranscript: normalizeChatTranscriptSettings(obj.chatTranscript),
     rightDock: normalizeRightDockSettings(obj.rightDock),
     // Read the retired field only to migrate persisted settings; normalization never emits it.
     interfaceFontFamily: normalizeFontFamily(
@@ -2450,6 +2472,12 @@ export function getRightDockProjectState(
   return normalizeRightDockProjectState(
     normalizedPathKey ? customSettings.rightDock.projects[normalizedPathKey] : {},
   );
+}
+
+export function updateChatTranscriptWidth(prev: AppSettings, width: number): AppSettings {
+  const nextWidth = normalizeChatTranscriptSettings({ width }).width;
+  if (prev.customSettings.chatTranscript.width === nextWidth) return prev;
+  return updateCustomSettings(prev, { chatTranscript: { width: nextWidth } });
 }
 
 export function updateRightDockWidth(prev: AppSettings, width: number): AppSettings {

--- a/crates/agent-gateway/web/src/lib/settings/sync.ts
+++ b/crates/agent-gateway/web/src/lib/settings/sync.ts
@@ -1,5 +1,6 @@
 import {
   type AppSettings,
+  DEFAULT_CHAT_TRANSCRIPT_WIDTH,
   getDefaultSystemProxyConfig,
   normalizeChatRuntimeControls,
   normalizeRightDockSettings,
@@ -350,10 +351,12 @@ function syncableCustomSettings(
       projectsCollapsed: false,
       recentCollapsed: false,
     },
-    // Typography is a local UI preference; keep its synced shape stable so visual changes do not broadcast.
+    // Typography, scale, and transcript width are local UI preferences; fixed
+    // defaults prevent visual preferences from being broadcast through the gateway.
     interfaceFontFamily: "",
     chatFontFamily: "",
     codeFontFamily: "",
+    chatTranscript: { width: DEFAULT_CHAT_TRANSCRIPT_WIDTH },
     fontScale: { sidebar: 1, chat: 1, rightDock: 1 },
   };
 }
@@ -996,10 +999,11 @@ export function applyGatewaySettingsSyncPayload(
           )
         : current.customSettings.rightDock,
       chatSidebar: current.customSettings.chatSidebar,
-      // Typography and font scale are local UI preferences and never accept gateway values.
+      // Typography, scale, and transcript width are local UI preferences, never gateway-synced.
       interfaceFontFamily: current.customSettings.interfaceFontFamily,
       chatFontFamily: current.customSettings.chatFontFamily,
       codeFontFamily: current.customSettings.codeFontFamily,
+      chatTranscript: current.customSettings.chatTranscript,
       fontScale: current.customSettings.fontScale,
     },
     skills: (source.skills as AppSettings["skills"] | undefined) ?? current.skills,

--- a/crates/agent-gateway/web/src/lib/transcript-virtual/measurementsLru.ts
+++ b/crates/agent-gateway/web/src/lib/transcript-virtual/measurementsLru.ts
@@ -13,6 +13,16 @@ export type TranscriptMeasurementsLru = {
   restore: (conversationId: string, layoutKey: string) => VirtualItem[] | null;
 };
 
+// The composite key both callers must use. Owning the shape here keeps the two
+// frontends from drifting, and returning "" for an unmeasured viewport or
+// column re-establishes the guard the plain-number key used to carry: save()
+// and restore() both reject blank keys, so a zero-width layout is never stored.
+export function buildTranscriptLayoutKey(viewportWidth: number, contentWidth: number): string {
+  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return "";
+  if (!Number.isFinite(contentWidth) || contentWidth <= 0) return "";
+  return `${Math.round(viewportWidth)}:${Math.round(contentWidth)}`;
+}
+
 const DEFAULT_CAPACITY = 12;
 
 export function createTranscriptMeasurementsLru(

--- a/crates/agent-gateway/web/src/lib/transcript-virtual/measurementsLru.ts
+++ b/crates/agent-gateway/web/src/lib/transcript-virtual/measurementsLru.ts
@@ -4,13 +4,13 @@ import type { VirtualItem } from "@tanstack/react-virtual";
 // taken on unmount (virtualizer.takeSnapshot()) and fed back through
 // initialMeasurementsCache when the conversation reopens — switching back to
 // a conversation then lays out with exact row heights instead of estimates.
-// In-memory only and width-gated: measured heights depend on the viewport
-// width (and zoom/font scale, which width changes track in practice), so a
-// snapshot is only restored at the width it was taken and never persisted.
+// In-memory only and layout-gated: measured heights depend on both the scroll
+// viewport and the centered transcript width, so callers provide a composite
+// layout key. Snapshots are never persisted.
 
 export type TranscriptMeasurementsLru = {
-  save: (conversationId: string, viewportWidth: number, measurements: VirtualItem[]) => void;
-  restore: (conversationId: string, viewportWidth: number) => VirtualItem[] | null;
+  save: (conversationId: string, layoutKey: string, measurements: VirtualItem[]) => void;
+  restore: (conversationId: string, layoutKey: string) => VirtualItem[] | null;
 };
 
 const DEFAULT_CAPACITY = 12;
@@ -18,24 +18,24 @@ const DEFAULT_CAPACITY = 12;
 export function createTranscriptMeasurementsLru(
   capacity = DEFAULT_CAPACITY,
 ): TranscriptMeasurementsLru {
-  const entries = new Map<string, { viewportWidth: number; measurements: VirtualItem[] }>();
+  const entries = new Map<string, { layoutKey: string; measurements: VirtualItem[] }>();
 
   return {
-    save: (conversationId, viewportWidth, measurements) => {
-      if (!conversationId || viewportWidth <= 0 || measurements.length === 0) {
+    save: (conversationId, layoutKey, measurements) => {
+      if (!conversationId || !layoutKey || measurements.length === 0) {
         return;
       }
       entries.delete(conversationId);
-      entries.set(conversationId, { viewportWidth, measurements });
+      entries.set(conversationId, { layoutKey, measurements });
       while (entries.size > capacity) {
         const oldest = entries.keys().next().value;
         if (oldest === undefined) break;
         entries.delete(oldest);
       }
     },
-    restore: (conversationId, viewportWidth) => {
+    restore: (conversationId, layoutKey) => {
       const hit = entries.get(conversationId);
-      if (!hit || hit.viewportWidth !== viewportWidth) {
+      if (!hit || hit.layoutKey !== layoutKey) {
         return null;
       }
       entries.delete(conversationId);

--- a/crates/agent-gateway/web/src/lib/transcript-width/transcriptWidthModel.ts
+++ b/crates/agent-gateway/web/src/lib/transcript-width/transcriptWidthModel.ts
@@ -1,0 +1,88 @@
+// Geometry for the resizable transcript column, kept free of React and DOM
+// imports: the component owns the CSS variable and the event wiring, this
+// module owns the arithmetic. Being a dependency-free leaf also lets both
+// frontends' test loaders exercise it directly.
+
+// Persisted preference bounds. A stored width outside these is normalized in.
+export const DEFAULT_CHAT_TRANSCRIPT_WIDTH = 768;
+export const MIN_CHAT_TRANSCRIPT_WIDTH = 560;
+export const MAX_CHAT_TRANSCRIPT_WIDTH = 1200;
+
+// Space kept between the column and the stage edges so the drag handles never
+// sit flush against the window frame.
+export const TRANSCRIPT_HORIZONTAL_SAFE_SPACE = 64;
+
+// Keyboard steps on the focusable handle; Shift picks the coarse one.
+export const TRANSCRIPT_WIDTH_KEY_STEP = 16;
+export const TRANSCRIPT_WIDTH_KEY_COARSE_STEP = 64;
+
+// The handles are a pointer affordance: below this stage width the column
+// already fills the available space, and a coarse pointer cannot hit a 12px
+// target. Mirrors the media query that hides `.transcript-width-controls`, so
+// the two gates cannot drift apart.
+export const TRANSCRIPT_WIDTH_CONTROLS_HIDDEN_MEDIA_QUERY = "(max-width: 820px), (pointer: coarse)";
+
+export type TranscriptResizeSide = "left" | "right";
+
+// Rounds to whole pixels and clamps to the persisted preference bounds.
+export function normalizePreferredWidth(width: number): number {
+  if (!Number.isFinite(width)) return DEFAULT_CHAT_TRANSCRIPT_WIDTH;
+  return Math.min(
+    MAX_CHAT_TRANSCRIPT_WIDTH,
+    Math.max(MIN_CHAT_TRANSCRIPT_WIDTH, Math.round(width)),
+  );
+}
+
+// The width actually rendered: the preference, further clamped by how much
+// room the stage has right now. Narrowing the window shrinks what is rendered
+// and never rewrites the stored preference, so widening restores it.
+export function clampWidthToStage(width: number, maxWidth: number): number {
+  return Math.min(maxWidth, normalizePreferredWidth(width));
+}
+
+// Largest column the stage can host. A missing or non-positive host width
+// means the stage has not been measured yet — the first ResizeObserver
+// delivery corrects it, so fall back to the upper bound rather than guessing
+// from the window, which would also count the sidebar and the right dock.
+export function resolveStageMaxWidth(hostWidth: number | null | undefined): number {
+  if (hostWidth == null || !Number.isFinite(hostWidth) || hostWidth <= 0) {
+    return MAX_CHAT_TRANSCRIPT_WIDTH;
+  }
+  return Math.max(
+    MIN_CHAT_TRANSCRIPT_WIDTH,
+    Math.min(MAX_CHAT_TRANSCRIPT_WIDTH, Math.floor(hostWidth - TRANSCRIPT_HORIZONTAL_SAFE_SPACE)),
+  );
+}
+
+// Handles are only worth showing while the stage can host more than the
+// minimum — otherwise every drag would be a no-op.
+export function areWidthControlsUsable(maxWidth: number): boolean {
+  return maxWidth > MIN_CHAT_TRANSCRIPT_WIDTH;
+}
+
+// Width for a drag of `deltaX` on `side`. The column is centered, so moving
+// one edge by d changes the width by 2d — that is what keeps the handle
+// under the pointer.
+export function resolveDragWidth(
+  startWidth: number,
+  deltaX: number,
+  side: TranscriptResizeSide,
+): number {
+  return startWidth + (side === "right" ? deltaX * 2 : -deltaX * 2);
+}
+
+// Next width for a key press, or null when the key is not a resize key.
+// Steps from the *rendered* width rather than the stored preference: while a
+// narrow stage clamps a wider preference, stepping from the preference would
+// take many presses before anything moved on screen.
+export function resolveKeyboardWidth(
+  key: string,
+  effectiveWidth: number,
+  coarseStep: boolean,
+): number | null {
+  if (key === "Home") return DEFAULT_CHAT_TRANSCRIPT_WIDTH;
+  const step = coarseStep ? TRANSCRIPT_WIDTH_KEY_COARSE_STEP : TRANSCRIPT_WIDTH_KEY_STEP;
+  if (key === "ArrowLeft") return effectiveWidth - step;
+  if (key === "ArrowRight") return effectiveWidth + step;
+  return null;
+}

--- a/crates/agent-gateway/web/src/pages/chat/transcript/TranscriptWidthControls.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/transcript/TranscriptWidthControls.tsx
@@ -4,20 +4,35 @@ import {
   type RefObject,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 
-import {
-  DEFAULT_CHAT_TRANSCRIPT_WIDTH,
-  MAX_CHAT_TRANSCRIPT_WIDTH,
-  MIN_CHAT_TRANSCRIPT_WIDTH,
-} from "../../../lib/settings";
 import { cn } from "../../../lib/shared/utils";
+import {
+  areWidthControlsUsable,
+  clampWidthToStage,
+  DEFAULT_CHAT_TRANSCRIPT_WIDTH,
+  MIN_CHAT_TRANSCRIPT_WIDTH,
+  normalizePreferredWidth,
+  resolveDragWidth,
+  resolveKeyboardWidth,
+  resolveStageMaxWidth,
+  TRANSCRIPT_HORIZONTAL_SAFE_SPACE,
+  TRANSCRIPT_WIDTH_CONTROLS_HIDDEN_MEDIA_QUERY,
+  type TranscriptResizeSide,
+} from "../../../lib/transcript-width/transcriptWidthModel";
 
 export const CHAT_TRANSCRIPT_WIDTH_CSS_VAR = "--chat-transcript-content-width";
 
-const TRANSCRIPT_HORIZONTAL_SAFE_SPACE = 64;
+// Who writes CHAT_TRANSCRIPT_WIDTH_CSS_VAR: the host element's own inline
+// style carries the *preferred* (persisted) width, so a fresh mount already
+// paints at the user's width. This component then narrows that to what the
+// stage can host — from a layout effect, before paint. A passive effect lands
+// after paint and would flash the unclamped width for a frame whenever a
+// commit has to be clamped.
 
 type TranscriptWidthControlsProps = {
   hostRef: RefObject<HTMLElement | null>;
@@ -27,26 +42,22 @@ type TranscriptWidthControlsProps = {
   resetLabel: string;
 };
 
-type ResizeSide = "left" | "right";
-
-function normalizePreferredWidth(width: number) {
-  return Math.min(
-    MAX_CHAT_TRANSCRIPT_WIDTH,
-    Math.max(MIN_CHAT_TRANSCRIPT_WIDTH, Math.round(width)),
-  );
+function subscribeControlsHidden(onChange: () => void) {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+  const query = window.matchMedia(TRANSCRIPT_WIDTH_CONTROLS_HIDDEN_MEDIA_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
 }
 
-function clampWidth(width: number, maxWidth: number) {
-  return Math.min(maxWidth, normalizePreferredWidth(width));
+function readControlsHidden() {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia(TRANSCRIPT_WIDTH_CONTROLS_HIDDEN_MEDIA_QUERY).matches;
 }
 
-function getMaxWidth(host: HTMLElement | null) {
-  const hostWidth = host?.getBoundingClientRect().width ?? globalThis.innerWidth ?? 0;
-  if (!Number.isFinite(hostWidth) || hostWidth <= 0) return MAX_CHAT_TRANSCRIPT_WIDTH;
-  return Math.max(
-    MIN_CHAT_TRANSCRIPT_WIDTH,
-    Math.min(MAX_CHAT_TRANSCRIPT_WIDTH, Math.floor(hostWidth - TRANSCRIPT_HORIZONTAL_SAFE_SPACE)),
-  );
+function measureStageMaxWidth(host: HTMLElement | null) {
+  return resolveStageMaxWidth(host?.getBoundingClientRect().width ?? null);
 }
 
 function applyWidth(host: HTMLElement | null, width: number) {
@@ -55,28 +66,41 @@ function applyWidth(host: HTMLElement | null, width: number) {
 
 export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
   const { hostRef, width, onWidthChange, resizeLabel, resetLabel } = props;
-  const [maxWidth, setMaxWidth] = useState(MAX_CHAT_TRANSCRIPT_WIDTH);
+  const [maxWidth, setMaxWidth] = useState(() => resolveStageMaxWidth(null));
   const [resizingWidth, setResizingWidth] = useState<number | null>(null);
   const pendingWidthRef = useRef(width);
   const resizingRef = useRef(false);
   const resizeFrameRef = useRef<number | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
-  const effectiveWidth = clampWidth(resizingWidth ?? width, maxWidth);
+  // Read by the stage observer, which must outlive individual width commits.
+  const widthRef = useRef(width);
+  widthRef.current = width;
+  const effectiveWidth = clampWidthToStage(resizingWidth ?? width, maxWidth);
+  // Same gate as the CSS that hides the handles, so a coarse pointer neither
+  // renders them nor pays for their listeners.
+  const controlsHidden = useSyncExternalStore(
+    subscribeControlsHidden,
+    readControlsHidden,
+    () => true,
+  );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    // Mid-drag the pointer owns the variable; that drag's commit reconciles it.
     if (resizingWidth !== null) return;
-    applyWidth(hostRef.current, clampWidth(width, maxWidth));
+    applyWidth(hostRef.current, clampWidthToStage(width, maxWidth));
   }, [hostRef, maxWidth, resizingWidth, width]);
 
+  // Keyed off the host alone on purpose: re-arming the observer on every width
+  // commit would tear it down and rebuild it mid-interaction for nothing.
   useEffect(() => {
     const host = hostRef.current;
     let frameId = 0;
     const updateMaxWidth = () => {
       frameId = 0;
-      const nextMaxWidth = getMaxWidth(host);
+      const nextMaxWidth = measureStageMaxWidth(host);
       setMaxWidth(nextMaxWidth);
       if (!resizingRef.current) {
-        applyWidth(host, clampWidth(width, nextMaxWidth));
+        applyWidth(host, clampWidthToStage(widthRef.current, nextMaxWidth));
       }
     };
     const scheduleUpdate = () => {
@@ -93,7 +117,7 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
       if (frameId !== 0) cancelAnimationFrame(frameId);
       observer?.disconnect();
     };
-  }, [hostRef, width]);
+  }, [hostRef]);
 
   useEffect(
     () => () => {
@@ -106,7 +130,10 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
   const commitWidth = useCallback(
     (nextWidth: number) => {
       const preferredWidth = normalizePreferredWidth(nextWidth);
-      const effectiveNextWidth = clampWidth(preferredWidth, getMaxWidth(hostRef.current));
+      const effectiveNextWidth = clampWidthToStage(
+        preferredWidth,
+        measureStageMaxWidth(hostRef.current),
+      );
       applyWidth(hostRef.current, effectiveNextWidth);
       pendingWidthRef.current = effectiveNextWidth;
       setResizingWidth(null);
@@ -116,16 +143,16 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
   );
 
   const handleResizeStart = useCallback(
-    (side: ResizeSide, event: ReactPointerEvent<HTMLButtonElement>) => {
+    (side: TranscriptResizeSide, event: ReactPointerEvent<HTMLButtonElement>) => {
       if (event.button !== 0 || event.pointerType === "touch") return;
       event.preventDefault();
       event.stopPropagation();
       cleanupRef.current?.();
 
       const host = hostRef.current;
-      const dragMaxWidth = getMaxWidth(host);
+      const dragMaxWidth = measureStageMaxWidth(host);
       const startX = event.clientX;
-      const startWidth = clampWidth(width, dragMaxWidth);
+      const startWidth = clampWidthToStage(width, dragMaxWidth);
       const previousCursor = document.body.style.cursor;
       const previousUserSelect = document.body.style.userSelect;
       pendingWidthRef.current = startWidth;
@@ -137,7 +164,7 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
       document.body.style.userSelect = "none";
 
       const scheduleWidth = (nextWidth: number) => {
-        pendingWidthRef.current = clampWidth(nextWidth, dragMaxWidth);
+        pendingWidthRef.current = clampWidthToStage(nextWidth, dragMaxWidth);
         if (resizeFrameRef.current !== null) return;
         resizeFrameRef.current = requestAnimationFrame(() => {
           resizeFrameRef.current = null;
@@ -163,8 +190,7 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
       };
 
       const handleMove = (moveEvent: PointerEvent) => {
-        const delta = moveEvent.clientX - startX;
-        scheduleWidth(startWidth + (side === "right" ? delta * 2 : -delta * 2));
+        scheduleWidth(resolveDragWidth(startWidth, moveEvent.clientX - startX, side));
       };
 
       const handleEnd = () => {
@@ -183,54 +209,63 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLButtonElement>) => {
-      const step = event.shiftKey ? 64 : 16;
-      let nextWidth: number | null = null;
-      if (event.key === "ArrowLeft") nextWidth = width - step;
-      if (event.key === "ArrowRight") nextWidth = width + step;
-      if (event.key === "Home") nextWidth = DEFAULT_CHAT_TRANSCRIPT_WIDTH;
+      const nextWidth = resolveKeyboardWidth(event.key, effectiveWidth, event.shiftKey);
       if (nextWidth === null) return;
       event.preventDefault();
       commitWidth(nextWidth);
     },
-    [commitWidth, width],
+    [commitWidth, effectiveWidth],
   );
 
   const resetWidth = useCallback(() => {
     commitWidth(DEFAULT_CHAT_TRANSCRIPT_WIDTH);
   }, [commitWidth]);
 
-  if (maxWidth <= MIN_CHAT_TRANSCRIPT_WIDTH) return null;
+  if (controlsHidden || !areWidthControlsUsable(maxWidth)) return null;
 
-  const renderHandle = (side: ResizeSide) => (
-    <button
-      type="button"
-      role="separator"
-      data-scroll-follow-ignore-keys
-      aria-label={resizeLabel}
-      aria-orientation="vertical"
-      aria-valuemin={MIN_CHAT_TRANSCRIPT_WIDTH}
-      aria-valuemax={maxWidth}
-      aria-valuenow={effectiveWidth}
-      title={side === "right" ? `${resizeLabel} · ${resetLabel}` : resetLabel}
-      tabIndex={side === "right" ? 0 : -1}
-      onPointerDown={(event) => handleResizeStart(side, event)}
-      onDoubleClick={resetWidth}
-      onKeyDown={side === "right" ? handleKeyDown : undefined}
-      className={cn(
-        "group pointer-events-auto absolute inset-y-0 z-10 w-3 touch-none cursor-col-resize border-0 bg-transparent p-0 focus-visible:outline-none",
-        side === "left" ? "left-0 -translate-x-1/2" : "right-0 translate-x-1/2",
-      )}
-    >
-      <span
-        aria-hidden="true"
+  const handleTitle = `${resizeLabel} · ${resetLabel}`;
+
+  // Only the right handle is exposed to assistive tech. Both handles drive one
+  // value, and aria-value* is only meaningful on a focusable separator — so
+  // the left handle stays a pointer-only affordance instead of advertising
+  // values nothing can focus to change.
+  const renderHandle = (side: TranscriptResizeSide) => {
+    const isPrimary = side === "right";
+    return (
+      <button
+        type="button"
+        {...(isPrimary
+          ? {
+              role: "separator",
+              "aria-label": resizeLabel,
+              "aria-orientation": "vertical" as const,
+              "aria-valuemin": MIN_CHAT_TRANSCRIPT_WIDTH,
+              "aria-valuemax": maxWidth,
+              "aria-valuenow": effectiveWidth,
+              tabIndex: 0,
+              onKeyDown: handleKeyDown,
+            }
+          : { "aria-hidden": true, tabIndex: -1 })}
+        data-scroll-follow-ignore-keys
+        title={handleTitle}
+        onPointerDown={(event) => handleResizeStart(side, event)}
+        onDoubleClick={resetWidth}
         className={cn(
-          "absolute left-1/2 top-1/2 h-10 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/25 opacity-0 shadow-sm transition-[height,background-color,opacity] duration-150",
-          "group-hover:h-16 group-hover:bg-primary/60 group-hover:opacity-100 group-focus-visible:h-16 group-focus-visible:bg-primary group-focus-visible:opacity-100",
-          resizingWidth !== null && "h-20 bg-primary opacity-100",
+          "group pointer-events-auto absolute inset-y-0 z-10 w-3 touch-none cursor-col-resize border-0 bg-transparent p-0 focus-visible:outline-none",
+          isPrimary ? "right-0 translate-x-1/2" : "left-0 -translate-x-1/2",
         )}
-      />
-    </button>
-  );
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            "absolute left-1/2 top-1/2 h-10 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/25 opacity-0 shadow-sm transition-[height,background-color,opacity] duration-150",
+            "group-hover:h-16 group-hover:bg-primary/60 group-hover:opacity-100 group-focus-visible:h-16 group-focus-visible:bg-primary group-focus-visible:opacity-100",
+            resizingWidth !== null && "h-20 bg-primary opacity-100",
+          )}
+        />
+      </button>
+    );
+  };
 
   return (
     <div

--- a/crates/agent-gateway/web/src/pages/chat/transcript/TranscriptWidthControls.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/transcript/TranscriptWidthControls.tsx
@@ -1,0 +1,252 @@
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  DEFAULT_CHAT_TRANSCRIPT_WIDTH,
+  MAX_CHAT_TRANSCRIPT_WIDTH,
+  MIN_CHAT_TRANSCRIPT_WIDTH,
+} from "../../../lib/settings";
+import { cn } from "../../../lib/shared/utils";
+
+export const CHAT_TRANSCRIPT_WIDTH_CSS_VAR = "--chat-transcript-content-width";
+
+const TRANSCRIPT_HORIZONTAL_SAFE_SPACE = 64;
+
+type TranscriptWidthControlsProps = {
+  hostRef: RefObject<HTMLElement | null>;
+  width: number;
+  onWidthChange: (width: number) => void;
+  resizeLabel: string;
+  resetLabel: string;
+};
+
+type ResizeSide = "left" | "right";
+
+function normalizePreferredWidth(width: number) {
+  return Math.min(
+    MAX_CHAT_TRANSCRIPT_WIDTH,
+    Math.max(MIN_CHAT_TRANSCRIPT_WIDTH, Math.round(width)),
+  );
+}
+
+function clampWidth(width: number, maxWidth: number) {
+  return Math.min(maxWidth, normalizePreferredWidth(width));
+}
+
+function getMaxWidth(host: HTMLElement | null) {
+  const hostWidth = host?.getBoundingClientRect().width ?? globalThis.innerWidth ?? 0;
+  if (!Number.isFinite(hostWidth) || hostWidth <= 0) return MAX_CHAT_TRANSCRIPT_WIDTH;
+  return Math.max(
+    MIN_CHAT_TRANSCRIPT_WIDTH,
+    Math.min(MAX_CHAT_TRANSCRIPT_WIDTH, Math.floor(hostWidth - TRANSCRIPT_HORIZONTAL_SAFE_SPACE)),
+  );
+}
+
+function applyWidth(host: HTMLElement | null, width: number) {
+  host?.style.setProperty(CHAT_TRANSCRIPT_WIDTH_CSS_VAR, `${Math.round(width)}px`);
+}
+
+export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
+  const { hostRef, width, onWidthChange, resizeLabel, resetLabel } = props;
+  const [maxWidth, setMaxWidth] = useState(MAX_CHAT_TRANSCRIPT_WIDTH);
+  const [resizingWidth, setResizingWidth] = useState<number | null>(null);
+  const pendingWidthRef = useRef(width);
+  const resizingRef = useRef(false);
+  const resizeFrameRef = useRef<number | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const effectiveWidth = clampWidth(resizingWidth ?? width, maxWidth);
+
+  useEffect(() => {
+    if (resizingWidth !== null) return;
+    applyWidth(hostRef.current, clampWidth(width, maxWidth));
+  }, [hostRef, maxWidth, resizingWidth, width]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    let frameId = 0;
+    const updateMaxWidth = () => {
+      frameId = 0;
+      const nextMaxWidth = getMaxWidth(host);
+      setMaxWidth(nextMaxWidth);
+      if (!resizingRef.current) {
+        applyWidth(host, clampWidth(width, nextMaxWidth));
+      }
+    };
+    const scheduleUpdate = () => {
+      if (frameId !== 0) return;
+      frameId = requestAnimationFrame(updateMaxWidth);
+    };
+    scheduleUpdate();
+    window.addEventListener("resize", scheduleUpdate);
+    const observer =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(scheduleUpdate);
+    if (host) observer?.observe(host);
+    return () => {
+      window.removeEventListener("resize", scheduleUpdate);
+      if (frameId !== 0) cancelAnimationFrame(frameId);
+      observer?.disconnect();
+    };
+  }, [hostRef, width]);
+
+  useEffect(
+    () => () => {
+      cleanupRef.current?.();
+      if (resizeFrameRef.current !== null) cancelAnimationFrame(resizeFrameRef.current);
+    },
+    [],
+  );
+
+  const commitWidth = useCallback(
+    (nextWidth: number) => {
+      const preferredWidth = normalizePreferredWidth(nextWidth);
+      const effectiveNextWidth = clampWidth(preferredWidth, getMaxWidth(hostRef.current));
+      applyWidth(hostRef.current, effectiveNextWidth);
+      pendingWidthRef.current = effectiveNextWidth;
+      setResizingWidth(null);
+      if (preferredWidth !== width) onWidthChange(preferredWidth);
+    },
+    [hostRef, onWidthChange, width],
+  );
+
+  const handleResizeStart = useCallback(
+    (side: ResizeSide, event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0 || event.pointerType === "touch") return;
+      event.preventDefault();
+      event.stopPropagation();
+      cleanupRef.current?.();
+
+      const host = hostRef.current;
+      const dragMaxWidth = getMaxWidth(host);
+      const startX = event.clientX;
+      const startWidth = clampWidth(width, dragMaxWidth);
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+      pendingWidthRef.current = startWidth;
+      resizingRef.current = true;
+      setMaxWidth(dragMaxWidth);
+      setResizingWidth(startWidth);
+      applyWidth(host, startWidth);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+
+      const scheduleWidth = (nextWidth: number) => {
+        pendingWidthRef.current = clampWidth(nextWidth, dragMaxWidth);
+        if (resizeFrameRef.current !== null) return;
+        resizeFrameRef.current = requestAnimationFrame(() => {
+          resizeFrameRef.current = null;
+          const pendingWidth = pendingWidthRef.current;
+          applyWidth(hostRef.current, pendingWidth);
+          setResizingWidth(pendingWidth);
+        });
+      };
+
+      const cleanup = () => {
+        window.removeEventListener("pointermove", handleMove);
+        window.removeEventListener("pointerup", handleEnd);
+        window.removeEventListener("pointercancel", handleEnd);
+        window.removeEventListener("blur", handleEnd);
+        if (resizeFrameRef.current !== null) {
+          cancelAnimationFrame(resizeFrameRef.current);
+          resizeFrameRef.current = null;
+        }
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
+        resizingRef.current = false;
+        cleanupRef.current = null;
+      };
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        const delta = moveEvent.clientX - startX;
+        scheduleWidth(startWidth + (side === "right" ? delta * 2 : -delta * 2));
+      };
+
+      const handleEnd = () => {
+        cleanup();
+        commitWidth(pendingWidthRef.current);
+      };
+
+      cleanupRef.current = cleanup;
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", handleEnd);
+      window.addEventListener("pointercancel", handleEnd);
+      window.addEventListener("blur", handleEnd);
+    },
+    [commitWidth, hostRef, width],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+      const step = event.shiftKey ? 64 : 16;
+      let nextWidth: number | null = null;
+      if (event.key === "ArrowLeft") nextWidth = width - step;
+      if (event.key === "ArrowRight") nextWidth = width + step;
+      if (event.key === "Home") nextWidth = DEFAULT_CHAT_TRANSCRIPT_WIDTH;
+      if (nextWidth === null) return;
+      event.preventDefault();
+      commitWidth(nextWidth);
+    },
+    [commitWidth, width],
+  );
+
+  const resetWidth = useCallback(() => {
+    commitWidth(DEFAULT_CHAT_TRANSCRIPT_WIDTH);
+  }, [commitWidth]);
+
+  if (maxWidth <= MIN_CHAT_TRANSCRIPT_WIDTH) return null;
+
+  const renderHandle = (side: ResizeSide) => (
+    <button
+      type="button"
+      role="separator"
+      data-scroll-follow-ignore-keys
+      aria-label={resizeLabel}
+      aria-orientation="vertical"
+      aria-valuemin={MIN_CHAT_TRANSCRIPT_WIDTH}
+      aria-valuemax={maxWidth}
+      aria-valuenow={effectiveWidth}
+      title={side === "right" ? `${resizeLabel} · ${resetLabel}` : resetLabel}
+      tabIndex={side === "right" ? 0 : -1}
+      onPointerDown={(event) => handleResizeStart(side, event)}
+      onDoubleClick={resetWidth}
+      onKeyDown={side === "right" ? handleKeyDown : undefined}
+      className={cn(
+        "group pointer-events-auto absolute inset-y-0 z-10 w-3 touch-none cursor-col-resize border-0 bg-transparent p-0 focus-visible:outline-none",
+        side === "left" ? "left-0 -translate-x-1/2" : "right-0 translate-x-1/2",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute left-1/2 top-1/2 h-10 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/25 opacity-0 shadow-sm transition-[height,background-color,opacity] duration-150",
+          "group-hover:h-16 group-hover:bg-primary/60 group-hover:opacity-100 group-focus-visible:h-16 group-focus-visible:bg-primary group-focus-visible:opacity-100",
+          resizingWidth !== null && "h-20 bg-primary opacity-100",
+        )}
+      />
+    </button>
+  );
+
+  return (
+    <div
+      className="transcript-width-controls pointer-events-none absolute inset-y-0 left-1/2 z-[9] -translate-x-1/2"
+      style={{
+        width: `var(${CHAT_TRANSCRIPT_WIDTH_CSS_VAR}, ${DEFAULT_CHAT_TRANSCRIPT_WIDTH}px)`,
+        maxWidth: `calc(100% - ${TRANSCRIPT_HORIZONTAL_SAFE_SPACE}px)`,
+      }}
+    >
+      {renderHandle("left")}
+      {renderHandle("right")}
+      {resizingWidth !== null ? (
+        <div className="absolute left-1/2 top-2 -translate-x-1/2 rounded-md border border-border/70 bg-background px-2 py-1 text-[11px] font-medium tabular-nums text-muted-foreground shadow-sm">
+          {effectiveWidth} px
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/crates/agent-gateway/web/src/styles.css
+++ b/crates/agent-gateway/web/src/styles.css
@@ -635,6 +635,12 @@ html[data-liveagent-webui="gateway"] [role="textbox"]:focus-visible {
   min-width: 0;
   flex: 1;
   flex-direction: column;
+  /* Two deliberately separate columns, both defaulting to 768px: the composer
+     keeps a fixed width while the transcript is user-resizable, so widening
+     the conversation never drags the input box along. Only the composer layer
+     may read --gateway-chat-column-width; the transcript reads
+     --chat-transcript-content-width, which TranscriptWidthControls overwrites
+     inline on .gateway-transcript-stage. */
   --gateway-chat-column-width: 768px;
   --chat-transcript-content-width: 768px;
   --gateway-chat-column-gutter: 16px;
@@ -2256,6 +2262,12 @@ html[data-liveagent-webui="gateway"]
   }
 }
 
+/*
+ * Transcript width handles are a pointer affordance. This query must stay in
+ * sync with TRANSCRIPT_WIDTH_CONTROLS_HIDDEN_MEDIA_QUERY in
+ * lib/transcript-width/transcriptWidthModel.ts, which gates the mount itself —
+ * this rule only covers the frame before that gate is read.
+ */
 @media (max-width: 820px), (pointer: coarse) {
   .transcript-width-controls {
     display: none !important;

--- a/crates/agent-gateway/web/src/styles.css
+++ b/crates/agent-gateway/web/src/styles.css
@@ -636,6 +636,7 @@ html[data-liveagent-webui="gateway"] [role="textbox"]:focus-visible {
   flex: 1;
   flex-direction: column;
   --gateway-chat-column-width: 768px;
+  --chat-transcript-content-width: 768px;
   --gateway-chat-column-gutter: 16px;
   --gateway-chat-composer-bottom: 16px;
   --gateway-chat-composer-overlay-height: 176px;
@@ -773,7 +774,7 @@ html[data-liveagent-webui="gateway"] [role="textbox"]:focus-visible {
   display: grid;
   grid-template-columns:
     minmax(var(--gateway-chat-column-gutter, 16px), 1fr)
-    minmax(0, min(var(--gateway-chat-column-width, 768px), 100%))
+    minmax(0, min(var(--chat-transcript-content-width, 768px), 100%))
     minmax(var(--gateway-chat-column-gutter, 16px), 1fr);
   width: 100%;
   min-width: 0;
@@ -2252,6 +2253,12 @@ html[data-liveagent-webui="gateway"]
 
   .login-form-card {
     max-width: 100%;
+  }
+}
+
+@media (max-width: 820px), (pointer: coarse) {
+  .transcript-width-controls {
+    display: none !important;
   }
 }
 

--- a/crates/agent-gateway/web/test/measurements-lru.test.mjs
+++ b/crates/agent-gateway/web/test/measurements-lru.test.mjs
@@ -9,30 +9,40 @@ const loader = createWebModuleLoader({
   rootDir: fileURLToPath(new URL("../", import.meta.url)),
 });
 
-const { createTranscriptMeasurementsLru } = loader.loadModule(
+const { buildTranscriptLayoutKey, createTranscriptMeasurementsLru } = loader.loadModule(
   "src/lib/transcript-virtual/measurementsLru.ts",
 );
-const transcriptListSource = readFileSync(
-  new URL("../src/components/GatewayTranscript.tsx", import.meta.url),
-  "utf8",
+const { SCROLL_FOLLOW_IGNORE_KEYS_ATTRIBUTE } = loader.loadModule(
+  "src/lib/chat-scroll/scrollFollowCore.ts",
 );
+const width = loader.loadModule("src/lib/transcript-width/transcriptWidthModel.ts");
 const transcriptStylesSource = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
 const transcriptWidthControlsSource = readFileSync(
   new URL("../src/pages/chat/transcript/TranscriptWidthControls.tsx", import.meta.url),
   "utf8",
 );
-const scrollFollowSource = readFileSync(
-  new URL("../src/lib/chat-scroll/useScrollFollow.ts", import.meta.url),
-  "utf8",
-);
 
 const item = (key, size) => ({ index: 0, key, start: 0, size, end: size, lane: 0 });
 
-const layoutKey = (viewportWidth, contentWidth) => `${viewportWidth}:${contentWidth}`;
+const layoutKey = buildTranscriptLayoutKey;
 
-test("width changes keep ResizeObserver measurements instead of clearing them", () => {
-  assert.doesNotMatch(transcriptListSource, /^\s*transcriptVirtualizer\.measure\(\);/m);
-  assert.match(transcriptListSource, /\$\{scrollViewport\.clientWidth\}:\$\{contentWidth\}/);
+test("layout keys separate viewport width from transcript content width", () => {
+  assert.equal(buildTranscriptLayoutKey(800, 768), "800:768");
+  assert.notEqual(buildTranscriptLayoutKey(800, 768), buildTranscriptLayoutKey(800, 960));
+  assert.notEqual(buildTranscriptLayoutKey(800, 768), buildTranscriptLayoutKey(900, 768));
+  // Subpixel viewport widths must not fragment the cache.
+  assert.equal(buildTranscriptLayoutKey(800.4, 768), buildTranscriptLayoutKey(800, 768));
+});
+
+test("unmeasured layouts produce a blank key so nothing is cached", () => {
+  assert.equal(buildTranscriptLayoutKey(0, 768), "");
+  assert.equal(buildTranscriptLayoutKey(800, 0), "");
+  assert.equal(buildTranscriptLayoutKey(Number.NaN, 768), "");
+  assert.equal(buildTranscriptLayoutKey(-1, 768), "");
+
+  const lru = createTranscriptMeasurementsLru();
+  lru.save("conv-1", buildTranscriptLayoutKey(0, 768), [item("a", 120)]);
+  assert.equal(lru.restore("conv-1", buildTranscriptLayoutKey(0, 768)), null);
 });
 
 test("gateway transcript grid consumes the stage width directly", () => {
@@ -44,8 +54,59 @@ test("gateway transcript grid consumes the stage width directly", () => {
 });
 
 test("keyboard width controls do not detach transcript scroll follow", () => {
-  assert.match(transcriptWidthControlsSource, /data-scroll-follow-ignore-keys/);
-  assert.match(scrollFollowSource, /closest\("\[data-scroll-follow-ignore-keys\]"\)/);
+  // Derived from the follow engine's own constant, so renaming the attribute
+  // in one place and not the other fails here instead of silently detaching
+  // bottom-follow on every arrow-key resize.
+  assert.ok(transcriptWidthControlsSource.includes(SCROLL_FOLLOW_IGNORE_KEYS_ATTRIBUTE));
+});
+
+test("preferred widths round and clamp to the persisted bounds", () => {
+  assert.equal(width.normalizePreferredWidth(920.4), 920);
+  assert.equal(width.normalizePreferredWidth(100), width.MIN_CHAT_TRANSCRIPT_WIDTH);
+  assert.equal(width.normalizePreferredWidth(9000), width.MAX_CHAT_TRANSCRIPT_WIDTH);
+  assert.equal(width.normalizePreferredWidth(Number.NaN), width.DEFAULT_CHAT_TRANSCRIPT_WIDTH);
+});
+
+test("a narrow stage clamps what is rendered without rewriting the preference", () => {
+  const stageMax = width.resolveStageMaxWidth(800);
+  assert.equal(stageMax, 800 - width.TRANSCRIPT_HORIZONTAL_SAFE_SPACE);
+  assert.equal(width.clampWidthToStage(1200, stageMax), stageMax);
+  // Widening the stage again restores the full preference.
+  assert.equal(width.clampWidthToStage(1200, width.resolveStageMaxWidth(1600)), 1200);
+});
+
+test("an unmeasured stage falls back to the upper bound, not the window", () => {
+  assert.equal(width.resolveStageMaxWidth(null), width.MAX_CHAT_TRANSCRIPT_WIDTH);
+  assert.equal(width.resolveStageMaxWidth(0), width.MAX_CHAT_TRANSCRIPT_WIDTH);
+  assert.equal(width.resolveStageMaxWidth(Number.NaN), width.MAX_CHAT_TRANSCRIPT_WIDTH);
+});
+
+test("handles hide once the stage can no longer host more than the minimum", () => {
+  assert.equal(width.areWidthControlsUsable(width.resolveStageMaxWidth(600)), false);
+  assert.equal(width.areWidthControlsUsable(width.resolveStageMaxWidth(1400)), true);
+});
+
+test("dragging either handle keeps it under the pointer", () => {
+  // Centered column: one edge moving by d changes the width by 2d.
+  assert.equal(width.resolveDragWidth(768, 40, "right"), 848);
+  assert.equal(width.resolveDragWidth(768, -40, "right"), 688);
+  assert.equal(width.resolveDragWidth(768, -40, "left"), 848);
+  assert.equal(width.resolveDragWidth(768, 40, "left"), 688);
+});
+
+test("keyboard resizing steps from the rendered width, not the preference", () => {
+  // Preference 1200 clamped to a 736px stage: one press must move the column,
+  // not spend ~29 presses walking the preference back down to what is shown.
+  const rendered = width.clampWidthToStage(1200, width.resolveStageMaxWidth(800));
+  assert.equal(width.resolveKeyboardWidth("ArrowLeft", rendered, false), rendered - 16);
+  assert.equal(width.resolveKeyboardWidth("ArrowLeft", rendered, true), rendered - 64);
+  assert.equal(width.resolveKeyboardWidth("ArrowRight", rendered, false), rendered + 16);
+  assert.equal(
+    width.resolveKeyboardWidth("Home", rendered, false),
+    width.DEFAULT_CHAT_TRANSCRIPT_WIDTH,
+  );
+  assert.equal(width.resolveKeyboardWidth("ArrowUp", rendered, false), null);
+  assert.equal(width.resolveKeyboardWidth("a", rendered, false), null);
 });
 
 test("save/restore round-trips measurements at the same layout width", () => {

--- a/crates/agent-gateway/web/test/measurements-lru.test.mjs
+++ b/crates/agent-gateway/web/test/measurements-lru.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -11,50 +12,84 @@ const loader = createWebModuleLoader({
 const { createTranscriptMeasurementsLru } = loader.loadModule(
   "src/lib/transcript-virtual/measurementsLru.ts",
 );
+const transcriptListSource = readFileSync(
+  new URL("../src/components/GatewayTranscript.tsx", import.meta.url),
+  "utf8",
+);
+const transcriptStylesSource = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
+const transcriptWidthControlsSource = readFileSync(
+  new URL("../src/pages/chat/transcript/TranscriptWidthControls.tsx", import.meta.url),
+  "utf8",
+);
+const scrollFollowSource = readFileSync(
+  new URL("../src/lib/chat-scroll/useScrollFollow.ts", import.meta.url),
+  "utf8",
+);
 
 const item = (key, size) => ({ index: 0, key, start: 0, size, end: size, lane: 0 });
 
-test("save/restore round-trips measurements at the same width", () => {
+const layoutKey = (viewportWidth, contentWidth) => `${viewportWidth}:${contentWidth}`;
+
+test("width changes keep ResizeObserver measurements instead of clearing them", () => {
+  assert.doesNotMatch(transcriptListSource, /^\s*transcriptVirtualizer\.measure\(\);/m);
+  assert.match(transcriptListSource, /\$\{scrollViewport\.clientWidth\}:\$\{contentWidth\}/);
+});
+
+test("gateway transcript grid consumes the stage width directly", () => {
+  assert.match(
+    transcriptStylesSource,
+    /minmax\(\s*0,\s*min\(var\(--chat-transcript-content-width,\s*768px\),\s*100%\)\s*\)/,
+  );
+  assert.doesNotMatch(transcriptStylesSource, /--gateway-transcript-column-width/);
+});
+
+test("keyboard width controls do not detach transcript scroll follow", () => {
+  assert.match(transcriptWidthControlsSource, /data-scroll-follow-ignore-keys/);
+  assert.match(scrollFollowSource, /closest\("\[data-scroll-follow-ignore-keys\]"\)/);
+});
+
+test("save/restore round-trips measurements at the same layout width", () => {
   const lru = createTranscriptMeasurementsLru();
   const measurements = [item("a", 120), item("b", 300)];
-  lru.save("conv-1", 800, measurements);
-  assert.equal(lru.restore("conv-1", 800), measurements);
+  lru.save("conv-1", layoutKey(800, 768), measurements);
+  assert.equal(lru.restore("conv-1", layoutKey(800, 768)), measurements);
 });
 
-test("restore is width-gated and misses unknown conversations", () => {
+test("restore is layout-gated and misses unknown conversations", () => {
   const lru = createTranscriptMeasurementsLru();
-  lru.save("conv-1", 800, [item("a", 120)]);
-  assert.equal(lru.restore("conv-1", 900), null);
-  assert.equal(lru.restore("conv-2", 800), null);
+  lru.save("conv-1", layoutKey(800, 768), [item("a", 120)]);
+  assert.equal(lru.restore("conv-1", layoutKey(900, 768)), null);
+  assert.equal(lru.restore("conv-1", layoutKey(800, 960)), null);
+  assert.equal(lru.restore("conv-2", layoutKey(800, 768)), null);
 });
 
-test("empty snapshots and blank ids are not stored", () => {
+test("empty snapshots, blank ids, and blank layout keys are not stored", () => {
   const lru = createTranscriptMeasurementsLru();
-  lru.save("conv-1", 800, []);
-  lru.save("", 800, [item("a", 120)]);
-  lru.save("conv-2", 0, [item("a", 120)]);
-  assert.equal(lru.restore("conv-1", 800), null);
-  assert.equal(lru.restore("", 800), null);
-  assert.equal(lru.restore("conv-2", 0), null);
+  lru.save("conv-1", layoutKey(800, 768), []);
+  lru.save("", layoutKey(800, 768), [item("a", 120)]);
+  lru.save("conv-2", "", [item("a", 120)]);
+  assert.equal(lru.restore("conv-1", layoutKey(800, 768)), null);
+  assert.equal(lru.restore("", layoutKey(800, 768)), null);
+  assert.equal(lru.restore("conv-2", ""), null);
 });
 
 test("capacity evicts the least recently used entry", () => {
   const lru = createTranscriptMeasurementsLru(2);
-  lru.save("conv-1", 800, [item("a", 1)]);
-  lru.save("conv-2", 800, [item("b", 2)]);
+  lru.save("conv-1", layoutKey(800, 768), [item("a", 1)]);
+  lru.save("conv-2", layoutKey(800, 768), [item("b", 2)]);
   // Touch conv-1 so conv-2 becomes the eviction candidate.
-  assert.ok(lru.restore("conv-1", 800));
-  lru.save("conv-3", 800, [item("c", 3)]);
-  assert.ok(lru.restore("conv-1", 800));
-  assert.equal(lru.restore("conv-2", 800), null);
-  assert.ok(lru.restore("conv-3", 800));
+  assert.ok(lru.restore("conv-1", layoutKey(800, 768)));
+  lru.save("conv-3", layoutKey(800, 768), [item("c", 3)]);
+  assert.ok(lru.restore("conv-1", layoutKey(800, 768)));
+  assert.equal(lru.restore("conv-2", layoutKey(800, 768)), null);
+  assert.ok(lru.restore("conv-3", layoutKey(800, 768)));
 });
 
 test("re-saving a conversation replaces its snapshot", () => {
   const lru = createTranscriptMeasurementsLru();
-  lru.save("conv-1", 800, [item("a", 1)]);
+  lru.save("conv-1", layoutKey(800, 768), [item("a", 1)]);
   const next = [item("a", 2)];
-  lru.save("conv-1", 820, next);
-  assert.equal(lru.restore("conv-1", 800), null);
-  assert.equal(lru.restore("conv-1", 820), next);
+  lru.save("conv-1", layoutKey(820, 960), next);
+  assert.equal(lru.restore("conv-1", layoutKey(800, 768)), null);
+  assert.equal(lru.restore("conv-1", layoutKey(820, 960)), next);
 });

--- a/crates/agent-gui/src/index.css
+++ b/crates/agent-gui/src/index.css
@@ -2417,6 +2417,12 @@
   }
 }
 
+@media (max-width: 820px), (pointer: coarse) {
+  .transcript-width-controls {
+    display: none !important;
+  }
+}
+
 /*
  * SSH settings — responsive helpers. Unlayered so these win over the
  * Tailwind flex/align/gap/padding utilities on the same elements

--- a/crates/agent-gui/src/index.css
+++ b/crates/agent-gui/src/index.css
@@ -2417,6 +2417,12 @@
   }
 }
 
+/*
+ * Transcript width handles are a pointer affordance. This query must stay in
+ * sync with TRANSCRIPT_WIDTH_CONTROLS_HIDDEN_MEDIA_QUERY in
+ * lib/transcript-width/transcriptWidthModel.ts, which gates the mount itself —
+ * this rule only covers the frame before that gate is read.
+ */
 @media (max-width: 820px), (pointer: coarse) {
   .transcript-width-controls {
     display: none !important;

--- a/crates/agent-gui/src/lib/chat-scroll/scrollFollowCore.ts
+++ b/crates/agent-gui/src/lib/chat-scroll/scrollFollowCore.ts
@@ -60,6 +60,13 @@ export const DIRECTION_SLOP_PX = 1;
 // can never read as "dragged away from the bottom".
 export const POINTER_DRAG_SLOP_PX = 4;
 
+// Elements carrying this attribute keep their arrow/Home/End keys to
+// themselves: the transcript width handles resize on those keys, which must
+// not also read as a scroll intent and detach bottom-follow. useScrollFollow
+// builds its selector from this constant, so widget code and the follow engine
+// cannot drift onto different attribute names.
+export const SCROLL_FOLLOW_IGNORE_KEYS_ATTRIBUTE = "data-scroll-follow-ignore-keys";
+
 // Attach-side gesture latch. Armed only by toward-bottom wheel/touch/key input
 // and extended by chained downward scroll events (touchscreen momentum carries
 // no input events); it can extend an active latch but never create one.

--- a/crates/agent-gui/src/lib/chat-scroll/useScrollFollow.ts
+++ b/crates/agent-gui/src/lib/chat-scroll/useScrollFollow.ts
@@ -15,7 +15,7 @@ import {
 // not change follow state, and nested elements under it don't consume wheels.
 const SCROLLABLE_OVERFLOW_MIN_PX = 4;
 
-function isEditableEventTarget(target: EventTarget | null) {
+function shouldIgnoreScrollKeyTarget(target: EventTarget | null) {
   if (!(target instanceof HTMLElement)) {
     return false;
   }
@@ -23,12 +23,13 @@ function isEditableEventTarget(target: EventTarget | null) {
     target.isContentEditable ||
     target instanceof HTMLInputElement ||
     target instanceof HTMLTextAreaElement ||
-    target instanceof HTMLSelectElement
+    target instanceof HTMLSelectElement ||
+    target.closest("[data-scroll-follow-ignore-keys]") !== null
   );
 }
 
 function isHistoryScrollKey(event: KeyboardEvent) {
-  if (isEditableEventTarget(event.target)) {
+  if (shouldIgnoreScrollKeyTarget(event.target)) {
     return false;
   }
   return (
@@ -40,7 +41,7 @@ function isHistoryScrollKey(event: KeyboardEvent) {
 }
 
 function isFollowScrollKey(event: KeyboardEvent) {
-  if (isEditableEventTarget(event.target)) {
+  if (shouldIgnoreScrollKeyTarget(event.target)) {
     return false;
   }
   return (

--- a/crates/agent-gui/src/lib/chat-scroll/useScrollFollow.ts
+++ b/crates/agent-gui/src/lib/chat-scroll/useScrollFollow.ts
@@ -9,6 +9,7 @@ import {
   isDominantVerticalWheel,
   POINTER_DRAG_SLOP_PX,
   reduceFollowEvent,
+  SCROLL_FOLLOW_IGNORE_KEYS_ATTRIBUTE,
 } from "./scrollFollowCore";
 
 // Below this the element cannot meaningfully scroll; wheel/touch on it must
@@ -24,7 +25,7 @@ function shouldIgnoreScrollKeyTarget(target: EventTarget | null) {
     target instanceof HTMLInputElement ||
     target instanceof HTMLTextAreaElement ||
     target instanceof HTMLSelectElement ||
-    target.closest("[data-scroll-follow-ignore-keys]") !== null
+    target.closest(`[${SCROLL_FOLLOW_IGNORE_KEYS_ATTRIBUTE}]`) !== null
   );
 }
 

--- a/crates/agent-gui/src/lib/settings/index.ts
+++ b/crates/agent-gui/src/lib/settings/index.ts
@@ -24,6 +24,11 @@ import { createUuid } from "../shared/id";
 import { mergeAlwaysEnabledSkillNames } from "../skills/builtin";
 import { normalizeFontFamily } from "../system/fontFamily";
 import { SYSTEM_TOOL_OPTIONS, type SystemToolId } from "../tools/systemToolOptions";
+import {
+  DEFAULT_CHAT_TRANSCRIPT_WIDTH,
+  MAX_CHAT_TRANSCRIPT_WIDTH,
+  MIN_CHAT_TRANSCRIPT_WIDTH,
+} from "../transcript-width/transcriptWidthModel";
 import { normalizeApiKey, normalizeBaseUrl, normalizeModels } from "./normalize";
 
 export { normalizeFontFamily } from "../system/fontFamily";
@@ -144,9 +149,9 @@ export type FontScaleSettings = {
   rightDock: number;
 };
 
-export const DEFAULT_CHAT_TRANSCRIPT_WIDTH = 768;
-export const MIN_CHAT_TRANSCRIPT_WIDTH = 560;
-export const MAX_CHAT_TRANSCRIPT_WIDTH = 1200;
+// Bounds live with the geometry that enforces them; re-exported here so
+// settings consumers keep a single import site.
+export { DEFAULT_CHAT_TRANSCRIPT_WIDTH, MAX_CHAT_TRANSCRIPT_WIDTH, MIN_CHAT_TRANSCRIPT_WIDTH };
 
 export type ChatTranscriptSettings = {
   width: number;

--- a/crates/agent-gui/src/lib/settings/index.ts
+++ b/crates/agent-gui/src/lib/settings/index.ts
@@ -144,9 +144,18 @@ export type FontScaleSettings = {
   rightDock: number;
 };
 
+export const DEFAULT_CHAT_TRANSCRIPT_WIDTH = 768;
+export const MIN_CHAT_TRANSCRIPT_WIDTH = 560;
+export const MAX_CHAT_TRANSCRIPT_WIDTH = 1200;
+
+export type ChatTranscriptSettings = {
+  width: number;
+};
+
 export type CustomSettings = {
   conversationTitleModel?: SelectedModel;
   chatSidebar: ChatSidebarSettings;
+  chatTranscript: ChatTranscriptSettings;
   rightDock: RightDockSettings;
   // Empty strings select the built-in stacks for each typography role.
   interfaceFontFamily: string;
@@ -1977,6 +1986,18 @@ export function normalizeFontScaleSettings(input: unknown): FontScaleSettings {
   };
 }
 
+export function normalizeChatTranscriptSettings(input: unknown): ChatTranscriptSettings {
+  const obj = (input && typeof input === "object" ? input : {}) as Record<string, unknown>;
+  return {
+    width: normalizeIntegerInRange(
+      obj.width,
+      MIN_CHAT_TRANSCRIPT_WIDTH,
+      MAX_CHAT_TRANSCRIPT_WIDTH,
+      DEFAULT_CHAT_TRANSCRIPT_WIDTH,
+    ),
+  };
+}
+
 export function normalizeCustomSettings(
   input: unknown,
   customProviders: CustomProvider[],
@@ -1994,6 +2015,7 @@ export function normalizeCustomSettings(
       projectsCollapsed: chatSidebar.projectsCollapsed === true,
       recentCollapsed: chatSidebar.recentCollapsed === true,
     },
+    chatTranscript: normalizeChatTranscriptSettings(obj.chatTranscript),
     rightDock: normalizeRightDockSettings(obj.rightDock),
     // fontFamily was the single pre-split preference. Read it only to migrate
     // saved local settings into the new interface-specific field.
@@ -2303,6 +2325,12 @@ export function getRightDockProjectState(
   return normalizeRightDockProjectState(
     normalizedPathKey ? customSettings.rightDock.projects[normalizedPathKey] : {},
   );
+}
+
+export function updateChatTranscriptWidth(prev: AppSettings, width: number): AppSettings {
+  const nextWidth = normalizeChatTranscriptSettings({ width }).width;
+  if (prev.customSettings.chatTranscript.width === nextWidth) return prev;
+  return updateCustomSettings(prev, { chatTranscript: { width: nextWidth } });
 }
 
 export function updateRightDockWidth(prev: AppSettings, width: number): AppSettings {

--- a/crates/agent-gui/src/lib/settings/storage.ts
+++ b/crates/agent-gui/src/lib/settings/storage.ts
@@ -7,6 +7,7 @@ import {
   type CloseWindowBehavior,
   getDefaultSettings,
   normalizeChatRuntimeControls,
+  normalizeChatTranscriptSettings,
   normalizeCloseWindowBehavior,
   normalizeFontFamily,
   normalizeFontScaleSettings,
@@ -86,6 +87,7 @@ function readLocalUiSettings(): {
         projectsCollapsed: chatSidebar.projectsCollapsed === true,
         recentCollapsed: chatSidebar.recentCollapsed === true,
       },
+      chatTranscript: normalizeChatTranscriptSettings(obj.chatTranscript),
       rightDock: normalizeRightDockSettings(obj.rightDock),
       // fontFamily was the single pre-split preference. Read it only to migrate
       // old local settings into the interface-specific field.

--- a/crates/agent-gui/src/lib/settings/sync.ts
+++ b/crates/agent-gui/src/lib/settings/sync.ts
@@ -1,5 +1,6 @@
 import {
   type AppSettings,
+  DEFAULT_CHAT_TRANSCRIPT_WIDTH,
   getDefaultSystemProxyConfig,
   normalizeChatRuntimeControls,
   normalizeRightDockSettings,
@@ -350,11 +351,12 @@ function syncableCustomSettings(
       projectsCollapsed: false,
       recentCollapsed: false,
     },
-    // Typography and scale are local UI preferences; fixed defaults prevent
-    // visual preferences from being broadcast through the gateway.
+    // Typography, scale, and transcript width are local UI preferences; fixed
+    // defaults prevent visual preferences from being broadcast through the gateway.
     interfaceFontFamily: "",
     chatFontFamily: "",
     codeFontFamily: "",
+    chatTranscript: { width: DEFAULT_CHAT_TRANSCRIPT_WIDTH },
     fontScale: { sidebar: 1, chat: 1, rightDock: 1 },
   };
 }
@@ -993,10 +995,11 @@ export function applyGatewaySettingsSyncPayload(
           )
         : current.customSettings.rightDock,
       chatSidebar: current.customSettings.chatSidebar,
-      // Typography and scale are local UI preferences, never gateway-synced.
+      // Typography, scale, and transcript width are local UI preferences, never gateway-synced.
       interfaceFontFamily: current.customSettings.interfaceFontFamily,
       chatFontFamily: current.customSettings.chatFontFamily,
       codeFontFamily: current.customSettings.codeFontFamily,
+      chatTranscript: current.customSettings.chatTranscript,
       fontScale: current.customSettings.fontScale,
     },
     skills: (source.skills as AppSettings["skills"] | undefined) ?? current.skills,

--- a/crates/agent-gui/src/lib/transcript-virtual/measurementsLru.ts
+++ b/crates/agent-gui/src/lib/transcript-virtual/measurementsLru.ts
@@ -13,6 +13,16 @@ export type TranscriptMeasurementsLru = {
   restore: (conversationId: string, layoutKey: string) => VirtualItem[] | null;
 };
 
+// The composite key both callers must use. Owning the shape here keeps the two
+// frontends from drifting, and returning "" for an unmeasured viewport or
+// column re-establishes the guard the plain-number key used to carry: save()
+// and restore() both reject blank keys, so a zero-width layout is never stored.
+export function buildTranscriptLayoutKey(viewportWidth: number, contentWidth: number): string {
+  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return "";
+  if (!Number.isFinite(contentWidth) || contentWidth <= 0) return "";
+  return `${Math.round(viewportWidth)}:${Math.round(contentWidth)}`;
+}
+
 const DEFAULT_CAPACITY = 12;
 
 export function createTranscriptMeasurementsLru(

--- a/crates/agent-gui/src/lib/transcript-virtual/measurementsLru.ts
+++ b/crates/agent-gui/src/lib/transcript-virtual/measurementsLru.ts
@@ -4,13 +4,13 @@ import type { VirtualItem } from "@tanstack/react-virtual";
 // taken on unmount (virtualizer.takeSnapshot()) and fed back through
 // initialMeasurementsCache when the conversation reopens — switching back to
 // a conversation then lays out with exact row heights instead of estimates.
-// In-memory only and width-gated: measured heights depend on the viewport
-// width (and zoom/font scale, which width changes track in practice), so a
-// snapshot is only restored at the width it was taken and never persisted.
+// In-memory only and layout-gated: measured heights depend on both the scroll
+// viewport and the centered transcript width, so callers provide a composite
+// layout key. Snapshots are never persisted.
 
 export type TranscriptMeasurementsLru = {
-  save: (conversationId: string, viewportWidth: number, measurements: VirtualItem[]) => void;
-  restore: (conversationId: string, viewportWidth: number) => VirtualItem[] | null;
+  save: (conversationId: string, layoutKey: string, measurements: VirtualItem[]) => void;
+  restore: (conversationId: string, layoutKey: string) => VirtualItem[] | null;
 };
 
 const DEFAULT_CAPACITY = 12;
@@ -18,24 +18,24 @@ const DEFAULT_CAPACITY = 12;
 export function createTranscriptMeasurementsLru(
   capacity = DEFAULT_CAPACITY,
 ): TranscriptMeasurementsLru {
-  const entries = new Map<string, { viewportWidth: number; measurements: VirtualItem[] }>();
+  const entries = new Map<string, { layoutKey: string; measurements: VirtualItem[] }>();
 
   return {
-    save: (conversationId, viewportWidth, measurements) => {
-      if (!conversationId || viewportWidth <= 0 || measurements.length === 0) {
+    save: (conversationId, layoutKey, measurements) => {
+      if (!conversationId || !layoutKey || measurements.length === 0) {
         return;
       }
       entries.delete(conversationId);
-      entries.set(conversationId, { viewportWidth, measurements });
+      entries.set(conversationId, { layoutKey, measurements });
       while (entries.size > capacity) {
         const oldest = entries.keys().next().value;
         if (oldest === undefined) break;
         entries.delete(oldest);
       }
     },
-    restore: (conversationId, viewportWidth) => {
+    restore: (conversationId, layoutKey) => {
       const hit = entries.get(conversationId);
-      if (!hit || hit.viewportWidth !== viewportWidth) {
+      if (!hit || hit.layoutKey !== layoutKey) {
         return null;
       }
       entries.delete(conversationId);

--- a/crates/agent-gui/src/lib/transcript-width/transcriptWidthModel.ts
+++ b/crates/agent-gui/src/lib/transcript-width/transcriptWidthModel.ts
@@ -1,0 +1,88 @@
+// Geometry for the resizable transcript column, kept free of React and DOM
+// imports: the component owns the CSS variable and the event wiring, this
+// module owns the arithmetic. Being a dependency-free leaf also lets both
+// frontends' test loaders exercise it directly.
+
+// Persisted preference bounds. A stored width outside these is normalized in.
+export const DEFAULT_CHAT_TRANSCRIPT_WIDTH = 768;
+export const MIN_CHAT_TRANSCRIPT_WIDTH = 560;
+export const MAX_CHAT_TRANSCRIPT_WIDTH = 1200;
+
+// Space kept between the column and the stage edges so the drag handles never
+// sit flush against the window frame.
+export const TRANSCRIPT_HORIZONTAL_SAFE_SPACE = 64;
+
+// Keyboard steps on the focusable handle; Shift picks the coarse one.
+export const TRANSCRIPT_WIDTH_KEY_STEP = 16;
+export const TRANSCRIPT_WIDTH_KEY_COARSE_STEP = 64;
+
+// The handles are a pointer affordance: below this stage width the column
+// already fills the available space, and a coarse pointer cannot hit a 12px
+// target. Mirrors the media query that hides `.transcript-width-controls`, so
+// the two gates cannot drift apart.
+export const TRANSCRIPT_WIDTH_CONTROLS_HIDDEN_MEDIA_QUERY = "(max-width: 820px), (pointer: coarse)";
+
+export type TranscriptResizeSide = "left" | "right";
+
+// Rounds to whole pixels and clamps to the persisted preference bounds.
+export function normalizePreferredWidth(width: number): number {
+  if (!Number.isFinite(width)) return DEFAULT_CHAT_TRANSCRIPT_WIDTH;
+  return Math.min(
+    MAX_CHAT_TRANSCRIPT_WIDTH,
+    Math.max(MIN_CHAT_TRANSCRIPT_WIDTH, Math.round(width)),
+  );
+}
+
+// The width actually rendered: the preference, further clamped by how much
+// room the stage has right now. Narrowing the window shrinks what is rendered
+// and never rewrites the stored preference, so widening restores it.
+export function clampWidthToStage(width: number, maxWidth: number): number {
+  return Math.min(maxWidth, normalizePreferredWidth(width));
+}
+
+// Largest column the stage can host. A missing or non-positive host width
+// means the stage has not been measured yet — the first ResizeObserver
+// delivery corrects it, so fall back to the upper bound rather than guessing
+// from the window, which would also count the sidebar and the right dock.
+export function resolveStageMaxWidth(hostWidth: number | null | undefined): number {
+  if (hostWidth == null || !Number.isFinite(hostWidth) || hostWidth <= 0) {
+    return MAX_CHAT_TRANSCRIPT_WIDTH;
+  }
+  return Math.max(
+    MIN_CHAT_TRANSCRIPT_WIDTH,
+    Math.min(MAX_CHAT_TRANSCRIPT_WIDTH, Math.floor(hostWidth - TRANSCRIPT_HORIZONTAL_SAFE_SPACE)),
+  );
+}
+
+// Handles are only worth showing while the stage can host more than the
+// minimum — otherwise every drag would be a no-op.
+export function areWidthControlsUsable(maxWidth: number): boolean {
+  return maxWidth > MIN_CHAT_TRANSCRIPT_WIDTH;
+}
+
+// Width for a drag of `deltaX` on `side`. The column is centered, so moving
+// one edge by d changes the width by 2d — that is what keeps the handle
+// under the pointer.
+export function resolveDragWidth(
+  startWidth: number,
+  deltaX: number,
+  side: TranscriptResizeSide,
+): number {
+  return startWidth + (side === "right" ? deltaX * 2 : -deltaX * 2);
+}
+
+// Next width for a key press, or null when the key is not a resize key.
+// Steps from the *rendered* width rather than the stored preference: while a
+// narrow stage clamps a wider preference, stepping from the preference would
+// take many presses before anything moved on screen.
+export function resolveKeyboardWidth(
+  key: string,
+  effectiveWidth: number,
+  coarseStep: boolean,
+): number | null {
+  if (key === "Home") return DEFAULT_CHAT_TRANSCRIPT_WIDTH;
+  const step = coarseStep ? TRANSCRIPT_WIDTH_KEY_COARSE_STEP : TRANSCRIPT_WIDTH_KEY_STEP;
+  if (key === "ArrowLeft") return effectiveWidth - step;
+  if (key === "ArrowRight") return effectiveWidth + step;
+  return null;
+}

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -64,6 +64,7 @@ import {
   type RightDockProjectState,
   resolveEffectiveTheme,
   type SelectedModel,
+  updateChatTranscriptWidth,
   updateRightDockFileTreeState,
   updateRightDockProjectState,
   updateRightDockWidth,
@@ -573,6 +574,12 @@ export function ChatPage(props: ChatPageProps) {
     : undefined;
   // RightDockPanel is memo'd: every callback handed to it must be stable or
   // the memo boundary is void (see the panel-side context useMemo).
+  const handleChatTranscriptWidthChange = useCallback(
+    (nextWidth: number) => {
+      setSettings((prev) => updateChatTranscriptWidth(prev, nextWidth));
+    },
+    [setSettings],
+  );
   const handleRightDockWidthChange = useCallback(
     (nextWidth: number) => {
       setSettings((prev) => updateRightDockWidth(prev, nextWidth));
@@ -1687,6 +1694,8 @@ export function ChatPage(props: ChatPageProps) {
                   liveTranscriptStore={liveTranscriptStore}
                   isCompactionRunning={isCompactionRunning}
                   bottomReservePx={composerOverlayHeight}
+                  contentWidth={settings.customSettings.chatTranscript.width}
+                  onContentWidthChange={handleChatTranscriptWidthChange}
                   onResendFromEdit={handleResendFromEdit}
                   onBranchConversation={
                     // 水合中/水合失败时 handler 只会静默 return——直接不传，

--- a/crates/agent-gui/src/pages/chat/transcript/ChatTranscript.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/ChatTranscript.tsx
@@ -24,10 +24,7 @@ import { FloorNavRail } from "./FloorNavRail";
 import { RowInteractionProvider, useRowInteractionStore } from "./rowInteraction";
 import { TranscriptList, type TranscriptNavHandle } from "./TranscriptList";
 import { HistorySwitchLoadingOverlay } from "./TranscriptLoadingStates";
-import {
-  CHAT_TRANSCRIPT_WIDTH_CSS_VAR,
-  TranscriptWidthControls,
-} from "./TranscriptWidthControls";
+import { CHAT_TRANSCRIPT_WIDTH_CSS_VAR, TranscriptWidthControls } from "./TranscriptWidthControls";
 import type { ChatTranscriptProps } from "./transcriptTypes";
 import {
   clampTranscriptContextMenuPosition,
@@ -221,7 +218,8 @@ export const ChatTranscript = memo(function ChatTranscript(props: ChatTranscript
     : null;
   const copySelectedTextLabel = locale === "en-US" ? "Copy selected text" : "复制选中文本";
   const jumpToBottomLabel = locale === "en-US" ? "Scroll to bottom" : "回到底部";
-  const resizeTranscriptLabel = locale === "en-US" ? "Resize conversation content" : "调整对话正文宽度";
+  const resizeTranscriptLabel =
+    locale === "en-US" ? "Resize conversation content" : "调整对话正文宽度";
   const resetTranscriptWidthLabel =
     locale === "en-US" ? "Double-click to reset" : "双击恢复默认宽度";
 

--- a/crates/agent-gui/src/pages/chat/transcript/ChatTranscript.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/ChatTranscript.tsx
@@ -1,4 +1,5 @@
 import {
+  type CSSProperties,
   memo,
   type MouseEvent as ReactMouseEvent,
   useCallback,
@@ -23,6 +24,10 @@ import { FloorNavRail } from "./FloorNavRail";
 import { RowInteractionProvider, useRowInteractionStore } from "./rowInteraction";
 import { TranscriptList, type TranscriptNavHandle } from "./TranscriptList";
 import { HistorySwitchLoadingOverlay } from "./TranscriptLoadingStates";
+import {
+  CHAT_TRANSCRIPT_WIDTH_CSS_VAR,
+  TranscriptWidthControls,
+} from "./TranscriptWidthControls";
 import type { ChatTranscriptProps } from "./transcriptTypes";
 import {
   clampTranscriptContextMenuPosition,
@@ -49,6 +54,8 @@ export const ChatTranscript = memo(function ChatTranscript(props: ChatTranscript
     liveTranscriptStore,
     isCompactionRunning,
     bottomReservePx = 0,
+    contentWidth,
+    onContentWidthChange,
     onResendFromEdit,
     onBranchConversation,
     branchPendingMessageId,
@@ -214,15 +221,23 @@ export const ChatTranscript = memo(function ChatTranscript(props: ChatTranscript
     : null;
   const copySelectedTextLabel = locale === "en-US" ? "Copy selected text" : "复制选中文本";
   const jumpToBottomLabel = locale === "en-US" ? "Scroll to bottom" : "回到底部";
+  const resizeTranscriptLabel = locale === "en-US" ? "Resize conversation content" : "调整对话正文宽度";
+  const resetTranscriptWidthLabel =
+    locale === "en-US" ? "Double-click to reset" : "双击恢复默认宽度";
 
   return (
     <div
       ref={transcriptRootRef}
       className="relative min-h-0 flex-1"
+      style={
+        {
+          [CHAT_TRANSCRIPT_WIDTH_CSS_VAR]: `${contentWidth}px`,
+        } as CSSProperties
+      }
       onContextMenu={handleTranscriptContextMenu}
     >
       <ScrollArea ref={setScrollAreaRoot} viewportRef={setScrollViewport} className="h-full">
-        <div className="mx-auto w-full max-w-[768px] px-5 py-4">
+        <div className="mx-auto w-full max-w-[var(--chat-transcript-content-width)] px-5 py-4">
           {showNoModelsState || showStartChatState ? (
             <div className="flex min-h-[calc(100vh-220px)] flex-col items-center justify-center">
               {/* Keyed per conversation so the hero entrance replays when
@@ -251,6 +266,7 @@ export const ChatTranscript = memo(function ChatTranscript(props: ChatTranscript
                 historyItems={historyItems}
                 liveTranscriptStore={liveTranscriptStore}
                 scrollViewport={scrollViewport}
+                layoutWidth={contentWidth}
                 isViewportFollowing={scrollFollowHandle.isFollowing}
                 isSending={isSending}
                 isAgentMode={isAgentMode}
@@ -271,6 +287,13 @@ export const ChatTranscript = memo(function ChatTranscript(props: ChatTranscript
           <div style={{ height: transcriptBottomReservePx }} />
         </div>
       </ScrollArea>
+      <TranscriptWidthControls
+        hostRef={transcriptRootRef}
+        width={contentWidth}
+        onWidthChange={onContentWidthChange}
+        resizeLabel={resizeTranscriptLabel}
+        resetLabel={resetTranscriptWidthLabel}
+      />
       {!showNoModelsState && !showStartChatState && !isTranscriptSettling ? (
         <FloorNavRail
           conversationId={conversationId}

--- a/crates/agent-gui/src/pages/chat/transcript/ChatTranscript.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/ChatTranscript.tsx
@@ -227,6 +227,9 @@ export const ChatTranscript = memo(function ChatTranscript(props: ChatTranscript
     <div
       ref={transcriptRootRef}
       className="relative min-h-0 flex-1"
+      // Preferred (persisted) width, so a fresh mount paints at the user's
+      // width instead of the default. TranscriptWidthControls narrows this
+      // same variable to the stage in a layout effect — see its header.
       style={
         {
           [CHAT_TRANSCRIPT_WIDTH_CSS_VAR]: `${contentWidth}px`,

--- a/crates/agent-gui/src/pages/chat/transcript/TranscriptList.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/TranscriptList.tsx
@@ -32,7 +32,10 @@ import type { GitClient } from "../../../lib/git/types";
 import { createEntranceRegistry } from "../../../lib/transcript-virtual/entranceOnce";
 import { extractLiveRange } from "../../../lib/transcript-virtual/liveRangeExtractor";
 import { createLiveRowScrollAdjustPolicy } from "../../../lib/transcript-virtual/liveScrollAdjustPolicy";
-import { createTranscriptMeasurementsLru } from "../../../lib/transcript-virtual/measurementsLru";
+import {
+  buildTranscriptLayoutKey,
+  createTranscriptMeasurementsLru,
+} from "../../../lib/transcript-virtual/measurementsLru";
 import { AssistantRow } from "./AssistantRow";
 import { createTranscriptRowModel } from "./rowModel";
 import { UserMessageRow } from "./UserMessageRow";
@@ -244,7 +247,7 @@ export const TranscriptList = memo(function TranscriptList(props: TranscriptList
       (scrollViewport
         ? transcriptMeasurementsLru.restore(
             conversationId,
-            `${scrollViewport.clientWidth}:${layoutWidth}`,
+            buildTranscriptLayoutKey(scrollViewport.clientWidth, layoutWidth),
           )
         : null) ?? [],
   );
@@ -468,7 +471,7 @@ export const TranscriptList = memo(function TranscriptList(props: TranscriptList
     if (!scrollViewport) return;
     transcriptMeasurementsLru.save(
       conversationId,
-      `${scrollViewport.clientWidth}:${layoutWidth}`,
+      buildTranscriptLayoutKey(scrollViewport.clientWidth, layoutWidth),
       virtualizer.takeSnapshot(),
     );
   };

--- a/crates/agent-gui/src/pages/chat/transcript/TranscriptList.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/TranscriptList.tsx
@@ -99,6 +99,7 @@ export type TranscriptListProps = {
   historyItems: RenderTimelineItem[];
   liveTranscriptStore: LiveTranscriptStore;
   scrollViewport: HTMLDivElement | null;
+  layoutWidth: number;
   // Whether the scroll-follow engine is attached to the bottom; gates the
   // virtualizer's resize-compensation carve-out for live-row growth.
   isViewportFollowing?: () => boolean;
@@ -137,6 +138,7 @@ export const TranscriptList = memo(function TranscriptList(props: TranscriptList
     historyItems,
     liveTranscriptStore,
     scrollViewport,
+    layoutWidth,
     isViewportFollowing,
     isSending,
     isAgentMode,
@@ -240,7 +242,10 @@ export const TranscriptList = memo(function TranscriptList(props: TranscriptList
   const [initialMeasurementsCache] = useState(
     () =>
       (scrollViewport
-        ? transcriptMeasurementsLru.restore(conversationId, scrollViewport.clientWidth)
+        ? transcriptMeasurementsLru.restore(
+            conversationId,
+            `${scrollViewport.clientWidth}:${layoutWidth}`,
+          )
         : null) ?? [],
   );
 
@@ -274,6 +279,12 @@ export const TranscriptList = memo(function TranscriptList(props: TranscriptList
     getLiveStartIndex: () => liveStartIndexRef.current,
     isFollowing: () => isViewportFollowing?.() ?? false,
   });
+
+  // Every mounted row is already tracked by the virtualizer's ResizeObserver,
+  // which updates its measured height as the centered transcript reflows.
+  // Do not call virtualizer.measure() on width commits: it clears those fresh
+  // measurements after the DOM has already resized, so no later resize event
+  // may repopulate them and estimate-based row positions can overlap.
 
   // 楼层导航跳转句柄：按行 key 定位 index 后 scrollToIndex。沿途行首次真实
   // 测量会不断修正总高度，连续若干帧重新对准，让滚动收敛在目标行顶部
@@ -457,7 +468,7 @@ export const TranscriptList = memo(function TranscriptList(props: TranscriptList
     if (!scrollViewport) return;
     transcriptMeasurementsLru.save(
       conversationId,
-      scrollViewport.clientWidth,
+      `${scrollViewport.clientWidth}:${layoutWidth}`,
       virtualizer.takeSnapshot(),
     );
   };

--- a/crates/agent-gui/src/pages/chat/transcript/TranscriptWidthControls.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/TranscriptWidthControls.tsx
@@ -4,20 +4,35 @@ import {
   type RefObject,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 
-import {
-  DEFAULT_CHAT_TRANSCRIPT_WIDTH,
-  MAX_CHAT_TRANSCRIPT_WIDTH,
-  MIN_CHAT_TRANSCRIPT_WIDTH,
-} from "../../../lib/settings";
 import { cn } from "../../../lib/shared/utils";
+import {
+  areWidthControlsUsable,
+  clampWidthToStage,
+  DEFAULT_CHAT_TRANSCRIPT_WIDTH,
+  MIN_CHAT_TRANSCRIPT_WIDTH,
+  normalizePreferredWidth,
+  resolveDragWidth,
+  resolveKeyboardWidth,
+  resolveStageMaxWidth,
+  TRANSCRIPT_HORIZONTAL_SAFE_SPACE,
+  TRANSCRIPT_WIDTH_CONTROLS_HIDDEN_MEDIA_QUERY,
+  type TranscriptResizeSide,
+} from "../../../lib/transcript-width/transcriptWidthModel";
 
 export const CHAT_TRANSCRIPT_WIDTH_CSS_VAR = "--chat-transcript-content-width";
 
-const TRANSCRIPT_HORIZONTAL_SAFE_SPACE = 64;
+// Who writes CHAT_TRANSCRIPT_WIDTH_CSS_VAR: the host element's own inline
+// style carries the *preferred* (persisted) width, so a fresh mount already
+// paints at the user's width. This component then narrows that to what the
+// stage can host — from a layout effect, before paint. A passive effect lands
+// after paint and would flash the unclamped width for a frame whenever a
+// commit has to be clamped.
 
 type TranscriptWidthControlsProps = {
   hostRef: RefObject<HTMLElement | null>;
@@ -27,26 +42,22 @@ type TranscriptWidthControlsProps = {
   resetLabel: string;
 };
 
-type ResizeSide = "left" | "right";
-
-function normalizePreferredWidth(width: number) {
-  return Math.min(
-    MAX_CHAT_TRANSCRIPT_WIDTH,
-    Math.max(MIN_CHAT_TRANSCRIPT_WIDTH, Math.round(width)),
-  );
+function subscribeControlsHidden(onChange: () => void) {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+  const query = window.matchMedia(TRANSCRIPT_WIDTH_CONTROLS_HIDDEN_MEDIA_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
 }
 
-function clampWidth(width: number, maxWidth: number) {
-  return Math.min(maxWidth, normalizePreferredWidth(width));
+function readControlsHidden() {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia(TRANSCRIPT_WIDTH_CONTROLS_HIDDEN_MEDIA_QUERY).matches;
 }
 
-function getMaxWidth(host: HTMLElement | null) {
-  const hostWidth = host?.getBoundingClientRect().width ?? globalThis.innerWidth ?? 0;
-  if (!Number.isFinite(hostWidth) || hostWidth <= 0) return MAX_CHAT_TRANSCRIPT_WIDTH;
-  return Math.max(
-    MIN_CHAT_TRANSCRIPT_WIDTH,
-    Math.min(MAX_CHAT_TRANSCRIPT_WIDTH, Math.floor(hostWidth - TRANSCRIPT_HORIZONTAL_SAFE_SPACE)),
-  );
+function measureStageMaxWidth(host: HTMLElement | null) {
+  return resolveStageMaxWidth(host?.getBoundingClientRect().width ?? null);
 }
 
 function applyWidth(host: HTMLElement | null, width: number) {
@@ -55,28 +66,41 @@ function applyWidth(host: HTMLElement | null, width: number) {
 
 export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
   const { hostRef, width, onWidthChange, resizeLabel, resetLabel } = props;
-  const [maxWidth, setMaxWidth] = useState(MAX_CHAT_TRANSCRIPT_WIDTH);
+  const [maxWidth, setMaxWidth] = useState(() => resolveStageMaxWidth(null));
   const [resizingWidth, setResizingWidth] = useState<number | null>(null);
   const pendingWidthRef = useRef(width);
   const resizingRef = useRef(false);
   const resizeFrameRef = useRef<number | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
-  const effectiveWidth = clampWidth(resizingWidth ?? width, maxWidth);
+  // Read by the stage observer, which must outlive individual width commits.
+  const widthRef = useRef(width);
+  widthRef.current = width;
+  const effectiveWidth = clampWidthToStage(resizingWidth ?? width, maxWidth);
+  // Same gate as the CSS that hides the handles, so a coarse pointer neither
+  // renders them nor pays for their listeners.
+  const controlsHidden = useSyncExternalStore(
+    subscribeControlsHidden,
+    readControlsHidden,
+    () => true,
+  );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    // Mid-drag the pointer owns the variable; that drag's commit reconciles it.
     if (resizingWidth !== null) return;
-    applyWidth(hostRef.current, clampWidth(width, maxWidth));
+    applyWidth(hostRef.current, clampWidthToStage(width, maxWidth));
   }, [hostRef, maxWidth, resizingWidth, width]);
 
+  // Keyed off the host alone on purpose: re-arming the observer on every width
+  // commit would tear it down and rebuild it mid-interaction for nothing.
   useEffect(() => {
     const host = hostRef.current;
     let frameId = 0;
     const updateMaxWidth = () => {
       frameId = 0;
-      const nextMaxWidth = getMaxWidth(host);
+      const nextMaxWidth = measureStageMaxWidth(host);
       setMaxWidth(nextMaxWidth);
       if (!resizingRef.current) {
-        applyWidth(host, clampWidth(width, nextMaxWidth));
+        applyWidth(host, clampWidthToStage(widthRef.current, nextMaxWidth));
       }
     };
     const scheduleUpdate = () => {
@@ -93,7 +117,7 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
       if (frameId !== 0) cancelAnimationFrame(frameId);
       observer?.disconnect();
     };
-  }, [hostRef, width]);
+  }, [hostRef]);
 
   useEffect(
     () => () => {
@@ -106,7 +130,10 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
   const commitWidth = useCallback(
     (nextWidth: number) => {
       const preferredWidth = normalizePreferredWidth(nextWidth);
-      const effectiveNextWidth = clampWidth(preferredWidth, getMaxWidth(hostRef.current));
+      const effectiveNextWidth = clampWidthToStage(
+        preferredWidth,
+        measureStageMaxWidth(hostRef.current),
+      );
       applyWidth(hostRef.current, effectiveNextWidth);
       pendingWidthRef.current = effectiveNextWidth;
       setResizingWidth(null);
@@ -116,16 +143,16 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
   );
 
   const handleResizeStart = useCallback(
-    (side: ResizeSide, event: ReactPointerEvent<HTMLButtonElement>) => {
+    (side: TranscriptResizeSide, event: ReactPointerEvent<HTMLButtonElement>) => {
       if (event.button !== 0 || event.pointerType === "touch") return;
       event.preventDefault();
       event.stopPropagation();
       cleanupRef.current?.();
 
       const host = hostRef.current;
-      const dragMaxWidth = getMaxWidth(host);
+      const dragMaxWidth = measureStageMaxWidth(host);
       const startX = event.clientX;
-      const startWidth = clampWidth(width, dragMaxWidth);
+      const startWidth = clampWidthToStage(width, dragMaxWidth);
       const previousCursor = document.body.style.cursor;
       const previousUserSelect = document.body.style.userSelect;
       pendingWidthRef.current = startWidth;
@@ -137,7 +164,7 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
       document.body.style.userSelect = "none";
 
       const scheduleWidth = (nextWidth: number) => {
-        pendingWidthRef.current = clampWidth(nextWidth, dragMaxWidth);
+        pendingWidthRef.current = clampWidthToStage(nextWidth, dragMaxWidth);
         if (resizeFrameRef.current !== null) return;
         resizeFrameRef.current = requestAnimationFrame(() => {
           resizeFrameRef.current = null;
@@ -163,8 +190,7 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
       };
 
       const handleMove = (moveEvent: PointerEvent) => {
-        const delta = moveEvent.clientX - startX;
-        scheduleWidth(startWidth + (side === "right" ? delta * 2 : -delta * 2));
+        scheduleWidth(resolveDragWidth(startWidth, moveEvent.clientX - startX, side));
       };
 
       const handleEnd = () => {
@@ -183,54 +209,63 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLButtonElement>) => {
-      const step = event.shiftKey ? 64 : 16;
-      let nextWidth: number | null = null;
-      if (event.key === "ArrowLeft") nextWidth = width - step;
-      if (event.key === "ArrowRight") nextWidth = width + step;
-      if (event.key === "Home") nextWidth = DEFAULT_CHAT_TRANSCRIPT_WIDTH;
+      const nextWidth = resolveKeyboardWidth(event.key, effectiveWidth, event.shiftKey);
       if (nextWidth === null) return;
       event.preventDefault();
       commitWidth(nextWidth);
     },
-    [commitWidth, width],
+    [commitWidth, effectiveWidth],
   );
 
   const resetWidth = useCallback(() => {
     commitWidth(DEFAULT_CHAT_TRANSCRIPT_WIDTH);
   }, [commitWidth]);
 
-  if (maxWidth <= MIN_CHAT_TRANSCRIPT_WIDTH) return null;
+  if (controlsHidden || !areWidthControlsUsable(maxWidth)) return null;
 
-  const renderHandle = (side: ResizeSide) => (
-    <button
-      type="button"
-      role="separator"
-      data-scroll-follow-ignore-keys
-      aria-label={resizeLabel}
-      aria-orientation="vertical"
-      aria-valuemin={MIN_CHAT_TRANSCRIPT_WIDTH}
-      aria-valuemax={maxWidth}
-      aria-valuenow={effectiveWidth}
-      title={side === "right" ? `${resizeLabel} · ${resetLabel}` : resetLabel}
-      tabIndex={side === "right" ? 0 : -1}
-      onPointerDown={(event) => handleResizeStart(side, event)}
-      onDoubleClick={resetWidth}
-      onKeyDown={side === "right" ? handleKeyDown : undefined}
-      className={cn(
-        "group pointer-events-auto absolute inset-y-0 z-10 w-3 touch-none cursor-col-resize border-0 bg-transparent p-0 focus-visible:outline-none",
-        side === "left" ? "left-0 -translate-x-1/2" : "right-0 translate-x-1/2",
-      )}
-    >
-      <span
-        aria-hidden="true"
+  const handleTitle = `${resizeLabel} · ${resetLabel}`;
+
+  // Only the right handle is exposed to assistive tech. Both handles drive one
+  // value, and aria-value* is only meaningful on a focusable separator — so
+  // the left handle stays a pointer-only affordance instead of advertising
+  // values nothing can focus to change.
+  const renderHandle = (side: TranscriptResizeSide) => {
+    const isPrimary = side === "right";
+    return (
+      <button
+        type="button"
+        {...(isPrimary
+          ? {
+              role: "separator",
+              "aria-label": resizeLabel,
+              "aria-orientation": "vertical" as const,
+              "aria-valuemin": MIN_CHAT_TRANSCRIPT_WIDTH,
+              "aria-valuemax": maxWidth,
+              "aria-valuenow": effectiveWidth,
+              tabIndex: 0,
+              onKeyDown: handleKeyDown,
+            }
+          : { "aria-hidden": true, tabIndex: -1 })}
+        data-scroll-follow-ignore-keys
+        title={handleTitle}
+        onPointerDown={(event) => handleResizeStart(side, event)}
+        onDoubleClick={resetWidth}
         className={cn(
-          "absolute left-1/2 top-1/2 h-10 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/25 opacity-0 shadow-sm transition-[height,background-color,opacity] duration-150",
-          "group-hover:h-16 group-hover:bg-primary/60 group-hover:opacity-100 group-focus-visible:h-16 group-focus-visible:bg-primary group-focus-visible:opacity-100",
-          resizingWidth !== null && "h-20 bg-primary opacity-100",
+          "group pointer-events-auto absolute inset-y-0 z-10 w-3 touch-none cursor-col-resize border-0 bg-transparent p-0 focus-visible:outline-none",
+          isPrimary ? "right-0 translate-x-1/2" : "left-0 -translate-x-1/2",
         )}
-      />
-    </button>
-  );
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            "absolute left-1/2 top-1/2 h-10 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/25 opacity-0 shadow-sm transition-[height,background-color,opacity] duration-150",
+            "group-hover:h-16 group-hover:bg-primary/60 group-hover:opacity-100 group-focus-visible:h-16 group-focus-visible:bg-primary group-focus-visible:opacity-100",
+            resizingWidth !== null && "h-20 bg-primary opacity-100",
+          )}
+        />
+      </button>
+    );
+  };
 
   return (
     <div

--- a/crates/agent-gui/src/pages/chat/transcript/TranscriptWidthControls.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/TranscriptWidthControls.tsx
@@ -1,0 +1,252 @@
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  DEFAULT_CHAT_TRANSCRIPT_WIDTH,
+  MAX_CHAT_TRANSCRIPT_WIDTH,
+  MIN_CHAT_TRANSCRIPT_WIDTH,
+} from "../../../lib/settings";
+import { cn } from "../../../lib/shared/utils";
+
+export const CHAT_TRANSCRIPT_WIDTH_CSS_VAR = "--chat-transcript-content-width";
+
+const TRANSCRIPT_HORIZONTAL_SAFE_SPACE = 64;
+
+type TranscriptWidthControlsProps = {
+  hostRef: RefObject<HTMLElement | null>;
+  width: number;
+  onWidthChange: (width: number) => void;
+  resizeLabel: string;
+  resetLabel: string;
+};
+
+type ResizeSide = "left" | "right";
+
+function normalizePreferredWidth(width: number) {
+  return Math.min(
+    MAX_CHAT_TRANSCRIPT_WIDTH,
+    Math.max(MIN_CHAT_TRANSCRIPT_WIDTH, Math.round(width)),
+  );
+}
+
+function clampWidth(width: number, maxWidth: number) {
+  return Math.min(maxWidth, normalizePreferredWidth(width));
+}
+
+function getMaxWidth(host: HTMLElement | null) {
+  const hostWidth = host?.getBoundingClientRect().width ?? globalThis.innerWidth ?? 0;
+  if (!Number.isFinite(hostWidth) || hostWidth <= 0) return MAX_CHAT_TRANSCRIPT_WIDTH;
+  return Math.max(
+    MIN_CHAT_TRANSCRIPT_WIDTH,
+    Math.min(MAX_CHAT_TRANSCRIPT_WIDTH, Math.floor(hostWidth - TRANSCRIPT_HORIZONTAL_SAFE_SPACE)),
+  );
+}
+
+function applyWidth(host: HTMLElement | null, width: number) {
+  host?.style.setProperty(CHAT_TRANSCRIPT_WIDTH_CSS_VAR, `${Math.round(width)}px`);
+}
+
+export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
+  const { hostRef, width, onWidthChange, resizeLabel, resetLabel } = props;
+  const [maxWidth, setMaxWidth] = useState(MAX_CHAT_TRANSCRIPT_WIDTH);
+  const [resizingWidth, setResizingWidth] = useState<number | null>(null);
+  const pendingWidthRef = useRef(width);
+  const resizingRef = useRef(false);
+  const resizeFrameRef = useRef<number | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const effectiveWidth = clampWidth(resizingWidth ?? width, maxWidth);
+
+  useEffect(() => {
+    if (resizingWidth !== null) return;
+    applyWidth(hostRef.current, clampWidth(width, maxWidth));
+  }, [hostRef, maxWidth, resizingWidth, width]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    let frameId = 0;
+    const updateMaxWidth = () => {
+      frameId = 0;
+      const nextMaxWidth = getMaxWidth(host);
+      setMaxWidth(nextMaxWidth);
+      if (!resizingRef.current) {
+        applyWidth(host, clampWidth(width, nextMaxWidth));
+      }
+    };
+    const scheduleUpdate = () => {
+      if (frameId !== 0) return;
+      frameId = requestAnimationFrame(updateMaxWidth);
+    };
+    scheduleUpdate();
+    window.addEventListener("resize", scheduleUpdate);
+    const observer =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(scheduleUpdate);
+    if (host) observer?.observe(host);
+    return () => {
+      window.removeEventListener("resize", scheduleUpdate);
+      if (frameId !== 0) cancelAnimationFrame(frameId);
+      observer?.disconnect();
+    };
+  }, [hostRef, width]);
+
+  useEffect(
+    () => () => {
+      cleanupRef.current?.();
+      if (resizeFrameRef.current !== null) cancelAnimationFrame(resizeFrameRef.current);
+    },
+    [],
+  );
+
+  const commitWidth = useCallback(
+    (nextWidth: number) => {
+      const preferredWidth = normalizePreferredWidth(nextWidth);
+      const effectiveNextWidth = clampWidth(preferredWidth, getMaxWidth(hostRef.current));
+      applyWidth(hostRef.current, effectiveNextWidth);
+      pendingWidthRef.current = effectiveNextWidth;
+      setResizingWidth(null);
+      if (preferredWidth !== width) onWidthChange(preferredWidth);
+    },
+    [hostRef, onWidthChange, width],
+  );
+
+  const handleResizeStart = useCallback(
+    (side: ResizeSide, event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0 || event.pointerType === "touch") return;
+      event.preventDefault();
+      event.stopPropagation();
+      cleanupRef.current?.();
+
+      const host = hostRef.current;
+      const dragMaxWidth = getMaxWidth(host);
+      const startX = event.clientX;
+      const startWidth = clampWidth(width, dragMaxWidth);
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+      pendingWidthRef.current = startWidth;
+      resizingRef.current = true;
+      setMaxWidth(dragMaxWidth);
+      setResizingWidth(startWidth);
+      applyWidth(host, startWidth);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+
+      const scheduleWidth = (nextWidth: number) => {
+        pendingWidthRef.current = clampWidth(nextWidth, dragMaxWidth);
+        if (resizeFrameRef.current !== null) return;
+        resizeFrameRef.current = requestAnimationFrame(() => {
+          resizeFrameRef.current = null;
+          const pendingWidth = pendingWidthRef.current;
+          applyWidth(hostRef.current, pendingWidth);
+          setResizingWidth(pendingWidth);
+        });
+      };
+
+      const cleanup = () => {
+        window.removeEventListener("pointermove", handleMove);
+        window.removeEventListener("pointerup", handleEnd);
+        window.removeEventListener("pointercancel", handleEnd);
+        window.removeEventListener("blur", handleEnd);
+        if (resizeFrameRef.current !== null) {
+          cancelAnimationFrame(resizeFrameRef.current);
+          resizeFrameRef.current = null;
+        }
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
+        resizingRef.current = false;
+        cleanupRef.current = null;
+      };
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        const delta = moveEvent.clientX - startX;
+        scheduleWidth(startWidth + (side === "right" ? delta * 2 : -delta * 2));
+      };
+
+      const handleEnd = () => {
+        cleanup();
+        commitWidth(pendingWidthRef.current);
+      };
+
+      cleanupRef.current = cleanup;
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", handleEnd);
+      window.addEventListener("pointercancel", handleEnd);
+      window.addEventListener("blur", handleEnd);
+    },
+    [commitWidth, hostRef, width],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+      const step = event.shiftKey ? 64 : 16;
+      let nextWidth: number | null = null;
+      if (event.key === "ArrowLeft") nextWidth = width - step;
+      if (event.key === "ArrowRight") nextWidth = width + step;
+      if (event.key === "Home") nextWidth = DEFAULT_CHAT_TRANSCRIPT_WIDTH;
+      if (nextWidth === null) return;
+      event.preventDefault();
+      commitWidth(nextWidth);
+    },
+    [commitWidth, width],
+  );
+
+  const resetWidth = useCallback(() => {
+    commitWidth(DEFAULT_CHAT_TRANSCRIPT_WIDTH);
+  }, [commitWidth]);
+
+  if (maxWidth <= MIN_CHAT_TRANSCRIPT_WIDTH) return null;
+
+  const renderHandle = (side: ResizeSide) => (
+    <button
+      type="button"
+      role="separator"
+      data-scroll-follow-ignore-keys
+      aria-label={resizeLabel}
+      aria-orientation="vertical"
+      aria-valuemin={MIN_CHAT_TRANSCRIPT_WIDTH}
+      aria-valuemax={maxWidth}
+      aria-valuenow={effectiveWidth}
+      title={side === "right" ? `${resizeLabel} · ${resetLabel}` : resetLabel}
+      tabIndex={side === "right" ? 0 : -1}
+      onPointerDown={(event) => handleResizeStart(side, event)}
+      onDoubleClick={resetWidth}
+      onKeyDown={side === "right" ? handleKeyDown : undefined}
+      className={cn(
+        "group pointer-events-auto absolute inset-y-0 z-10 w-3 touch-none cursor-col-resize border-0 bg-transparent p-0 focus-visible:outline-none",
+        side === "left" ? "left-0 -translate-x-1/2" : "right-0 translate-x-1/2",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute left-1/2 top-1/2 h-10 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/25 opacity-0 shadow-sm transition-[height,background-color,opacity] duration-150",
+          "group-hover:h-16 group-hover:bg-primary/60 group-hover:opacity-100 group-focus-visible:h-16 group-focus-visible:bg-primary group-focus-visible:opacity-100",
+          resizingWidth !== null && "h-20 bg-primary opacity-100",
+        )}
+      />
+    </button>
+  );
+
+  return (
+    <div
+      className="transcript-width-controls pointer-events-none absolute inset-y-0 left-1/2 z-[9] -translate-x-1/2"
+      style={{
+        width: `var(${CHAT_TRANSCRIPT_WIDTH_CSS_VAR}, ${DEFAULT_CHAT_TRANSCRIPT_WIDTH}px)`,
+        maxWidth: `calc(100% - ${TRANSCRIPT_HORIZONTAL_SAFE_SPACE}px)`,
+      }}
+    >
+      {renderHandle("left")}
+      {renderHandle("right")}
+      {resizingWidth !== null ? (
+        <div className="absolute left-1/2 top-2 -translate-x-1/2 rounded-md border border-border/70 bg-background px-2 py-1 text-[11px] font-medium tabular-nums text-muted-foreground shadow-sm">
+          {effectiveWidth} px
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/crates/agent-gui/src/pages/chat/transcript/transcriptTypes.ts
+++ b/crates/agent-gui/src/pages/chat/transcript/transcriptTypes.ts
@@ -27,6 +27,8 @@ export type ChatTranscriptProps = {
   liveTranscriptStore: LiveTranscriptStore;
   isCompactionRunning: boolean;
   bottomReservePx?: number;
+  contentWidth: number;
+  onContentWidthChange: (width: number) => void;
   onResendFromEdit: (
     messageRef: HistoryMessageRef,
     text: string,

--- a/crates/agent-gui/test/chat/measurements-lru.test.mjs
+++ b/crates/agent-gui/test/chat/measurements-lru.test.mjs
@@ -4,34 +4,95 @@ import test from "node:test";
 import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 
 const loader = createTsModuleLoader();
-const { createTranscriptMeasurementsLru } = loader.loadModule(
+const { buildTranscriptLayoutKey, createTranscriptMeasurementsLru } = loader.loadModule(
   "src/lib/transcript-virtual/measurementsLru.ts",
 );
-const transcriptListSource = readFileSync(
-  new URL("../../src/pages/chat/transcript/TranscriptList.tsx", import.meta.url),
-  "utf8",
+const { SCROLL_FOLLOW_IGNORE_KEYS_ATTRIBUTE } = loader.loadModule(
+  "src/lib/chat-scroll/scrollFollowCore.ts",
 );
+const width = loader.loadModule("src/lib/transcript-width/transcriptWidthModel.ts");
 const transcriptWidthControlsSource = readFileSync(
   new URL("../../src/pages/chat/transcript/TranscriptWidthControls.tsx", import.meta.url),
-  "utf8",
-);
-const scrollFollowSource = readFileSync(
-  new URL("../../src/lib/chat-scroll/useScrollFollow.ts", import.meta.url),
   "utf8",
 );
 
 const item = (key, size) => ({ index: 0, key, start: 0, size, end: size, lane: 0 });
 
-const layoutKey = (viewportWidth, contentWidth) => `${viewportWidth}:${contentWidth}`;
+const layoutKey = buildTranscriptLayoutKey;
 
-test("width changes keep ResizeObserver measurements instead of clearing them", () => {
-  assert.doesNotMatch(transcriptListSource, /^\s*virtualizer\.measure\(\);/m);
-  assert.match(transcriptListSource, /\$\{scrollViewport\.clientWidth\}:\$\{layoutWidth\}/);
+test("layout keys separate viewport width from transcript content width", () => {
+  assert.equal(buildTranscriptLayoutKey(800, 768), "800:768");
+  assert.notEqual(buildTranscriptLayoutKey(800, 768), buildTranscriptLayoutKey(800, 960));
+  assert.notEqual(buildTranscriptLayoutKey(800, 768), buildTranscriptLayoutKey(900, 768));
+  // Subpixel viewport widths must not fragment the cache.
+  assert.equal(buildTranscriptLayoutKey(800.4, 768), buildTranscriptLayoutKey(800, 768));
+});
+
+test("unmeasured layouts produce a blank key so nothing is cached", () => {
+  assert.equal(buildTranscriptLayoutKey(0, 768), "");
+  assert.equal(buildTranscriptLayoutKey(800, 0), "");
+  assert.equal(buildTranscriptLayoutKey(Number.NaN, 768), "");
+  assert.equal(buildTranscriptLayoutKey(-1, 768), "");
+
+  const lru = createTranscriptMeasurementsLru();
+  lru.save("conv-1", buildTranscriptLayoutKey(0, 768), [item("a", 120)]);
+  assert.equal(lru.restore("conv-1", buildTranscriptLayoutKey(0, 768)), null);
 });
 
 test("keyboard width controls do not detach transcript scroll follow", () => {
-  assert.match(transcriptWidthControlsSource, /data-scroll-follow-ignore-keys/);
-  assert.match(scrollFollowSource, /closest\("\[data-scroll-follow-ignore-keys\]"\)/);
+  // Derived from the follow engine's own constant, so renaming the attribute
+  // in one place and not the other fails here instead of silently detaching
+  // bottom-follow on every arrow-key resize.
+  assert.ok(transcriptWidthControlsSource.includes(SCROLL_FOLLOW_IGNORE_KEYS_ATTRIBUTE));
+});
+
+test("preferred widths round and clamp to the persisted bounds", () => {
+  assert.equal(width.normalizePreferredWidth(920.4), 920);
+  assert.equal(width.normalizePreferredWidth(100), width.MIN_CHAT_TRANSCRIPT_WIDTH);
+  assert.equal(width.normalizePreferredWidth(9000), width.MAX_CHAT_TRANSCRIPT_WIDTH);
+  assert.equal(width.normalizePreferredWidth(Number.NaN), width.DEFAULT_CHAT_TRANSCRIPT_WIDTH);
+});
+
+test("a narrow stage clamps what is rendered without rewriting the preference", () => {
+  const stageMax = width.resolveStageMaxWidth(800);
+  assert.equal(stageMax, 800 - width.TRANSCRIPT_HORIZONTAL_SAFE_SPACE);
+  assert.equal(width.clampWidthToStage(1200, stageMax), stageMax);
+  // Widening the stage again restores the full preference.
+  assert.equal(width.clampWidthToStage(1200, width.resolveStageMaxWidth(1600)), 1200);
+});
+
+test("an unmeasured stage falls back to the upper bound, not the window", () => {
+  assert.equal(width.resolveStageMaxWidth(null), width.MAX_CHAT_TRANSCRIPT_WIDTH);
+  assert.equal(width.resolveStageMaxWidth(0), width.MAX_CHAT_TRANSCRIPT_WIDTH);
+  assert.equal(width.resolveStageMaxWidth(Number.NaN), width.MAX_CHAT_TRANSCRIPT_WIDTH);
+});
+
+test("handles hide once the stage can no longer host more than the minimum", () => {
+  assert.equal(width.areWidthControlsUsable(width.resolveStageMaxWidth(600)), false);
+  assert.equal(width.areWidthControlsUsable(width.resolveStageMaxWidth(1400)), true);
+});
+
+test("dragging either handle keeps it under the pointer", () => {
+  // Centered column: one edge moving by d changes the width by 2d.
+  assert.equal(width.resolveDragWidth(768, 40, "right"), 848);
+  assert.equal(width.resolveDragWidth(768, -40, "right"), 688);
+  assert.equal(width.resolveDragWidth(768, -40, "left"), 848);
+  assert.equal(width.resolveDragWidth(768, 40, "left"), 688);
+});
+
+test("keyboard resizing steps from the rendered width, not the preference", () => {
+  // Preference 1200 clamped to a 736px stage: one press must move the column,
+  // not spend ~29 presses walking the preference back down to what is shown.
+  const rendered = width.clampWidthToStage(1200, width.resolveStageMaxWidth(800));
+  assert.equal(width.resolveKeyboardWidth("ArrowLeft", rendered, false), rendered - 16);
+  assert.equal(width.resolveKeyboardWidth("ArrowLeft", rendered, true), rendered - 64);
+  assert.equal(width.resolveKeyboardWidth("ArrowRight", rendered, false), rendered + 16);
+  assert.equal(
+    width.resolveKeyboardWidth("Home", rendered, false),
+    width.DEFAULT_CHAT_TRANSCRIPT_WIDTH,
+  );
+  assert.equal(width.resolveKeyboardWidth("ArrowUp", rendered, false), null);
+  assert.equal(width.resolveKeyboardWidth("a", rendered, false), null);
 });
 
 test("save/restore round-trips measurements at the same layout width", () => {

--- a/crates/agent-gui/test/chat/measurements-lru.test.mjs
+++ b/crates/agent-gui/test/chat/measurements-lru.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 
@@ -6,50 +7,75 @@ const loader = createTsModuleLoader();
 const { createTranscriptMeasurementsLru } = loader.loadModule(
   "src/lib/transcript-virtual/measurementsLru.ts",
 );
+const transcriptListSource = readFileSync(
+  new URL("../../src/pages/chat/transcript/TranscriptList.tsx", import.meta.url),
+  "utf8",
+);
+const transcriptWidthControlsSource = readFileSync(
+  new URL("../../src/pages/chat/transcript/TranscriptWidthControls.tsx", import.meta.url),
+  "utf8",
+);
+const scrollFollowSource = readFileSync(
+  new URL("../../src/lib/chat-scroll/useScrollFollow.ts", import.meta.url),
+  "utf8",
+);
 
 const item = (key, size) => ({ index: 0, key, start: 0, size, end: size, lane: 0 });
 
-test("save/restore round-trips measurements at the same width", () => {
+const layoutKey = (viewportWidth, contentWidth) => `${viewportWidth}:${contentWidth}`;
+
+test("width changes keep ResizeObserver measurements instead of clearing them", () => {
+  assert.doesNotMatch(transcriptListSource, /^\s*virtualizer\.measure\(\);/m);
+  assert.match(transcriptListSource, /\$\{scrollViewport\.clientWidth\}:\$\{layoutWidth\}/);
+});
+
+test("keyboard width controls do not detach transcript scroll follow", () => {
+  assert.match(transcriptWidthControlsSource, /data-scroll-follow-ignore-keys/);
+  assert.match(scrollFollowSource, /closest\("\[data-scroll-follow-ignore-keys\]"\)/);
+});
+
+test("save/restore round-trips measurements at the same layout width", () => {
   const lru = createTranscriptMeasurementsLru();
   const measurements = [item("a", 120), item("b", 300)];
-  lru.save("conv-1", 800, measurements);
-  assert.equal(lru.restore("conv-1", 800), measurements);
+  lru.save("conv-1", layoutKey(800, 768), measurements);
+  assert.equal(lru.restore("conv-1", layoutKey(800, 768)), measurements);
 });
 
-test("restore is width-gated and misses unknown conversations", () => {
+test("restore is layout-gated and misses unknown conversations", () => {
   const lru = createTranscriptMeasurementsLru();
-  lru.save("conv-1", 800, [item("a", 120)]);
-  assert.equal(lru.restore("conv-1", 900), null);
-  assert.equal(lru.restore("conv-2", 800), null);
+  lru.save("conv-1", layoutKey(800, 768), [item("a", 120)]);
+  assert.equal(lru.restore("conv-1", layoutKey(900, 768)), null);
+  assert.equal(lru.restore("conv-1", layoutKey(800, 960)), null);
+  assert.equal(lru.restore("conv-2", layoutKey(800, 768)), null);
 });
 
-test("empty snapshots and blank ids are not stored", () => {
+test("empty snapshots, blank ids, and blank layout keys are not stored", () => {
   const lru = createTranscriptMeasurementsLru();
-  lru.save("conv-1", 800, []);
-  lru.save("", 800, [item("a", 120)]);
-  lru.save("conv-2", 0, [item("a", 120)]);
-  assert.equal(lru.restore("conv-1", 800), null);
-  assert.equal(lru.restore("", 800), null);
-  assert.equal(lru.restore("conv-2", 0), null);
+  lru.save("conv-1", layoutKey(800, 768), []);
+  lru.save("", layoutKey(800, 768), [item("a", 120)]);
+  lru.save("conv-2", "", [item("a", 120)]);
+  assert.equal(lru.restore("conv-1", layoutKey(800, 768)), null);
+  assert.equal(lru.restore("", layoutKey(800, 768)), null);
+  assert.equal(lru.restore("conv-2", ""), null);
 });
 
 test("capacity evicts the least recently used entry", () => {
   const lru = createTranscriptMeasurementsLru(2);
-  lru.save("conv-1", 800, [item("a", 1)]);
-  lru.save("conv-2", 800, [item("b", 2)]);
+  lru.save("conv-1", layoutKey(800, 768), [item("a", 1)]);
+  lru.save("conv-2", layoutKey(800, 768), [item("b", 2)]);
   // Touch conv-1 so conv-2 becomes the eviction candidate.
-  assert.ok(lru.restore("conv-1", 800));
-  lru.save("conv-3", 800, [item("c", 3)]);
-  assert.ok(lru.restore("conv-1", 800));
-  assert.equal(lru.restore("conv-2", 800), null);
-  assert.ok(lru.restore("conv-3", 800));
+  assert.ok(lru.restore("conv-1", layoutKey(800, 768)));
+  lru.save("conv-3", layoutKey(800, 768), [item("c", 3)]);
+  assert.ok(lru.restore("conv-1", layoutKey(800, 768)));
+  assert.equal(lru.restore("conv-2", layoutKey(800, 768)), null);
+  assert.ok(lru.restore("conv-3", layoutKey(800, 768)));
 });
 
 test("re-saving a conversation replaces its snapshot", () => {
   const lru = createTranscriptMeasurementsLru();
-  lru.save("conv-1", 800, [item("a", 1)]);
+  lru.save("conv-1", layoutKey(800, 768), [item("a", 1)]);
   const next = [item("a", 2)];
-  lru.save("conv-1", 820, next);
-  assert.equal(lru.restore("conv-1", 800), null);
-  assert.equal(lru.restore("conv-1", 820), next);
+  lru.save("conv-1", layoutKey(820, 960), next);
+  assert.equal(lru.restore("conv-1", layoutKey(800, 768)), null);
+  assert.equal(lru.restore("conv-1", layoutKey(820, 960)), next);
 });

--- a/crates/agent-gui/test/settings/normalization.test.mjs
+++ b/crates/agent-gui/test/settings/normalization.test.mjs
@@ -1358,6 +1358,7 @@ test("settings reload uses persisted right dock state only", () => {
 test("gateway settings sync keeps right dock width local and syncs project state", () => {
   const current = settings.normalizeSettings({
     customSettings: {
+      chatTranscript: { width: 920 },
       rightDock: {
         width: 612,
         projects: {
@@ -1403,6 +1404,7 @@ test("gateway settings sync keeps right dock width local and syncs project state
   });
   const incoming = settings.normalizeSettings({
     customSettings: {
+      chatTranscript: { width: 1100 },
       rightDock: {
         width: 360,
         projects: {
@@ -1449,6 +1451,8 @@ test("gateway settings sync keeps right dock width local and syncs project state
   const payload = sync.buildGatewaySettingsSyncPayload(incoming);
   const synced = sync.applyGatewaySettingsSyncPayload(current, payload);
 
+  assert.equal(payload.customSettings.chatTranscript.width, 768);
+  assert.equal(synced.customSettings.chatTranscript.width, 920);
   assert.equal(synced.customSettings.rightDock.width, 612);
   assert.deepEqual(Object.keys(synced.customSettings.rightDock.projects).sort(), [
     "/desktop/project",
@@ -2183,6 +2187,18 @@ test("font scale settings normalize invalid values to 1 and clamp out-of-range v
 
   const custom = settings.normalizeCustomSettings({ fontScale: { chat: 1.2 } }, []);
   assert.deepEqual(custom.fontScale, { sidebar: 1, chat: 1.2, rightDock: 1 });
+});
+
+test("chat transcript width defaults, clamps, and updates locally", () => {
+  assert.deepEqual(settings.normalizeChatTranscriptSettings(undefined), { width: 768 });
+  assert.deepEqual(settings.normalizeChatTranscriptSettings({ width: 400 }), { width: 560 });
+  assert.deepEqual(settings.normalizeChatTranscriptSettings({ width: 1400 }), { width: 1200 });
+  assert.deepEqual(settings.normalizeChatTranscriptSettings({ width: 920.4 }), { width: 920 });
+
+  const current = settings.normalizeSettings({ customSettings: { chatTranscript: { width: 768 } } });
+  const updated = settings.updateChatTranscriptWidth(current, 960);
+  assert.equal(updated.customSettings.chatTranscript.width, 960);
+  assert.equal(settings.updateChatTranscriptWidth(updated, 960), updated);
 });
 
 test("close window behavior defaults to minimize and only accepts exit", () => {

--- a/scripts/mirror-manifest.json
+++ b/scripts/mirror-manifest.json
@@ -48,6 +48,7 @@
     "lib/chat-floor-nav/floorModel.ts",
     "lib/chat-floor-nav/floorBookmarks.ts",
     "pages/chat/transcript/FloorNavRail.tsx",
+    "pages/chat/transcript/TranscriptWidthControls.tsx",
     "lib/transcript-virtual/entranceOnce.ts",
     "lib/transcript-virtual/liveRangeExtractor.ts",
     "lib/transcript-virtual/liveScrollAdjustPolicy.ts",

--- a/scripts/mirror-manifest.json
+++ b/scripts/mirror-manifest.json
@@ -53,6 +53,7 @@
     "lib/transcript-virtual/liveRangeExtractor.ts",
     "lib/transcript-virtual/liveScrollAdjustPolicy.ts",
     "lib/transcript-virtual/measurementsLru.ts",
+    "lib/transcript-width/transcriptWidthModel.ts",
     "lib/transcript-virtual/rowEstimates.ts",
     "lib/workspace-activity/types.ts",
     "lib/workspace-activity/useWorkspaceInvalidation.ts",


### PR DESCRIPTION
## Summary

- add locally persisted transcript-body width controls to desktop and gateway chat views
- support bilateral dragging, keyboard resizing, double-click reset, responsive clamping, and coarse-pointer hiding
- keep the composer width independent and exclude the preference from gateway settings synchronization
- preserve width-qualified virtualizer measurements and bottom-follow behavior across resize and conversation switches

## Validation

- desktop Tauri runtime: 39 interaction checkpoints, zero mounted-row overlaps
- gateway browser runtime: verified 1200 px and 800 px transcript widths with a 768 px composer and zero overlaps
- desktop focused tests: 7/7
- gateway focused tests: 8/8
- settings normalization tests: 53/53
- desktop and gateway production builds
- mirror check: 105 files
- staged diff whitespace check