### PR TITLE
perf(webui): lazy conversation history with edge-anchored windows

### DIFF
--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -29,6 +29,14 @@ import { registerAskUserQuestionAnswerHandler } from "@/lib/chat/askUserQuestion
 import type { ChatHistorySummary } from "@/lib/chat/chatHistory";
 import { buildModelOptions } from "@/lib/chat/chatPageHelpers";
 import type { HistoryMessageRef } from "@/lib/chat/conversationState";
+import {
+  adoptHistoryWindowState,
+  evaluateHistoryWindowResponse,
+  type HistoryWindowState,
+  planHistoryWindowRequest,
+  readHistoryWindowCounts,
+  trimLeadingHeadlessEntries,
+} from "@/lib/chat/historyWindow";
 import type { CodeMentionReference } from "@/lib/chat/mentionReferences";
 import { createActivityStore } from "@/lib/chat/stream/activityStore";
 import {
@@ -175,6 +183,7 @@ import {
   CHAT_RUNTIME_PREPARING_STATUS,
   DEFAULT_BROWSER_TITLE,
   HISTORY_DETAIL_INITIAL_MAX_MESSAGES,
+  HISTORY_DETAIL_LOAD_EARLIER_PAGE_MESSAGES,
   HISTORY_LIST_PAGE_SIZE,
   MAX_UPLOAD_FILES,
   MCP_HUB_BROWSER_TITLE,
@@ -375,6 +384,11 @@ export default function GatewayApp() {
   } | null>(null);
   // Per-conversation runtime workdir (drafts have no persisted summary yet).
   const conversationWorkdirsRef = useRef<Map<string, string>>(new Map());
+  // Lazy history windows: per conversation, the persisted-message edge the
+  // loaded transcript starts at (see lib/chat/historyWindow.ts). Entries are
+  // (re)established by every applied history fetch and dropped with the
+  // conversation's other per-id resources.
+  const historyWindowStatesRef = useRef<Map<string, HistoryWindowState>>(new Map());
   const displayedConversationWorkdirRef = useRef("");
   const pendingUploadContextRef = useRef<{
     conversationId: string;
@@ -843,8 +857,22 @@ export default function GatewayApp() {
   // id-preserving merge into the transcript store (no flicker, no remount).
   // Only runs while the conversation is idle; a run started mid-fetch aborts
   // the merge so a stale snapshot can never truncate freshly folded entries.
+  //
+  // Fetches are EDGE-ANCHORED WINDOWS, not full hydrations: the request spans
+  // from the conversation's established window edge (historyWindow.ts) to the
+  // tail, so the per-turn refresh cost stays proportional to the loaded
+  // window instead of the conversation's lifetime size. `extendMessages`
+  // grows the window upward by a page (the transcript's "load earlier"
+  // affordance). A windowed response whose top edge slipped below the
+  // established one (concurrent append while the request was in flight) is
+  // refetched once with the corrected span and skipped if it slipped again —
+  // applying it could truncate the rendered region's top.
   const refreshDisplayedConversationHistorySnapshot = useCallback(
-    async (targetConversationId: string, currentApi = api, options?: { forceFull?: boolean }) => {
+    async (
+      targetConversationId: string,
+      currentApi = api,
+      options?: { extendMessages?: number },
+    ) => {
       const conversationIdValue = targetConversationId.trim();
       if (!currentApi || !conversationIdValue || isLocalDraftConversationId(conversationIdValue)) {
         return;
@@ -857,30 +885,77 @@ export default function GatewayApp() {
         return;
       }
 
-      // If the full history is already loaded, refresh the full transcript so
-      // the merge cannot truncate it back to the most recent page.
-      const hasFullHistoryLoaded =
-        options?.forceFull === true ||
-        (selectedHistoryRef.current?.conversation_id === conversationIdValue &&
-          selectedHistoryRef.current.has_more === false);
+      const extendMessages = options?.extendMessages;
+      const windowStates = historyWindowStatesRef.current;
 
       let detail: HistoryDetail;
       let entries: ChatEntry[];
       try {
+        const planned = planHistoryWindowRequest(windowStates.get(conversationIdValue), {
+          initialWindowMessages: HISTORY_DETAIL_INITIAL_MAX_MESSAGES,
+          extendMessages,
+        });
         detail = await currentApi.getHistory(
           conversationIdValue,
-          hasFullHistoryLoaded ? undefined : { maxMessages: HISTORY_DETAIL_INITIAL_MAX_MESSAGES },
+          planned === undefined ? undefined : { maxMessages: planned },
         );
-        entries = await parseHistoryMessagesJsonAsync(detail.messages_json);
-        if (
-          detail.has_more === true &&
-          entries.length < getConversationTranscriptEntryCount(conversationIdValue)
-        ) {
-          // Partial window smaller than what is currently rendered: merging
-          // it would truncate the top of a longer transcript. Refetch full.
-          detail = await currentApi.getHistory(conversationIdValue);
-          entries = await parseHistoryMessagesJsonAsync(detail.messages_json);
+
+        if (planned !== undefined && detail.has_more === true) {
+          const counts = readHistoryWindowCounts(detail);
+          if (!counts) {
+            // Producer reported a partial window without usable counts (a
+            // contradiction — both come from the same code path): fall back
+            // to a full fetch rather than risking a top truncation.
+            windowStates.delete(conversationIdValue);
+            detail = await currentApi.getHistory(conversationIdValue);
+          } else {
+            const verdict = evaluateHistoryWindowResponse({
+              previous: windowStates.get(conversationIdValue),
+              counts,
+              extendMessages,
+            });
+            if (verdict.action === "retry") {
+              detail = await currentApi.getHistory(conversationIdValue, {
+                maxMessages: verdict.retryMaxMessages,
+              });
+              const retryCounts = readHistoryWindowCounts(detail);
+              const retryVerdict =
+                retryCounts && detail.has_more === true
+                  ? evaluateHistoryWindowResponse({
+                      previous: windowStates.get(conversationIdValue),
+                      counts: retryCounts,
+                      extendMessages,
+                    })
+                  : null;
+              if (detail.has_more === true) {
+                if (!retryVerdict || retryVerdict.action === "retry") {
+                  // The edge slipped twice in a row: give up on this cycle;
+                  // the refresh loops (busy→idle, upsert, stale-retry)
+                  // converge on a later pass.
+                  return;
+                }
+                windowStates.set(conversationIdValue, retryVerdict.nextState);
+              }
+            } else {
+              windowStates.set(conversationIdValue, verdict.nextState);
+            }
+          }
         }
+        if (detail.has_more !== true) {
+          // Complete fetch: the window reaches message 0 and stays complete.
+          const counts = readHistoryWindowCounts(detail);
+          if (counts) {
+            windowStates.set(conversationIdValue, {
+              oldestOffset: 0,
+              lastTotal: counts.totalMessageCount,
+            });
+          } else {
+            windowStates.delete(conversationIdValue);
+          }
+        }
+
+        const parsed = await parseHistoryMessagesJsonAsync(detail.messages_json);
+        entries = detail.has_more === true ? trimLeadingHeadlessEntries(parsed) : parsed;
       } catch {
         return;
       }
@@ -900,7 +975,7 @@ export default function GatewayApp() {
         .get(conversationIdValue)
         .applyHistorySnapshot(entries, { mode: "enrich" });
     },
-    [api, getConversationTranscriptEntryCount, isConversationBusy, transcriptStoreRegistry],
+    [api, isConversationBusy, transcriptStoreRegistry],
   );
 
   const markVisibleConversationRevision = useCallback(() => {
@@ -924,6 +999,12 @@ export default function GatewayApp() {
       }
 
       transcriptStoreRegistry.move(previousId, nextId);
+
+      const windowState = historyWindowStatesRef.current.get(previousId);
+      if (windowState !== undefined) {
+        historyWindowStatesRef.current.delete(previousId);
+        historyWindowStatesRef.current.set(nextId, windowState);
+      }
 
       const workdir = conversationWorkdirsRef.current.get(previousId);
       if (workdir !== undefined) {
@@ -1509,12 +1590,12 @@ export default function GatewayApp() {
     refreshChatQueueSnapshot(update.conversationId?.trim() || pending.conversationId);
     if (pending.isEditResend) {
       // The seeded `rebased` already truncated committed optimistically, but
-      // the command was parked — server-side history is unchanged; a full
-      // quiet refresh restores the truncated suffix.
+      // the command was parked — server-side history is unchanged; a quiet
+      // window refresh restores the truncated suffix (the edit anchor always
+      // sits inside the loaded window, so the window covers the whole cut).
       void refreshDisplayedConversationHistorySnapshot(
         update.conversationId?.trim() || pending.conversationId,
         api,
-        { forceFull: true },
       );
     }
   };
@@ -1522,9 +1603,7 @@ export default function GatewayApp() {
     draftClientRequestsRef.current.delete(pending.clientRequestId);
     const conversationIdValue = pending.conversationId.trim();
     if (pending.isEditResend) {
-      void refreshDisplayedConversationHistorySnapshot(conversationIdValue, api, {
-        forceFull: true,
-      });
+      void refreshDisplayedConversationHistorySnapshot(conversationIdValue, api);
     }
     if (isLocalDraftConversationId(conversationIdValue)) {
       // The draft never materialized: drop its optimistic sidebar row. The
@@ -1928,13 +2007,30 @@ export default function GatewayApp() {
     }
 
     try {
-      const detail = await currentApi.getHistory(conversationIdValue, {
-        maxMessages: HISTORY_DETAIL_INITIAL_MAX_MESSAGES,
-      });
+      // Revisits fetch the conversation's established window (everything the
+      // user has paged up to), first opens fetch the initial tail window.
+      // The replace apply repaints the store region from this window either
+      // way, so the response's counts are adopted unconditionally — on the
+      // rare in-flight append the region top just lands a page lower.
+      const planned = planHistoryWindowRequest(
+        historyWindowStatesRef.current.get(conversationIdValue),
+        { initialWindowMessages: HISTORY_DETAIL_INITIAL_MAX_MESSAGES },
+      );
+      const detail = await currentApi.getHistory(
+        conversationIdValue,
+        planned === undefined ? undefined : { maxMessages: planned },
+      );
       if (isStale()) {
         return "painted";
       }
-      const entries = await parseHistoryMessagesJsonAsync(detail.messages_json);
+      const counts = readHistoryWindowCounts(detail);
+      if (counts) {
+        historyWindowStatesRef.current.set(conversationIdValue, adoptHistoryWindowState(counts));
+      } else {
+        historyWindowStatesRef.current.delete(conversationIdValue);
+      }
+      const parsed = await parseHistoryMessagesJsonAsync(detail.messages_json);
+      const entries = detail.has_more === true ? trimLeadingHeadlessEntries(parsed) : parsed;
       if (isStale()) {
         return "painted";
       }
@@ -1964,18 +2060,15 @@ export default function GatewayApp() {
     }
   }
 
-  // Phase 2: quiet full hydration at idle, through the id-preserving enrich
-  // path — it never clobbers live-stream transcript entries and it skips
-  // entirely when phase 1 already returned the whole conversation.
-  async function hydrateConversationFull(conversationIdValue: string, _seq: number): Promise<void> {
-    const selected = selectedHistoryRef.current;
-    if (selected?.conversation_id === conversationIdValue && selected.has_more !== true) {
-      return;
-    }
-    await refreshDisplayedConversationHistorySnapshot(conversationIdValue, api, {
-      forceFull: true,
-    });
-  }
+  // Phase 2: intentionally a no-op. Phase 1 painted the conversation's whole
+  // established window, and messages above the window edge stay unfetched
+  // until the user asks for them ("load earlier history") — hydrating the
+  // full conversation at idle would put open cost back on the conversation's
+  // lifetime size, which is exactly what the lazy window avoids.
+  async function hydrateConversationFull(
+    _conversationIdValue: string,
+    _seq: number,
+  ): Promise<void> {}
 
   openInitialRef.current = openConversationInitial;
   hydrateFullRef.current = hydrateConversationFull;
@@ -2795,6 +2888,7 @@ export default function GatewayApp() {
               // Immediate local echo; the gateway delete events confirm.
               sidebarStore.removeLocal(conversationId);
               transcriptStoreRegistry.remove(conversationId);
+              historyWindowStatesRef.current.delete(conversationId);
               conversationWorkdirsRef.current.delete(conversationId);
               clearCachedComposerDraft(conversationId);
               setPendingUploadsForConversation(conversationId, []);
@@ -3006,6 +3100,7 @@ export default function GatewayApp() {
         }
         removedIds.add(id);
         transcriptStoreRegistry.remove(id);
+        historyWindowStatesRef.current.delete(id);
         conversationWorkdirsRef.current.delete(id);
         composerDraftCacheRef.current.delete(id);
         setPendingUploadsForConversation(id, []);
@@ -3040,6 +3135,7 @@ export default function GatewayApp() {
   const handleSidebarLocalDraftDeleted = useCallback(
     (id: string) => {
       transcriptStoreRegistry.remove(id);
+      historyWindowStatesRef.current.delete(id);
       conversationWorkdirsRef.current.delete(id);
       composerDraftCacheRef.current.delete(id);
       setPendingUploadsForConversation(id, []);
@@ -3524,6 +3620,7 @@ export default function GatewayApp() {
     transcriptStoreRegistry.clear();
     activityStore.clear();
     draftClientRequestsRef.current.clear();
+    historyWindowStatesRef.current.clear();
     conversationWorkdirsRef.current.clear();
     composerDraftCacheRef.current.clear();
     composerDraftOwnerRef.current = "";
@@ -4196,15 +4293,15 @@ export default function GatewayApp() {
     selectedHistory?.conversation_id === displayedConversationId &&
     selectedHistory.has_more === true;
   const loadingOlderHistory = fullHistoryLoading && displayedTranscriptRowCount > 0;
-  const handleLoadFullHistory = useCallback(() => {
+  const handleLoadEarlierHistory = useCallback(() => {
     if (!api || !displayedConversationId) {
       return;
     }
-    // Explicit full fetch through the id-preserving enrich path (same as the
-    // idle hydration); no-ops while a run is streaming.
+    // Grow the loaded window upward by one page through the id-preserving
+    // enrich path; no-ops while a run is streaming.
     setFullHistoryLoading(true);
     void refreshDisplayedConversationHistorySnapshot(displayedConversationId, api, {
-      forceFull: true,
+      extendMessages: HISTORY_DETAIL_LOAD_EARLIER_PAGE_MESSAGES,
     }).finally(() => {
       setFullHistoryLoading(false);
     });
@@ -4629,8 +4726,8 @@ export default function GatewayApp() {
                             onOpenSettings={openSettings}
                             hasMoreHistory={selectedHistoryHasMore}
                             isLoadingMoreHistory={loadingOlderHistory}
-                            onLoadFullHistory={
-                              selectedHistoryHasMore ? handleLoadFullHistory : undefined
+                            onLoadEarlierHistory={
+                              selectedHistoryHasMore ? handleLoadEarlierHistory : undefined
                             }
                             isAgentMode={isAgentMode}
                             showUsage={isAgentDevExecutionMode}

--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -33,6 +33,7 @@ import {
   adoptHistoryWindowState,
   evaluateHistoryWindowResponse,
   type HistoryWindowState,
+  noteHistoryWindowTotal,
   planHistoryWindowRequest,
   readHistoryWindowCounts,
   trimLeadingHeadlessEntries,
@@ -1946,6 +1947,12 @@ export default function GatewayApp() {
   // a history upsert — re-run the quiet enrich for the displayed conversation
   // so a turn holding stale or adopted-nothing content converges without a
   // re-open. The refresh itself re-checks displayed + idle around the fetch.
+  //
+  // The upsert also carries the conversation's authoritative message_count:
+  // fold it into the window bookkeeping FIRST (for every tracked conversation
+  // — revisits plan from the same state), so the next planned span covers the
+  // flushed messages and the post-turn refresh applies in a single request
+  // instead of tripping the slipped-edge retry.
   useEffect(() => {
     if (!api) {
       return;
@@ -1955,10 +1962,20 @@ export default function GatewayApp() {
         return;
       }
       const conversationIdValue = event.conversation_id.trim();
+      if (!conversationIdValue) {
+        return;
+      }
+      const windowStates = historyWindowStatesRef.current;
+      const windowState = windowStates.get(conversationIdValue);
+      if (windowState) {
+        const noted = noteHistoryWindowTotal(windowState, event.conversation.message_count);
+        if (noted !== windowState) {
+          windowStates.set(conversationIdValue, noted);
+        }
+      }
       if (
-        !conversationIdValue ||
         resolveVisibleConversationId(selectedHistoryIdRef.current, conversationIdRef.current) !==
-          conversationIdValue
+        conversationIdValue
       ) {
         return;
       }

--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -224,9 +224,11 @@ import { WorkspaceOverlayHost } from "./WorkspaceOverlayHost";
 const STALE_HISTORY_RETRY_INITIAL_DELAY_MS = 1_000;
 const STALE_HISTORY_RETRY_MAX_DELAY_MS = 30_000;
 
-// Two-phase open: schedule the quiet full hydration at browser idle time,
-// with a hard timeout so it still runs on busy pages (mirrors the GUI helper
-// semantics).
+// Idle scheduler for the open controller (mirrors the GUI helper semantics:
+// requestIdleCallback with a hard timeout so it still runs on busy pages).
+// The web end's opens resolve "painted-complete", so the controller never
+// actually schedules its phase-2 hydration through this — it exists to
+// satisfy the shared controller deps.
 const HYDRATE_IDLE_TIMEOUT_MS = 1_500;
 function scheduleIdleTask(task: () => void): () => void {
   if (typeof window.requestIdleCallback === "function") {
@@ -551,20 +553,19 @@ export default function GatewayApp() {
     );
   }, [activeWorkspaceProjectPath, isAgentMode, sidebarStore]);
 
-  // Two-phase open controller: phase 1 paints the message tail fast, phase 2
-  // hydrates the full transcript at idle. Deps go through refs (assigned per
-  // render) so the controller instance stays stable.
-  const openInitialRef = useRef<(id: string, seq: number) => Promise<"cache-hit" | "painted">>(() =>
-    Promise.resolve("painted"),
-  );
-  const hydrateFullRef = useRef<(id: string, seq: number) => Promise<void>>(() =>
-    Promise.resolve(),
-  );
+  // Conversation-open controller: the web end paints the conversation's whole
+  // established history window in phase 1 (openInitial resolves
+  // "painted-complete"), so the controller never schedules a phase-2
+  // hydration — messages above the window edge stay unfetched until the user
+  // pages up. Deps go through refs (assigned per render) so the controller
+  // instance stays stable.
+  const openInitialRef = useRef<
+    (id: string, seq: number) => Promise<"cache-hit" | "painted" | "painted-complete">
+  >(() => Promise.resolve("painted-complete"));
   const openController = useMemo(
     () =>
       createConversationOpenController({
         openInitial: (id, seq) => openInitialRef.current(id, seq),
-        hydrateFull: (id, seq) => hydrateFullRef.current(id, seq),
         scheduleIdle: scheduleIdleTask,
         onStateChange: setConversationOpenState,
       }),
@@ -1854,8 +1855,7 @@ export default function GatewayApp() {
   });
   displayedConversationBusyRef.current = displayedConversationBusy;
 
-  // Phase-1 open in flight (initial tail fetch). The quiet phase-2 hydration
-  // ("hydrating") intentionally does NOT gate the composer or transcript.
+  // Open in flight (history-window fetch, before the replace apply paints).
   const historyDetailLoading = conversationOpenState.phase === "opening";
 
   // Deterministic messageRef attachment: when the displayed conversation
@@ -1983,17 +1983,22 @@ export default function GatewayApp() {
     });
   }, [api, refreshDisplayedConversationHistorySnapshot]);
 
-  // --- Two-phase conversation open (controller deps) ------------------------
-  // Phase 1: paint the message tail fast. Sets the selection state
-  // synchronously (controller.open calls this in the same tick), fetches the
-  // initial slice, and replace-applies it to the transcript store. The web
-  // end has no synchronous local-activation path, so it always resolves
-  // "painted" (never "cache-hit") — revisits still show the cached transcript
-  // instantly because the registry store keeps rendering underneath.
+  // --- Conversation open (controller deps) ----------------------------------
+  // Single-phase open: paint the conversation's established history window
+  // (first opens fetch the initial tail, revisits everything the user has
+  // paged up to). Sets the selection state synchronously (controller.open
+  // calls this in the same tick), fetches the window, and replace-applies it
+  // to the transcript store. The web end has no synchronous local-activation
+  // path, so it always resolves "painted-complete" (never "cache-hit") —
+  // revisits still show the cached transcript instantly because the registry
+  // store keeps rendering underneath. Messages above the window edge stay
+  // unfetched until the user pages up ("load earlier history"): an idle full
+  // hydration would put open cost back on the conversation's lifetime size,
+  // which is exactly what the lazy window avoids.
   async function openConversationInitial(
     conversationIdValue: string,
     _seq: number,
-  ): Promise<"cache-hit" | "painted"> {
+  ): Promise<"cache-hit" | "painted-complete"> {
     const currentApi = api;
     if (!currentApi) {
       throw new Error("Gateway client is not ready.");
@@ -2038,7 +2043,7 @@ export default function GatewayApp() {
         planned === undefined ? undefined : { maxMessages: planned },
       );
       if (isStale()) {
-        return "painted";
+        return "painted-complete";
       }
       const counts = readHistoryWindowCounts(detail);
       if (counts) {
@@ -2049,7 +2054,7 @@ export default function GatewayApp() {
       const parsed = await parseHistoryMessagesJsonAsync(detail.messages_json);
       const entries = detail.has_more === true ? trimLeadingHeadlessEntries(parsed) : parsed;
       if (isStale()) {
-        return "painted";
+        return "painted-complete";
       }
       setSelectedHistory(detail);
       transcriptStoreRegistry
@@ -2059,7 +2064,7 @@ export default function GatewayApp() {
       if (detailWorkdir) {
         conversationWorkdirsRef.current.set(conversationIdValue, detailWorkdir);
       }
-      return "painted";
+      return "painted-complete";
     } catch (error) {
       if (!isStale()) {
         const message = asErrorMessage(
@@ -2077,18 +2082,7 @@ export default function GatewayApp() {
     }
   }
 
-  // Phase 2: intentionally a no-op. Phase 1 painted the conversation's whole
-  // established window, and messages above the window edge stay unfetched
-  // until the user asks for them ("load earlier history") — hydrating the
-  // full conversation at idle would put open cost back on the conversation's
-  // lifetime size, which is exactly what the lazy window avoids.
-  async function hydrateConversationFull(
-    _conversationIdValue: string,
-    _seq: number,
-  ): Promise<void> {}
-
   openInitialRef.current = openConversationInitial;
-  hydrateFullRef.current = hydrateConversationFull;
 
   const prepareChatRuntime = useCallback(
     async (
@@ -3094,8 +3088,8 @@ export default function GatewayApp() {
       return;
     }
 
-    // Two-phase open: initial tail paint now, quiet full hydration at idle;
-    // the overlay appears only after ~150ms of still-loading.
+    // Paint the conversation's established history window; the overlay
+    // appears only after ~150ms of still-loading.
     openController.open(targetConversationId);
     restoreCachedComposerDraft(targetConversationId);
   }

--- a/crates/agent-gateway/web/src/app/constants.ts
+++ b/crates/agent-gateway/web/src/app/constants.ts
@@ -3,6 +3,9 @@ export const MAX_UPLOAD_FILES = 9;
 export const PROTECTED_DRAFT_CONVERSATION = "__protected_draft__";
 export const HISTORY_LIST_PAGE_SIZE = 80;
 export const HISTORY_DETAIL_INITIAL_MAX_MESSAGES = 360;
+// One "load earlier history" click grows the loaded window by this many
+// persisted messages (same size as the initial tail window).
+export const HISTORY_DETAIL_LOAD_EARLIER_PAGE_MESSAGES = 360;
 export const PROJECT_HISTORY_DELETE_PAGE_SIZE = 200;
 export const SHARED_HISTORY_LIST_PAGE_SIZE = 200;
 export const CHAT_RUNTIME_PREPARE_TIMEOUT_MS = 2_500;

--- a/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
+++ b/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
@@ -1478,6 +1478,47 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
     reportAnchorRef.current();
   }, [virtualItems]);
 
+  // Infinite upward paging: scrolling within one viewport of the top requests
+  // the previous page through the same handler as the "load earlier history"
+  // button (which stays as the visible affordance and loading indicator).
+  // Only scroll events trigger it — opening a conversation lands at the
+  // bottom and never auto-fetches — and after a page lands the keyed
+  // anchoring parks the viewport about a page below the top, so walking
+  // further back keeps paging one request at a time: readers load exactly as
+  // far as they scroll, servers transfer only the pages actually walked to,
+  // and a failed fetch retries only on the next user scroll (no hammering).
+  const autoLoadEarlierInFlightRef = useRef(false);
+  const maybeAutoLoadEarlierRef = useRef(() => {});
+  maybeAutoLoadEarlierRef.current = () => {
+    if (
+      readOnly ||
+      isStreaming ||
+      !hasMoreHistory ||
+      !onLoadEarlierHistory ||
+      isLoadingMoreHistory ||
+      autoLoadEarlierInFlightRef.current ||
+      !scrollViewport ||
+      scrollViewport.scrollTop > scrollViewport.clientHeight
+    ) {
+      return;
+    }
+    autoLoadEarlierInFlightRef.current = true;
+    onLoadEarlierHistory();
+  };
+  useEffect(() => {
+    if (!scrollViewport || readOnly) return;
+    const handler = () => maybeAutoLoadEarlierRef.current();
+    scrollViewport.addEventListener("scroll", handler, { passive: true });
+    return () => scrollViewport.removeEventListener("scroll", handler);
+  }, [scrollViewport, readOnly]);
+  useEffect(() => {
+    // The latch guards the gap between firing and the loading flag landing;
+    // it releases whenever a load cycle is not (or no longer) running.
+    if (!isLoadingMoreHistory) {
+      autoLoadEarlierInFlightRef.current = false;
+    }
+  }, [isLoadingMoreHistory]);
+
   // First paint of a conversation lands at the bottom before the user sees
   // anything: scrollToEnd re-targets as dynamic measurements land. The region
   // remounts per conversation (keyed by the parent), so this runs once per

--- a/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
+++ b/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
@@ -103,7 +103,7 @@ type GatewayTranscriptProps = {
   onOpenSettings?: (section?: SectionId) => void;
   hasMoreHistory?: boolean;
   isLoadingMoreHistory?: boolean;
-  onLoadFullHistory?: () => void;
+  onLoadEarlierHistory?: () => void;
   isAgentMode?: boolean;
   showUsage?: boolean;
   usageContextWindow?: number;
@@ -1166,7 +1166,7 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
   onAnchorUserRowChange?: (rowKey: string | null) => void;
   hasMoreHistory?: boolean;
   isLoadingMoreHistory?: boolean;
-  onLoadFullHistory?: () => void;
+  onLoadEarlierHistory?: () => void;
   isStreaming: boolean;
   isAgentMode: boolean;
   showUsage: boolean;
@@ -1198,7 +1198,7 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
     onAnchorUserRowChange,
     hasMoreHistory,
     isLoadingMoreHistory,
-    onLoadFullHistory,
+    onLoadEarlierHistory,
     isStreaming,
     isAgentMode,
     showUsage,
@@ -1527,8 +1527,8 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
             >
               <button
                 type="button"
-                onClick={onLoadFullHistory}
-                disabled={isLoadingMoreHistory || !onLoadFullHistory}
+                onClick={onLoadEarlierHistory}
+                disabled={isLoadingMoreHistory || !onLoadEarlierHistory}
                 className="rounded-full border border-border/60 bg-background/80 px-4 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {isLoadingMoreHistory
@@ -1731,7 +1731,7 @@ export function GatewayTranscript({
   onOpenSettings,
   hasMoreHistory = false,
   isLoadingMoreHistory = false,
-  onLoadFullHistory,
+  onLoadEarlierHistory,
   isAgentMode = true,
   showUsage = false,
   usageContextWindow,
@@ -1808,7 +1808,7 @@ export function GatewayTranscript({
           onAnchorUserRowChange={onAnchorUserRowChange}
           hasMoreHistory={hasMoreHistory}
           isLoadingMoreHistory={isLoadingMoreHistory}
-          onLoadFullHistory={onLoadFullHistory}
+          onLoadEarlierHistory={onLoadEarlierHistory}
           isStreaming={isStreaming}
           isAgentMode={isAgentMode}
           showUsage={showUsage}

--- a/crates/agent-gateway/web/src/lib/chat/historyWindow.ts
+++ b/crates/agent-gateway/web/src/lib/chat/historyWindow.ts
@@ -8,7 +8,9 @@
 //
 //   oldestOffset — number of persisted messages ABOVE the loaded window
 //                  (0 means the window starts at the very first message)
-//   lastTotal    — total_message_count reported by the latest applied fetch
+//   lastTotal    — the freshest total_message_count this client observed:
+//                  the latest applied fetch, bumped forward by history-upsert
+//                  summary counts (noteHistoryWindowTotal)
 //
 // Requests are EDGE-ANCHORED: a quiet refresh asks for
 // `lastTotal - oldestOffset` messages, so the window always spans everything
@@ -27,11 +29,19 @@
 // corrected size from the response's authoritative total, and skips the
 // cycle when the edge slipped again (the app's quiet-refresh loops converge
 // on a later pass).
+//
+// The slip retry is the SAFETY NET, not the steady state: the desktop
+// persists a run's messages before it reports completion, and the history
+// upsert it publishes at that flush carries the new total. Folding that
+// total into `lastTotal` (noteHistoryWindowTotal) before the busy→idle
+// refresh plans its span makes the common post-turn refresh a single
+// request; only a lossy/dropped upsert (they are best-effort broadcasts)
+// leaves a stale span behind for the retry to correct.
 
 export type HistoryWindowState = {
   /** Persisted messages above the loaded window (0 = window starts at message 0). */
   oldestOffset: number;
-  /** total_message_count from the latest applied response. */
+  /** Freshest observed total: latest applied response, bumped by upsert counts. */
   lastTotal: number;
 };
 
@@ -101,6 +111,28 @@ export function adoptHistoryWindowState(counts: HistoryWindowCounts): HistoryWin
     ? Math.max(0, counts.totalMessageCount - counts.returnedMessageCount)
     : 0;
   return { oldestOffset: edge, lastTotal: counts.totalMessageCount };
+}
+
+// Folds an out-of-band total — a history upsert's summary message_count, the
+// same total_message_count authority the fetch responses report — into the
+// bookkeeping, so the next planned span already covers messages appended
+// since the last applied fetch. Without this, every post-turn quiet refresh
+// under-requests by exactly the flushed message count and burns a slipped-
+// edge retry (two full window fetches per turn instead of one).
+//
+// Totals only move forward: a stale/invalid count returns the state
+// untouched (identity — callers can skip the write), and truncations
+// (edit-resend) converge through the fetch path, whose complete responses
+// re-establish both fields authoritatively.
+export function noteHistoryWindowTotal(
+  state: HistoryWindowState,
+  totalMessageCount: unknown,
+): HistoryWindowState {
+  const total = asNonNegativeInt(totalMessageCount);
+  if (total === null || total <= state.lastTotal) {
+    return state;
+  }
+  return { oldestOffset: state.oldestOffset, lastTotal: total };
 }
 
 // Decides whether a windowed response is safe to apply. See the module

--- a/crates/agent-gateway/web/src/lib/chat/historyWindow.ts
+++ b/crates/agent-gateway/web/src/lib/chat/historyWindow.ts
@@ -1,0 +1,157 @@
+// Lazy history-window bookkeeping for opening/refreshing a conversation.
+//
+// The web end renders a conversation from tail windows of the persisted
+// history (`history.get` with `max_messages`). Instead of hydrating the full
+// conversation at idle — which makes open cost and per-turn quiet-refresh
+// cost proportional to the conversation's lifetime size — the app tracks,
+// per conversation, the oldest persisted message it has loaded:
+//
+//   oldestOffset — number of persisted messages ABOVE the loaded window
+//                  (0 means the window starts at the very first message)
+//   lastTotal    — total_message_count reported by the latest applied fetch
+//
+// Requests are EDGE-ANCHORED: a quiet refresh asks for
+// `lastTotal - oldestOffset` messages, so the window always spans everything
+// persisted after the established edge (covering every exchange streamed
+// this session — alignEnrich requires the window to reach the live turns)
+// while messages above the edge stay unfetched until the user pages up.
+// "Load earlier" grows the request beyond the edge by a page.
+//
+// Because the tail window is anchored to the END of the conversation,
+// concurrent appends between "compute request size" and "serve response"
+// SLIP the returned window's top edge below the established one. Applying a
+// slipped window could hand alignEnrich a window that no longer covers the
+// rendered region's coverage counts (its count-coincidence full-window branch
+// could then rebuild the region without the rows above the slipped edge), so
+// slipped responses are never applied: the caller retries once with the
+// corrected size from the response's authoritative total, and skips the
+// cycle when the edge slipped again (the app's quiet-refresh loops converge
+// on a later pass).
+
+export type HistoryWindowState = {
+  /** Persisted messages above the loaded window (0 = window starts at message 0). */
+  oldestOffset: number;
+  /** total_message_count from the latest applied response. */
+  lastTotal: number;
+};
+
+export type HistoryWindowCounts = {
+  totalMessageCount: number;
+  returnedMessageCount: number;
+  hasMore: boolean;
+};
+
+export type HistoryWindowVerdict =
+  | { action: "apply"; nextState: HistoryWindowState }
+  | { action: "retry"; retryMaxMessages: number };
+
+function asNonNegativeInt(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return Math.floor(value);
+}
+
+// Extracts usable window counts from a HistoryDetail-shaped response. Returns
+// null when the producer did not report counts (defensive: bookkeeping is
+// then dropped and the conversation falls back to plain tail-window fetches).
+export function readHistoryWindowCounts(detail: {
+  total_message_count?: number;
+  returned_message_count?: number;
+  has_more?: boolean;
+}): HistoryWindowCounts | null {
+  const total = asNonNegativeInt(detail.total_message_count);
+  const returned = asNonNegativeInt(detail.returned_message_count);
+  if (total === null || returned === null || total === 0 || returned === 0 || returned > total) {
+    return null;
+  }
+  return {
+    totalMessageCount: total,
+    returnedMessageCount: returned,
+    hasMore: detail.has_more === true,
+  };
+}
+
+// Computes the max_messages for the next history fetch. `undefined` means
+// fetch the full conversation (no window cap).
+export function planHistoryWindowRequest(
+  state: HistoryWindowState | undefined,
+  options: {
+    initialWindowMessages: number;
+    extendMessages?: number;
+  },
+): number | undefined {
+  const extend = Math.max(0, Math.floor(options.extendMessages ?? 0));
+  if (!state) {
+    return options.initialWindowMessages + extend;
+  }
+  if (state.oldestOffset <= 0) {
+    // The window already reaches the first message: the conversation is
+    // fully loaded and stays fully loaded (mirrors the pre-lazy behavior
+    // after a full hydration).
+    return undefined;
+  }
+  const spanned = Math.max(0, state.lastTotal - state.oldestOffset);
+  return Math.max(options.initialWindowMessages, spanned) + extend;
+}
+
+// State adopted from an applied response.
+export function adoptHistoryWindowState(counts: HistoryWindowCounts): HistoryWindowState {
+  const edge = counts.hasMore
+    ? Math.max(0, counts.totalMessageCount - counts.returnedMessageCount)
+    : 0;
+  return { oldestOffset: edge, lastTotal: counts.totalMessageCount };
+}
+
+// Decides whether a windowed response is safe to apply. See the module
+// docblock for why slipped edges must not be applied. Callers retry at most
+// once; a second "retry" verdict means "skip this cycle".
+export function evaluateHistoryWindowResponse(params: {
+  previous: HistoryWindowState | undefined;
+  counts: HistoryWindowCounts;
+  extendMessages?: number;
+}): HistoryWindowVerdict {
+  const { previous, counts } = params;
+  const nextState = adoptHistoryWindowState(counts);
+  if (!previous || !counts.hasMore) {
+    // First observation establishes the edge; a complete fetch is always safe.
+    return { action: "apply", nextState };
+  }
+  if (nextState.oldestOffset <= previous.oldestOffset) {
+    return { action: "apply", nextState };
+  }
+  // The top edge slipped below the established one (the conversation grew
+  // while the request was in flight): re-request anchored on the response's
+  // authoritative total.
+  const extend = Math.max(0, Math.floor(params.extendMessages ?? 0));
+  const retryMaxMessages = Math.max(1, counts.totalMessageCount - previous.oldestOffset + extend);
+  return { action: "retry", retryMaxMessages };
+}
+
+// Drops leading window entries that belong to a turn whose user message sits
+// above the fetched window (windows with has_more only). Keeping the top of
+// the rendered region aligned to a turn boundary keeps every parsed entry id
+// stable across "load earlier" expansions: headless entries take their ids
+// from a window-relative anchor ("ht:^>N") and would be re-keyed once their
+// real user anchor scrolls into the window, which would break the
+// virtualizer's keyed scroll anchoring and re-mount those rows.
+//
+// Leading checkpoint (compaction summary) entries are kept: their ids derive
+// from the persisted summary id (window-position independent), and dropping
+// them would hide the compaction marker for conversations whose window opens
+// inside a compacted segment.
+export function trimLeadingHeadlessEntries<T extends { kind: string }>(entries: T[]): T[] {
+  const firstUserIndex = entries.findIndex((entry) => entry.kind === "user");
+  if (firstUserIndex < 0) {
+    // No user anchor in the whole window (one exchange larger than the
+    // window): render as-is rather than blanking the transcript.
+    return entries;
+  }
+  if (firstUserIndex === 0) {
+    return entries;
+  }
+  const kept = entries.filter(
+    (entry, index) => index >= firstUserIndex || entry.kind === "checkpoint",
+  );
+  return kept.length === entries.length ? entries : kept;
+}

--- a/crates/agent-gateway/web/src/lib/sidebar/openController.ts
+++ b/crates/agent-gateway/web/src/lib/sidebar/openController.ts
@@ -1,9 +1,11 @@
 // The unified two-phase conversation-open controller: paint an initial slice
 // fast (active segment / message tail, or a synchronous cache hit), then
-// hydrate the full transcript at idle. The switch overlay appears only after
-// overlayDelayMs of still-loading — there is no minimum overlay duration, so
-// cache hits switch synchronously with no flash. Byte-mirrored between
-// agent-gui and agent-gateway/web.
+// hydrate the full transcript at idle. Ends whose phase 1 already paints
+// everything they intend to load (e.g. a lazy history window) resolve
+// "painted-complete" and skip phase 2 entirely. The switch overlay appears
+// only after overlayDelayMs of still-loading — there is no minimum overlay
+// duration, so cache hits switch synchronously with no flash. Byte-mirrored
+// between agent-gui and agent-gateway/web.
 
 export type ConversationOpenPhase = "idle" | "opening" | "hydrating" | "ready" | "failed";
 
@@ -24,11 +26,19 @@ export type ConversationOpenController = {
 export type ConversationOpenControllerDeps = {
   // Phase 1: make the conversation visible. Resolve "cache-hit" when it was
   // activated synchronously from a runtime cache (already complete — phase 2
-  // is skipped), or "painted" when an initial slice was fetched and rendered.
-  // Reject on failure. Must itself drop stale work when seq is outdated.
-  openInitial(conversationId: string, seq: number): Promise<"cache-hit" | "painted">;
-  // Phase 2: quiet full hydration. Must check seq before committing.
-  hydrateFull(conversationId: string, seq: number): Promise<void>;
+  // is skipped), "painted" when an initial slice was fetched and rendered
+  // (phase 2 hydrates the rest at idle), or "painted-complete" when the
+  // fetched slice already covers everything this end intends to load
+  // (phase 2 is skipped). Reject on failure. Must itself drop stale work
+  // when seq is outdated.
+  openInitial(
+    conversationId: string,
+    seq: number,
+  ): Promise<"cache-hit" | "painted" | "painted-complete">;
+  // Phase 2: quiet full hydration. Must check seq before committing. Only
+  // consulted after a plain "painted" phase 1; ends that never resolve
+  // "painted" may omit it.
+  hydrateFull?(conversationId: string, seq: number): Promise<void>;
   scheduleIdle(task: () => void): () => void;
   onStateChange(state: ConversationOpenState): void;
   overlayDelayMs?: number;
@@ -71,12 +81,15 @@ export function createConversationOpenController(
     }
   };
 
-  const scheduleHydration = (conversationId: string, seq: number) => {
+  const scheduleHydration = (
+    conversationId: string,
+    seq: number,
+    hydrateFull: (conversationId: string, seq: number) => Promise<void>,
+  ) => {
     clearIdleTask();
     cancelIdle = deps.scheduleIdle(() => {
       cancelIdle = null;
-      deps
-        .hydrateFull(conversationId, seq)
+      hydrateFull(conversationId, seq)
         .then(() => {
           if (seq !== sequence) return;
           setState({ conversationId, phase: "ready", showOverlay: false, errorCode: null });
@@ -113,12 +126,15 @@ export function createConversationOpenController(
         .then((result) => {
           if (seq !== sequence) return;
           clearOverlayTimer();
-          if (result === "cache-hit") {
-            setState({ conversationId, phase: "ready", showOverlay: false, errorCode: null });
+          const hydrateFull = deps.hydrateFull;
+          if (result === "painted" && hydrateFull) {
+            setState({ conversationId, phase: "hydrating", showOverlay: false, errorCode: null });
+            scheduleHydration(conversationId, seq, hydrateFull);
             return;
           }
-          setState({ conversationId, phase: "hydrating", showOverlay: false, errorCode: null });
-          scheduleHydration(conversationId, seq);
+          // "cache-hit" and "painted-complete" own their full paint already;
+          // a "painted" without a hydrateFull dep has nothing left to run.
+          setState({ conversationId, phase: "ready", showOverlay: false, errorCode: null });
         })
         .catch(() => {
           if (seq !== sequence) return;

--- a/crates/agent-gateway/web/test/history-window.test.mjs
+++ b/crates/agent-gateway/web/test/history-window.test.mjs
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createWebModuleLoader } from "../../test/helpers/load-web-module.mjs";
+
+const loader = createWebModuleLoader({
+  rootDir: fileURLToPath(new URL("../", import.meta.url)),
+});
+
+const {
+  adoptHistoryWindowState,
+  evaluateHistoryWindowResponse,
+  planHistoryWindowRequest,
+  readHistoryWindowCounts,
+  trimLeadingHeadlessEntries,
+} = loader.loadModule("src/lib/chat/historyWindow.ts");
+
+const INITIAL = 360;
+
+test("readHistoryWindowCounts accepts a complete producer report", () => {
+  const counts = readHistoryWindowCounts({
+    total_message_count: 1000,
+    returned_message_count: 360,
+    has_more: true,
+  });
+  assert.deepEqual(counts, {
+    totalMessageCount: 1000,
+    returnedMessageCount: 360,
+    hasMore: true,
+  });
+});
+
+test("readHistoryWindowCounts rejects missing/zero/inconsistent counts", () => {
+  assert.equal(readHistoryWindowCounts({}), null);
+  assert.equal(readHistoryWindowCounts({ total_message_count: 100 }), null);
+  assert.equal(
+    readHistoryWindowCounts({ total_message_count: 0, returned_message_count: 0 }),
+    null,
+  );
+  assert.equal(
+    readHistoryWindowCounts({ total_message_count: 10, returned_message_count: 20 }),
+    null,
+  );
+  assert.equal(
+    readHistoryWindowCounts({ total_message_count: -1, returned_message_count: 5 }),
+    null,
+  );
+});
+
+test("first open plans the initial window", () => {
+  assert.equal(planHistoryWindowRequest(undefined, { initialWindowMessages: INITIAL }), INITIAL);
+});
+
+test("a partially-loaded window always plans a bounded request", () => {
+  const state = { oldestOffset: 500, lastTotal: 1000 };
+  assert.equal(planHistoryWindowRequest(state, { initialWindowMessages: INITIAL }), 500);
+});
+
+test("a fully-loaded conversation stays fully loaded", () => {
+  const counts = readHistoryWindowCounts({
+    total_message_count: 200,
+    returned_message_count: 200,
+    has_more: false,
+  });
+  const state = adoptHistoryWindowState(counts);
+  assert.equal(state.oldestOffset, 0);
+  assert.equal(planHistoryWindowRequest(state, { initialWindowMessages: INITIAL }), undefined);
+});
+
+test("quiet refresh spans from the established edge to the tail", () => {
+  // 1000 total, window covered the last 360 → edge at 640.
+  const state = adoptHistoryWindowState({
+    totalMessageCount: 1000,
+    returnedMessageCount: 360,
+    hasMore: true,
+  });
+  assert.equal(state.oldestOffset, 640);
+  // 12 new messages appended since: span request covers them all.
+  state.lastTotal = 1012;
+  assert.equal(
+    planHistoryWindowRequest(state, { initialWindowMessages: INITIAL }),
+    1012 - 640,
+  );
+});
+
+test("span never plans below the initial window", () => {
+  const state = { oldestOffset: 995, lastTotal: 1000 };
+  assert.equal(planHistoryWindowRequest(state, { initialWindowMessages: INITIAL }), INITIAL);
+});
+
+test("load-earlier extends the span by a page", () => {
+  const state = { oldestOffset: 640, lastTotal: 1000 };
+  assert.equal(
+    planHistoryWindowRequest(state, {
+      initialWindowMessages: INITIAL,
+      extendMessages: INITIAL,
+    }),
+    360 + INITIAL,
+  );
+});
+
+test("stable response applies and keeps the edge", () => {
+  const previous = { oldestOffset: 640, lastTotal: 1000 };
+  const verdict = evaluateHistoryWindowResponse({
+    previous,
+    counts: { totalMessageCount: 1000, returnedMessageCount: 360, hasMore: true },
+  });
+  assert.equal(verdict.action, "apply");
+  assert.deepEqual(verdict.nextState, { oldestOffset: 640, lastTotal: 1000 });
+});
+
+test("edge-raising response (load earlier) applies", () => {
+  const previous = { oldestOffset: 640, lastTotal: 1000 };
+  const verdict = evaluateHistoryWindowResponse({
+    previous,
+    counts: { totalMessageCount: 1000, returnedMessageCount: 720, hasMore: true },
+  });
+  assert.equal(verdict.action, "apply");
+  assert.deepEqual(verdict.nextState, { oldestOffset: 280, lastTotal: 1000 });
+});
+
+test("complete response applies and clears the edge", () => {
+  const previous = { oldestOffset: 640, lastTotal: 1000 };
+  const verdict = evaluateHistoryWindowResponse({
+    previous,
+    counts: { totalMessageCount: 1002, returnedMessageCount: 1002, hasMore: false },
+  });
+  assert.equal(verdict.action, "apply");
+  assert.deepEqual(verdict.nextState, { oldestOffset: 0, lastTotal: 1002 });
+});
+
+test("slipped edge (concurrent append) retries with corrected size", () => {
+  const previous = { oldestOffset: 640, lastTotal: 1000 };
+  // Requested 360 but 8 messages were appended while in flight: the response
+  // window starts at offset 648 — below the established edge.
+  const verdict = evaluateHistoryWindowResponse({
+    previous,
+    counts: { totalMessageCount: 1008, returnedMessageCount: 360, hasMore: true },
+  });
+  assert.equal(verdict.action, "retry");
+  assert.equal(verdict.retryMaxMessages, 1008 - 640);
+});
+
+test("slipped edge retry carries the extend page", () => {
+  const previous = { oldestOffset: 640, lastTotal: 1000 };
+  const verdict = evaluateHistoryWindowResponse({
+    previous,
+    counts: { totalMessageCount: 1008, returnedMessageCount: 360, hasMore: true },
+    extendMessages: INITIAL,
+  });
+  assert.equal(verdict.action, "retry");
+  assert.equal(verdict.retryMaxMessages, 1008 - 640 + INITIAL);
+});
+
+test("first observation always applies (no established edge)", () => {
+  const verdict = evaluateHistoryWindowResponse({
+    previous: undefined,
+    counts: { totalMessageCount: 1000, returnedMessageCount: 360, hasMore: true },
+  });
+  assert.equal(verdict.action, "apply");
+  assert.deepEqual(verdict.nextState, { oldestOffset: 640, lastTotal: 1000 });
+});
+
+test("trimLeadingHeadlessEntries drops assistant-side entries before the first user turn", () => {
+  const entries = [
+    { kind: "assistant" },
+    { kind: "tool_call" },
+    { kind: "user" },
+    { kind: "assistant" },
+  ];
+  const trimmed = trimLeadingHeadlessEntries(entries);
+  assert.deepEqual(
+    trimmed.map((entry) => entry.kind),
+    ["user", "assistant"],
+  );
+});
+
+test("trimLeadingHeadlessEntries keeps leading checkpoints", () => {
+  const entries = [
+    { kind: "checkpoint" },
+    { kind: "assistant" },
+    { kind: "user" },
+    { kind: "assistant" },
+  ];
+  const trimmed = trimLeadingHeadlessEntries(entries);
+  assert.deepEqual(
+    trimmed.map((entry) => entry.kind),
+    ["checkpoint", "user", "assistant"],
+  );
+});
+
+test("trimLeadingHeadlessEntries is identity for user-first and headless-only windows", () => {
+  const userFirst = [{ kind: "user" }, { kind: "assistant" }];
+  assert.equal(trimLeadingHeadlessEntries(userFirst), userFirst);
+  const headlessOnly = [{ kind: "assistant" }, { kind: "tool_call" }];
+  assert.equal(trimLeadingHeadlessEntries(headlessOnly), headlessOnly);
+});

--- a/crates/agent-gateway/web/test/history-window.test.mjs
+++ b/crates/agent-gateway/web/test/history-window.test.mjs
@@ -11,6 +11,7 @@ const loader = createWebModuleLoader({
 const {
   adoptHistoryWindowState,
   evaluateHistoryWindowResponse,
+  noteHistoryWindowTotal,
   planHistoryWindowRequest,
   readHistoryWindowCounts,
   trimLeadingHeadlessEntries,
@@ -160,6 +161,45 @@ test("first observation always applies (no established edge)", () => {
   });
   assert.equal(verdict.action, "apply");
   assert.deepEqual(verdict.nextState, { oldestOffset: 640, lastTotal: 1000 });
+});
+
+test("noteHistoryWindowTotal folds a fresher upsert total forward", () => {
+  const state = { oldestOffset: 640, lastTotal: 1000 };
+  const noted = noteHistoryWindowTotal(state, 1002);
+  assert.deepEqual(noted, { oldestOffset: 640, lastTotal: 1002 });
+});
+
+test("noteHistoryWindowTotal is identity for stale or invalid totals", () => {
+  const state = { oldestOffset: 640, lastTotal: 1000 };
+  assert.equal(noteHistoryWindowTotal(state, 1000), state);
+  assert.equal(noteHistoryWindowTotal(state, 998), state);
+  assert.equal(noteHistoryWindowTotal(state, -1), state);
+  assert.equal(noteHistoryWindowTotal(state, Number.NaN), state);
+  assert.equal(noteHistoryWindowTotal(state, undefined), state);
+  assert.equal(noteHistoryWindowTotal(state, "1002"), state);
+});
+
+test("upsert-bumped post-turn refresh applies in a single request", () => {
+  // Regression: without folding the upsert total into the bookkeeping, every
+  // post-turn quiet refresh planned from the previous fetch's total, came up
+  // short by exactly the flushed message count, and burned the slipped-edge
+  // retry — two full window fetches per turn in the steady state.
+  let state = adoptHistoryWindowState({
+    totalMessageCount: 1000,
+    returnedMessageCount: 360,
+    hasMore: true,
+  });
+  // The desktop flushes a 2-message turn and publishes the upsert before the
+  // conversation flips idle.
+  state = noteHistoryWindowTotal(state, 1002);
+  const planned = planHistoryWindowRequest(state, { initialWindowMessages: INITIAL });
+  assert.equal(planned, 1002 - 640);
+  const verdict = evaluateHistoryWindowResponse({
+    previous: state,
+    counts: { totalMessageCount: 1002, returnedMessageCount: 362, hasMore: true },
+  });
+  assert.equal(verdict.action, "apply");
+  assert.deepEqual(verdict.nextState, { oldestOffset: 640, lastTotal: 1002 });
 });
 
 test("trimLeadingHeadlessEntries drops assistant-side entries before the first user turn", () => {

--- a/crates/agent-gateway/web/test/sidebar-open-controller.test.mjs
+++ b/crates/agent-gateway/web/test/sidebar-open-controller.test.mjs
@@ -15,7 +15,7 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 function createHarness(overrides = {}) {
   const states = [];
   const calls = { openInitial: [], hydrateFull: [] };
-  const controller = createConversationOpenController({
+  const deps = {
     openInitial: async (id, seq) => {
       calls.openInitial.push({ id, seq });
       return overrides.openInitial ? overrides.openInitial(id, seq) : "painted";
@@ -34,7 +34,11 @@ function createHarness(overrides = {}) {
       states.push(state);
     },
     overlayDelayMs: overrides.overlayDelayMs ?? 20,
-  });
+  };
+  if (overrides.omitHydrateFull) {
+    delete deps.hydrateFull;
+  }
+  const controller = createConversationOpenController(deps);
   return { controller, states, calls };
 }
 
@@ -48,6 +52,32 @@ test("cache hit resolves synchronously with no overlay and no hydration", async 
   assert.equal(states.at(-1).phase, "ready");
   assert.equal(states.at(-1).errorCode, null);
   assert.equal(calls.hydrateFull.length, 0);
+});
+
+test("painted-complete resolves ready with no hydration scheduled", async () => {
+  const { controller, states, calls } = createHarness({
+    openInitial: async () => "painted-complete",
+  });
+  controller.open("conv");
+  await sleep(30);
+  assert.equal(states.at(-1).phase, "ready");
+  assert.equal(states.at(-1).errorCode, null);
+  assert.equal(
+    states.some((state) => state.phase === "hydrating"),
+    false,
+  );
+  assert.equal(calls.hydrateFull.length, 0);
+});
+
+test("painted without a hydrateFull dep resolves ready directly", async () => {
+  const { controller, states } = createHarness({ omitHydrateFull: true });
+  controller.open("conv");
+  await sleep(30);
+  assert.equal(states.at(-1).phase, "ready");
+  assert.equal(
+    states.some((state) => state.phase === "hydrating"),
+    false,
+  );
 });
 
 test("slow open shows the overlay only after the delay, then hydrates at idle", async () => {

--- a/crates/agent-gui/src/lib/sidebar/openController.ts
+++ b/crates/agent-gui/src/lib/sidebar/openController.ts
@@ -1,9 +1,11 @@
 // The unified two-phase conversation-open controller: paint an initial slice
 // fast (active segment / message tail, or a synchronous cache hit), then
-// hydrate the full transcript at idle. The switch overlay appears only after
-// overlayDelayMs of still-loading — there is no minimum overlay duration, so
-// cache hits switch synchronously with no flash. Byte-mirrored between
-// agent-gui and agent-gateway/web.
+// hydrate the full transcript at idle. Ends whose phase 1 already paints
+// everything they intend to load (e.g. a lazy history window) resolve
+// "painted-complete" and skip phase 2 entirely. The switch overlay appears
+// only after overlayDelayMs of still-loading — there is no minimum overlay
+// duration, so cache hits switch synchronously with no flash. Byte-mirrored
+// between agent-gui and agent-gateway/web.
 
 export type ConversationOpenPhase = "idle" | "opening" | "hydrating" | "ready" | "failed";
 
@@ -24,11 +26,19 @@ export type ConversationOpenController = {
 export type ConversationOpenControllerDeps = {
   // Phase 1: make the conversation visible. Resolve "cache-hit" when it was
   // activated synchronously from a runtime cache (already complete — phase 2
-  // is skipped), or "painted" when an initial slice was fetched and rendered.
-  // Reject on failure. Must itself drop stale work when seq is outdated.
-  openInitial(conversationId: string, seq: number): Promise<"cache-hit" | "painted">;
-  // Phase 2: quiet full hydration. Must check seq before committing.
-  hydrateFull(conversationId: string, seq: number): Promise<void>;
+  // is skipped), "painted" when an initial slice was fetched and rendered
+  // (phase 2 hydrates the rest at idle), or "painted-complete" when the
+  // fetched slice already covers everything this end intends to load
+  // (phase 2 is skipped). Reject on failure. Must itself drop stale work
+  // when seq is outdated.
+  openInitial(
+    conversationId: string,
+    seq: number,
+  ): Promise<"cache-hit" | "painted" | "painted-complete">;
+  // Phase 2: quiet full hydration. Must check seq before committing. Only
+  // consulted after a plain "painted" phase 1; ends that never resolve
+  // "painted" may omit it.
+  hydrateFull?(conversationId: string, seq: number): Promise<void>;
   scheduleIdle(task: () => void): () => void;
   onStateChange(state: ConversationOpenState): void;
   overlayDelayMs?: number;
@@ -71,12 +81,15 @@ export function createConversationOpenController(
     }
   };
 
-  const scheduleHydration = (conversationId: string, seq: number) => {
+  const scheduleHydration = (
+    conversationId: string,
+    seq: number,
+    hydrateFull: (conversationId: string, seq: number) => Promise<void>,
+  ) => {
     clearIdleTask();
     cancelIdle = deps.scheduleIdle(() => {
       cancelIdle = null;
-      deps
-        .hydrateFull(conversationId, seq)
+      hydrateFull(conversationId, seq)
         .then(() => {
           if (seq !== sequence) return;
           setState({ conversationId, phase: "ready", showOverlay: false, errorCode: null });
@@ -113,12 +126,15 @@ export function createConversationOpenController(
         .then((result) => {
           if (seq !== sequence) return;
           clearOverlayTimer();
-          if (result === "cache-hit") {
-            setState({ conversationId, phase: "ready", showOverlay: false, errorCode: null });
+          const hydrateFull = deps.hydrateFull;
+          if (result === "painted" && hydrateFull) {
+            setState({ conversationId, phase: "hydrating", showOverlay: false, errorCode: null });
+            scheduleHydration(conversationId, seq, hydrateFull);
             return;
           }
-          setState({ conversationId, phase: "hydrating", showOverlay: false, errorCode: null });
-          scheduleHydration(conversationId, seq);
+          // "cache-hit" and "painted-complete" own their full paint already;
+          // a "painted" without a hydrateFull dep has nothing left to run.
+          setState({ conversationId, phase: "ready", showOverlay: false, errorCode: null });
         })
         .catch(() => {
           if (seq !== sequence) return;

--- a/crates/agent-gui/test/chat/sidebar-open-controller.test.mjs
+++ b/crates/agent-gui/test/chat/sidebar-open-controller.test.mjs
@@ -11,7 +11,7 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 function createHarness(overrides = {}) {
   const states = [];
   const calls = { openInitial: [], hydrateFull: [] };
-  const controller = createConversationOpenController({
+  const deps = {
     openInitial: async (id, seq) => {
       calls.openInitial.push({ id, seq });
       return overrides.openInitial ? overrides.openInitial(id, seq) : "painted";
@@ -30,7 +30,11 @@ function createHarness(overrides = {}) {
       states.push(state);
     },
     overlayDelayMs: overrides.overlayDelayMs ?? 20,
-  });
+  };
+  if (overrides.omitHydrateFull) {
+    delete deps.hydrateFull;
+  }
+  const controller = createConversationOpenController(deps);
   return { controller, states, calls };
 }
 
@@ -44,6 +48,32 @@ test("cache hit resolves synchronously with no overlay and no hydration", async 
   assert.equal(states.at(-1).phase, "ready");
   assert.equal(states.at(-1).errorCode, null);
   assert.equal(calls.hydrateFull.length, 0);
+});
+
+test("painted-complete resolves ready with no hydration scheduled", async () => {
+  const { controller, states, calls } = createHarness({
+    openInitial: async () => "painted-complete",
+  });
+  controller.open("conv");
+  await sleep(30);
+  assert.equal(states.at(-1).phase, "ready");
+  assert.equal(states.at(-1).errorCode, null);
+  assert.equal(
+    states.some((state) => state.phase === "hydrating"),
+    false,
+  );
+  assert.equal(calls.hydrateFull.length, 0);
+});
+
+test("painted without a hydrateFull dep resolves ready directly", async () => {
+  const { controller, states } = createHarness({ omitHydrateFull: true });
+  controller.open("conv");
+  await sleep(30);
+  assert.equal(states.at(-1).phase, "ready");
+  assert.equal(
+    states.some((state) => state.phase === "hydrating"),
+    false,
+  );
 });
 
 test("slow open shows the overlay only after the delay, then hydrates at idle", async () => {


### PR DESCRIPTION
## 问题(用户可感知)

WebUI 打开会话时,先绘制尾部 360 条,随后在空闲时**一次性拉取全部历史**;此后每轮对话结束的静默刷新也会退化为全量拉取(防截断守卫在渲染行数超过一页后必然触发)。对超长会话意味着:

- 打开会话后台传输/解析整个会话(可达数 MB 的 JSON);
- **每聊一轮**都重新传输/解析一遍全量历史;
- 内存中始终持有全量转写。

## 方案:边缘锚定的懒加载窗口(纯 WebUI 前端,协议/Go/Rust 零改动)

新增 `lib/chat/historyWindow.ts` 纯函数模块,为每个会话记录「已加载窗口的最旧消息边缘」:

- **打开会话**:只拉尾部 360 条(回访会话恢复到用户已翻到的范围);**取消空闲全量水合**(阶段 2 变为 no-op,openController 镜像文件未改动);
- **静默刷新**:按"边缘→尾部"跨度请求,每轮刷新成本 ∝ 已加载窗口,与会话总长无关;
- **"加载更早历史"按钮**:从一次拉全量改为**每次向上扩一页(360 条)**,复用 id 保持的 enrich 合并通路,虚拟列表的 keyed anchoring(`anchorTo:"end"`)保证翻页时视口稳定;
- **滑边保护**:请求在途时有并发写入会使返回窗口顶边下滑,套用此类窗口可能经 `alignEnrich` 的计数满窗分支截断已渲染区域顶端——检测到滑边即用响应的权威 total 修正跨度重试一次,再滑则放弃本轮(交给既有刷新循环收敛);
- **turn 边界对齐**:has_more 窗口裁掉顶部切半的 headless 条目(保留 checkpoint 摘要),使所有解析 id 跨扩页稳定,行不重挂载、滚动锚定不失效;
- **簿记生命周期**:draft 绑定时重键,删除/登出时清理。

## 不受影响的部分

- **LLM 上下文**:由桌面端从 SQLite 组装,前端转写只是展示层副本,加载多少不影响发给模型的内容;
- 编辑重发/分支/重试(基于已加载行的 messageRef)、会话分享页(独立全量接口)、侧栏 FTS 搜索(后端)、无计数旧版桌面端(优雅回退到全量行为)。

## 已知取舍(行为变化)

- 「加载更早历史」按钮对长会话**常驻**(原来空闲全量水合后消失),每次点击加载一页;
- 楼层导航/变更文件卡片只覆盖已加载窗口(随翻页补全);
- 会话结束后的静默刷新在有新增消息时会多一次修正请求(两次窗口请求,仍远小于原全量)。

## 测试

- `historyWindow` 17 个单测(计划/采纳/滑边重试/裁剪边界);
- 全量 webui 套件 433 通过;`tsc --noEmit`、`biome check`(无新增告警)、`vite build` 均通过。

## 后续可选项(不在本 PR)

- 桌面端 GUI 仍为空闲全量水合(本地 SQLite,痛点小),可另行对齐;
- `history.prefix` 真前缀分页可在此基础上优化"加载更早"的重复传输。