### PR TITLE
fix(chat): stop duplicating pasted-text attachments when editing a sent message

### DIFF
--- a/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
+++ b/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
@@ -733,12 +733,26 @@ const EditableUserMessageBubble = memo(function EditableUserMessageBubble(props:
     resizeEditableTextarea(textareaRef.current);
   }, [draftText]);
 
+  // A large paste is stored as an uploaded text file *plus* a
+  // "[Pasted text N: path]" marker inlined into the message text (rendered
+  // as a chip once sent, see GatewayUserMessageBubbleBody above). Editing
+  // must hide that same file's attachment card while its marker is still
+  // present in the text, otherwise the paste shows up twice: once as a
+  // card, once as raw marker text in the textarea below. The full
+  // (unfiltered) list — including pasted-text files — is still what gets
+  // submitted, so nothing is lost on resend; only the card list is
+  // narrowed for display.
+  const visibleAttachments = useMemo(
+    () => splitUserAttachmentsForDisplay(draftAttachments, draftText).visibleFiles,
+    [draftAttachments, draftText],
+  );
+
   const canSubmit = draftText.trim().length > 0 || draftAttachments.length > 0;
 
   return (
     <div className="chat-user-bubble-editor w-full max-w-[min(85%,calc(50em+2.5rem))] rounded-2xl border border-border bg-[hsl(var(--chat-user-bg))] p-3">
       <GatewayUserAttachmentCards
-        files={draftAttachments}
+        files={visibleAttachments}
         workspaceRoot={workspaceRoot}
         onLoadUploadedImagePreview={onLoadUploadedImagePreview}
         onRemove={(relativePath) => {

--- a/crates/agent-gui/src/pages/chat/transcript/EditableUserMessageBubble.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/EditableUserMessageBubble.tsx
@@ -1,7 +1,8 @@
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 
 import { useLocale } from "../../../i18n";
 import type { PendingUploadedFile } from "../../../lib/chat/messages/uploadedFiles";
+import { splitUserAttachmentsForDisplay } from "./transcriptUtils";
 import { UserAttachmentCards } from "./UserAttachmentCards";
 
 export const EditableUserMessageBubble = memo(function EditableUserMessageBubble(props: {
@@ -44,6 +45,19 @@ export const EditableUserMessageBubble = memo(function EditableUserMessageBubble
     setDraftAttachments(attachments);
   }, [attachments]);
 
+  // A large paste is stored as an uploaded text file *plus* a
+  // "[Pasted text N: path]" marker inlined into the message text (rendered
+  // as a chip once sent, see UserMessageRow). Editing must hide that same
+  // file's attachment card while its marker is still present in the text,
+  // otherwise the paste shows up twice: once as a card, once as raw marker
+  // text in the textarea below. The full (unfiltered) list — including
+  // pasted-text files — is still what gets submitted, so nothing is lost on
+  // resend; only the card list is narrowed for display.
+  const visibleAttachments = useMemo(
+    () => splitUserAttachmentsForDisplay(draftAttachments, draftText).visibleFiles,
+    [draftAttachments, draftText],
+  );
+
   const canSubmit = draftText.trim().length > 0 || draftAttachments.length > 0;
 
   return (
@@ -51,7 +65,7 @@ export const EditableUserMessageBubble = memo(function EditableUserMessageBubble
       className={`w-full max-w-[min(85%,calc(50em+2.5rem))] rounded-2xl border border-border bg-[hsl(var(--chat-user-bg))] p-3 ${compactedClass}`}
     >
       <UserAttachmentCards
-        files={draftAttachments}
+        files={visibleAttachments}
         workspaceRoot={workspaceRoot}
         onRemove={(relativePath) => {
           setDraftAttachments((prev) => prev.filter((file) => file.relativePath !== relativePath));

--- a/crates/agent-gui/test/chat/editable-user-message-bubble.test.mjs
+++ b/crates/agent-gui/test/chat/editable-user-message-bubble.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import * as jsxRuntime from "react/jsx-runtime";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+// Regression coverage for: pasting a long text turns it into an uploaded
+// "pasted text" file referenced inline by the message as a
+// "[Pasted text N: path]" marker (rendered as a chip once sent — see
+// UserMessageRow / PastedTextChip). Editing that sent message used to show
+// the *same* pasted-text file twice: once as a floating attachment card
+// (EditableUserMessageBubble rendered the raw, unfiltered attachment list)
+// and once as the raw marker text inside the editable textarea. The fix
+// reuses splitUserAttachmentsForDisplay — already used by the read-only
+// bubble — to hide that redundant card while still submitting the full,
+// unfiltered attachment list on resend.
+
+const rootDir = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const userAttachmentCardsPath = path.resolve(
+  rootDir,
+  "src/pages/chat/transcript/UserAttachmentCards.tsx",
+);
+
+let capturedCardsProps = [];
+
+function MockUserAttachmentCards(props) {
+  capturedCardsProps.push(props);
+  return null;
+}
+
+const loader = createTsModuleLoader({
+  mocks: {
+    "react/jsx-runtime": jsxRuntime,
+    [userAttachmentCardsPath]: { UserAttachmentCards: MockUserAttachmentCards },
+  },
+});
+
+const { EditableUserMessageBubble } = loader.loadModule(
+  "src/pages/chat/transcript/EditableUserMessageBubble.tsx",
+);
+
+function renderBubble(props) {
+  capturedCardsProps = [];
+  renderToStaticMarkup(
+    jsxRuntime.jsx(EditableUserMessageBubble, {
+      compactedClass: "",
+      onCancel: () => {},
+      onSubmit: () => {},
+      ...props,
+    }),
+  );
+  assert.equal(capturedCardsProps.length, 1, "UserAttachmentCards should render exactly once");
+  return capturedCardsProps[0];
+}
+
+const pastedFile = {
+  relativePath: ".liveagent/uploads/session-1/pasted-text-1.txt",
+  fileName: "pasted-text-1.txt",
+  kind: "text",
+  sizeBytes: 4096,
+  displayMode: "largePaste",
+  displayLabel: "Pasted text 1",
+  displayCharCount: 4096,
+  displayLineCount: 120,
+};
+
+const normalFile = {
+  relativePath: "docs/report.pdf",
+  fileName: "report.pdf",
+  kind: "pdf",
+  sizeBytes: 2048,
+};
+
+test("editing hides the attachment card for a pasted-text file still referenced by its marker", () => {
+  const text = `请看下 [Pasted text 1: ${pastedFile.relativePath}] 和附件`;
+
+  const cardsProps = renderBubble({
+    initialText: text,
+    attachments: [normalFile, pastedFile],
+  });
+
+  assert.deepEqual(
+    cardsProps.files.map((file) => file.relativePath),
+    [normalFile.relativePath],
+    "the pasted-text file must not double up as a card while its marker is still in the text",
+  );
+});
+
+test("editing shows every attachment once no pasted-text marker references it", () => {
+  const cardsProps = renderBubble({
+    initialText: "普通消息，没有引用附件",
+    attachments: [normalFile, pastedFile],
+  });
+
+  assert.deepEqual(
+    new Set(cardsProps.files.map((file) => file.relativePath)),
+    new Set([normalFile.relativePath, pastedFile.relativePath]),
+    "without a marker in the text every attachment should still be visible and removable",
+  );
+});
+
+test("removing the pasted-text marker text makes its attachment card reappear live", () => {
+  // draftText starts with the marker (card hidden); the component's own
+  // useMemo must react as the user keeps typing/removes the marker later —
+  // simulated here by rendering with the marker already absent from a text
+  // that still differs from initialText's default state.
+  const cardsProps = renderBubble({
+    initialText: "已经删除了粘贴引用，只剩下普通文字",
+    attachments: [pastedFile],
+  });
+
+  assert.deepEqual(
+    cardsProps.files.map((file) => file.relativePath),
+    [pastedFile.relativePath],
+    "once its marker is gone, the pasted-text file falls back to a normal, removable card",
+  );
+});

--- a/crates/agent-gui/test/chat/editable-user-message-bubble.test.mjs
+++ b/crates/agent-gui/test/chat/editable-user-message-bubble.test.mjs
@@ -101,19 +101,43 @@ test("editing shows every attachment once no pasted-text marker references it", 
   );
 });
 
-test("removing the pasted-text marker text makes its attachment card reappear live", () => {
-  // draftText starts with the marker (card hidden); the component's own
-  // useMemo must react as the user keeps typing/removes the marker later —
-  // simulated here by rendering with the marker already absent from a text
-  // that still differs from initialText's default state.
+test("editing hides a card per marker when the message references several pastes", () => {
+  const secondPastedFile = {
+    ...pastedFile,
+    relativePath: ".liveagent/uploads/session-1/pasted-text-2.txt",
+    fileName: "pasted-text-2.txt",
+    displayLabel: "Pasted text 2",
+  };
+  const text = [
+    `先看 [Pasted text 1: ${pastedFile.relativePath}]`,
+    `再看 [Pasted text 2: ${secondPastedFile.relativePath}]`,
+  ].join("\n");
+
   const cardsProps = renderBubble({
-    initialText: "已经删除了粘贴引用，只剩下普通文字",
-    attachments: [pastedFile],
+    initialText: text,
+    attachments: [pastedFile, normalFile, secondPastedFile],
   });
 
   assert.deepEqual(
     cardsProps.files.map((file) => file.relativePath),
-    [pastedFile.relativePath],
-    "once its marker is gone, the pasted-text file falls back to a normal, removable card",
+    [normalFile.relativePath],
+    "every marker in the text must suppress its own card, not just the first one",
+  );
+});
+
+test("a marker pointing at a path with no attachment hides nothing", () => {
+  // Guards against matching markers positionally (or by label/index) instead
+  // of by relativePath: an editor can leave a stale marker behind whose file
+  // is already gone from the attachment list, and that must not blank out an
+  // unrelated card.
+  const cardsProps = renderBubble({
+    initialText: "[Pasted text 1: .liveagent/uploads/session-1/already-removed.txt] 还有附件",
+    attachments: [normalFile, pastedFile],
+  });
+
+  assert.deepEqual(
+    new Set(cardsProps.files.map((file) => file.relativePath)),
+    new Set([normalFile.relativePath, pastedFile.relativePath]),
+    "an unresolvable marker must not hide a card that it does not reference",
   );
 });


### PR DESCRIPTION
## 问题

复制一段长文本粘贴到输入框时，会被转成"粘贴文本"附件并在正文里插入 `[Pasted text N: 相对路径]` 标记；发送后只读气泡会把该附件从卡片列表里隐藏，只用 `PastedTextChip` 把它渲染成内嵌的绿色 tag。

点击该用户气泡上的"编辑"按钮后，编辑态直接复用了未经过滤的附件列表，同时文本框展示的是原始文本（仍带着 `[Pasted text N: 路径]` 标记）。于是同一份粘贴内容被展示了两次：一次是附件卡片，一次是文本框里那段本该被渲染成 tag 的原始标记文字。

`agent-gui`（桌面主实现）与 `agent-gateway/web`（网关 WebUI 镜像）的 `EditableUserMessageBubble` 是各自独立实现，同样的疏漏两边都存在。

## 修复

复用只读气泡已经在用的 `splitUserAttachmentsForDisplay`，让编辑态的附件卡片列表也按"文本里是否还带着该文件的标记"过滤；**提交/重发时仍然使用完整、未过滤的附件列表**，因此不会因为隐藏了卡片就把该附件从消息里丢掉。

- `crates/agent-gui/src/pages/chat/transcript/EditableUserMessageBubble.tsx`
- `crates/agent-gateway/web/src/components/GatewayTranscript.tsx`（镜像同步）

## 测试

- `crates/agent-gui/test/chat/editable-user-message-bubble.test.mjs`（新增，4 个用例）：
  - 标记存在时隐藏重复卡片 / 无标记时正常显示全部附件 / 一条消息引用多段粘贴时**每个**标记各自隐藏对应卡片 / 陈旧标记（对应附件已不在列表）不误伤任何卡片。
  - 其中前者与「多段粘贴」两个用例已对旧代码验证过必现失败，确认是真实回归守卫。
  - 本仓库测试仅有 `renderToStaticMarkup`（无 jsdom/testing-library），无法驱动 state 变更，因此不含「边打字边删标记」的实时用例；`useMemo` 依赖为 `[draftAttachments, draftText]`。
- `agent-gui`：`test:frontend`（1251 用例）、`tsc --noEmit`、`biome lint` 全部通过；lint 警告数与 main 基线一致（365 条，均为历史遗留、与本次改动无关）。
- `agent-gateway/web`：`tsc --noEmit`、`node --test`（416 用例）全部通过；`biome check src/` 306 条警告，与 main 基线逐条一致（全为历史遗留）。

无用户可见的行为回归——粘贴附件在发送/重发链路上的内容不变（提交时仍使用完整、未过滤的附件列表），只是编辑视图不再重复展示。
