### PR TITLE
chore(settings): 删除未被引用的 sortModelsBySelection

### DIFF
--- a/crates/agent-gateway/web/src/pages/settings/providerUtils.ts
+++ b/crates/agent-gateway/web/src/pages/settings/providerUtils.ts
@@ -317,21 +317,6 @@ export function mergeFetchedModels(
   return merged;
 }
 
-export function sortModelsBySelection(
-  models: ProviderModelConfig[],
-  activeModels: ReadonlySet<string>,
-): ProviderModelConfig[] {
-  const selected: ProviderModelConfig[] = [];
-  const unselected: ProviderModelConfig[] = [];
-
-  for (const model of models) {
-    if (activeModels.has(model.id)) selected.push(model);
-    else unselected.push(model);
-  }
-
-  return [...selected, ...unselected];
-}
-
 export function getModelBulkActionCounts(
   selectedModels: ReadonlySet<string>,
   activeModels: ReadonlySet<string>,

--- a/crates/agent-gui/src/pages/settings/providerUtils.ts
+++ b/crates/agent-gui/src/pages/settings/providerUtils.ts
@@ -317,21 +317,6 @@ export function mergeFetchedModels(
   return merged;
 }
 
-export function sortModelsBySelection(
-  models: ProviderModelConfig[],
-  activeModels: ReadonlySet<string>,
-): ProviderModelConfig[] {
-  const selected: ProviderModelConfig[] = [];
-  const unselected: ProviderModelConfig[] = [];
-
-  for (const model of models) {
-    if (activeModels.has(model.id)) selected.push(model);
-    else unselected.push(model);
-  }
-
-  return [...selected, ...unselected];
-}
-
 export function getModelBulkActionCounts(
   selectedModels: ReadonlySet<string>,
   activeModels: ReadonlySet<string>,


### PR DESCRIPTION
## 改动说明

删除 `providerUtils.ts` 中未被任何代码引用的 `sortModelsBySelection`，GUI 与 Gateway WebUI 各一份。

该函数自 initial commit 起就没有调用点。供应商模型列表的排序职责现在由 `lib/providers/modelVendor` 承担（`sortModelsByActiveStateAndVendor` 负责启用态+厂商排序，`createModelOrderSnapshot` / `applyModelOrderSnapshot` 负责模态框内的显示顺序快照），这份实现属于历史遗留。

纯删除，无行为变更。

> 缘起：审核 #265 时顺带发现。当时刻意没有夹带进那个功能 PR —— `providerUtils.ts` 不在 #265 的改动范围内，也不在 `scripts/mirror-manifest.json` 中（两端靠手工同步，CI 查不出漂移），故单开此 PR。

## 改动类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 重构
- [ ] 文档更新
- [ ] 其他

## 测试说明

基于 main `dd519470`（即 #265 合入后）验证：

- [x] GUI `tsc --noEmit` 通过（0 error）
- [x] Gateway WebUI `tsc --noEmit` 通过（0 error）
- [x] GUI 前端测试 1255/1255 通过
- [x] Gateway WebUI 全量测试 440/440 通过
- [x] GUI 与 Gateway WebUI build 均通过
- [x] Mirror Check 通过（105 文件）
- [x] 改动文件 Biome 检查零警告
- [x] `git diff --check` 干净
- [x] 全仓检索 `sortModelsBySelection` 已无残留引用（含 re-export 与动态引用检查）
- [x] 删除后两份 `providerUtils.ts` 仍逐字节一致

## 关联 Issue

无