### PR TITLE
fix(chat): generate conversation titles in the UI locale

### DIFF
--- a/crates/agent-gui/src/lib/chat/page/chatPageHelpers.ts
+++ b/crates/agent-gui/src/lib/chat/page/chatPageHelpers.ts
@@ -1,4 +1,5 @@
 import type { Context } from "@earendil-works/pi-ai";
+import { DEFAULT_LOCALE, type Locale } from "../../../i18n/config";
 import { type ModelOption, toModelValue } from "../../providers/llm";
 import type { AppSettings } from "../../settings";
 import { createUuid } from "../../shared/id";
@@ -7,6 +8,10 @@ import { getMessageText } from "../messages/uiMessages";
 
 const FALLBACK_TITLE_MAX_CHARS = 48;
 const TITLE_LOOKAHEAD_TIMEOUT_MS = 1_200;
+const TITLE_MAX_LATIN_WORDS = 10;
+const TITLE_MAX_CJK_CHARS = 24;
+const TITLE_MAX_CHARS = 80;
+const CJK_CHAR_PATTERN = /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff]/;
 const MODEL_GENERATING_STATUS_PATTERN = /^第\s*\d+\s*轮：模型生成中\.\.\.$/;
 
 export const VIBING_STATUS = "Vibing...";
@@ -113,8 +118,23 @@ export function buildModelOptions(
   return options;
 }
 
-export function buildConversationTitlePrompt(content: string) {
-  return `Based on the following content, generate a title within 10 words for this conversation and output it directly without any other content:${content}`;
+/** System prompt for the lightweight first-turn title job. Follows UI locale. */
+export function buildConversationTitleSystemPrompt(locale: Locale = DEFAULT_LOCALE) {
+  if (locale === "zh-CN") {
+    return "你负责生成简洁的会话标题。只输出标题本身，不要解释、不要引号。标题必须使用简体中文；专有名词（如 Grok、API）可保留原文。";
+  }
+  return "You generate concise conversation titles. Output the title only, with no extra explanation or quotes.";
+}
+
+/**
+ * User prompt for the title job. Language follows the app UI locale so Chinese
+ * installs no longer get English titles by default.
+ */
+export function buildConversationTitlePrompt(content: string, locale: Locale = DEFAULT_LOCALE) {
+  if (locale === "zh-CN") {
+    return `根据以下内容，为本次会话生成一个简练的简体中文标题（约 8～18 个字，概括主题，不要照抄整句问话），直接输出标题，不要其他内容：\n${content}`;
+  }
+  return `Based on the following content, generate a title within 10 words for this conversation and output it directly without any other content:\n${content}`;
 }
 
 export function normalizeConversationTitle(raw: string) {
@@ -126,9 +146,17 @@ export function normalizeConversationTitle(raw: string) {
 
   if (!singleLine) return "";
 
+  // CJK titles are character-dense and usually unspaced; word caps would keep them whole.
+  if (CJK_CHAR_PATTERN.test(singleLine)) {
+    return singleLine.slice(0, TITLE_MAX_CJK_CHARS).trim();
+  }
+
   const words = singleLine.split(" ").filter(Boolean);
-  const limitedWords = words.length > 10 ? words.slice(0, 10).join(" ") : singleLine;
-  return limitedWords.slice(0, 80).trim();
+  const limitedWords =
+    words.length > TITLE_MAX_LATIN_WORDS
+      ? words.slice(0, TITLE_MAX_LATIN_WORDS).join(" ")
+      : singleLine;
+  return limitedWords.slice(0, TITLE_MAX_CHARS).trim();
 }
 
 export function buildFallbackConversationTitle(content: string) {

--- a/crates/agent-gui/src/lib/chat/page/chatPageHelpers.ts
+++ b/crates/agent-gui/src/lib/chat/page/chatPageHelpers.ts
@@ -1,5 +1,5 @@
 import type { Context } from "@earendil-works/pi-ai";
-import { DEFAULT_LOCALE, type Locale } from "../../../i18n/config";
+import type { Locale } from "../../../i18n/config";
 import { type ModelOption, toModelValue } from "../../providers/llm";
 import type { AppSettings } from "../../settings";
 import { createUuid } from "../../shared/id";
@@ -11,7 +11,9 @@ const TITLE_LOOKAHEAD_TIMEOUT_MS = 1_200;
 const TITLE_MAX_LATIN_WORDS = 10;
 const TITLE_MAX_CJK_CHARS = 24;
 const TITLE_MAX_CHARS = 80;
-const CJK_CHAR_PATTERN = /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff]/;
+// Global on purpose: only ever used with String#match below, never with #test
+// (a sticky lastIndex would make alternating calls disagree).
+const CJK_CHAR_PATTERN = /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff]/g;
 const MODEL_GENERATING_STATUS_PATTERN = /^第\s*\d+\s*轮：模型生成中\.\.\.$/;
 
 export const VIBING_STATUS = "Vibing...";
@@ -119,7 +121,7 @@ export function buildModelOptions(
 }
 
 /** System prompt for the lightweight first-turn title job. Follows UI locale. */
-export function buildConversationTitleSystemPrompt(locale: Locale = DEFAULT_LOCALE) {
+export function buildConversationTitleSystemPrompt(locale: Locale) {
   if (locale === "zh-CN") {
     return "你负责生成简洁的会话标题。只输出标题本身，不要解释、不要引号。标题必须使用简体中文；专有名词（如 Grok、API）可保留原文。";
   }
@@ -130,13 +132,18 @@ export function buildConversationTitleSystemPrompt(locale: Locale = DEFAULT_LOCA
  * User prompt for the title job. Language follows the app UI locale so Chinese
  * installs no longer get English titles by default.
  */
-export function buildConversationTitlePrompt(content: string, locale: Locale = DEFAULT_LOCALE) {
+export function buildConversationTitlePrompt(content: string, locale: Locale) {
   if (locale === "zh-CN") {
     return `根据以下内容，为本次会话生成一个简练的简体中文标题（约 8～18 个字，概括主题，不要照抄整句问话），直接输出标题，不要其他内容：\n${content}`;
   }
   return `Based on the following content, generate a title within 10 words for this conversation and output it directly without any other content:\n${content}`;
 }
 
+/**
+ * Shared title normalizer: also used to sanitize titles the user types in the
+ * sidebar rename box, so it must never shorten a title more than the historical
+ * latin word/char caps did.
+ */
 export function normalizeConversationTitle(raw: string) {
   const singleLine = raw
     .replace(/[\r\n]+/g, " ")
@@ -146,17 +153,34 @@ export function normalizeConversationTitle(raw: string) {
 
   if (!singleLine) return "";
 
-  // CJK titles are character-dense and usually unspaced; word caps would keep them whole.
-  if (CJK_CHAR_PATTERN.test(singleLine)) {
-    return singleLine.slice(0, TITLE_MAX_CJK_CHARS).trim();
-  }
-
   const words = singleLine.split(" ").filter(Boolean);
   const limitedWords =
     words.length > TITLE_MAX_LATIN_WORDS
       ? words.slice(0, TITLE_MAX_LATIN_WORDS).join(" ")
       : singleLine;
   return limitedWords.slice(0, TITLE_MAX_CHARS).trim();
+}
+
+/**
+ * Normalizer for model-generated titles only. CJK titles are character-dense
+ * and usually unspaced, so the latin word cap would let them run the full 80
+ * chars; cap those by character count instead. Applies only when the title is
+ * predominantly CJK, so a latin title containing a stray CJK token keeps the
+ * word cap. Never used on user-typed renames.
+ */
+export function normalizeGeneratedConversationTitle(raw: string) {
+  const title = normalizeConversationTitle(raw);
+  if (!title) return "";
+
+  // Code points, not UTF-16 units: slicing mid-surrogate would leave a lone
+  // half that renders as U+FFFD.
+  const chars = Array.from(title);
+  const cjkCount = title.match(CJK_CHAR_PATTERN)?.length ?? 0;
+  if (cjkCount * 2 < chars.length) return title;
+
+  return chars.length > TITLE_MAX_CJK_CHARS
+    ? chars.slice(0, TITLE_MAX_CJK_CHARS).join("").trim()
+    : title;
 }
 
 export function buildFallbackConversationTitle(content: string) {

--- a/crates/agent-gui/src/pages/chat/runtime/conversationTitleJob.ts
+++ b/crates/agent-gui/src/pages/chat/runtime/conversationTitleJob.ts
@@ -1,11 +1,10 @@
 import type { MutableRefObject } from "react";
 import type { Locale } from "../../../i18n/config";
-import { DEFAULT_LOCALE } from "../../../i18n/config";
 import type { GatewayBridgeEventController } from "../../../lib/chat/conversation/run";
 import {
   buildConversationTitlePrompt,
   buildConversationTitleSystemPrompt,
-  normalizeConversationTitle,
+  normalizeGeneratedConversationTitle,
 } from "../../../lib/chat/page/chatPageHelpers";
 import { assistantMessageToText, streamAssistantMessage } from "../../../lib/providers/llm";
 import type { ProviderId } from "../../../lib/settings";
@@ -24,8 +23,11 @@ type StartConversationTitleJobParams = {
   conversationId: string;
   titleSourceText: string;
   content: string;
-  /** UI locale; title language follows this (default zh-CN). */
-  locale?: Locale;
+  /**
+   * UI locale; the generated title language follows it. Required so a new
+   * caller cannot silently fall back to Chinese titles in an English UI.
+   */
+  locale: Locale;
   // Only the pending row's title is streamed into the sidebar; persisted rows
   // are renamed through the history IPC by the caller.
   sidebarStore: Pick<SidebarStore, "peek" | "upsertLocal">;
@@ -55,7 +57,7 @@ export function startConversationTitleJob(params: StartConversationTitleJobParam
     conversationId,
     titleSourceText,
     content,
-    locale = DEFAULT_LOCALE,
+    locale,
     sidebarStore,
     titleJobRef,
     gatewayBridgeEvents,
@@ -114,7 +116,7 @@ export function startConversationTitleJob(params: StartConversationTitleJobParam
       });
     },
   })
-    .then((assistant) => normalizeConversationTitle(assistantMessageToText(assistant)))
+    .then((assistant) => normalizeGeneratedConversationTitle(assistantMessageToText(assistant)))
     .then((title) => title || null)
     .catch(() => null);
 

--- a/crates/agent-gui/src/pages/chat/runtime/conversationTitleJob.ts
+++ b/crates/agent-gui/src/pages/chat/runtime/conversationTitleJob.ts
@@ -1,7 +1,10 @@
 import type { MutableRefObject } from "react";
+import type { Locale } from "../../../i18n/config";
+import { DEFAULT_LOCALE } from "../../../i18n/config";
 import type { GatewayBridgeEventController } from "../../../lib/chat/conversation/run";
 import {
   buildConversationTitlePrompt,
+  buildConversationTitleSystemPrompt,
   normalizeConversationTitle,
 } from "../../../lib/chat/page/chatPageHelpers";
 import { assistantMessageToText, streamAssistantMessage } from "../../../lib/providers/llm";
@@ -21,6 +24,8 @@ type StartConversationTitleJobParams = {
   conversationId: string;
   titleSourceText: string;
   content: string;
+  /** UI locale; title language follows this (default zh-CN). */
+  locale?: Locale;
   // Only the pending row's title is streamed into the sidebar; persisted rows
   // are renamed through the history IPC by the caller.
   sidebarStore: Pick<SidebarStore, "peek" | "upsertLocal">;
@@ -50,6 +55,7 @@ export function startConversationTitleJob(params: StartConversationTitleJobParam
     conversationId,
     titleSourceText,
     content,
+    locale = DEFAULT_LOCALE,
     sidebarStore,
     titleJobRef,
     gatewayBridgeEvents,
@@ -82,12 +88,11 @@ export function startConversationTitleJob(params: StartConversationTitleJobParam
     cacheRetention: "none",
     nativeWebSearch: false,
     context: {
-      systemPrompt:
-        "You generate concise conversation titles. Output the title only, with no extra explanation.",
+      systemPrompt: buildConversationTitleSystemPrompt(locale),
       messages: [
         {
           role: "user",
-          content: buildConversationTitlePrompt(titleSourceText || content),
+          content: buildConversationTitlePrompt(titleSourceText || content, locale),
           timestamp: Date.now(),
         },
       ],

--- a/crates/agent-gui/src/pages/chat/runtime/useSendChatTurn.ts
+++ b/crates/agent-gui/src/pages/chat/runtime/useSendChatTurn.ts
@@ -595,6 +595,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         conversationId,
         titleSourceText,
         content,
+        locale: settings.locale,
         sidebarStore,
         titleJobRef,
         gatewayBridgeEvents,

--- a/crates/agent-gui/test/chat/conversation-title-job.test.mjs
+++ b/crates/agent-gui/test/chat/conversation-title-job.test.mjs
@@ -70,6 +70,7 @@ test("conversation title job disables thinking, caching, and native web search",
     conversationId: "conversation-1",
     titleSourceText: "Please build a fast settings drawer.",
     content: "Please build a fast settings drawer.",
+    locale: "en-US",
     sidebarStore,
     titleJobRef,
     gatewayBridgeEvents: {
@@ -88,4 +89,32 @@ test("conversation title job disables thinking, caching, and native web search",
   assert.equal(capturedParams.cacheRetention, "none");
   assert.equal(historyItemsById.get("conversation-1").title, "Fast title");
   assert.equal(forwardedTitles[0], "Fast title");
+  // The requested locale must reach the model, not just the prompt builders.
+  assert.match(capturedParams.context.systemPrompt, /concise conversation titles/i);
+  assert.match(capturedParams.context.messages[0].content, /within 10 words/i);
+
+  historyItemsById.set("conversation-1", {
+    id: "conversation-1",
+    title: "新会话",
+    updatedAt: 1,
+    isPending: true,
+  });
+  await startConversationTitleJob({
+    providerId: "codex",
+    model: "gpt-5",
+    runtime,
+    signal: new AbortController().signal,
+    conversationId: "conversation-1",
+    titleSourceText: "请帮我做一个很快的设置抽屉。",
+    content: "请帮我做一个很快的设置抽屉。",
+    locale: "zh-CN",
+    sidebarStore,
+    titleJobRef,
+    gatewayBridgeEvents: {
+      queueTitle: (nextTitle) => forwardedTitles.push(nextTitle),
+    },
+  });
+
+  assert.match(capturedParams.context.systemPrompt, /简体中文/);
+  assert.match(capturedParams.context.messages[0].content, /简体中文标题/);
 });

--- a/crates/agent-gui/test/chat/messages.test.mjs
+++ b/crates/agent-gui/test/chat/messages.test.mjs
@@ -2285,10 +2285,36 @@ test("chat page helpers keep model options stable and normalize status/title edg
   );
   assert.equal(chatHelpers.normalizeConversationTitle("  one two \n three  "), "one two three");
   assert.equal(chatHelpers.normalizeConversationTitle("one two three four five six seven eight nine ten eleven"), "one two three four five six seven eight nine ten");
+  // Rename box shares this normalizer: a long CJK title the user typed must survive intact.
   assert.equal(
-    chatHelpers.normalizeConversationTitle("侧边栏会话标题改成中文简要总结并写入全局记忆偏好"),
-    "侧边栏会话标题改成中文简要总结并写入全局记忆偏好".slice(0, 24),
+    chatHelpers.normalizeConversationTitle("关于侧边栏会话标题生成逻辑的重构与国际化适配讨论记录第二版"),
+    "关于侧边栏会话标题生成逻辑的重构与国际化适配讨论记录第二版",
   );
+  assert.equal(
+    chatHelpers.normalizeConversationTitle("Fix 中文 encoding in the parser module and add regression tests"),
+    "Fix 中文 encoding in the parser module and add regression",
+  );
+  // Generated titles additionally get a CJK character cap.
+  assert.equal(
+    chatHelpers.normalizeGeneratedConversationTitle("关于侧边栏会话标题生成逻辑的重构与国际化适配讨论记录第二版"),
+    "关于侧边栏会话标题生成逻辑的重构与国际化适配讨论",
+  );
+  // Latin-dominant titles keep the word cap even when they contain a CJK token.
+  assert.equal(
+    chatHelpers.normalizeGeneratedConversationTitle("Fix 中文 encoding in the parser module and add regression tests"),
+    "Fix 中文 encoding in the parser module and add regression",
+  );
+  assert.equal(
+    chatHelpers.normalizeGeneratedConversationTitle("one two three four five six seven eight nine ten eleven"),
+    "one two three four five six seven eight nine ten",
+  );
+  // The CJK cap counts code points, so an astral char at the boundary is not split in half.
+  const cappedAstralTitle = chatHelpers.normalizeGeneratedConversationTitle(
+    `${"中".repeat(23)}😀尾`,
+  );
+  assert.equal(cappedAstralTitle, `${"中".repeat(23)}😀`);
+  assert.equal(/[\uD800-\uDBFF]$/.test(cappedAstralTitle), false);
+  assert.equal(chatHelpers.normalizeGeneratedConversationTitle("  "), "");
   assert.match(chatHelpers.buildConversationTitleSystemPrompt("zh-CN"), /简体中文/);
   assert.match(chatHelpers.buildConversationTitleSystemPrompt("en-US"), /concise conversation titles/i);
   assert.match(chatHelpers.buildConversationTitlePrompt("hello", "zh-CN"), /简体中文标题/);

--- a/crates/agent-gui/test/chat/messages.test.mjs
+++ b/crates/agent-gui/test/chat/messages.test.mjs
@@ -2285,6 +2285,14 @@ test("chat page helpers keep model options stable and normalize status/title edg
   );
   assert.equal(chatHelpers.normalizeConversationTitle("  one two \n three  "), "one two three");
   assert.equal(chatHelpers.normalizeConversationTitle("one two three four five six seven eight nine ten eleven"), "one two three four five six seven eight nine ten");
+  assert.equal(
+    chatHelpers.normalizeConversationTitle("侧边栏会话标题改成中文简要总结并写入全局记忆偏好"),
+    "侧边栏会话标题改成中文简要总结并写入全局记忆偏好".slice(0, 24),
+  );
+  assert.match(chatHelpers.buildConversationTitleSystemPrompt("zh-CN"), /简体中文/);
+  assert.match(chatHelpers.buildConversationTitleSystemPrompt("en-US"), /concise conversation titles/i);
+  assert.match(chatHelpers.buildConversationTitlePrompt("hello", "zh-CN"), /简体中文标题/);
+  assert.match(chatHelpers.buildConversationTitlePrompt("hello", "en-US"), /within 10 words/i);
   assert.equal(chatHelpers.buildFallbackConversationTitle("x".repeat(60)), `${"x".repeat(48)}...`);
   assert.equal(chatHelpers.normalizeLiveToolStatus("第 2 轮：模型生成中..."), chatHelpers.VIBING_STATUS);
   assert.equal(chatHelpers.normalizeLiveToolStatus("Running"), "Running");


### PR DESCRIPTION
## Summary
- Conversation title generation previously always used **English** system/user prompts, so users with Chinese UI still got English sidebar titles.
- Title prompts now follow `settings.locale` (app default is `zh-CN`): Chinese UI → 简体中文标题; English UI → English titles.
- CJK titles use a character-based length cap (24) instead of an English word cap that does not fit unspaced Chinese.

## Why
LiveAgent UI default locale is already `zh-CN`, but `conversationTitleJob` hard-coded English prompts like *"You generate concise conversation titles..."* and *"generate a title within 10 words"*. Models therefore defaulted to English titles.

## Changes
- `buildConversationTitleSystemPrompt(locale)` / `buildConversationTitlePrompt(content, locale)` in `chatPageHelpers.ts`
- `startConversationTitleJob` accepts `locale` and passes it into the title LLM call
- `useSendChatTurn` passes `settings.locale`
- unit tests for zh-CN / en-US prompts and CJK normalize

## Test plan
- [x] `node --test test/chat/messages.test.mjs` (49 pass)
- [x] `biome check` on touched files
- [ ] Manual: set Settings → Language to 简体中文, start a new chat with a Chinese first message, confirm sidebar title is Chinese
- [ ] Manual: switch Language to English, new chat gets English title

## Notes
- Does **not** rewrite existing history titles (those remain until renamed / re-titled).
- Official signed builds still come from upstream Releases; this PR needs merge + release to ship in installers. Local `make dev` / build-from-source can verify earlier.