### PR TITLE
fix(providers): stop dropping custom request headers across chat paths

### DIFF
--- a/crates/agent-gateway/web/src/i18n/config.ts
+++ b/crates/agent-gateway/web/src/i18n/config.ts
@@ -1368,6 +1368,8 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.removeCustomHeader": "删除请求头",
     "settings.invalidCustomHeaderKey":
       "请求头名称无效。仅支持合法 HTTP Header 名称，例如 X-Environment、X-Request-ID。",
+    "settings.invalidCustomHeaderValue":
+      "请求头取值无效。仅支持可见 ASCII 字符（不含换行），请勿填入中文或换行。",
     "settings.close": "关闭",
     "settings.hideApiKey": "隐藏 API Key",
     "settings.showApiKey": "显示 API Key",
@@ -3547,6 +3549,8 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.removeCustomHeader": "Remove header",
     "settings.invalidCustomHeaderKey":
       "Invalid HTTP header name. Examples: X-Environment, X-Request-ID.",
+    "settings.invalidCustomHeaderValue":
+      "Invalid header value. Only printable ASCII is allowed — no line breaks or non-ASCII characters.",
     "settings.close": "Close",
     "settings.hideApiKey": "Hide API Key",
     "settings.showApiKey": "Show API Key",

--- a/crates/agent-gateway/web/src/lib/providers/customHeaders.ts
+++ b/crates/agent-gateway/web/src/lib/providers/customHeaders.ts
@@ -8,7 +8,13 @@ const RESERVED_CUSTOM_HEADER_KEYS = new Set([
   "host",
   "content-length",
 ]);
+// 本地反代的内部通道命名空间：放行会让用户把代理令牌/上游 origin 等控制头注入
+// 上游请求。反代自己也会剥掉这一前缀，这里在配置侧提前拒绝以便给出明确反馈。
+const RESERVED_CUSTOM_HEADER_KEY_PREFIX = "x-liveagent-";
 const HTTP_HEADER_TOKEN_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+// 头取值只允许可见 ASCII 与水平制表符：CR/LF 会造成 header 注入，非 ASCII 会让
+// WebView 的 fetch() 直接抛错、把整轮对话打断成一条与请求头无关的报错。
+const HTTP_HEADER_VALUE_PATTERN = /^[\t\x20-\x7e]*$/;
 
 export const ANTHROPIC_DEFAULT_REQUEST_HEADERS = {
   "x-app": "cli",
@@ -81,21 +87,20 @@ function findHeaderKey(
   return Object.keys(headers).find((key) => key.toLowerCase() === expected);
 }
 
-export function readHeaderValue(
-  headers: Record<string, string | null | undefined> | undefined,
-  name: string,
-): string | undefined {
-  if (!headers) return undefined;
-  const key = findHeaderKey(headers, name);
-  return key === undefined ? undefined : (headers[key] ?? undefined);
-}
-
 export function isValidCustomHeaderKey(key: string): boolean {
   return HTTP_HEADER_TOKEN_PATTERN.test(key);
 }
 
+export function isValidCustomHeaderValue(value: string): boolean {
+  return HTTP_HEADER_VALUE_PATTERN.test(value);
+}
+
 export function isReservedCustomHeaderKey(key: string): boolean {
-  return RESERVED_CUSTOM_HEADER_KEYS.has(key.toLowerCase());
+  const normalized = key.toLowerCase();
+  return (
+    RESERVED_CUSTOM_HEADER_KEYS.has(normalized) ||
+    normalized.startsWith(RESERVED_CUSTOM_HEADER_KEY_PREFIX)
+  );
 }
 export function mergeCustomHeaders(
   base: Record<string, string>,
@@ -104,7 +109,11 @@ export function mergeCustomHeaders(
   const merged = { ...base };
 
   for (const header of customHeaders ?? []) {
-    if (!isValidCustomHeaderKey(header.key) || isReservedCustomHeaderKey(header.key)) {
+    if (
+      !isValidCustomHeaderKey(header.key) ||
+      !isValidCustomHeaderValue(header.value) ||
+      isReservedCustomHeaderKey(header.key)
+    ) {
       continue;
     }
 

--- a/crates/agent-gateway/web/src/lib/providers/proxy.ts
+++ b/crates/agent-gateway/web/src/lib/providers/proxy.ts
@@ -1,15 +1,26 @@
 import { invoke } from "@tauri-apps/api/core";
 
 import type { ProviderId } from "../settings";
-import { readHeaderValue } from "./customHeaders";
 
 export const LIVEAGENT_PROXY_TOKEN_HEADER = "x-liveagent-proxy-token";
 export const LIVEAGENT_UPSTREAM_ORIGIN_HEADER = "x-liveagent-upstream-origin";
-export const LIVEAGENT_UPSTREAM_USER_AGENT_HEADER = "x-liveagent-upstream-user-agent";
-export const LIVEAGENT_UPSTREAM_CONTENT_TYPE_HEADER = "x-liveagent-upstream-content-type";
+// 上游头覆盖包：base64(utf8(JSON))。WebView 的 fetch 会静默丢弃 User-Agent /
+// Cookie / Referer 等 forbidden header names，SDK 也可能自行注入同名头，所以最终
+// 头集经这一条通道下发，由本地反代在转发前作为最后一步覆盖写入上游请求——
+// “自定义头覆盖内置默认头”的唯一裁决点就在那里。
+export const LIVEAGENT_UPSTREAM_HEADERS_HEADER = "x-liveagent-upstream-headers";
 // 布尔标记头：声明该请求经系统代理出网。代理地址/凭据只存于桌面 Rust 侧，
 // 由本地反代按此头选择带代理的 client（x-liveagent-* 头不会转发给上游）。
 export const LIVEAGENT_USE_SYSTEM_PROXY_HEADER = "x-liveagent-use-system-proxy";
+
+// 鉴权头不进覆盖包：它们不属浏览器禁止名（常规通道必然送达），且是保留头用户
+// 改不了，没有覆盖需求——不必把密钥再复制一份进旁路通道。
+const UPSTREAM_HEADER_OVERRIDE_EXCLUDED_KEYS = new Set([
+  "authorization",
+  "x-api-key",
+  "x-goog-api-key",
+]);
+const UPSTREAM_HEADER_OVERRIDE_MAX_BYTES = 8 * 1024;
 
 type ProxyServerInfo = {
   baseUrl: string;
@@ -21,15 +32,26 @@ export type PreparedProxyRequest = {
   headers: Record<string, string>;
 };
 
-export function buildUpstreamHeaderOverrideHeaders(
-  headers: Record<string, string>,
-): Record<string, string> {
-  const userAgent = readHeaderValue(headers, "user-agent");
-  const contentType = readHeaderValue(headers, "content-type");
-  return {
-    ...(userAgent !== undefined ? { [LIVEAGENT_UPSTREAM_USER_AGENT_HEADER]: userAgent } : {}),
-    ...(contentType !== undefined ? { [LIVEAGENT_UPSTREAM_CONTENT_TYPE_HEADER]: contentType } : {}),
-  };
+export function encodeUpstreamHeaderOverrides(headers: Record<string, string>): string | undefined {
+  const overrides: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (UPSTREAM_HEADER_OVERRIDE_EXCLUDED_KEYS.has(key.toLowerCase())) continue;
+    if (key.toLowerCase().startsWith("x-liveagent-")) continue;
+    overrides[key] = value;
+  }
+  if (Object.keys(overrides).length === 0) return undefined;
+
+  // base64 而非裸 JSON：既杜绝取值里的 CR/LF 造成 header 注入，也免去引号与逗号
+  // 在 header 值里的解析歧义。
+  const encoded = new TextEncoder().encode(JSON.stringify(overrides));
+  if (encoded.byteLength > UPSTREAM_HEADER_OVERRIDE_MAX_BYTES) {
+    throw new Error(
+      `Custom request headers are too large (${encoded.byteLength} bytes, limit ${UPSTREAM_HEADER_OVERRIDE_MAX_BYTES}). Trim the provider's custom request headers.`,
+    );
+  }
+  let binary = "";
+  for (const byte of encoded) binary += String.fromCharCode(byte);
+  return btoa(binary);
 }
 
 let proxyServerInfoPromise: Promise<ProxyServerInfo> | null = null;
@@ -191,12 +213,15 @@ export async function prepareProxyRequest(
     upstreamBaseUrl,
     proxyServerInfo.baseUrl,
   );
+  const upstreamHeaderOverrides = encodeUpstreamHeaderOverrides(headers);
 
   return {
     baseUrl,
     headers: {
       ...headers,
-      ...buildUpstreamHeaderOverrideHeaders(headers),
+      ...(upstreamHeaderOverrides
+        ? { [LIVEAGENT_UPSTREAM_HEADERS_HEADER]: upstreamHeaderOverrides }
+        : {}),
       [LIVEAGENT_UPSTREAM_ORIGIN_HEADER]: upstreamOrigin,
       [LIVEAGENT_PROXY_TOKEN_HEADER]: proxyServerInfo.token,
       ...(options?.useSystemProxy ? { [LIVEAGENT_USE_SYSTEM_PROXY_HEADER]: "1" } : {}),

--- a/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
@@ -42,6 +42,7 @@ import {
   getCustomHeaderKeyPresets,
   isReservedCustomHeaderKey,
   isValidCustomHeaderKey,
+  isValidCustomHeaderValue,
 } from "../../lib/providers/customHeaders";
 import { parseModelValue, toModelValue } from "../../lib/providers/llm";
 import {
@@ -234,12 +235,24 @@ function parsePositiveInteger(input: string): number | null {
   return normalized > 0 ? normalized : null;
 }
 
-type CustomHeaderKeyIssue = "reserved" | "invalid";
+type CustomHeaderIssue = "reserved" | "invalid-key" | "invalid-value";
 
-function getCustomHeaderKeyIssue(key: string, includeEmpty = false): CustomHeaderKeyIssue | null {
-  if (!key && !includeEmpty) return null;
-  if (isReservedCustomHeaderKey(key)) return "reserved";
-  return isValidCustomHeaderKey(key) ? null : "invalid";
+function customHeaderIssueMessage(issue: CustomHeaderIssue, t: (key: string) => string): string {
+  if (issue === "reserved") return t("settings.customHeaderReservedTitle");
+  if (issue === "invalid-value") return t("settings.invalidCustomHeaderValue");
+  return t("settings.invalidCustomHeaderKey");
+}
+
+function getCustomHeaderIssue(
+  header: { key: string; value: string },
+  includeEmpty = false,
+): CustomHeaderIssue | null {
+  if (!header.key && !includeEmpty) return null;
+  if (isReservedCustomHeaderKey(header.key)) return "reserved";
+  if (!isValidCustomHeaderKey(header.key)) return "invalid-key";
+  // 取值含非 ASCII / CR / LF 时 fetch() 会直接抛错，整轮对话被打断成一条与请求头
+  // 无关的报错——在保存前拦住，把问题指回这一行配置。
+  return isValidCustomHeaderValue(header.value) ? null : "invalid-value";
 }
 
 function DialogSwitch(props: {
@@ -765,13 +778,18 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
   async function handleSave() {
     if (!name.trim()) return;
     const invalidHeaderIndex = customHeaders.findIndex(
-      (header) => getCustomHeaderKeyIssue(header.key, true) !== null,
+      (header) => getCustomHeaderIssue(header, true) !== null,
     );
     if (invalidHeaderIndex >= 0) {
       setHeaderValidationSubmitted(true);
       exitModelBulkMode();
       setActivePanel("request");
-      focusCustomHeader(invalidHeaderIndex, "key");
+      focusCustomHeader(
+        invalidHeaderIndex,
+        getCustomHeaderIssue(customHeaders[invalidHeaderIndex], true) === "invalid-value"
+          ? "value"
+          : "key",
+      );
       return;
     }
     if (requiresCustomUsageQueryConfirmation(usageQuery, customUsageQueryConfirmed)) {
@@ -945,14 +963,11 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
   );
   const firstHeaderIssue =
     customHeaders
-      .map((header) => getCustomHeaderKeyIssue(header.key, headerValidationSubmitted))
+      .map((header) => getCustomHeaderIssue(header, headerValidationSubmitted))
       .find((issue) => issue !== null) ?? null;
-  const headerIssueMessage =
-    firstHeaderIssue === "reserved"
-      ? t("settings.customHeaderReservedTitle")
-      : firstHeaderIssue === "invalid"
-        ? t("settings.invalidCustomHeaderKey")
-        : null;
+  const headerIssueMessage = firstHeaderIssue
+    ? customHeaderIssueMessage(firstHeaderIssue, t)
+    : null;
 
   return createPortal(
     <div
@@ -1606,16 +1621,10 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                       onScroll={() => setHeaderSuggest(null)}
                     >
                       {customHeaders.map((header, index) => {
-                        const issue = getCustomHeaderKeyIssue(
-                          header.key,
-                          headerValidationSubmitted,
-                        );
-                        const issueTitle =
-                          issue === "reserved"
-                            ? t("settings.customHeaderReservedTitle")
-                            : issue === "invalid"
-                              ? t("settings.invalidCustomHeaderKey")
-                              : undefined;
+                        const issue = getCustomHeaderIssue(header, headerValidationSubmitted);
+                        const issueTitle = issue ? customHeaderIssueMessage(issue, t) : undefined;
+                        const valueIssue = issue === "invalid-value";
+                        const keyIssue = issue !== null && !valueIssue;
                         const valueVisible = visibleHeaderValues.has(index);
                         const suggestOpen =
                           headerSuggest?.index === index && headerSuggestItems.length > 0;
@@ -1636,11 +1645,11 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                               value={header.key}
                               className={cn(
                                 "h-10 w-[210px] shrink-0 rounded-none border-0 border-r bg-muted/30 px-3 font-mono text-xs shadow-none focus-visible:ring-0 max-[720px]:w-full max-[720px]:border-b max-[720px]:border-r-0 max-[720px]:bg-muted/40",
-                                issue && "text-destructive",
+                                keyIssue && "text-destructive",
                               )}
                               placeholder={t("settings.customHeaderKeyPlaceholder")}
                               aria-label={t("settings.customHeaderName")}
-                              aria-invalid={issue ? true : undefined}
+                              aria-invalid={keyIssue ? true : undefined}
                               role="combobox"
                               aria-expanded={suggestOpen}
                               aria-controls={suggestOpen ? "provider-header-suggest" : undefined}
@@ -1697,9 +1706,14 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                                 }}
                                 type={valueVisible ? "text" : "password"}
                                 value={header.value}
-                                className="h-10 w-full rounded-none border-0 bg-transparent pl-3 pr-[4.5rem] font-mono text-xs shadow-none focus-visible:ring-0"
+                                className={cn(
+                                  "h-10 w-full rounded-none border-0 bg-transparent pl-3 pr-[4.5rem] font-mono text-xs shadow-none focus-visible:ring-0",
+                                  valueIssue && "text-destructive",
+                                )}
                                 placeholder={t("settings.customHeaderValue")}
                                 aria-label={t("settings.customHeaderValue")}
+                                aria-invalid={valueIssue ? true : undefined}
+                                title={valueIssue ? issueTitle : undefined}
                                 autoComplete="off"
                                 spellCheck={false}
                                 onChange={(event) =>

--- a/crates/agent-gui/src-tauri/src/services/proxy.rs
+++ b/crates/agent-gui/src-tauri/src/services/proxy.rs
@@ -12,8 +12,10 @@ use axum::{
     routing::{any, get},
     Router,
 };
+use base64::Engine as _;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tokio::net::TcpListener as TokioTcpListener;
 use uuid::Uuid;
 
@@ -37,10 +39,10 @@ const TRAILER: &str = "trailer";
 const TRANSFER_ENCODING: &str = "transfer-encoding";
 const UPGRADE: &str = "upgrade";
 const UPSTREAM_ORIGIN_HEADER: &str = "x-liveagent-upstream-origin";
-const UPSTREAM_USER_AGENT_HEADER: &str = "x-liveagent-upstream-user-agent";
-const UPSTREAM_CONTENT_TYPE_HEADER: &str = "x-liveagent-upstream-content-type";
+const UPSTREAM_HEADERS_HEADER: &str = "x-liveagent-upstream-headers";
+const UPSTREAM_HEADERS_MAX_BYTES: usize = 8 * 1024;
 const USE_SYSTEM_PROXY_HEADER: &str = "x-liveagent-use-system-proxy";
-const DEFAULT_ALLOW_HEADERS: &str = "authorization,content-type,x-api-key,x-goog-api-key,anthropic-version,x-liveagent-upstream-origin,x-liveagent-upstream-user-agent,x-liveagent-upstream-content-type,x-liveagent-proxy-token,x-liveagent-use-system-proxy";
+const DEFAULT_ALLOW_HEADERS: &str = "authorization,content-type,x-api-key,x-goog-api-key,anthropic-version,x-liveagent-upstream-origin,x-liveagent-upstream-headers,x-liveagent-proxy-token,x-liveagent-use-system-proxy";
 const ALLOW_METHODS_VALUE: &str = "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD";
 const VARY_VALUE: &str = "Origin, Access-Control-Request-Method, Access-Control-Request-Headers";
 const IMAGE_PROXY_MAX_BYTES: usize = 25 * 1024 * 1024;
@@ -382,9 +384,13 @@ async fn handle_proxy(
     } else {
         state.client.clone()
     };
+    let upstream_request_headers = match build_upstream_request_headers(&headers) {
+        Ok(upstream_request_headers) => upstream_request_headers,
+        Err(message) => return error_response(StatusCode::BAD_REQUEST, &message, &headers),
+    };
     let mut request = client
         .request(method, target_url)
-        .headers(build_upstream_request_headers(&headers));
+        .headers(upstream_request_headers);
     if !body_bytes.is_empty() {
         request = request.body(body_bytes);
     }
@@ -548,20 +554,85 @@ fn should_forward_request_header(name: &HeaderName) -> bool {
         && !lowered.starts_with(PROXY_PREFIX)
 }
 
-fn build_upstream_request_headers(headers: &HeaderMap) -> HeaderMap {
+/// 覆盖包的拒绝清单**窄于** should_forward_request_header：只拒会破坏请求本身的
+/// 头（host / content-length / hop-by-hop）与本地反代的内部命名空间。
+///
+/// 有意放行 origin / referer / cookie —— 常规拷贝过滤器的职责是剥掉 *WebView 自己
+/// 注入的* Origin/Referer，而不是否决用户在供应商配置里显式写下的同名头。
+fn is_protected_upstream_override(name: &HeaderName) -> bool {
+    let lowered = name.as_str();
+    matches!(
+        lowered,
+        HOST | CONTENT_LENGTH
+            | CONNECTION
+            | KEEP_ALIVE
+            | PROXY_CONNECTION
+            | PROXY_AUTHENTICATE
+            | PROXY_AUTHORIZATION
+            | TE
+            | TRAILER
+            | TRANSFER_ENCODING
+            | UPGRADE
+    ) || lowered.starts_with(PROXY_PREFIX)
+}
+
+/// 解出 x-liveagent-upstream-headers 覆盖包。畸形输入一律 Err（由调用方回 400）：
+/// 静默跳过会把「自定义请求头没生效」变成难查的偶发问题。
+fn decode_upstream_header_overrides(encoded: &str) -> Result<Vec<(HeaderName, HeaderValue)>, String> {
+    if encoded.len() > UPSTREAM_HEADERS_MAX_BYTES {
+        return Err(format!(
+            "{UPSTREAM_HEADERS_HEADER} exceeds {UPSTREAM_HEADERS_MAX_BYTES} bytes"
+        ));
+    }
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|error| format!("{UPSTREAM_HEADERS_HEADER} is not valid base64: {error}"))?;
+    if decoded.len() > UPSTREAM_HEADERS_MAX_BYTES {
+        return Err(format!(
+            "{UPSTREAM_HEADERS_HEADER} exceeds {UPSTREAM_HEADERS_MAX_BYTES} bytes"
+        ));
+    }
+    let parsed: serde_json::Map<String, Value> = serde_json::from_slice(&decoded)
+        .map_err(|error| format!("{UPSTREAM_HEADERS_HEADER} is not a valid JSON object: {error}"))?;
+
+    let mut overrides = Vec::with_capacity(parsed.len());
+    for (name, value) in parsed {
+        let Value::String(value) = value else {
+            return Err(format!(
+                "{UPSTREAM_HEADERS_HEADER} entry \"{name}\" must be a string"
+            ));
+        };
+        let header_name = HeaderName::from_bytes(name.to_ascii_lowercase().as_bytes())
+            .map_err(|_| format!("{UPSTREAM_HEADERS_HEADER} entry \"{name}\" is not a valid header name"))?;
+        if is_protected_upstream_override(&header_name) {
+            continue;
+        }
+        let header_value = HeaderValue::from_str(&value).map_err(|_| {
+            format!("{UPSTREAM_HEADERS_HEADER} entry \"{name}\" has a value that is not valid for an HTTP header")
+        })?;
+        overrides.push((header_name, header_value));
+    }
+    Ok(overrides)
+}
+
+fn build_upstream_request_headers(headers: &HeaderMap) -> Result<HeaderMap, String> {
     let mut upstream_headers = HeaderMap::new();
     for (name, value) in headers {
         if should_forward_request_header(name) {
             upstream_headers.append(name, value.clone());
         }
     }
-    if let Some(value) = headers.get(UPSTREAM_USER_AGENT_HEADER) {
-        upstream_headers.insert(HeaderName::from_static("user-agent"), value.clone());
+    // 覆盖包是转发前的最后一步：insert 替换掉 SDK 或 WebView 注入的同名头，
+    // 让「自定义请求头覆盖内置默认头」在任意头名上都成立。
+    if let Some(encoded) = headers.get(UPSTREAM_HEADERS_HEADER) {
+        let encoded = encoded
+            .to_str()
+            .map_err(|_| format!("{UPSTREAM_HEADERS_HEADER} must be ASCII"))?;
+        for (name, value) in decode_upstream_header_overrides(encoded)? {
+            upstream_headers.insert(name, value);
+        }
     }
-    if let Some(value) = headers.get(UPSTREAM_CONTENT_TYPE_HEADER) {
-        upstream_headers.insert(HeaderName::from_static(CONTENT_TYPE), value.clone());
-    }
-    upstream_headers
+    Ok(upstream_headers)
 }
 
 fn should_forward_response_header(name: &HeaderName) -> bool {
@@ -750,29 +821,116 @@ mod tests {
             HeaderValue::from_static("application/json"),
         );
         headers.insert(
-            HeaderName::from_static(UPSTREAM_USER_AGENT_HEADER),
-            HeaderValue::from_static("codex_cli_rs/0.72.0"),
-        );
-        headers.insert(
-            HeaderName::from_static(UPSTREAM_CONTENT_TYPE_HEADER),
-            HeaderValue::from_static("application/custom+json"),
+            HeaderName::from_static(UPSTREAM_HEADERS_HEADER),
+            encoded_overrides(serde_json::json!({
+                "User-Agent": "codex_cli_rs/0.72.0",
+                "Content-Type": "application/custom+json",
+                "X-Request-Id": "trace-1",
+            })),
         );
 
-        let upstream_headers = build_upstream_request_headers(&headers);
+        let upstream_headers = build_upstream_request_headers(&headers).expect("overrides decode");
 
+        assert_eq!(header_str(&upstream_headers, "user-agent"), Some("codex_cli_rs/0.72.0"));
         assert_eq!(
-            upstream_headers
-                .get("user-agent")
-                .and_then(|value| value.to_str().ok()),
-            Some("codex_cli_rs/0.72.0")
-        );
-        assert_eq!(
-            upstream_headers
-                .get(CONTENT_TYPE)
-                .and_then(|value| value.to_str().ok()),
+            header_str(&upstream_headers, CONTENT_TYPE),
             Some("application/custom+json")
         );
-        assert!(!upstream_headers.contains_key(UPSTREAM_USER_AGENT_HEADER));
-        assert!(!upstream_headers.contains_key(UPSTREAM_CONTENT_TYPE_HEADER));
+        assert_eq!(header_str(&upstream_headers, "x-request-id"), Some("trace-1"));
+        assert!(!upstream_headers.contains_key(UPSTREAM_HEADERS_HEADER));
+    }
+
+    #[test]
+    fn upstream_overrides_restore_browser_forbidden_header_names() {
+        // WebView 的 fetch 根本不会发出 Cookie / Referer；常规拷贝过滤器还会主动
+        // 剥掉浏览器注入的 Referer。用户显式配置的同名头必须仍然送达上游。
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static(REFERER),
+            HeaderValue::from_static("http://tauri.localhost"),
+        );
+        headers.insert(
+            HeaderName::from_static(UPSTREAM_HEADERS_HEADER),
+            encoded_overrides(serde_json::json!({
+                "Cookie": "session=abc",
+                "Referer": "https://relay.example/app",
+            })),
+        );
+
+        let upstream_headers = build_upstream_request_headers(&headers).expect("overrides decode");
+
+        assert_eq!(header_str(&upstream_headers, "cookie"), Some("session=abc"));
+        assert_eq!(
+            header_str(&upstream_headers, REFERER),
+            Some("https://relay.example/app")
+        );
+    }
+
+    #[test]
+    fn upstream_overrides_skip_protected_header_names() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static(UPSTREAM_HEADERS_HEADER),
+            encoded_overrides(serde_json::json!({
+                "Host": "attacker.example",
+                "Content-Length": "0",
+                "Connection": "close",
+                "x-liveagent-proxy-token": "leaked",
+                "X-Kept": "yes",
+            })),
+        );
+
+        let upstream_headers = build_upstream_request_headers(&headers).expect("overrides decode");
+
+        assert_eq!(header_str(&upstream_headers, "x-kept"), Some("yes"));
+        for protected in ["host", "content-length", "connection", PROXY_TOKEN_HEADER] {
+            assert!(
+                !upstream_headers.contains_key(protected),
+                "{protected} must not be settable through the override channel"
+            );
+        }
+    }
+
+    #[test]
+    fn upstream_overrides_reject_malformed_payloads() {
+        for encoded in ["not-base64!!", "eyJhIjo="] {
+            assert!(decode_upstream_header_overrides(encoded).is_err());
+        }
+        // 合法 base64 但不是 JSON 对象
+        assert!(decode_upstream_header_overrides(
+            &base64::engine::general_purpose::STANDARD.encode(b"[1,2,3]")
+        )
+        .is_err());
+        // 非字符串取值
+        assert!(decode_upstream_header_overrides(
+            &base64::engine::general_purpose::STANDARD.encode(br#"{"X-A":1}"#)
+        )
+        .is_err());
+        // 头名非法
+        assert!(decode_upstream_header_overrides(
+            &base64::engine::general_purpose::STANDARD.encode(br#"{"Bad Header":"v"}"#)
+        )
+        .is_err());
+        // 取值含 CR/LF（header 注入）
+        assert!(decode_upstream_header_overrides(
+            &base64::engine::general_purpose::STANDARD.encode(b"{\"X-A\":\"a\\r\\nb\"}")
+        )
+        .is_err());
+        // 超限
+        let oversized = "A".repeat(UPSTREAM_HEADERS_MAX_BYTES + 4);
+        assert!(decode_upstream_header_overrides(&oversized).is_err());
+    }
+
+    fn encoded_overrides(value: serde_json::Value) -> HeaderValue {
+        let encoded = base64::engine::general_purpose::STANDARD
+            .encode(serde_json::to_vec(&value).expect("serialize overrides"));
+        HeaderValue::from_str(&encoded).expect("override header value")
+    }
+
+    fn header_str<K>(headers: &HeaderMap, name: K) -> Option<&str>
+    where
+        K: axum::http::header::AsHeaderName,
+    {
+        headers.get(name).and_then(|value| value.to_str().ok())
     }
 }

--- a/crates/agent-gui/src/components/cron/CronPromptRunner.tsx
+++ b/crates/agent-gui/src/components/cron/CronPromptRunner.tsx
@@ -5,12 +5,11 @@ import type { CompletePromptRunInput, PromptRunRequest } from "../../lib/automat
 import { backend } from "../../lib/automation/backend";
 import { runAssistantWithTools } from "../../lib/chat/runner/agentRunner";
 import { createStreamDebugLogger } from "../../lib/debug/agentDebug";
-import { assistantMessageToText } from "../../lib/providers/llm";
+import { assistantMessageToText, createProviderRuntimeConfig } from "../../lib/providers/llm";
 import { resolveRuntimePlatform } from "../../lib/runtimePlatform";
 import {
   type AppSettings,
   DEFAULT_CHAT_RUNTIME_CONTROLS,
-  findProviderModelConfig,
   isAgentDevMode,
   isAgentExecutionMode,
   type ReasoningLevel,
@@ -208,15 +207,13 @@ async function executeCronPromptRun(
     providerId: provider.type,
     model: request.model,
     runtime: {
-      baseUrl: provider.baseUrl,
-      apiKey: provider.apiKey,
-      customHeaders: provider.customHeaders,
-      requestFormat: provider.requestFormat,
-      reasoning: resolveCronReasoning(request.reasoning),
+      ...createProviderRuntimeConfig(provider, request.model, {
+        ...DEFAULT_CHAT_RUNTIME_CONTROLS,
+        reasoning: resolveCronReasoning(request.reasoning),
+      }),
+      // 后台定时任务恒开提示词缓存：与前台会话共享同一前缀，命中率远高于按
+      // 供应商开关逐个判断。
       promptCachingEnabled: true,
-      nativeWebSearchEnabled: DEFAULT_CHAT_RUNTIME_CONTROLS.nativeWebSearchEnabled,
-      useSystemProxy: provider.useSystemProxy,
-      modelConfig: findProviderModelConfig(provider, request.model),
     },
     runtimePlatform,
     context,

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -1406,6 +1406,8 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.removeCustomHeader": "删除请求头",
     "settings.invalidCustomHeaderKey":
       "请求头名称无效。仅支持合法 HTTP Header 名称，例如 X-Environment、X-Request-ID。",
+    "settings.invalidCustomHeaderValue":
+      "请求头取值无效。仅支持可见 ASCII 字符（不含换行），请勿填入中文或换行。",
     "settings.close": "关闭",
     "settings.hideApiKey": "隐藏 API Key",
     "settings.showApiKey": "显示 API Key",
@@ -3645,6 +3647,8 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.removeCustomHeader": "Remove header",
     "settings.invalidCustomHeaderKey":
       "Invalid HTTP header name. Examples: X-Environment, X-Request-ID.",
+    "settings.invalidCustomHeaderValue":
+      "Invalid header value. Only printable ASCII is allowed — no line breaks or non-ASCII characters.",
     "settings.close": "Close",
     "settings.hideApiKey": "Hide API Key",
     "settings.showApiKey": "Show API Key",

--- a/crates/agent-gui/src/lib/chat/compaction/types.ts
+++ b/crates/agent-gui/src/lib/chat/compaction/types.ts
@@ -1,27 +1,9 @@
-import type {
-  CodexRequestFormat,
-  CustomProvider,
-  ProviderModelConfig,
-  ReasoningLevel,
-} from "../../settings";
+export type { ProviderRuntimeConfig } from "../../providers/runtime/types";
 
 export type CompactionTrigger = "pre-send" | "mid-stream" | "post-tool";
 
 // optimization = 发送前的从容压缩（阈值更宽），protection = 运行中的保护性压缩（阈值更紧）。
 export type CompactionIntent = "optimization" | "protection";
-
-export type ProviderRuntimeConfig = {
-  baseUrl: string;
-  apiKey: string;
-  customHeaders?: CustomProvider["customHeaders"];
-  requestFormat?: CodexRequestFormat;
-  reasoning?: ReasoningLevel;
-  promptCachingEnabled?: boolean;
-  promptCacheRetention?: "short" | "long";
-  nativeWebSearchEnabled?: boolean;
-  useSystemProxy?: boolean;
-  modelConfig?: ProviderModelConfig;
-};
 
 export type CompactionStatus =
   | { phase: "idle" }

--- a/crates/agent-gui/src/lib/chat/memory/extractionEngine.ts
+++ b/crates/agent-gui/src/lib/chat/memory/extractionEngine.ts
@@ -51,31 +51,16 @@ import {
   type ExtractionRejectionEntry,
 } from "../../memory/prompts/extraction";
 import type { MemoryReviewerMode, ValidatedPlanItem } from "../../memory/schema";
-import type {
-  CodexRequestFormat,
-  ProviderId,
-  ProviderModelConfig,
-  ReasoningLevel,
-  SelectedModel,
-} from "../../settings";
+import type { ProviderRuntimeConfig } from "../../providers/runtime/types";
+import type { ProviderId, SelectedModel } from "../../settings";
 import { createMemoryTools } from "../../tools/memoryTools";
 import { isAbortLikeError } from "../page/chatPageHelpers";
 import { runAssistantWithTools } from "../runner/agentRunner";
 
-export type MemoryExtractionRuntimeConfig = {
-  baseUrl: string;
-  apiKey: string;
-  requestFormat?: CodexRequestFormat;
-  reasoning?: ReasoningLevel;
-  promptCachingEnabled?: boolean;
-  nativeWebSearchEnabled?: boolean;
-  modelConfig?: ProviderModelConfig;
-};
-
 export type MemoryExtractionModelConfig = {
   providerId: ProviderId;
   model: string;
-  runtime: MemoryExtractionRuntimeConfig;
+  runtime: ProviderRuntimeConfig;
   selectedModel?: SelectedModel;
 };
 

--- a/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
+++ b/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
@@ -9,7 +9,6 @@ import type {
 } from "@earendil-works/pi-ai";
 import { buildStreamRequestDebugPayload, type StreamDebugLogger } from "../../debug/agentDebug";
 import { buildMemoryToolsSuffixSection } from "../../memory/prompts/injection";
-import { mergeCustomHeaders } from "../../providers/customHeaders";
 import {
   createHostedSearchEventAggregator,
   createHostedSearchProbeId,
@@ -17,12 +16,13 @@ import {
   withHostedSearchProbeHeader,
 } from "../../providers/hostedSearchEvents";
 import {
-  buildProviderRequestHeaders,
   buildProviderRequestMetadata,
   createModelFromConfig,
   createStreamingTextReconciler,
   finalizeProviderStreamOptions,
   normalizeErrorMessage,
+  type ProviderRuntimeConfig,
+  prepareProviderRequest,
   resolveProviderCacheRetention,
   type StreamOptionsEx,
   streamSimpleByApi,
@@ -36,7 +36,6 @@ import {
   isProviderNativeWebFetchToolName,
   isProviderNativeWebSearchToolName,
 } from "../../providers/nativeWebSearch";
-import { prepareProxyRequest } from "../../providers/proxy";
 import type { RetryAttemptRecord } from "../../providers/runtime/streamRetry";
 import {
   inferRuntimePlatform,
@@ -44,13 +43,7 @@ import {
   type RuntimePlatform,
   runtimePlatformLabel,
 } from "../../runtimePlatform";
-import type {
-  CodexRequestFormat,
-  CustomProvider,
-  ProviderId,
-  ProviderModelConfig,
-  ReasoningLevel,
-} from "../../settings";
+import type { ProviderId, ReasoningLevel } from "../../settings";
 import { createSubagentScheduler, type SubagentScheduler } from "../../subagents/scheduler";
 import { withPowerActivity } from "../../system/powerActivity";
 import { sanitizeContextForModelRequest } from "../context/requestContextSanitizer";
@@ -652,18 +645,7 @@ function findLastAssistantMessage(messages: Message[]): AssistantMessage | null 
 export async function runAssistantWithTools(params: {
   providerId: ProviderId;
   model: string;
-  runtime: {
-    baseUrl: string;
-    apiKey: string;
-    customHeaders?: CustomProvider["customHeaders"];
-    requestFormat?: CodexRequestFormat;
-    reasoning?: ReasoningLevel;
-    promptCachingEnabled?: boolean;
-    promptCacheRetention?: "short" | "long";
-    nativeWebSearchEnabled?: boolean;
-    useSystemProxy?: boolean;
-    modelConfig?: ProviderModelConfig;
-  };
+  runtime: ProviderRuntimeConfig;
   runtimePlatform?: RuntimePlatform;
   context: Context;
   workdir: string;
@@ -714,20 +696,9 @@ export async function runAssistantWithTools(params: {
   const subagentScheduler = params.subagentScheduler ?? createSubagentScheduler();
 
   return withPowerActivity("assistant-tools", `${params.providerId}:${modelId}`, async () => {
-    const proxyRequest = await prepareProxyRequest(
-      params.providerId,
-      params.runtime.baseUrl.trim(),
-      mergeCustomHeaders(
-        buildProviderRequestHeaders(
-          params.providerId,
-          params.runtime.apiKey,
-          params.sessionId,
-          params.runtime.requestFormat,
-        ),
-        params.runtime.customHeaders,
-      ),
-      { useSystemProxy: params.runtime.useSystemProxy === true },
-    );
+    const proxyRequest = await prepareProviderRequest(params.providerId, params.runtime, {
+      sessionId: params.sessionId,
+    });
 
     const model = createModelFromConfig(
       params.providerId,

--- a/crates/agent-gui/src/lib/debug/agentDebug.ts
+++ b/crates/agent-gui/src/lib/debug/agentDebug.ts
@@ -8,6 +8,7 @@ type DebugLineType = "request" | "result" | "error";
 type RuntimeDebugInput = {
   baseUrl: string;
   apiKey: string;
+  customHeaders?: { key: string; value: string }[];
   requestFormat?: CodexRequestFormat;
   reasoning?: ReasoningLevel;
   promptCachingEnabled?: boolean;
@@ -193,6 +194,9 @@ export function buildRuntimeDebugInfo(runtime: RuntimeDebugInput) {
     nativeWebSearchEnabled: runtime.nativeWebSearchEnabled,
     useSystemProxy: runtime.useSystemProxy,
     hasApiKey: runtime.apiKey.trim().length > 0,
+    // 只记 key：取值继续整体脱敏。这是端到端确认「自定义请求头是否真的走到了
+    // 这条链路」的唯一低成本手段——配置一旦在中途被丢弃，这里就是空数组。
+    customHeaderKeys: (runtime.customHeaders ?? []).map((header) => header.key),
   };
 }
 

--- a/crates/agent-gui/src/lib/memory/organizer/service.ts
+++ b/crates/agent-gui/src/lib/memory/organizer/service.ts
@@ -7,12 +7,11 @@
 import type { Context, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
 import { runAssistantWithTools } from "../../chat/runner/agentRunner";
 import { createStreamDebugLogger } from "../../debug/agentDebug";
-import { assistantMessageToText } from "../../providers/llm";
+import { assistantMessageToText, createProviderRuntimeConfig } from "../../providers/llm";
 import {
   type AppSettings,
   computeNextMemoryOrganizerRunAt,
   DEFAULT_CHAT_RUNTIME_CONTROLS,
-  findProviderModelConfig,
   isAgentDevMode,
 } from "../../settings";
 import { createMemoryTools } from "../../tools/memoryTools";
@@ -243,15 +242,10 @@ async function runOrganizerModelPrompt(params: {
     providerId: provider.type,
     model,
     runtime: {
-      baseUrl: provider.baseUrl,
-      apiKey: provider.apiKey,
-      customHeaders: provider.customHeaders,
-      requestFormat: provider.requestFormat,
-      reasoning: DEFAULT_CHAT_RUNTIME_CONTROLS.reasoning,
+      ...createProviderRuntimeConfig(provider, model, DEFAULT_CHAT_RUNTIME_CONTROLS),
+      // 后台整理恒开提示词缓存：多轮 prompt 共享同一前缀，命中率远高于按供应商
+      // 开关逐个判断。
       promptCachingEnabled: true,
-      nativeWebSearchEnabled: DEFAULT_CHAT_RUNTIME_CONTROLS.nativeWebSearchEnabled,
-      useSystemProxy: provider.useSystemProxy,
-      modelConfig: findProviderModelConfig(provider, model),
     },
     context,
     workdir: params.workdir,

--- a/crates/agent-gui/src/lib/providers/customHeaders.ts
+++ b/crates/agent-gui/src/lib/providers/customHeaders.ts
@@ -8,7 +8,13 @@ const RESERVED_CUSTOM_HEADER_KEYS = new Set([
   "host",
   "content-length",
 ]);
+// 本地反代的内部通道命名空间：放行会让用户把代理令牌/上游 origin 等控制头注入
+// 上游请求。反代自己也会剥掉这一前缀，这里在配置侧提前拒绝以便给出明确反馈。
+const RESERVED_CUSTOM_HEADER_KEY_PREFIX = "x-liveagent-";
 const HTTP_HEADER_TOKEN_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+// 头取值只允许可见 ASCII 与水平制表符：CR/LF 会造成 header 注入，非 ASCII 会让
+// WebView 的 fetch() 直接抛错、把整轮对话打断成一条与请求头无关的报错。
+const HTTP_HEADER_VALUE_PATTERN = /^[\t\x20-\x7e]*$/;
 
 export const ANTHROPIC_DEFAULT_REQUEST_HEADERS = {
   "x-app": "cli",
@@ -81,21 +87,20 @@ function findHeaderKey(
   return Object.keys(headers).find((key) => key.toLowerCase() === expected);
 }
 
-export function readHeaderValue(
-  headers: Record<string, string | null | undefined> | undefined,
-  name: string,
-): string | undefined {
-  if (!headers) return undefined;
-  const key = findHeaderKey(headers, name);
-  return key === undefined ? undefined : (headers[key] ?? undefined);
-}
-
 export function isValidCustomHeaderKey(key: string): boolean {
   return HTTP_HEADER_TOKEN_PATTERN.test(key);
 }
 
+export function isValidCustomHeaderValue(value: string): boolean {
+  return HTTP_HEADER_VALUE_PATTERN.test(value);
+}
+
 export function isReservedCustomHeaderKey(key: string): boolean {
-  return RESERVED_CUSTOM_HEADER_KEYS.has(key.toLowerCase());
+  const normalized = key.toLowerCase();
+  return (
+    RESERVED_CUSTOM_HEADER_KEYS.has(normalized) ||
+    normalized.startsWith(RESERVED_CUSTOM_HEADER_KEY_PREFIX)
+  );
 }
 export function mergeCustomHeaders(
   base: Record<string, string>,
@@ -104,7 +109,11 @@ export function mergeCustomHeaders(
   const merged = { ...base };
 
   for (const header of customHeaders ?? []) {
-    if (!isValidCustomHeaderKey(header.key) || isReservedCustomHeaderKey(header.key)) {
+    if (
+      !isValidCustomHeaderKey(header.key) ||
+      !isValidCustomHeaderValue(header.value) ||
+      isReservedCustomHeaderKey(header.key)
+    ) {
       continue;
     }
 

--- a/crates/agent-gui/src/lib/providers/llm.ts
+++ b/crates/agent-gui/src/lib/providers/llm.ts
@@ -20,6 +20,7 @@ export {
   finalizeProviderStreamOptions,
   type ProviderPayloadMiddleware,
 } from "./runtime/payloadPipeline";
+export { createProviderRuntimeConfig } from "./runtime/providerRuntimeConfig";
 export {
   buildAnthropicAuthHeaders,
   buildGeminiAuthHeaders,
@@ -27,7 +28,7 @@ export {
   buildProviderRequestHeaders,
   buildProviderRequestMetadata,
   isValidCustomHeaderKey,
-  mergeCustomHeaders,
+  prepareProviderRequest,
   resolveProviderCacheRetention,
   toSimpleStreamReasoning,
 } from "./runtime/requestOptions";

--- a/crates/agent-gui/src/lib/providers/proxy.ts
+++ b/crates/agent-gui/src/lib/providers/proxy.ts
@@ -1,15 +1,26 @@
 import { invoke } from "@tauri-apps/api/core";
 
 import type { ProviderId } from "../settings";
-import { readHeaderValue } from "./customHeaders";
 
 export const LIVEAGENT_PROXY_TOKEN_HEADER = "x-liveagent-proxy-token";
 export const LIVEAGENT_UPSTREAM_ORIGIN_HEADER = "x-liveagent-upstream-origin";
-export const LIVEAGENT_UPSTREAM_USER_AGENT_HEADER = "x-liveagent-upstream-user-agent";
-export const LIVEAGENT_UPSTREAM_CONTENT_TYPE_HEADER = "x-liveagent-upstream-content-type";
+// 上游头覆盖包：base64(utf8(JSON))。WebView 的 fetch 会静默丢弃 User-Agent /
+// Cookie / Referer 等 forbidden header names，SDK 也可能自行注入同名头，所以最终
+// 头集经这一条通道下发，由本地反代在转发前作为最后一步覆盖写入上游请求——
+// “自定义头覆盖内置默认头”的唯一裁决点就在那里。
+export const LIVEAGENT_UPSTREAM_HEADERS_HEADER = "x-liveagent-upstream-headers";
 // 布尔标记头：声明该请求经系统代理出网。代理地址/凭据只存于桌面 Rust 侧，
 // 由本地反代按此头选择带代理的 client（x-liveagent-* 头不会转发给上游）。
 export const LIVEAGENT_USE_SYSTEM_PROXY_HEADER = "x-liveagent-use-system-proxy";
+
+// 鉴权头不进覆盖包：它们不属浏览器禁止名（常规通道必然送达），且是保留头用户
+// 改不了，没有覆盖需求——不必把密钥再复制一份进旁路通道。
+const UPSTREAM_HEADER_OVERRIDE_EXCLUDED_KEYS = new Set([
+  "authorization",
+  "x-api-key",
+  "x-goog-api-key",
+]);
+const UPSTREAM_HEADER_OVERRIDE_MAX_BYTES = 8 * 1024;
 
 type ProxyServerInfo = {
   baseUrl: string;
@@ -21,15 +32,26 @@ export type PreparedProxyRequest = {
   headers: Record<string, string>;
 };
 
-export function buildUpstreamHeaderOverrideHeaders(
-  headers: Record<string, string>,
-): Record<string, string> {
-  const userAgent = readHeaderValue(headers, "user-agent");
-  const contentType = readHeaderValue(headers, "content-type");
-  return {
-    ...(userAgent !== undefined ? { [LIVEAGENT_UPSTREAM_USER_AGENT_HEADER]: userAgent } : {}),
-    ...(contentType !== undefined ? { [LIVEAGENT_UPSTREAM_CONTENT_TYPE_HEADER]: contentType } : {}),
-  };
+export function encodeUpstreamHeaderOverrides(headers: Record<string, string>): string | undefined {
+  const overrides: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (UPSTREAM_HEADER_OVERRIDE_EXCLUDED_KEYS.has(key.toLowerCase())) continue;
+    if (key.toLowerCase().startsWith("x-liveagent-")) continue;
+    overrides[key] = value;
+  }
+  if (Object.keys(overrides).length === 0) return undefined;
+
+  // base64 而非裸 JSON：既杜绝取值里的 CR/LF 造成 header 注入，也免去引号与逗号
+  // 在 header 值里的解析歧义。
+  const encoded = new TextEncoder().encode(JSON.stringify(overrides));
+  if (encoded.byteLength > UPSTREAM_HEADER_OVERRIDE_MAX_BYTES) {
+    throw new Error(
+      `Custom request headers are too large (${encoded.byteLength} bytes, limit ${UPSTREAM_HEADER_OVERRIDE_MAX_BYTES}). Trim the provider's custom request headers.`,
+    );
+  }
+  let binary = "";
+  for (const byte of encoded) binary += String.fromCharCode(byte);
+  return btoa(binary);
 }
 
 let proxyServerInfoPromise: Promise<ProxyServerInfo> | null = null;
@@ -191,12 +213,15 @@ export async function prepareProxyRequest(
     upstreamBaseUrl,
     proxyServerInfo.baseUrl,
   );
+  const upstreamHeaderOverrides = encodeUpstreamHeaderOverrides(headers);
 
   return {
     baseUrl,
     headers: {
       ...headers,
-      ...buildUpstreamHeaderOverrideHeaders(headers),
+      ...(upstreamHeaderOverrides
+        ? { [LIVEAGENT_UPSTREAM_HEADERS_HEADER]: upstreamHeaderOverrides }
+        : {}),
       [LIVEAGENT_UPSTREAM_ORIGIN_HEADER]: upstreamOrigin,
       [LIVEAGENT_PROXY_TOKEN_HEADER]: proxyServerInfo.token,
       ...(options?.useSystemProxy ? { [LIVEAGENT_USE_SYSTEM_PROXY_HEADER]: "1" } : {}),

--- a/crates/agent-gui/src/lib/providers/runtime/providerRuntimeConfig.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/providerRuntimeConfig.ts
@@ -1,0 +1,42 @@
+import {
+  type ChatRuntimeControls,
+  type CustomProvider,
+  findProviderModelConfig,
+  getChatRuntimeReasoningLevelsForProvider,
+  normalizeChatRuntimeControlsForProvider,
+} from "../../settings";
+import type { ProviderRuntimeConfig } from "./types";
+
+/**
+ * ProviderRuntimeConfig 的唯一构造点——全仓仅此一处注入品牌。任何调用方都只能
+ * 拿到完整对象并整体传递（需要改档位等请用展开派生），不得再逐字段转抄。
+ */
+export function createProviderRuntimeConfig(
+  provider: CustomProvider,
+  model: string,
+  controlsInput?: ChatRuntimeControls,
+): ProviderRuntimeConfig {
+  const reasoningParams = {
+    providerId: provider.type,
+    requestFormat: provider.requestFormat,
+    modelId: model,
+  };
+  const controls = normalizeChatRuntimeControlsForProvider(controlsInput, reasoningParams);
+  const reasoningSupported = getChatRuntimeReasoningLevelsForProvider(reasoningParams).length > 0;
+  return {
+    baseUrl: provider.baseUrl,
+    apiKey: provider.apiKey,
+    customHeaders: provider.customHeaders,
+    requestFormat: provider.requestFormat,
+    reasoning: reasoningSupported
+      ? controls.thinkingEnabled
+        ? controls.reasoning
+        : "off"
+      : undefined,
+    promptCachingEnabled: provider.promptCachingEnabled,
+    promptCacheRetention: provider.promptCacheRetention,
+    nativeWebSearchEnabled: controls.nativeWebSearchEnabled,
+    useSystemProxy: provider.useSystemProxy,
+    modelConfig: findProviderModelConfig(provider, model),
+  } as ProviderRuntimeConfig;
+}

--- a/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
@@ -1,10 +1,5 @@
 import type { CacheRetention, SimpleStreamOptions } from "@earendil-works/pi-ai";
-import type {
-  CodexRequestFormat,
-  CustomProvider,
-  ProviderId,
-  ReasoningLevel,
-} from "../../settings";
+import type { CodexRequestFormat, ProviderId, ReasoningLevel } from "../../settings";
 import { createUuid } from "../../shared/id";
 import {
   ANTHROPIC_DEFAULT_REQUEST_HEADERS,
@@ -12,10 +7,12 @@ import {
   CODEX_DEFAULT_USER_AGENT,
   CODEX_SESSION_ID_HEADER,
   isAnthropicOAuthApiKey,
-  mergeCustomHeaders as mergeCustomHeadersBase,
+  mergeCustomHeaders,
   XAI_DEFAULT_USER_AGENT,
 } from "../customHeaders";
+import { type PreparedProxyRequest, prepareProxyRequest } from "../proxy";
 import { normalizeSessionId } from "./common";
+import type { ProviderRuntimeConfig } from "./types";
 
 export { isValidCustomHeaderKey } from "../customHeaders";
 
@@ -82,11 +79,29 @@ export function buildProviderRequestHeaders(
   return authHeaders;
 }
 
-export function mergeCustomHeaders(
-  base: Record<string, string>,
-  customHeaders?: CustomProvider["customHeaders"],
-): Record<string, string> {
-  return mergeCustomHeadersBase(base, customHeaders);
+/**
+ * 供应商上游请求的唯一装配入口：内置身份头 → 合并用户自定义头 → 过本地反代。
+ * 聊天 / 文本 / 摘要三条链路都走这里，杜绝各自重复装配时漏掉 customHeaders。
+ */
+export async function prepareProviderRequest(
+  providerId: ProviderId,
+  runtime: ProviderRuntimeConfig,
+  options?: { sessionId?: string },
+): Promise<PreparedProxyRequest> {
+  return prepareProxyRequest(
+    providerId,
+    runtime.baseUrl.trim(),
+    mergeCustomHeaders(
+      buildProviderRequestHeaders(
+        providerId,
+        runtime.apiKey,
+        options?.sessionId,
+        runtime.requestFormat,
+      ),
+      runtime.customHeaders,
+    ),
+    { useSystemProxy: runtime.useSystemProxy === true },
+  );
 }
 
 export function toSimpleStreamReasoning(

--- a/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
@@ -15,16 +15,14 @@ import {
   withHostedSearchProbeHeader,
 } from "../hostedSearchEvents";
 import { providerSupportsNativeWebSearch } from "../nativeWebSearch";
-import { prepareProxyRequest } from "../proxy";
 import { appendSystemPrompt, normalizeSessionId } from "./common";
 import { normalizeErrorMessage } from "./errors";
 import { createStreamingTextReconciler } from "./messageUtils";
 import { createModelFromConfig } from "./modelFactory";
 import { finalizeProviderStreamOptions } from "./payloadPipeline";
 import {
-  buildProviderRequestHeaders,
   buildProviderRequestMetadata,
-  mergeCustomHeaders,
+  prepareProviderRequest,
   resolveProviderCacheRetention,
   toSimpleStreamReasoning,
 } from "./requestOptions";
@@ -144,20 +142,9 @@ export async function streamAssistantMessage(params: {
   if (!params.runtime.baseUrl.trim()) throw new Error("Base URL cannot be empty");
   if (!params.runtime.apiKey.trim()) throw new Error("API Key cannot be empty");
 
-  const proxyRequest = await prepareProxyRequest(
-    params.providerId,
-    params.runtime.baseUrl.trim(),
-    mergeCustomHeaders(
-      buildProviderRequestHeaders(
-        params.providerId,
-        params.runtime.apiKey,
-        params.sessionId,
-        params.runtime.requestFormat,
-      ),
-      params.runtime.customHeaders,
-    ),
-    { useSystemProxy: params.runtime.useSystemProxy === true },
-  );
+  const proxyRequest = await prepareProviderRequest(params.providerId, params.runtime, {
+    sessionId: params.sessionId,
+  });
 
   const m = createModelFromConfig(
     params.providerId,
@@ -344,20 +331,9 @@ export async function completeAssistantMessage(params: {
   if (!params.runtime.baseUrl.trim()) throw new Error("Base URL cannot be empty");
   if (!params.runtime.apiKey.trim()) throw new Error("API Key cannot be empty");
 
-  const proxyRequest = await prepareProxyRequest(
-    params.providerId,
-    params.runtime.baseUrl.trim(),
-    mergeCustomHeaders(
-      buildProviderRequestHeaders(
-        params.providerId,
-        params.runtime.apiKey,
-        params.sessionId,
-        params.runtime.requestFormat,
-      ),
-      params.runtime.customHeaders,
-    ),
-    { useSystemProxy: params.runtime.useSystemProxy === true },
-  );
+  const proxyRequest = await prepareProviderRequest(params.providerId, params.runtime, {
+    sessionId: params.sessionId,
+  });
 
   const m = createModelFromConfig(
     params.providerId,

--- a/crates/agent-gui/src/lib/providers/runtime/types.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/types.ts
@@ -17,7 +17,19 @@ export type ModelOption = {
   model: string;
 };
 
+declare const PROVIDER_RUNTIME_CONFIG_BRAND: unique symbol;
+
+/**
+ * 供应商请求运行时配置——全仓唯一定义，唯一构造点是
+ * createProviderRuntimeConfig()（见 ./providerRuntimeConfig）。
+ *
+ * 品牌字段让手写对象字面量一律编译不过：字段几乎全是可选的，逐字段转抄漏掉
+ * customHeaders / promptCacheRetention 时 TypeScript 不会报警，而那正是自定义
+ * 请求头在聊天全链路上失效的根因。需要派生请用展开（{...runtime, reasoning}），
+ * 品牌随展开保留。
+ */
 export type ProviderRuntimeConfig = {
+  readonly [PROVIDER_RUNTIME_CONFIG_BRAND]: true;
   baseUrl: string;
   apiKey: string;
   customHeaders?: CustomProvider["customHeaders"];

--- a/crates/agent-gui/src/lib/subagents/agentTool.ts
+++ b/crates/agent-gui/src/lib/subagents/agentTool.ts
@@ -1,6 +1,7 @@
 import type { Tool, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 
+import type { ProviderRuntimeConfig } from "../providers/runtime/types";
 import type { RuntimePlatform } from "../runtimePlatform";
 import type { ProviderId } from "../settings";
 import {
@@ -28,12 +29,7 @@ import {
   formatRoster,
   formatTemplates,
 } from "./roster";
-import {
-  buildSubagentRunId,
-  executeSubagentRun,
-  type SubagentProviderRuntime,
-  type SubagentRunEnvironment,
-} from "./run";
+import { buildSubagentRunId, executeSubagentRun, type SubagentRunEnvironment } from "./run";
 import type { SubagentScheduler } from "./scheduler";
 import { createSendMessageTools } from "./sendMessageTool";
 import type { SubagentConversationStore } from "./store";
@@ -184,7 +180,7 @@ async function resolveOutputPaths(params: {
 export type SubagentRuntimeConfig = {
   providerId: ProviderId;
   model: string;
-  runtime: SubagentProviderRuntime;
+  runtime: ProviderRuntimeConfig;
   sessionId?: string;
   templates: SubagentTemplate[];
   store: SubagentConversationStore;
@@ -194,7 +190,7 @@ export type SubagentRuntimeConfig = {
 export function createSubagentTools(params: {
   providerId: ProviderId;
   model: string;
-  runtime: SubagentProviderRuntime;
+  runtime: ProviderRuntimeConfig;
   runtimePlatform?: RuntimePlatform;
   workdir: string;
   resolveHomeDir?: () => Promise<string>;

--- a/crates/agent-gui/src/lib/subagents/index.ts
+++ b/crates/agent-gui/src/lib/subagents/index.ts
@@ -12,7 +12,6 @@ export type {
 } from "./protocol";
 export { buildSubagentCardToolCallId, isSubagentCardArguments } from "./protocol";
 export { buildRosterReminder } from "./roster";
-export type { SubagentProviderRuntime } from "./run";
 export {
   createSubagentScheduler,
   DEFAULT_SUBAGENT_MAX_PARALLEL_RUNS,

--- a/crates/agent-gui/src/lib/subagents/run.ts
+++ b/crates/agent-gui/src/lib/subagents/run.ts
@@ -9,14 +9,9 @@ import {
 } from "../chat/conversation/conversationState";
 import { createTurnCancellationFromSignal } from "../chat/conversation/turnCancellation";
 import { runAssistantWithTools } from "../chat/runner/agentRunner";
+import type { ProviderRuntimeConfig } from "../providers/runtime/types";
 import type { RuntimePlatform } from "../runtimePlatform";
-import type {
-  CodexRequestFormat,
-  CustomProvider,
-  ProviderId,
-  ProviderModelConfig,
-  ReasoningLevel,
-} from "../settings";
+import type { ProviderId } from "../settings";
 import { renderMessageBusSnapshot } from "./bus";
 import { toolErrorResult } from "./errors";
 import type { SubagentWorktreeIpc } from "./ipc/worktree";
@@ -49,25 +44,12 @@ import {
   truncateText,
 } from "./utils";
 
-export type SubagentProviderRuntime = {
-  baseUrl: string;
-  apiKey: string;
-  customHeaders?: CustomProvider["customHeaders"];
-  requestFormat?: CodexRequestFormat;
-  reasoning?: ReasoningLevel;
-  promptCachingEnabled?: boolean;
-  promptCacheRetention?: "short" | "long";
-  nativeWebSearchEnabled?: boolean;
-  useSystemProxy?: boolean;
-  modelConfig?: ProviderModelConfig;
-};
-
 type ChildToolExecutor = (toolCall: ToolCall, signal?: AbortSignal) => Promise<ToolResultMessage>;
 
 export type SubagentRunEnvironment = {
   providerId: ProviderId;
   model: string;
-  runtime: SubagentProviderRuntime;
+  runtime: ProviderRuntimeConfig;
   runtimePlatform?: RuntimePlatform;
   workdir: string;
   sessionId?: string;

--- a/crates/agent-gui/src/pages/chat/runtime/providerRuntimeConfig.ts
+++ b/crates/agent-gui/src/pages/chat/runtime/providerRuntimeConfig.ts
@@ -1,11 +1,4 @@
-import {
-  type AppSettings,
-  type ChatRuntimeControls,
-  findProviderModelConfig,
-  getChatRuntimeReasoningLevelsForProvider,
-  normalizeChatRuntimeControlsForProvider,
-  type SelectedModel,
-} from "../../../lib/settings";
+import type { AppSettings, SelectedModel } from "../../../lib/settings";
 import type { EffectiveChatModelSelection } from "./modelSelection";
 
 export function resolveMemorySummaryModelSelection(
@@ -50,37 +43,6 @@ export function resolveConversationTitleModelSelection(
     provider,
     providerId: provider.type,
     model: titleModel.model,
-  };
-}
-
-export function buildProviderRuntimeConfig(
-  provider: AppSettings["customProviders"][number],
-  model: string,
-  controlsInput?: ChatRuntimeControls,
-) {
-  const modelConfig = findProviderModelConfig(provider, model);
-  const reasoningParams = {
-    providerId: provider.type,
-    requestFormat: provider.requestFormat,
-    modelId: model,
-  };
-  const controls = normalizeChatRuntimeControlsForProvider(controlsInput, reasoningParams);
-  const reasoningSupported = getChatRuntimeReasoningLevelsForProvider(reasoningParams).length > 0;
-  return {
-    baseUrl: provider.baseUrl,
-    apiKey: provider.apiKey,
-    customHeaders: provider.customHeaders,
-    requestFormat: provider.requestFormat,
-    reasoning: reasoningSupported
-      ? controls.thinkingEnabled
-        ? controls.reasoning
-        : "off"
-      : undefined,
-    promptCachingEnabled: provider.promptCachingEnabled,
-    promptCacheRetention: provider.promptCacheRetention,
-    nativeWebSearchEnabled: controls.nativeWebSearchEnabled,
-    useSystemProxy: provider.useSystemProxy,
-    modelConfig,
   };
 }
 

--- a/crates/agent-gui/src/pages/chat/runtime/useSendChatTurn.ts
+++ b/crates/agent-gui/src/pages/chat/runtime/useSendChatTurn.ts
@@ -41,7 +41,7 @@ import {
 import type { ScrollFollowHandle } from "../../../lib/chat-scroll/useScrollFollow";
 import { createStreamDebugLogger } from "../../../lib/debug/agentDebug";
 import { buildMemoryOverviewSection } from "../../../lib/memory/prompts/injection";
-import { createModelFromConfig } from "../../../lib/providers/llm";
+import { createModelFromConfig, createProviderRuntimeConfig } from "../../../lib/providers/llm";
 import {
   type AppSettings,
   applyMcpOpsToAppSettings,
@@ -94,7 +94,6 @@ import {
   resolveEffectiveChatModelSelection,
 } from "./modelSelection";
 import {
-  buildProviderRuntimeConfig,
   resolveConversationTitleModelSelection,
   resolveMemorySummaryModelSelection,
   selectedModelsMatch,
@@ -425,13 +424,13 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
       gatewayBridgeRequest?.runtimeControlsOverride ??
       overrides?.runtimeControlsOverride ??
       settings.chatRuntimeControls;
-    const providerConfig = buildProviderRuntimeConfig(provider, model, runtimeControls);
+    const providerConfig = createProviderRuntimeConfig(provider, model, runtimeControls);
     const memorySummaryModelSelection = resolveMemorySummaryModelSelection(settings);
     const memoryExtractionModel = memorySummaryModelSelection
       ? {
           providerId: memorySummaryModelSelection.providerId,
           model: memorySummaryModelSelection.model,
-          runtime: buildProviderRuntimeConfig(
+          runtime: createProviderRuntimeConfig(
             memorySummaryModelSelection.provider,
             memorySummaryModelSelection.model,
             runtimeControls,
@@ -603,7 +602,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
         settings,
         effectiveSelectedModel,
       );
-      const titleProviderConfig = buildProviderRuntimeConfig(
+      const titleProviderConfig = createProviderRuntimeConfig(
         titleModelSelection.provider,
         titleModelSelection.model,
         runtimeControls,
@@ -611,16 +610,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
       titlePromise = startConversationTitleJob({
         providerId: titleModelSelection.providerId,
         model: titleModelSelection.model,
-        runtime: {
-          baseUrl: titleProviderConfig.baseUrl,
-          apiKey: titleProviderConfig.apiKey,
-          requestFormat: titleProviderConfig.requestFormat,
-          reasoning: titleProviderConfig.reasoning,
-          promptCachingEnabled: titleProviderConfig.promptCachingEnabled,
-          nativeWebSearchEnabled: titleProviderConfig.nativeWebSearchEnabled,
-          useSystemProxy: titleProviderConfig.useSystemProxy,
-          modelConfig: titleProviderConfig.modelConfig,
-        },
+        runtime: titleProviderConfig,
         signal: cancellation.deriveScope().controller.signal,
         conversationId,
         titleSourceText,
@@ -1048,16 +1038,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
     compaction.bindTurn({
       providerId,
       model,
-      runtime: {
-        baseUrl: providerConfig.baseUrl,
-        apiKey: providerConfig.apiKey,
-        requestFormat: providerConfig.requestFormat,
-        reasoning: providerConfig.reasoning,
-        promptCachingEnabled: providerConfig.promptCachingEnabled,
-        nativeWebSearchEnabled: providerConfig.nativeWebSearchEnabled,
-        useSystemProxy: providerConfig.useSystemProxy,
-        modelConfig: providerConfig.modelConfig,
-      },
+      runtime: providerConfig,
       cancellation,
       debugLogger: compactionDebugLogger,
       buildPreparedContext,
@@ -1316,16 +1297,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
           params: {
             providerId,
             model,
-            runtime: {
-              baseUrl: providerConfig.baseUrl,
-              apiKey: providerConfig.apiKey,
-              requestFormat: providerConfig.requestFormat,
-              reasoning: providerConfig.reasoning,
-              promptCachingEnabled: providerConfig.promptCachingEnabled,
-              nativeWebSearchEnabled: providerConfig.nativeWebSearchEnabled,
-              useSystemProxy: providerConfig.useSystemProxy,
-              modelConfig: providerConfig.modelConfig,
-            },
+            runtime: providerConfig,
             runtimeModel,
             selectedModel,
             memoryExtractionModel,
@@ -1395,16 +1367,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
           params: {
             providerId,
             model,
-            runtime: {
-              baseUrl: providerConfig.baseUrl,
-              apiKey: providerConfig.apiKey,
-              requestFormat: providerConfig.requestFormat,
-              reasoning: providerConfig.reasoning,
-              promptCachingEnabled: providerConfig.promptCachingEnabled,
-              nativeWebSearchEnabled: providerConfig.nativeWebSearchEnabled,
-              useSystemProxy: providerConfig.useSystemProxy,
-              modelConfig: providerConfig.modelConfig,
-            },
+            runtime: providerConfig,
             runtimeModel,
             selectedModel,
             memoryExtractionModel,

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -57,6 +57,7 @@ import {
   getCustomHeaderKeyPresets,
   isReservedCustomHeaderKey,
   isValidCustomHeaderKey,
+  isValidCustomHeaderValue,
 } from "../../lib/providers/customHeaders";
 import { parseModelValue, toModelValue } from "../../lib/providers/llm";
 import {
@@ -291,12 +292,24 @@ function parsePositiveInteger(input: string): number | null {
   return normalized > 0 ? normalized : null;
 }
 
-type CustomHeaderKeyIssue = "reserved" | "invalid";
+type CustomHeaderIssue = "reserved" | "invalid-key" | "invalid-value";
 
-function getCustomHeaderKeyIssue(key: string, includeEmpty = false): CustomHeaderKeyIssue | null {
-  if (!key && !includeEmpty) return null;
-  if (isReservedCustomHeaderKey(key)) return "reserved";
-  return isValidCustomHeaderKey(key) ? null : "invalid";
+function customHeaderIssueMessage(issue: CustomHeaderIssue, t: (key: string) => string): string {
+  if (issue === "reserved") return t("settings.customHeaderReservedTitle");
+  if (issue === "invalid-value") return t("settings.invalidCustomHeaderValue");
+  return t("settings.invalidCustomHeaderKey");
+}
+
+function getCustomHeaderIssue(
+  header: { key: string; value: string },
+  includeEmpty = false,
+): CustomHeaderIssue | null {
+  if (!header.key && !includeEmpty) return null;
+  if (isReservedCustomHeaderKey(header.key)) return "reserved";
+  if (!isValidCustomHeaderKey(header.key)) return "invalid-key";
+  // 取值含非 ASCII / CR / LF 时 fetch() 会直接抛错，整轮对话被打断成一条与请求头
+  // 无关的报错——在保存前拦住，把问题指回这一行配置。
+  return isValidCustomHeaderValue(header.value) ? null : "invalid-value";
 }
 
 function DialogSwitch(props: {
@@ -821,13 +834,18 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
   async function handleSave() {
     if (!name.trim()) return;
     const invalidHeaderIndex = customHeaders.findIndex(
-      (header) => getCustomHeaderKeyIssue(header.key, true) !== null,
+      (header) => getCustomHeaderIssue(header, true) !== null,
     );
     if (invalidHeaderIndex >= 0) {
       setHeaderValidationSubmitted(true);
       exitModelBulkMode();
       setActivePanel("request");
-      focusCustomHeader(invalidHeaderIndex, "key");
+      focusCustomHeader(
+        invalidHeaderIndex,
+        getCustomHeaderIssue(customHeaders[invalidHeaderIndex], true) === "invalid-value"
+          ? "value"
+          : "key",
+      );
       return;
     }
     if (requiresCustomUsageQueryConfirmation(usageQuery, customUsageQueryConfirmed)) {
@@ -1000,14 +1018,11 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
   );
   const firstHeaderIssue =
     customHeaders
-      .map((header) => getCustomHeaderKeyIssue(header.key, headerValidationSubmitted))
+      .map((header) => getCustomHeaderIssue(header, headerValidationSubmitted))
       .find((issue) => issue !== null) ?? null;
-  const headerIssueMessage =
-    firstHeaderIssue === "reserved"
-      ? t("settings.customHeaderReservedTitle")
-      : firstHeaderIssue === "invalid"
-        ? t("settings.invalidCustomHeaderKey")
-        : null;
+  const headerIssueMessage = firstHeaderIssue
+    ? customHeaderIssueMessage(firstHeaderIssue, t)
+    : null;
 
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 max-[720px]:p-0">
@@ -1658,16 +1673,10 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                       onScroll={() => setHeaderSuggest(null)}
                     >
                       {customHeaders.map((header, index) => {
-                        const issue = getCustomHeaderKeyIssue(
-                          header.key,
-                          headerValidationSubmitted,
-                        );
-                        const issueTitle =
-                          issue === "reserved"
-                            ? t("settings.customHeaderReservedTitle")
-                            : issue === "invalid"
-                              ? t("settings.invalidCustomHeaderKey")
-                              : undefined;
+                        const issue = getCustomHeaderIssue(header, headerValidationSubmitted);
+                        const issueTitle = issue ? customHeaderIssueMessage(issue, t) : undefined;
+                        const valueIssue = issue === "invalid-value";
+                        const keyIssue = issue !== null && !valueIssue;
                         const valueVisible = visibleHeaderValues.has(index);
                         const suggestOpen =
                           headerSuggest?.index === index && headerSuggestItems.length > 0;
@@ -1688,11 +1697,11 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                               value={header.key}
                               className={cn(
                                 "h-10 w-[210px] shrink-0 rounded-none border-0 border-r bg-muted/30 px-3 font-mono text-xs shadow-none focus-visible:ring-0 max-[720px]:w-full max-[720px]:border-b max-[720px]:border-r-0 max-[720px]:bg-muted/40",
-                                issue && "text-destructive",
+                                keyIssue && "text-destructive",
                               )}
                               placeholder={t("settings.customHeaderKeyPlaceholder")}
                               aria-label={t("settings.customHeaderName")}
-                              aria-invalid={issue ? true : undefined}
+                              aria-invalid={keyIssue ? true : undefined}
                               role="combobox"
                               aria-expanded={suggestOpen}
                               aria-controls={suggestOpen ? "provider-header-suggest" : undefined}
@@ -1749,9 +1758,14 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                                 }}
                                 type={valueVisible ? "text" : "password"}
                                 value={header.value}
-                                className="h-10 w-full rounded-none border-0 bg-transparent pl-3 pr-[4.5rem] font-mono text-xs shadow-none focus-visible:ring-0"
+                                className={cn(
+                                  "h-10 w-full rounded-none border-0 bg-transparent pl-3 pr-[4.5rem] font-mono text-xs shadow-none focus-visible:ring-0",
+                                  valueIssue && "text-destructive",
+                                )}
                                 placeholder={t("settings.customHeaderValue")}
                                 aria-label={t("settings.customHeaderValue")}
+                                aria-invalid={valueIssue ? true : undefined}
+                                title={valueIssue ? issueTitle : undefined}
                                 autoComplete="off"
                                 spellCheck={false}
                                 onChange={(event) =>

--- a/crates/agent-gui/test/chat/agent-runner.test.mjs
+++ b/crates/agent-gui/test/chat/agent-runner.test.mjs
@@ -252,9 +252,10 @@ const llmMock = {
       Authorization: `Bearer ${apiKey}`,
     };
   },
-  buildProviderRequestHeaders(_providerId, apiKey, _sessionId) {
+  async prepareProviderRequest(_providerId, runtime) {
     return {
-      Authorization: `Bearer ${apiKey}`,
+      baseUrl: runtime.baseUrl.trim(),
+      headers: { Authorization: `Bearer ${runtime.apiKey}`, "x-liveagent-test": "1" },
     };
   },
   createModelFromConfig(providerId, modelId, baseUrl) {

--- a/crates/agent-gui/test/providers/custom-headers-propagation.test.mjs
+++ b/crates/agent-gui/test/providers/custom-headers-propagation.test.mjs
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+// 回归网：自定义请求头曾在 Agent 聊天 / 文本聊天 / 自动标题 / Compaction 四条链路
+// 上被逐字段转抄的 runtime 对象整体丢弃。这里对每个真实的供应商请求入口各跑一遍，
+// 断言 customHeaders 与 promptCacheRetention 一路抵达上游头集与覆盖包。
+
+const rootDir = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const powerActivityModulePath = path.join(rootDir, "src/lib/system/powerActivity.ts");
+
+const PROXY_SERVER_INFO = { baseUrl: "http://127.0.0.1:18080", token: "proxy-token" };
+
+const CUSTOM_HEADERS = [
+  { key: "X-Trace-Id", value: "liveagent-e2e" },
+  // 覆盖内置默认头，且大小写与内置键不同——必须替换而非并存。
+  { key: "user-agent", value: "my-agent/9.9" },
+  // 浏览器禁止头名：只能靠覆盖包送达上游。
+  { key: "Cookie", value: "session=abc" },
+  // 保留头：一律丢弃。
+  { key: "Authorization", value: "Bearer hijacked" },
+  { key: "anthropic-beta", value: "hijacked" },
+  { key: "x-liveagent-proxy-token", value: "hijacked" },
+];
+
+function createUsage() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function createAssistantStream() {
+  const assistant = {
+    role: "assistant",
+    content: [{ type: "text", text: "ok" }],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    usage: createUsage(),
+    stopReason: "stop",
+    timestamp: 1,
+  };
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "text_delta", contentIndex: 0, delta: "ok" };
+    },
+    async result() {
+      return assistant;
+    },
+  };
+}
+
+/**
+ * 走真实的 prepareProviderRequest + prepareProxyRequest（只把 tauri invoke 与
+ * 电源活动这两个平台边界换成 mock），因此断言覆盖整条装配链。
+ */
+function loadProvidersWithCapturedStream() {
+  const captured = [];
+  const loader = createTsModuleLoader({
+    mocks: {
+      "@tauri-apps/api/core": {
+        async invoke(command) {
+          if (command === "proxy_get_server_info") return PROXY_SERVER_INFO;
+          throw new Error(`unexpected tauri invoke: ${command}`);
+        },
+      },
+      "@earendil-works/pi-ai/api/anthropic-messages": {
+        stream(model, context, options) {
+          captured.push({ model, context, options });
+          return createAssistantStream();
+        },
+      },
+      [powerActivityModulePath]: {
+        async withPowerActivity(_scope, _reason, run) {
+          return run();
+        },
+      },
+    },
+  });
+  return { providers: loader.loadModule("src/lib/providers/llm.ts"), captured };
+}
+
+function buildRuntime() {
+  return {
+    baseUrl: "https://relay.example/v1",
+    apiKey: "test-key",
+    customHeaders: CUSTOM_HEADERS,
+    promptCachingEnabled: true,
+    promptCacheRetention: "long",
+  };
+}
+
+function readHeader(headers, name) {
+  const matches = Object.keys(headers).filter((key) => key.toLowerCase() === name.toLowerCase());
+  assert.ok(matches.length <= 1, `${name} must not appear twice (found ${matches.join(", ")})`);
+  return matches.length === 1 ? headers[matches[0]] : undefined;
+}
+
+function decodeOverrides(headers) {
+  const encoded = readHeader(headers, "x-liveagent-upstream-headers");
+  assert.ok(encoded, "the upstream override package must be present");
+  return JSON.parse(Buffer.from(encoded, "base64").toString("utf8"));
+}
+
+function assertCustomHeadersReachedUpstream(options) {
+  const headers = options.headers ?? {};
+
+  // 1) 普通自定义头抵达请求头集。
+  assert.equal(readHeader(headers, "x-trace-id"), "liveagent-e2e");
+  // 2) 同名内置头被替换而非并存（内置值是 claude-cli/... 的 UA）。
+  assert.equal(readHeader(headers, "user-agent"), "my-agent/9.9");
+  // 3) 浏览器禁止头名同样进入头集，并由覆盖包负责真正送达。
+  assert.equal(readHeader(headers, "cookie"), "session=abc");
+  // 4) 保留头不可被自定义头劫持。
+  assert.equal(readHeader(headers, "authorization"), undefined);
+  assert.equal(readHeader(headers, "x-api-key"), "test-key");
+  // anthropic-beta 由长上下文中间件独占：劫持尝试被保留头策略拦下，中间件算出的
+  // beta 串必须完好无损（覆盖包在其之前构建，不含该头，因此不会回头压掉它）。
+  assert.equal(readHeader(headers, "anthropic-beta"), "context-1m-2025-08-07");
+  assert.equal(readHeader(headers, "x-liveagent-proxy-token"), PROXY_SERVER_INFO.token);
+
+  // 5) 覆盖包携带全部非鉴权头，由 Rust 反代在转发前最后一步覆盖写入。
+  const overrides = decodeOverrides(headers);
+  assert.equal(overrides["X-Trace-Id"], "liveagent-e2e");
+  assert.equal(overrides["user-agent"], "my-agent/9.9");
+  assert.equal(overrides.Cookie, "session=abc");
+  for (const excluded of ["authorization", "x-api-key", "x-goog-api-key"]) {
+    assert.ok(
+      !Object.keys(overrides).some((key) => key.toLowerCase() === excluded),
+      `${excluded} must not be duplicated into the override package`,
+    );
+  }
+  assert.ok(
+    !Object.keys(overrides).some((key) => key.toLowerCase().startsWith("x-liveagent-")),
+    "the proxy's own control headers must never be echoed into the override package",
+  );
+  assert.ok(
+    !Object.keys(overrides).some((key) => key.toLowerCase() === "anthropic-beta"),
+    "anthropic-beta must stay owned by attachAnthropicLongContextBeta",
+  );
+
+  // 6) promptCacheRetention 与 customHeaders 一同在四条链路上失效过，一并锁定。
+  assert.equal(options.cacheRetention, "long");
+}
+
+test("streamAssistantMessage sends provider custom headers and cache retention", async () => {
+  const { providers, captured } = loadProvidersWithCapturedStream();
+
+  await providers.streamAssistantMessage({
+    providerId: "claude_code",
+    model: "claude-sonnet-4-6",
+    runtime: buildRuntime(),
+    context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+    onTextDelta() {},
+  });
+
+  assert.equal(captured.length, 1);
+  assertCustomHeadersReachedUpstream(captured[0].options);
+});
+
+test("completeAssistantMessage sends provider custom headers (compaction summarizer path)", async () => {
+  const { providers, captured } = loadProvidersWithCapturedStream();
+
+  await providers.completeAssistantMessage({
+    providerId: "claude_code",
+    model: "claude-sonnet-4-6",
+    runtime: buildRuntime(),
+    context: { messages: [{ role: "user", content: "summarize", timestamp: 1 }] },
+  });
+
+  assert.equal(captured.length, 1);
+  const { options } = captured[0];
+  const headers = options.headers ?? {};
+  assert.equal(readHeader(headers, "x-trace-id"), "liveagent-e2e");
+  assert.equal(readHeader(headers, "user-agent"), "my-agent/9.9");
+  assert.equal(decodeOverrides(headers).Cookie, "session=abc");
+});
+
+test("compaction summarizer forwards the whole runtime config untouched", async () => {
+  // 摘要器只改 reasoning 档位（展开派生），其余字段必须原样透传——曾经的
+  // 逐字段转抄正是在这一层之上把 customHeaders 抹掉的。
+  const loader = createTsModuleLoader();
+  const { summarizeConversation } = loader.loadModule("src/lib/chat/compaction/summarizer.ts");
+  const runtime = buildRuntime();
+  const seen = [];
+
+  await summarizeConversation({
+    providerId: "codex",
+    model: "gpt-5",
+    runtime,
+    payload: {
+      active_segment_messages: [{ role: "user", content: "hello" }],
+      compaction_reason: { omitted_message_count: 0 },
+    },
+    async complete(params) {
+      seen.push(params.runtime);
+      return {
+        role: "assistant",
+        content: [{ type: "text", text: SUMMARY_TEXT }],
+        api: "liveagent-compaction",
+        provider: "codex",
+        model: "gpt-5",
+        usage: createUsage(),
+        stopReason: "stop",
+        timestamp: 1,
+      };
+    },
+  });
+
+  assert.equal(seen.length, 1);
+  assert.deepEqual(seen[0].customHeaders, CUSTOM_HEADERS);
+  assert.equal(seen[0].promptCacheRetention, "long");
+  // Codex 摘要固定用 medium 档，其余字段来自原 runtime。
+  assert.equal(seen[0].reasoning, "medium");
+});
+
+const SUMMARY_TEXT = `<summary>
+<task>Verify that custom request headers survive the compaction path</task>
+<state>Runtime config is forwarded whole to the summarizer request ${"x".repeat(300)}</state>
+<artifacts>
+- [file] src/lib/chat/compaction/summarizer.ts | reviewed | forwards runtime untouched
+</artifacts>
+<next_steps>
+1. keep the runtime object intact across every provider entry point
+</next_steps>
+</summary>`;

--- a/crates/agent-gui/test/providers/provider-runtime-config.test.mjs
+++ b/crates/agent-gui/test/providers/provider-runtime-config.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const { createProviderRuntimeConfig } = loader.loadModule(
+  "src/lib/providers/runtime/providerRuntimeConfig.ts",
+);
+const settings = loader.loadModule("src/lib/settings/index.ts");
+
+function createProvider(overrides = {}) {
+  return {
+    id: "provider-1",
+    name: "Relay",
+    type: "claude_code",
+    baseUrl: "https://relay.example/v1",
+    apiKey: "test-key",
+    customHeaders: [{ key: "X-Trace-Id", value: "abc" }],
+    models: [],
+    activeModels: [],
+    promptCachingEnabled: true,
+    promptCacheRetention: "long",
+    useSystemProxy: true,
+    ...overrides,
+  };
+}
+
+// 工厂是 ProviderRuntimeConfig 的唯一构造点，所以“工厂自己漏字段”是唯一还能
+// 复现旧 bug 的路径。这里把必须落到 runtime 上的字段逐一锁死。
+test("createProviderRuntimeConfig carries every provider transport field", () => {
+  const runtime = createProviderRuntimeConfig(
+    createProvider(),
+    "claude-sonnet-4-6",
+    settings.DEFAULT_CHAT_RUNTIME_CONTROLS,
+  );
+
+  assert.equal(runtime.baseUrl, "https://relay.example/v1");
+  assert.equal(runtime.apiKey, "test-key");
+  assert.deepEqual(runtime.customHeaders, [{ key: "X-Trace-Id", value: "abc" }]);
+  assert.equal(runtime.promptCachingEnabled, true);
+  assert.equal(runtime.promptCacheRetention, "long");
+  assert.equal(runtime.useSystemProxy, true);
+  assert.equal(runtime.nativeWebSearchEnabled, true);
+
+  for (const field of [
+    "baseUrl",
+    "apiKey",
+    "customHeaders",
+    "requestFormat",
+    "reasoning",
+    "promptCachingEnabled",
+    "promptCacheRetention",
+    "nativeWebSearchEnabled",
+    "useSystemProxy",
+    "modelConfig",
+  ]) {
+    assert.ok(field in runtime, `${field} must be present on the runtime config`);
+  }
+});
+
+test("createProviderRuntimeConfig gates reasoning on model support", () => {
+  const thinkingOff = createProviderRuntimeConfig(createProvider(), "claude-sonnet-4-6", {
+    ...settings.DEFAULT_CHAT_RUNTIME_CONTROLS,
+    thinkingEnabled: false,
+  });
+  assert.equal(thinkingOff.reasoning, "off");
+
+  // 不支持思考的模型一律拿到 undefined，绝不下发无效档位（Cron / 记忆整理
+  // 以前绕过工厂手搓 runtime，正是会踩到这里）。
+  const unsupported = createProviderRuntimeConfig(
+    createProvider({ type: "gemini", baseUrl: "https://generativelanguage.googleapis.com/v1beta" }),
+    "gemini-embedding-001",
+    settings.DEFAULT_CHAT_RUNTIME_CONTROLS,
+  );
+  assert.equal(unsupported.reasoning, undefined);
+});

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -72,7 +72,8 @@ test("llm facade preserves provider runtime exports", () => {
     "buildProviderRequestHeaders",
     "buildProviderRequestMetadata",
     "isValidCustomHeaderKey",
-    "mergeCustomHeaders",
+    "prepareProviderRequest",
+    "createProviderRuntimeConfig",
     "completeAssistantMessage",
     "composePayloadMiddlewares",
     "createModelFromConfig",
@@ -282,16 +283,57 @@ test("provider-specific custom header suggestions include standard model headers
   assert.ok(!xaiPresets.includes("anthropic-version"));
 });
 
-test("local proxy preserves explicit user-agent and content-type values for the upstream hop", () => {
-  assert.deepEqual(
-    proxy.buildUpstreamHeaderOverrideHeaders({
-      "user-agent": "custom-agent/1.0",
-      "CONTENT-TYPE": "application/custom+json",
-    }),
-    {
-      "x-liveagent-upstream-user-agent": "custom-agent/1.0",
-      "x-liveagent-upstream-content-type": "application/custom+json",
-    },
+function decodeUpstreamHeaderOverrides(encoded) {
+  return JSON.parse(Buffer.from(encoded, "base64").toString("utf8"));
+}
+
+test("upstream override channel carries every non-auth header for the local proxy hop", () => {
+  // 这些头名里 user-agent 会被 WebView 的 fetch 静默丢弃，靠覆盖包才能送达上游。
+  const encoded = proxy.encodeUpstreamHeaderOverrides({
+    "user-agent": "custom-agent/1.0",
+    "CONTENT-TYPE": "application/custom+json",
+    Cookie: "session=abc",
+    "X-Request-ID": "trace-1",
+    Authorization: "Bearer secret",
+    "x-api-key": "secret",
+    "x-goog-api-key": "secret",
+    "x-liveagent-proxy-token": "internal",
+  });
+
+  assert.deepEqual(decodeUpstreamHeaderOverrides(encoded), {
+    "user-agent": "custom-agent/1.0",
+    "CONTENT-TYPE": "application/custom+json",
+    Cookie: "session=abc",
+    "X-Request-ID": "trace-1",
+  });
+});
+
+test("upstream override channel stays empty when there is nothing to override", () => {
+  assert.equal(proxy.encodeUpstreamHeaderOverrides({}), undefined);
+  assert.equal(
+    proxy.encodeUpstreamHeaderOverrides({ Authorization: "Bearer secret" }),
+    undefined,
+  );
+});
+
+test("upstream override channel rejects oversized custom header sets", () => {
+  assert.throws(
+    () => proxy.encodeUpstreamHeaderOverrides({ "X-Big": "v".repeat(9 * 1024) }),
+    /too large/i,
+  );
+});
+
+test("anthropic-beta never enters the upstream override package", () => {
+  // 覆盖包在 prepareProxyRequest 时刻构建，早于长上下文中间件算出 anthropic-beta；
+  // 它是保留头（用户填不进来），因此绝不会回头压掉中间件的 beta 串。
+  const base = providers.buildProviderRequestHeaders("claude_code", "secret");
+  const merged = customHeaderHelpers.mergeCustomHeaders(base, [
+    { key: "anthropic-beta", value: "hijacked" },
+  ]);
+  const overrides = decodeUpstreamHeaderOverrides(proxy.encodeUpstreamHeaderOverrides(merged));
+  assert.ok(
+    !Object.keys(overrides).some((key) => key.toLowerCase() === "anthropic-beta"),
+    "anthropic-beta must stay owned by attachAnthropicLongContextBeta",
   );
 });
 
@@ -1285,7 +1327,7 @@ test("streaming text reconciler emits only missing final text suffixes", () => {
 test("custom provider headers merge without mutating the base headers", () => {
   const base = { Accept: "application/json", "X-Tenant": "old" };
   assert.deepEqual(
-    providers.mergeCustomHeaders(base, [
+    customHeaderHelpers.mergeCustomHeaders(base, [
       { key: "X-Tenant", value: "new" },
       { key: "X-Request-ID", value: "request-123" },
     ]),
@@ -1306,7 +1348,7 @@ test("custom provider headers override model defaults but not credential or prot
     "Content-Length": "42",
   };
   assert.deepEqual(
-    providers.mergeCustomHeaders(base, [
+    customHeaderHelpers.mergeCustomHeaders(base, [
       { key: "authorization", value: "Bearer attacker" },
       { key: "X-API-KEY", value: "attacker" },
       { key: "X-GOOG-API-KEY", value: "attacker" },
@@ -1331,7 +1373,7 @@ test("custom provider headers override model defaults but not credential or prot
 
 test("custom provider headers filter invalid HTTP token keys", () => {
   assert.deepEqual(
-    providers.mergeCustomHeaders({}, [
+    customHeaderHelpers.mergeCustomHeaders({}, [
       { key: "", value: "empty" },
       { key: "Bad Header", value: "space" },
       { key: "Bad:Header", value: "colon" },
@@ -1344,12 +1386,30 @@ test("custom provider headers filter invalid HTTP token keys", () => {
   assert.equal(customHeaderHelpers.isReservedCustomHeaderKey("Anthropic-Beta"), true);
   assert.equal(providers.isValidCustomHeaderKey("X-Request-ID"), true);
   assert.equal(providers.isValidCustomHeaderKey("Bad Header"), false);
+  // 本地反代的内部命名空间不可被自定义头注入。
+  assert.equal(customHeaderHelpers.isReservedCustomHeaderKey("X-LiveAgent-Proxy-Token"), true);
+  assert.equal(customHeaderHelpers.isReservedCustomHeaderKey("x-liveagent-anything"), true);
+});
+
+test("custom provider headers reject values fetch() cannot transmit", () => {
+  assert.equal(customHeaderHelpers.isValidCustomHeaderValue("plain-ascii/1.0"), true);
+  assert.equal(customHeaderHelpers.isValidCustomHeaderValue(""), true);
+  assert.equal(customHeaderHelpers.isValidCustomHeaderValue("中文"), false);
+  assert.equal(customHeaderHelpers.isValidCustomHeaderValue("a\r\nb"), false);
+  assert.deepEqual(
+    customHeaderHelpers.mergeCustomHeaders({}, [
+      { key: "X-Bad", value: "中文" },
+      { key: "X-Injected", value: "a\r\nHost: evil" },
+      { key: "X-Good", value: "kept" },
+    ]),
+    { "X-Good": "kept" },
+  );
 });
 
 test("custom provider headers accept undefined and empty arrays", () => {
   const base = { Accept: "application/json" };
-  assert.deepEqual(providers.mergeCustomHeaders(base, undefined), base);
-  assert.deepEqual(providers.mergeCustomHeaders(base, []), base);
+  assert.deepEqual(customHeaderHelpers.mergeCustomHeaders(base, undefined), base);
+  assert.deepEqual(customHeaderHelpers.mergeCustomHeaders(base, []), base);
 });
 
 test("resolveProviderCacheRetention maps provider settings and per-request overrides", () => {


### PR DESCRIPTION
## 问题

供应商配置里的「自定义请求头」在**所有聊天链路上完全失效**，同时无法覆盖内置默认请求头。

根因不在传输层。`buildProviderRuntimeConfig()` 一直产出完整配置，但 `useSendChatTurn.ts` 里有 **4 处手写的字段逐一转抄**，每处都漏抄 `customHeaders` 和 `promptCacheRetention`：

| 链路 | 位置 |
|---|---|
| 自动标题 | `useSendChatTurn.ts:614` |
| Compaction | `useSendChatTurn.ts:1051` |
| Agent 聊天（+ 子代理 + 记忆抽取回退） | `useSendChatTurn.ts:1319` |
| 文本聊天 | `useSendChatTurn.ts:1398` |

两个字段都是**可选**的，TypeScript 对漏抄零告警 —— 这是一整类 bug，不是一个 bug。同一份配置在仓库里存在 5 份近似类型定义，每份都在邀请下一次转抄。Cron 和记忆整理是另外手搓的完整对象，成了唯二能生效的链路。

顺带确认的同源问题：
- **`promptCacheRetention` 一并失效** —— 设置页「缓存保留 · 1 小时（仅官方 API）」在四条链路上从未生效。
- **浏览器禁止头名被静默丢弃** —— 自定义头最终由 WKWebView `fetch` 发出，`User-Agent` / `Cookie` / `Referer` 属于 fetch 的 forbidden header names，浏览器直接不发；此前只有 UA 和 Content-Type 两个专用旁路通道。
- **请求头取值无校验** —— 填中文或换行会让 `fetch()` 直接抛错，整轮对话被打断成一条与请求头无关的报错。

## 方案

### A. 让这一类 bug 在类型层面不可表达

- `ProviderRuntimeConfig` 加 `unique symbol` 品牌字段：**手写对象字面量一律编译不过**。唯一构造点是 `createProviderRuntimeConfig()`（下沉到 `lib/providers/runtime`，全仓仅此一处断言），派生只能展开。
- 删掉 5 份重复定义（compaction、agentRunner 内联、`SubagentProviderRuntime`、`MemoryExtractionRuntimeConfig` —— 后者类型层面就少了 3 个字段），统一 import 真源。
- 删掉 4 处转抄，直接传对象。
- Cron / 记忆整理改走工厂，顺带修掉它们绕过 `reasoningSupported` 门控、可能给不支持思考的模型下发无效档位的旧缺陷。

### B. 传输层根治「覆盖内置默认头」

- 三处重复的 14 行装配收敛为 `prepareProviderRequest()`。
- 两个专用旁路通道合并为单一 `x-liveagent-upstream-headers`（base64 JSON，排除鉴权头，8 KiB 上限），Rust 本地反代在转发前逐项 `insert()` 覆盖写入。任何头名都能送达，precedence 只有一个裁决点，不再依赖 pi-ai 合并顺序 / SDK `defaultHeaders` 语义 / 浏览器是否肯发。
- 覆盖包的拒绝清单**故意窄于**常规拷贝过滤器：放行 `origin`/`referer`/`cookie` —— 常规过滤器的职责是剥掉 *WebView 自己注入的* 那份，而不是否决用户显式配置的同名头。
- 畸形覆盖包 400 fail fast，不静默降级。

### C. 校验与可验证性

- 新增 `isValidCustomHeaderValue`（仅可见 ASCII + tab），两端设置页保存前拦截并聚焦到出错的取值输入框；`x-liveagent-` 前缀进保留判定。
- dev 调试日志新增 `runtime.customHeaderKeys`（只记 key，取值继续脱敏），用于端到端确认配置是否真的走到请求。

保留头清单（鉴权三头 + `anthropic-beta` + `host` + `content-length`）维持硬拒绝。

**必须锁死的顺序不变量**：覆盖包在 `prepareProxyRequest` 时刻构建，早于 `attachAnthropicLongContextBeta` 计算 beta 串；`anthropic-beta` 是保留头且不在内置基础头里，因此绝不会回头压掉中间件算出的值。已加测试锁定。

## 验证

- 两端 `tsc --noEmit` 干净；两端 biome lint 干净
- GUI 前端 **1318 tests pass / 0 fail**（含新增的传播回归测试与工厂字段测试）
- Rust **620 tests pass**；`services::proxy` 14 条全绿（新增：禁止头名恢复、protected 头拒绝、畸形 base64/JSON/超限 → 400）
- `scripts/check-mirror.mjs` 111 文件通过
- 净减 398 行

品牌护栏实测有效：展开派生通过，手写字面量报 `TS2741`。

## 范围说明

本 PR 只覆盖聊天全链路。**「获取模型列表」探测链路有意不改**（`fetchModelsFromApi` / Rust `fetch_provider_models` / 网关 `ProviderModelsRequest`），仍不带自定义头 —— 需要时得给 proto 加字段。因此若某中转靠自定义头鉴权，聊天能通但拉模型列表仍会失败。

## 风险

- 改动集中在桌面端，网关 Go 侧与 proto 零改动，无需先部署网关。
- 最大回归面是覆盖通道：所有经本地反代的上游请求都多走一次覆盖写入。缓解是「覆盖包为空则整条头不下发」，行为与改前一致。
