### PR TITLE
feat(composer): compact attachment thumbnails with click-to-preview

### DIFF
--- a/crates/agent-gateway/web/src/components/chat/ComposerAttachmentCard.tsx
+++ b/crates/agent-gateway/web/src/components/chat/ComposerAttachmentCard.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 
 import { X } from "../icons";
+import { ImagePreview, type ImagePreviewSlide } from "./ImagePreview";
 
 export function ComposerAttachmentCard(props: {
   fileName: string;
@@ -10,6 +11,8 @@ export function ComposerAttachmentCard(props: {
   fallbackIcon: ReactNode;
   disabled: boolean;
   removeLabel: string;
+  previewLabel?: string;
+  closePreviewLabel?: string;
   onRemove: () => void;
 }) {
   const {
@@ -20,25 +23,68 @@ export function ComposerAttachmentCard(props: {
     fallbackIcon,
     disabled,
     removeLabel,
+    previewLabel,
+    closePreviewLabel,
     onRemove,
   } = props;
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const previewSlides = useMemo<ImagePreviewSlide[]>(
+    () => (imageSrc ? [{ src: imageSrc, alt: fileName, title: fileName }] : []),
+    [fileName, imageSrc],
+  );
+
+  // 图片附件：纯缩略图方块，点击放大预览，文件名放悬浮提示，角标删除。
+  if (imageSrc || isImageLoading) {
+    return (
+      <div
+        title={fileName}
+        className="group relative h-12 w-12 shrink-0 overflow-hidden rounded-lg border border-black/[0.075] bg-black/[0.035] transition-[border-color] hover:border-black/[0.16] dark:border-white/[0.11] dark:bg-white/[0.065] dark:hover:border-white/[0.22]"
+      >
+        {imageSrc ? (
+          <button
+            type="button"
+            onClick={() => setPreviewOpen(true)}
+            className="block h-full w-full cursor-zoom-in outline-hidden focus-visible:ring-2 focus-visible:ring-ring/60"
+            aria-label={previewLabel ? `${previewLabel}: ${fileName}` : fileName}
+            title={previewLabel}
+          >
+            <img src={imageSrc} alt="" draggable={false} className="h-full w-full object-cover" />
+          </button>
+        ) : (
+          <span className="block h-full w-full animate-pulse bg-black/[0.055] dark:bg-white/[0.09]" />
+        )}
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onRemove}
+          className="absolute right-0.5 top-0.5 z-10 inline-flex h-4 w-4 items-center justify-center rounded-full bg-black/50 text-white/95 backdrop-blur-sm transition-[background-color,scale] hover:bg-black/70 active:scale-90 focus-visible:bg-black/70 disabled:pointer-events-none disabled:opacity-35"
+          aria-label={`${removeLabel} ${fileName}`}
+          title={removeLabel}
+        >
+          <X className="h-2.5 w-2.5" />
+        </button>
+        {previewOpen ? (
+          <ImagePreview
+            open={previewOpen}
+            slides={previewSlides}
+            closeLabel={closePreviewLabel}
+            onClose={() => setPreviewOpen(false)}
+          />
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div
       title={pathTitle}
-      className="group flex h-16 w-[min(26rem,100%)] shrink-0 items-center gap-2.5 rounded-xl border border-black/[0.075] bg-black/[0.035] p-2 pr-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.64)] transition-[border-color,background-color] hover:border-black/[0.11] hover:bg-black/[0.05] dark:border-white/[0.11] dark:bg-white/[0.065] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.055)] dark:hover:border-white/[0.16] dark:hover:bg-white/[0.09]"
+      className="group flex h-9 w-36 max-w-[calc(100vw-5rem)] shrink-0 items-center gap-1 rounded-lg border border-black/[0.075] bg-black/[0.035] p-1 pr-1.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.64)] transition-[border-color,background-color] hover:border-black/[0.11] hover:bg-black/[0.05] dark:border-white/[0.11] dark:bg-white/[0.065] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.055)] dark:hover:border-white/[0.16] dark:hover:bg-white/[0.09]"
     >
-      <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-black/[0.045] text-muted-foreground dark:bg-white/[0.08]">
-        {imageSrc ? (
-          <img src={imageSrc} alt="" draggable={false} className="h-full w-full object-cover" />
-        ) : isImageLoading ? (
-          <span className="h-full w-full animate-pulse bg-black/[0.055] dark:bg-white/[0.09]" />
-        ) : (
-          fallbackIcon
-        )}
-      </div>
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-md bg-black/[0.045] text-muted-foreground dark:bg-white/[0.08]">
+        {fallbackIcon}
+      </span>
 
-      <span className="min-w-0 flex-1 truncate text-[calc(13px*var(--zone-font-scale,1))] font-medium leading-5 tracking-tight text-foreground/90">
+      <span className="min-w-0 flex-1 truncate text-[calc(11px*var(--zone-font-scale,1))] font-medium leading-4 tracking-tight text-foreground/90">
         {fileName}
       </span>
 
@@ -46,11 +92,11 @@ export function ComposerAttachmentCard(props: {
         type="button"
         disabled={disabled}
         onClick={onRemove}
-        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground/75 outline-hidden transition-[background-color,color,scale] hover:bg-foreground/[0.07] hover:text-foreground active:scale-90 focus-visible:bg-foreground/[0.07] focus-visible:text-foreground disabled:pointer-events-none disabled:opacity-35"
+        className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-muted-foreground/75 outline-hidden transition-[background-color,color,scale] hover:bg-foreground/[0.07] hover:text-foreground active:scale-90 focus-visible:bg-foreground/[0.07] focus-visible:text-foreground disabled:pointer-events-none disabled:opacity-35"
         aria-label={`${removeLabel} ${fileName}`}
         title={removeLabel}
       >
-        <X className="h-4 w-4" />
+        <X className="h-3 w-3" />
       </button>
     </div>
   );

--- a/crates/agent-gateway/web/src/index.css
+++ b/crates/agent-gateway/web/src/index.css
@@ -382,32 +382,16 @@
     background: hsl(var(--muted-foreground) / 0.35);
   }
 
-  /* Upload file list scrollbar */
+  /* Upload file list: scrollable without a visible scrollbar */
   .upload-file-list {
-    scrollbar-width: thin;
-    scrollbar-color: transparent transparent;
-    transition: scrollbar-color 0.3s;
-  }
-  .upload-file-list:hover {
-    scrollbar-color: hsl(var(--muted-foreground) / 0.25) transparent;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
   }
   .upload-file-list::-webkit-scrollbar {
-    height: 4px;
-  }
-  .upload-file-list::-webkit-scrollbar-track {
-    background: transparent;
-    margin: 0 8px;
-  }
-  .upload-file-list::-webkit-scrollbar-thumb {
-    background: transparent;
-    border-radius: 2px;
-    transition: background 0.3s;
-  }
-  .upload-file-list:hover::-webkit-scrollbar-thumb {
-    background: hsl(var(--muted-foreground) / 0.25);
-  }
-  .upload-file-list:hover::-webkit-scrollbar-thumb:hover {
-    background: hsl(var(--muted-foreground) / 0.4);
+    display: none;
+    width: 0;
+    height: 0;
   }
 
   .tool-text-scroll {

--- a/crates/agent-gateway/web/src/pages/chat/ChatComposerBar.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/ChatComposerBar.tsx
@@ -151,10 +151,21 @@ function PendingComposerAttachment(props: {
   workdir: string;
   disabled: boolean;
   removeLabel: string;
+  previewLabel: string;
+  closePreviewLabel: string;
   imagePreviewLoader?: UploadedImagePreviewLoader;
   onRemove: (relativePath: string) => void;
 }) {
-  const { file, workdir, disabled, removeLabel, imagePreviewLoader, onRemove } = props;
+  const {
+    file,
+    workdir,
+    disabled,
+    removeLabel,
+    previewLabel,
+    closePreviewLabel,
+    imagePreviewLoader,
+    onRemove,
+  } = props;
   const { imageSrc, isLoading } = useComposerUploadedImagePreview(
     file,
     workdir,
@@ -171,6 +182,8 @@ function PendingComposerAttachment(props: {
       fallbackIcon={<TypeIcon className="h-4 w-4" />}
       disabled={disabled}
       removeLabel={removeLabel}
+      previewLabel={previewLabel}
+      closePreviewLabel={closePreviewLabel}
       onRemove={() => onRemove(file.relativePath)}
     />
   );
@@ -277,6 +290,8 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
   const [isComposerExpanded, setIsComposerExpanded] = useState(false);
   const isComposerExpandedRef = useRef(false);
   const glassCardRef = useRef<HTMLDivElement | null>(null);
+  const attachmentListRef = useRef<HTMLDivElement | null>(null);
+  const previousPendingUploadCountRef = useRef(0);
   /** 切换瞬间记录的卡片旧高度，供 FLIP 动画用；消费后立即置空。 */
   const expandFromHeightRef = useRef<number | null>(null);
   const expandAnimationRef = useRef<Animation | null>(null);
@@ -334,6 +349,15 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
   const toggleQueueCollapsed = useCallback(() => {
     setQueueCollapsed((current) => !current);
   }, []);
+
+  useLayoutEffect(() => {
+    const previousCount = previousPendingUploadCountRef.current;
+    previousPendingUploadCountRef.current = pendingUploadedFiles.length;
+    if (pendingUploadedFiles.length <= previousCount) return;
+
+    const attachmentList = attachmentListRef.current;
+    if (attachmentList) attachmentList.scrollLeft = attachmentList.scrollWidth;
+  }, [pendingUploadedFiles.length]);
 
   // ref 与 state 同步更新：高度上报的 RO 回调可能先于 effect 执行，
   // 必须在布局变化前就能读到最新展开态。切换前记录卡片当前高度，
@@ -779,7 +803,10 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
           />
 
           {pendingUploadedFiles.length > 0 ? (
-            <div className="upload-file-list relative z-10 flex shrink-0 gap-2 overflow-x-auto pb-1 pl-4 pr-12 pt-3.5">
+            <div
+              ref={attachmentListRef}
+              className="upload-file-list relative z-10 flex shrink-0 items-center gap-1.5 overflow-x-auto overflow-y-hidden pb-1 pl-4 pr-12 pt-2"
+            >
               {pendingUploadedFiles.map((file) => (
                 <PendingComposerAttachment
                   key={`${file.relativePath}-${file.absolutePath ?? file.fileName}`}
@@ -787,6 +814,8 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
                   workdir={workdir}
                   disabled={isInputDisabled}
                   removeLabel={t("chat.upload.removeFile")}
+                  previewLabel={t("chat.upload.previewImage")}
+                  closePreviewLabel={t("chat.upload.closePreview")}
                   imagePreviewLoader={onLoadUploadedImagePreview}
                   onRemove={onRemovePendingUpload}
                 />
@@ -815,7 +844,7 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
           <div
             className={cn(
               "relative flex flex-1 px-4",
-              pendingUploadedFiles.length > 0 ? "pt-2" : "pt-3.5",
+              pendingUploadedFiles.length > 0 ? "pt-1.5" : "pt-3.5",
               isComposerExpanded && "min-h-0",
             )}
             onFocusCapture={onPrepareChatRuntime}

--- a/crates/agent-gateway/web/src/styles.css
+++ b/crates/agent-gateway/web/src/styles.css
@@ -395,14 +395,24 @@ html[data-liveagent-webui="gateway"] .scroll-area-thumb:active {
   background: var(--gateway-scrollbar-thumb-active);
 }
 
-html[data-liveagent-webui="gateway"] .upload-file-list,
 html[data-liveagent-webui="gateway"] .tool-text-scroll,
 html[data-liveagent-webui="gateway"] .mention-popup-scroll,
 html[data-liveagent-webui="gateway"] .settings-provider-tabs-wrap {
   scrollbar-color: var(--gateway-scrollbar-thumb) transparent;
 }
 
-html[data-liveagent-webui="gateway"] .upload-file-list::-webkit-scrollbar,
+/* Upload file list: scrollable without a visible scrollbar (overrides gateway globals) */
+html[data-liveagent-webui="gateway"] .upload-file-list {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+html[data-liveagent-webui="gateway"] .upload-file-list::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 html[data-liveagent-webui="gateway"] .settings-provider-tabs-wrap::-webkit-scrollbar {
   height: 8px;
 }
@@ -3254,11 +3264,6 @@ html[data-liveagent-webui="gateway"]
 
   .gateway-composer-layer > .gateway-chat-column {
     min-width: 0;
-  }
-
-  .gateway-chat-frame .upload-file-list > div {
-    width: min(76vw, 17rem);
-    min-width: min(76vw, 17rem);
   }
 
   .gateway-chat-frame .mention-composer {

--- a/crates/agent-gui/src/components/chat/ComposerAttachmentCard.tsx
+++ b/crates/agent-gui/src/components/chat/ComposerAttachmentCard.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 
 import { X } from "../icons";
+import { ImagePreview, type ImagePreviewSlide } from "./ImagePreview";
 
 export function ComposerAttachmentCard(props: {
   fileName: string;
@@ -10,6 +11,8 @@ export function ComposerAttachmentCard(props: {
   fallbackIcon: ReactNode;
   disabled: boolean;
   removeLabel: string;
+  previewLabel?: string;
+  closePreviewLabel?: string;
   onRemove: () => void;
 }) {
   const {
@@ -20,25 +23,68 @@ export function ComposerAttachmentCard(props: {
     fallbackIcon,
     disabled,
     removeLabel,
+    previewLabel,
+    closePreviewLabel,
     onRemove,
   } = props;
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const previewSlides = useMemo<ImagePreviewSlide[]>(
+    () => (imageSrc ? [{ src: imageSrc, alt: fileName, title: fileName }] : []),
+    [fileName, imageSrc],
+  );
+
+  // 图片附件：纯缩略图方块，点击放大预览，文件名放悬浮提示，角标删除。
+  if (imageSrc || isImageLoading) {
+    return (
+      <div
+        title={fileName}
+        className="group relative h-12 w-12 shrink-0 overflow-hidden rounded-lg border border-black/[0.075] bg-black/[0.035] transition-[border-color] hover:border-black/[0.16] dark:border-white/[0.11] dark:bg-white/[0.065] dark:hover:border-white/[0.22]"
+      >
+        {imageSrc ? (
+          <button
+            type="button"
+            onClick={() => setPreviewOpen(true)}
+            className="block h-full w-full cursor-zoom-in outline-hidden focus-visible:ring-2 focus-visible:ring-ring/60"
+            aria-label={previewLabel ? `${previewLabel}: ${fileName}` : fileName}
+            title={previewLabel}
+          >
+            <img src={imageSrc} alt="" draggable={false} className="h-full w-full object-cover" />
+          </button>
+        ) : (
+          <span className="block h-full w-full animate-pulse bg-black/[0.055] dark:bg-white/[0.09]" />
+        )}
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onRemove}
+          className="absolute right-0.5 top-0.5 z-10 inline-flex h-4 w-4 items-center justify-center rounded-full bg-black/50 text-white/95 backdrop-blur-sm transition-[background-color,scale] hover:bg-black/70 active:scale-90 focus-visible:bg-black/70 disabled:pointer-events-none disabled:opacity-35"
+          aria-label={`${removeLabel} ${fileName}`}
+          title={removeLabel}
+        >
+          <X className="h-2.5 w-2.5" />
+        </button>
+        {previewOpen ? (
+          <ImagePreview
+            open={previewOpen}
+            slides={previewSlides}
+            closeLabel={closePreviewLabel}
+            onClose={() => setPreviewOpen(false)}
+          />
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div
       title={pathTitle}
-      className="group flex h-16 w-[min(26rem,100%)] shrink-0 items-center gap-2.5 rounded-xl border border-black/[0.075] bg-black/[0.035] p-2 pr-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.64)] transition-[border-color,background-color] hover:border-black/[0.11] hover:bg-black/[0.05] dark:border-white/[0.11] dark:bg-white/[0.065] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.055)] dark:hover:border-white/[0.16] dark:hover:bg-white/[0.09]"
+      className="group flex h-9 w-36 max-w-[calc(100vw-5rem)] shrink-0 items-center gap-1 rounded-lg border border-black/[0.075] bg-black/[0.035] p-1 pr-1.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.64)] transition-[border-color,background-color] hover:border-black/[0.11] hover:bg-black/[0.05] dark:border-white/[0.11] dark:bg-white/[0.065] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.055)] dark:hover:border-white/[0.16] dark:hover:bg-white/[0.09]"
     >
-      <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-black/[0.045] text-muted-foreground dark:bg-white/[0.08]">
-        {imageSrc ? (
-          <img src={imageSrc} alt="" draggable={false} className="h-full w-full object-cover" />
-        ) : isImageLoading ? (
-          <span className="h-full w-full animate-pulse bg-black/[0.055] dark:bg-white/[0.09]" />
-        ) : (
-          fallbackIcon
-        )}
-      </div>
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-md bg-black/[0.045] text-muted-foreground dark:bg-white/[0.08]">
+        {fallbackIcon}
+      </span>
 
-      <span className="min-w-0 flex-1 truncate text-[calc(13px*var(--zone-font-scale,1))] font-medium leading-5 tracking-tight text-foreground/90">
+      <span className="min-w-0 flex-1 truncate text-[calc(11px*var(--zone-font-scale,1))] font-medium leading-4 tracking-tight text-foreground/90">
         {fileName}
       </span>
 
@@ -46,11 +92,11 @@ export function ComposerAttachmentCard(props: {
         type="button"
         disabled={disabled}
         onClick={onRemove}
-        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground/75 outline-hidden transition-[background-color,color,scale] hover:bg-foreground/[0.07] hover:text-foreground active:scale-90 focus-visible:bg-foreground/[0.07] focus-visible:text-foreground disabled:pointer-events-none disabled:opacity-35"
+        className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-muted-foreground/75 outline-hidden transition-[background-color,color,scale] hover:bg-foreground/[0.07] hover:text-foreground active:scale-90 focus-visible:bg-foreground/[0.07] focus-visible:text-foreground disabled:pointer-events-none disabled:opacity-35"
         aria-label={`${removeLabel} ${fileName}`}
         title={removeLabel}
       >
-        <X className="h-4 w-4" />
+        <X className="h-3 w-3" />
       </button>
     </div>
   );

--- a/crates/agent-gui/src/index.css
+++ b/crates/agent-gui/src/index.css
@@ -434,32 +434,16 @@
     background: hsl(var(--muted-foreground) / 0.36);
   }
 
-  /* Upload file list scrollbar */
+  /* Upload file list: scrollable without a visible scrollbar */
   .upload-file-list {
-    scrollbar-width: thin;
-    scrollbar-color: transparent transparent;
-    transition: scrollbar-color 0.3s;
-  }
-  .upload-file-list:hover {
-    scrollbar-color: hsl(var(--muted-foreground) / 0.25) transparent;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
   }
   .upload-file-list::-webkit-scrollbar {
-    height: 4px;
-  }
-  .upload-file-list::-webkit-scrollbar-track {
-    background: transparent;
-    margin: 0 8px;
-  }
-  .upload-file-list::-webkit-scrollbar-thumb {
-    background: transparent;
-    border-radius: 2px;
-    transition: background 0.3s;
-  }
-  .upload-file-list:hover::-webkit-scrollbar-thumb {
-    background: hsl(var(--muted-foreground) / 0.25);
-  }
-  .upload-file-list:hover::-webkit-scrollbar-thumb:hover {
-    background: hsl(var(--muted-foreground) / 0.4);
+    display: none;
+    width: 0;
+    height: 0;
   }
 
   .chat-queue-scroll {

--- a/crates/agent-gui/src/pages/chat/components/ChatComposerBar.tsx
+++ b/crates/agent-gui/src/pages/chat/components/ChatComposerBar.tsx
@@ -113,9 +113,11 @@ function PendingComposerAttachment(props: {
   workdir: string;
   disabled: boolean;
   removeLabel: string;
+  previewLabel: string;
+  closePreviewLabel: string;
   onRemove: (relativePath: string) => void;
 }) {
-  const { file, workdir, disabled, removeLabel, onRemove } = props;
+  const { file, workdir, disabled, removeLabel, previewLabel, closePreviewLabel, onRemove } = props;
   const shouldPreviewImage =
     file.kind === "image" && typeof file.absolutePath === "string" && file.absolutePath.trim();
   const { imageSrc, isLoading } = useUploadedImagePreview(
@@ -134,6 +136,8 @@ function PendingComposerAttachment(props: {
       fallbackIcon={<TypeIcon className="h-4 w-4" />}
       disabled={disabled}
       removeLabel={removeLabel}
+      previewLabel={previewLabel}
+      closePreviewLabel={closePreviewLabel}
       onRemove={() => onRemove(file.relativePath)}
     />
   );
@@ -235,6 +239,8 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
   } = props;
   const { t } = useLocale();
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const attachmentListRef = useRef<HTMLDivElement | null>(null);
+  const previousPendingUploadCountRef = useRef(0);
   const queuePanelRef = useRef<HTMLDivElement | null>(null);
   const queueListRef = useRef<HTMLUListElement | null>(null);
   const queueScrollbarTrackRef = useRef<HTMLDivElement | null>(null);
@@ -295,6 +301,15 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
   const toggleQueueCollapsed = useCallback(() => {
     setQueueCollapsed((current) => !current);
   }, []);
+
+  useLayoutEffect(() => {
+    const previousCount = previousPendingUploadCountRef.current;
+    previousPendingUploadCountRef.current = pendingUploadedFiles.length;
+    if (pendingUploadedFiles.length <= previousCount) return;
+
+    const attachmentList = attachmentListRef.current;
+    if (attachmentList) attachmentList.scrollLeft = attachmentList.scrollWidth;
+  }, [pendingUploadedFiles.length]);
 
   // ref 与 state 同步更新：高度上报的 RO/rAF 回调可能先于 effect 执行，
   // 必须在布局变化前就能读到最新展开态。切换前记录卡片当前高度，
@@ -737,7 +752,10 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
           />
 
           {pendingUploadedFiles.length > 0 ? (
-            <div className="upload-file-list relative z-10 flex shrink-0 gap-2 overflow-x-auto pb-1 pl-4 pr-12 pt-3.5">
+            <div
+              ref={attachmentListRef}
+              className="upload-file-list relative z-10 flex shrink-0 items-center gap-1.5 overflow-x-auto overflow-y-hidden pb-1 pl-4 pr-12 pt-2"
+            >
               {pendingUploadedFiles.map((file) => (
                 <PendingComposerAttachment
                   key={`${file.relativePath}-${file.absolutePath ?? file.fileName}`}
@@ -745,6 +763,8 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
                   workdir={workdir}
                   disabled={isInputDisabled}
                   removeLabel={t("chat.upload.removeFile")}
+                  previewLabel={t("chat.upload.previewImage")}
+                  closePreviewLabel={t("chat.upload.closePreview")}
                   onRemove={onRemovePendingUpload}
                 />
               ))}
@@ -772,7 +792,7 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: {
           <div
             className={cn(
               "relative flex flex-1 px-4",
-              pendingUploadedFiles.length > 0 ? "pt-2" : "pt-3.5",
+              pendingUploadedFiles.length > 0 ? "pt-1.5" : "pt-3.5",
               isComposerExpanded && "min-h-0",
             )}
           >


### PR DESCRIPTION
## 用户可感知的变化

- **图片附件占位大幅缩小**：粘贴的图片在输入框上方显示为 48px 纯缩略图方块（原为 64px 高、约 416px 宽的大卡片），文件名移入悬浮提示，右上角小角标删除
- **点击图片可放大预览**：点击缩略图打开 lightbox 大图（支持滚轮缩放、点击背景关闭），与聊天气泡内图片预览体验一致
- **多图不再遮挡**：附件行超出输入框宽度时隐藏滚动条、保持横向滑动，粘贴新图自动滚动到最新一张，不会再出现后粘贴的图片看不到的问题
- 非图片附件保留带文件名的紧凑胶囊样式

## 实现说明

- `ComposerAttachmentCard`（两端镜像文件）：图片分支改为缩略图方块 + `ImagePreview` lightbox；文件分支保留胶囊布局
- `ChatComposerBar`（两端）：附件列表隐藏滚动条、新增粘贴后自动滚动到末尾的 layout effect
- 网关 WebUI 端补充了压过全局 `scrollbar-width: thin` 的隐藏滚动条规则，并移除了移动端把附件卡片强制拉宽的旧覆盖样式

## 验证

- `node scripts/check-mirror.mjs` 通过（105 个镜像文件）
- 两端 `tsc --noEmit`、biome 通过；两端 `npm run build` 通过
- 桌面端 `make dev` 实测：粘贴多图、点击预览、横向滑动、删除均正常