### PR TITLE
fix(mermaid): 大图拖动不再抖动

### DIFF
--- a/crates/agent-gateway/web/src/index.css
+++ b/crates/agent-gateway/web/src/index.css
@@ -146,6 +146,22 @@
     max-width: 100%;
     max-height: 100%;
   }
+
+  /*
+   * Streamdown pan-zoom always attaches `transition-transform duration-150`.
+   * That eases zoom-button / wheel scale changes nicely, but it also eases
+   * every pointermove pan update — large diagrams lag and jitter while
+   * dragging. Keep the idle transition; drop it only for an active drag:
+   * `:active` covers the pointerdown frame before React flips the cursor,
+   * and the grabbing cursor (set on the pan surface) covers the rest of the
+   * gesture, including pointer-captured moves outside the element.
+   */
+  [data-streamdown="mermaid"] [role="application"]:active,
+  [data-streamdown="mermaid"] [style*="cursor: grabbing"] [role="application"],
+  [data-streamdown="mermaid"] [style*="cursor:grabbing"] [role="application"] {
+    transition: none !important;
+    transition-property: none !important;
+  }
 }
 
 @layer base {
@@ -2065,6 +2081,18 @@ body > div:has([data-streamdown="table-fullscreen"]):not(#root) {
 body > div:not(#root) [data-streamdown="mermaid"] svg {
   -webkit-transform: translateZ(0);
   transform: translateZ(0);
+}
+/*
+ * The SVG translateZ above promotes a second compositor layer under the pan
+ * transform. Fine while idle, but during drag WebKit thrash-composites the
+ * nested layers on large diagrams. Drop the SVG's own transform for the
+ * gesture; the portal layer above still keeps the fullscreen paint fix.
+ */
+body > div:not(#root) [data-streamdown="mermaid"]:has([role="application"]:active) svg,
+body > div:not(#root) [data-streamdown="mermaid"]:has([style*="cursor: grabbing"]) svg,
+body > div:not(#root) [data-streamdown="mermaid"]:has([style*="cursor:grabbing"]) svg {
+  -webkit-transform: none;
+  transform: none;
 }
 
 /* Git review diff views live under app chrome that disables selection by default. */

--- a/crates/agent-gui/src/index.css
+++ b/crates/agent-gui/src/index.css
@@ -146,6 +146,22 @@
     max-width: 100%;
     max-height: 100%;
   }
+
+  /*
+   * Streamdown pan-zoom always attaches `transition-transform duration-150`.
+   * That eases zoom-button / wheel scale changes nicely, but it also eases
+   * every pointermove pan update — large diagrams lag and jitter while
+   * dragging. Keep the idle transition; drop it only for an active drag:
+   * `:active` covers the pointerdown frame before React flips the cursor,
+   * and the grabbing cursor (set on the pan surface) covers the rest of the
+   * gesture, including pointer-captured moves outside the element.
+   */
+  [data-streamdown="mermaid"] [role="application"]:active,
+  [data-streamdown="mermaid"] [style*="cursor: grabbing"] [role="application"],
+  [data-streamdown="mermaid"] [style*="cursor:grabbing"] [role="application"] {
+    transition: none !important;
+    transition-property: none !important;
+  }
 }
 
 @layer base {
@@ -2500,6 +2516,18 @@ body > div:has([data-streamdown="table-fullscreen"]):not(#root) {
 body > div:not(#root) [data-streamdown="mermaid"] svg {
   -webkit-transform: translateZ(0);
   transform: translateZ(0);
+}
+/*
+ * The SVG translateZ above promotes a second compositor layer under the pan
+ * transform. Fine while idle, but during drag WebKit thrash-composites the
+ * nested layers on large diagrams. Drop the SVG's own transform for the
+ * gesture; the portal layer above still keeps the fullscreen paint fix.
+ */
+body > div:not(#root) [data-streamdown="mermaid"]:has([role="application"]:active) svg,
+body > div:not(#root) [data-streamdown="mermaid"]:has([style*="cursor: grabbing"]) svg,
+body > div:not(#root) [data-streamdown="mermaid"]:has([style*="cursor:grabbing"]) svg {
+  -webkit-transform: none;
+  transform: none;
 }
 
 .chat-history-sidebar,


### PR DESCRIPTION
Closes #284

## 问题
Mermaid 全屏大图拖动平移会抖动、跟手延迟。

## 原因
streamdown 平移层始终带 `transition-transform 150ms`；全屏 SVG 的 `translateZ(0)` 再叠一层合成，大图更抖。

## 修复
- 空闲保留缩放缓动
- 仅拖动时关掉 transition（`:active` + `cursor: grabbing`）
- 拖动时去掉 SVG 嵌套合成层，portal 层保留全屏可绘制修复

GUI / WebUI 同步。