### PR TITLE
fix(git-review): list untracked files individually and watch external git metadata

### DIFF
--- a/crates/agent-gateway/web/src/components/project-tools/git-review/useGitReviewData.ts
+++ b/crates/agent-gateway/web/src/components/project-tools/git-review/useGitReviewData.ts
@@ -872,7 +872,11 @@ export function useGitReviewData(options: UseGitReviewDataOptions) {
   }, [handleWorkspaceInvalidate]);
 
   // Invalidation stays keyed to the workspace folder: activity events cover
-  // subdirectory repositories because they live inside the workspace tree.
+  // subdirectory repositories because they live inside the workspace tree,
+  // and the desktop watcher additionally covers the git metadata (index,
+  // HEAD, refs) of a repository that contains the workspace folder as a
+  // subfolder or links it as a worktree (services/workspace_watch). Worktree
+  // file edits outside the workspace subtree still need a manual refresh.
   useWorkspaceInvalidation({
     client: workspaceActivityClient,
     workdir: workspaceCwd,

--- a/crates/agent-gui/src-tauri/src/commands/workspace/git.rs
+++ b/crates/agent-gui/src-tauri/src/commands/workspace/git.rs
@@ -1014,9 +1014,20 @@ pub(crate) fn git_status_sync(workdir: String) -> Result<GitRepositoryState, Str
     let Some(repo_root) = discover_repo(&workdir)? else {
         return Ok(not_repo_state(&workdir));
     };
+    // --untracked-files=all: without it git collapses a fully-untracked
+    // directory into a single `dir/` entry, so the files inside never show up
+    // in the review list (and the collapsed entry has no diff). The explicit
+    // flag also overrides a user-level `status.showUntrackedFiles = no`.
     let output = git_output(
         &repo_root,
-        &["status", "--porcelain=v2", "--branch", "--show-stash", "-z"],
+        &[
+            "status",
+            "--porcelain=v2",
+            "--branch",
+            "--show-stash",
+            "--untracked-files=all",
+            "-z",
+        ],
     )?;
     if !output.status.success() {
         return Ok(GitRepositoryState {
@@ -4051,6 +4062,64 @@ mod tests {
         assert!(discarded_all.state.entries.is_empty());
         assert!(!temp.path().join("bulk-staged.txt").exists());
         assert!(!temp.path().join("bulk-untracked.txt").exists());
+    }
+
+    #[test]
+    fn git_status_lists_files_inside_untracked_directories() {
+        let Some(repo) = init_temp_repo() else {
+            return;
+        };
+        let workdir = repo.path().to_string_lossy().to_string();
+        fs::create_dir_all(repo.path().join("newdir").join("nested")).expect("create untracked");
+        fs::write(repo.path().join("newdir").join("a.txt"), "a\n").expect("write a");
+        fs::write(
+            repo.path().join("newdir").join("nested").join("b.txt"),
+            "b\n",
+        )
+        .expect("write b");
+
+        // --untracked-files=all: every file inside the untracked directory is
+        // listed individually instead of one collapsed `newdir/` entry.
+        let state = git_status_sync(workdir.clone()).expect("status");
+        assert_eq!(state.status, "ready");
+        let untracked: Vec<&str> = state
+            .entries
+            .iter()
+            .filter(|entry| entry.untracked)
+            .map(|entry| entry.path.as_str())
+            .collect();
+        assert!(
+            untracked.contains(&"newdir/a.txt"),
+            "entries: {untracked:?}"
+        );
+        assert!(
+            untracked.contains(&"newdir/nested/b.txt"),
+            "entries: {untracked:?}"
+        );
+        assert!(!untracked.contains(&"newdir/"), "entries: {untracked:?}");
+        assert_eq!(state.dirty_counts.untracked, 2);
+
+        // The per-file entries stay actionable end to end: diff, stage, discard.
+        let diff = git_diff_sync(
+            workdir.clone(),
+            Some("working_tree".to_string()),
+            Some("newdir/a.txt".to_string()),
+        )
+        .expect("untracked diff");
+        assert!(diff.patch.contains("+a"), "diff patch:\n{}", diff.patch);
+        let staged = git_stage_sync(workdir.clone(), "newdir/a.txt".to_string()).expect("stage");
+        assert!(staged.ok, "stage failed: {}", staged.message);
+        assert_eq!(staged.state.dirty_counts.staged, 1);
+        assert_eq!(staged.state.dirty_counts.untracked, 1);
+        let discarded = git_discard_sync(workdir.clone(), "newdir/nested/b.txt".to_string(), None)
+            .expect("discard untracked");
+        assert!(discarded.ok, "discard failed: {}", discarded.message);
+        assert!(!repo
+            .path()
+            .join("newdir")
+            .join("nested")
+            .join("b.txt")
+            .exists());
     }
 
     #[test]

--- a/crates/agent-gui/src-tauri/src/services/workspace_watch/watcher.rs
+++ b/crates/agent-gui/src-tauri/src/services/workspace_watch/watcher.rs
@@ -1,6 +1,13 @@
 //! Per-workdir watcher: a recursive `notify` watcher whose raw events are
 //! debounced (250ms window) and classified into workspace activity, with a 2s
 //! mtime-sampling fallback when the native watcher cannot be created.
+//!
+//! The git review panel reviews the repository *containing* the workdir, which
+//! is not necessarily rooted at it (monorepo subfolder opened as a workspace,
+//! linked worktree with a `.git` file). The repository's bookkeeping (index,
+//! HEAD, refs) then lives outside the watched subtree, so each watcher also
+//! attaches to those external git metadata directories; their events raise the
+//! git flag only (see `ActivityBatch::absorb`).
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -39,6 +46,7 @@ pub(super) fn spawn_workdir_watcher(
 ) -> WorkdirWatcherHandle {
     let stop = Arc::new(AtomicBool::new(false));
     let (tx, rx) = std::sync::mpsc::channel::<notify::Result<Event>>();
+    let topology = resolve_git_meta_topology(Path::new(&workdir));
 
     let watcher = RecommendedWatcher::new(tx, Config::default()).and_then(|mut watcher| {
         watcher
@@ -47,11 +55,22 @@ pub(super) fn spawn_workdir_watcher(
     });
 
     match watcher {
-        Ok(watcher) => {
+        Ok(mut watcher) => {
+            // Best-effort extra watches on git metadata living outside the
+            // workdir subtree (monorepo subfolder / linked worktree); failing
+            // to attach one must not take down the workdir watch itself.
+            for root in &topology.watch_roots {
+                if let Err(error) = watcher.watch(root, RecursiveMode::Recursive) {
+                    eprintln!(
+                        "workspace watcher: external git dir {} not watched: {error}",
+                        root.display()
+                    );
+                }
+            }
             let thread_workdir = workdir.clone();
             let spawned = thread::Builder::new()
                 .name("workspace-watch".to_string())
-                .spawn(move || run_aggregator(thread_workdir, rx, service));
+                .spawn(move || run_aggregator(thread_workdir, topology, rx, service));
             if let Err(error) = spawned {
                 eprintln!("spawn workspace watch aggregator for {workdir} failed: {error}");
             }
@@ -65,9 +84,10 @@ pub(super) fn spawn_workdir_watcher(
                 "workspace watcher for {workdir} failed ({error}); falling back to 2s sampling"
             );
             let poll_stop = Arc::clone(&stop);
+            let git_dir = topology.git_dir;
             let spawned = thread::Builder::new()
                 .name("workspace-watch-poll".to_string())
-                .spawn(move || run_poll_fallback(workdir, poll_stop, service));
+                .spawn(move || run_poll_fallback(workdir, git_dir, poll_stop, service));
             if let Err(error) = spawned {
                 eprintln!("spawn workspace watch poll fallback failed: {error}");
             }
@@ -79,7 +99,146 @@ pub(super) fn spawn_workdir_watcher(
     }
 }
 
+// ---- repository geometry ----
+
+/// Where the git metadata for a workdir lives. Resolved once per watcher
+/// spawn from pure filesystem probes (no git subprocess: `set_desired` runs on
+/// command handlers and must not block on a child process).
+pub(super) struct GitMetaTopology {
+    /// Git metadata directories outside the workdir subtree that need their
+    /// own recursive watch (deduped, none nested inside another).
+    pub(super) watch_roots: Vec<PathBuf>,
+    /// Prefixes used to classify out-of-subtree event paths, longest first so
+    /// a linked worktree's gitdir wins over the commondir that contains it.
+    /// Includes canonicalized alternates (FSEvents may report resolved paths).
+    pub(super) class_roots: Vec<PathBuf>,
+    /// Resolved gitdir holding this worktree's HEAD/index; defaults to
+    /// `<workdir>/.git` when the workdir is not inside a repository.
+    pub(super) git_dir: PathBuf,
+}
+
+pub(super) fn resolve_git_meta_topology(workdir: &Path) -> GitMetaTopology {
+    let mut roots: Vec<PathBuf> = Vec::new();
+    let mut git_dir = workdir.join(".git");
+    if let Some(dot_git) = find_nearest_dot_git(workdir) {
+        if dot_git.is_dir() {
+            git_dir = dot_git.clone();
+            roots.push(dot_git);
+        } else if let Some(resolved) = resolve_gitdir_file(&dot_git) {
+            // `.git` file (linked worktree / submodule): the gitdir holds the
+            // per-worktree HEAD/index, the commondir the shared refs.
+            if let Some(common) = resolve_commondir(&resolved) {
+                roots.push(common);
+            }
+            git_dir = resolved.clone();
+            roots.push(resolved);
+        }
+    }
+
+    let mut class_roots: Vec<PathBuf> = Vec::new();
+    for root in &roots {
+        if !class_roots.contains(root) {
+            class_roots.push(root.clone());
+        }
+        if let Ok(canonical) = std::fs::canonicalize(root) {
+            if !class_roots.contains(&canonical) {
+                class_roots.push(canonical);
+            }
+        }
+    }
+    class_roots.sort_by_key(|root| std::cmp::Reverse(root.as_os_str().len()));
+
+    let canonical_workdir = std::fs::canonicalize(workdir).ok();
+    let covered_by_workdir = |root: &Path| {
+        root.starts_with(workdir)
+            || canonical_workdir
+                .as_deref()
+                .is_some_and(|prefix| root.starts_with(prefix))
+    };
+    let mut watch_roots: Vec<PathBuf> = Vec::new();
+    for root in roots {
+        if covered_by_workdir(&root) {
+            continue;
+        }
+        if watch_roots
+            .iter()
+            .any(|existing| root.starts_with(existing))
+        {
+            continue;
+        }
+        watch_roots.retain(|existing| !existing.starts_with(&root));
+        watch_roots.push(root);
+    }
+
+    GitMetaTopology {
+        watch_roots,
+        class_roots,
+        git_dir,
+    }
+}
+
+/// Nearest `.git` entry (directory, or file for linked worktrees/submodules)
+/// at the workdir or one of its ancestors. A plain filesystem approximation of
+/// git's own repository discovery — good enough for deciding what to watch: a
+/// false positive only costs a spurious extra watch.
+fn find_nearest_dot_git(workdir: &Path) -> Option<PathBuf> {
+    let mut current = Some(workdir);
+    while let Some(dir) = current {
+        let candidate = dir.join(".git");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+/// Resolves a `.git` *file*'s `gitdir: <path>` pointer (relative paths are
+/// anchored at the file's parent directory).
+fn resolve_gitdir_file(dot_git_file: &Path) -> Option<PathBuf> {
+    let content = std::fs::read_to_string(dot_git_file).ok()?;
+    let target = content
+        .lines()
+        .find_map(|line| line.strip_prefix("gitdir:"))?
+        .trim();
+    if target.is_empty() {
+        return None;
+    }
+    let raw = Path::new(target);
+    let resolved = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        dot_git_file.parent()?.join(raw)
+    };
+    Some(std::fs::canonicalize(&resolved).unwrap_or(resolved))
+}
+
+/// Resolves a gitdir's `commondir` pointer (relative paths are anchored at the
+/// gitdir). Absent for a primary worktree's gitdir.
+fn resolve_commondir(git_dir: &Path) -> Option<PathBuf> {
+    let content = std::fs::read_to_string(git_dir.join("commondir")).ok()?;
+    let target = content.trim();
+    if target.is_empty() {
+        return None;
+    }
+    let raw = Path::new(target);
+    let resolved = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        git_dir.join(raw)
+    };
+    Some(std::fs::canonicalize(&resolved).unwrap_or(resolved))
+}
+
 // ---- notify event aggregation ----
+
+/// Everything `absorb` needs to attribute an event path: the workdir prefix
+/// (raw and canonical) plus the external git metadata prefixes.
+struct WatchScope {
+    workdir: PathBuf,
+    canonical_workdir: Option<PathBuf>,
+    git_class_roots: Vec<PathBuf>,
+}
 
 #[derive(Default)]
 struct ActivityBatch {
@@ -105,12 +264,7 @@ impl ActivityBatch {
         self.changed.insert(rel);
     }
 
-    fn absorb(
-        &mut self,
-        workdir: &Path,
-        canonical_workdir: Option<&Path>,
-        event: notify::Result<Event>,
-    ) {
+    fn absorb(&mut self, scope: &WatchScope, event: notify::Result<Event>) {
         let event = match event {
             Ok(event) => event,
             Err(_) => {
@@ -127,7 +281,7 @@ impl ActivityBatch {
             return;
         }
         for path in &event.paths {
-            match relativize(workdir, canonical_workdir, path) {
+            match relativize(&scope.workdir, scope.canonical_workdir.as_deref(), path) {
                 Some(rel) => match classify_rel_path(&rel) {
                     PathClass::Worktree => {
                         self.fs = true;
@@ -140,12 +294,21 @@ impl ActivityBatch {
                     }
                     PathClass::Ignored => {}
                 },
-                None => {
-                    // Cannot attribute the path: err on the dirty side.
-                    self.fs = true;
-                    self.git = true;
-                    self.truncated = true;
-                }
+                None => match classify_external_git_path(&scope.git_class_roots, path) {
+                    // Bookkeeping of the repository that contains this workdir
+                    // (or of a linked worktree's gitdir): affects git status
+                    // only. The path cannot be expressed workdir-relative and
+                    // the file tree ignores fs=false batches, so only the git
+                    // flag is raised and no changed path is recorded.
+                    Some(PathClass::GitMeta) => self.git = true,
+                    Some(_) => {}
+                    None => {
+                        // Cannot attribute the path: err on the dirty side.
+                        self.fs = true;
+                        self.git = true;
+                        self.truncated = true;
+                    }
+                },
             }
         }
     }
@@ -153,6 +316,7 @@ impl ActivityBatch {
 
 fn run_aggregator(
     workdir: String,
+    topology: GitMetaTopology,
     rx: Receiver<notify::Result<Event>>,
     service: Weak<WorkspaceWatchService>,
 ) {
@@ -161,6 +325,11 @@ fn run_aggregator(
     // paths; keep the canonical form as an alternate strip prefix.
     let canonical = std::fs::canonicalize(&workdir_path).ok();
     let canonical = canonical.filter(|resolved| resolved != &workdir_path);
+    let scope = WatchScope {
+        workdir: workdir_path,
+        canonical_workdir: canonical,
+        git_class_roots: topology.class_roots,
+    };
 
     loop {
         // Block for the first event of a burst, then keep absorbing until the
@@ -170,7 +339,7 @@ fn run_aggregator(
             Err(_) => return,
         };
         let mut batch = ActivityBatch::default();
-        batch.absorb(&workdir_path, canonical.as_deref(), first);
+        batch.absorb(&scope, first);
         let window_end = Instant::now() + DEBOUNCE_WINDOW;
         let mut disconnected = false;
         loop {
@@ -179,7 +348,7 @@ fn run_aggregator(
                 break;
             }
             match rx.recv_timeout(window_end - now) {
-                Ok(event) => batch.absorb(&workdir_path, canonical.as_deref(), event),
+                Ok(event) => batch.absorb(&scope, event),
                 Err(RecvTimeoutError::Timeout) => break,
                 Err(RecvTimeoutError::Disconnected) => {
                     disconnected = true;
@@ -240,6 +409,15 @@ pub(super) fn classify_rel_path(rel: &str) -> PathClass {
         }
         return PathClass::Worktree;
     };
+    if is_git_meta_inner(inner) {
+        PathClass::GitMeta
+    } else {
+        PathClass::Ignored
+    }
+}
+
+/// Paths inside a git directory whose change affects `git status` output.
+fn is_git_meta_inner(inner: &str) -> bool {
     const GIT_META_FILES: &[&str] = &[
         "HEAD",
         "index",
@@ -248,11 +426,27 @@ pub(super) fn classify_rel_path(rel: &str) -> PathClass {
         "ORIG_HEAD",
         "COMMIT_EDITMSG",
     ];
-    if GIT_META_FILES.contains(&inner) || inner == "refs" || inner.starts_with("refs/") {
-        PathClass::GitMeta
-    } else {
-        PathClass::Ignored
+    GIT_META_FILES.contains(&inner) || inner == "refs" || inner.starts_with("refs/")
+}
+
+/// Classifies an absolute event path against the out-of-subtree git metadata
+/// roots (longest prefix first). Returns None when the path belongs to none of
+/// them; the roots themselves and their non-meta contents are Ignored.
+pub(super) fn classify_external_git_path(
+    class_roots: &[PathBuf],
+    path: &Path,
+) -> Option<PathClass> {
+    for root in class_roots {
+        let Ok(inner) = path.strip_prefix(root) else {
+            continue;
+        };
+        let inner = inner.to_string_lossy().replace('\\', "/");
+        if !inner.is_empty() && is_git_meta_inner(&inner) {
+            return Some(PathClass::GitMeta);
+        }
+        return Some(PathClass::Ignored);
     }
+    None
 }
 
 // ---- polling fallback ----
@@ -264,11 +458,11 @@ struct PollSample {
     index_mtime: Option<SystemTime>,
 }
 
-fn sample_workdir(workdir: &Path) -> PollSample {
+fn sample_workdir(workdir: &Path, git_dir: &Path) -> PollSample {
     PollSample {
         workdir_mtime: mtime_of(workdir),
-        head_mtime: mtime_of(&workdir.join(".git").join("HEAD")),
-        index_mtime: mtime_of(&workdir.join(".git").join("index")),
+        head_mtime: mtime_of(&git_dir.join("HEAD")),
+        index_mtime: mtime_of(&git_dir.join("index")),
     }
 }
 
@@ -278,9 +472,14 @@ fn mtime_of(path: &Path) -> Option<SystemTime> {
         .and_then(|meta| meta.modified().ok())
 }
 
-fn run_poll_fallback(workdir: String, stop: Arc<AtomicBool>, service: Weak<WorkspaceWatchService>) {
+fn run_poll_fallback(
+    workdir: String,
+    git_dir: PathBuf,
+    stop: Arc<AtomicBool>,
+    service: Weak<WorkspaceWatchService>,
+) {
     let workdir_path = PathBuf::from(&workdir);
-    let mut last = sample_workdir(&workdir_path);
+    let mut last = sample_workdir(&workdir_path, &git_dir);
     loop {
         // Sleep the poll interval in short slices so a dropped handle stops
         // the thread promptly.
@@ -298,7 +497,7 @@ fn run_poll_fallback(workdir: String, stop: Arc<AtomicBool>, service: Weak<Works
             return;
         };
 
-        let current = sample_workdir(&workdir_path);
+        let current = sample_workdir(&workdir_path, &git_dir);
         if current == last {
             continue;
         }
@@ -326,7 +525,11 @@ fn run_poll_fallback(workdir: String, stop: Arc<AtomicBool>, service: Weak<Works
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_rel_path, PathClass};
+    use std::path::{Path, PathBuf};
+
+    use super::{
+        classify_external_git_path, classify_rel_path, resolve_git_meta_topology, PathClass,
+    };
 
     #[test]
     fn classify_rel_path_routes_worktree_git_meta_and_ignored() {
@@ -366,5 +569,98 @@ mod tests {
                 "{rel}"
             );
         }
+    }
+
+    #[test]
+    fn classify_external_git_path_prefers_longest_root_and_meta_rules() {
+        // Linked-worktree layout: the per-worktree gitdir nests inside the
+        // shared commondir; longest-first ordering must attribute its files
+        // to the gitdir, not as `worktrees/...` junk under the commondir.
+        let roots = vec![
+            PathBuf::from("/main/.git/worktrees/feat"),
+            PathBuf::from("/main/.git"),
+        ];
+        for (path, expect_meta) in [
+            ("/main/.git/worktrees/feat/index", true),
+            ("/main/.git/worktrees/feat/HEAD", true),
+            ("/main/.git/index", true),
+            ("/main/.git/refs/heads/main", true),
+            ("/main/.git/packed-refs", true),
+            ("/main/.git/objects/ab/cdef", false),
+            ("/main/.git/worktrees/feat/index.lock", false),
+            ("/main/.git", false),
+        ] {
+            let class = classify_external_git_path(&roots, Path::new(path));
+            match class {
+                Some(PathClass::GitMeta) => assert!(expect_meta, "{path}"),
+                Some(PathClass::Ignored) => assert!(!expect_meta, "{path}"),
+                other => panic!("{path}: unexpected class {:?}", other.is_some()),
+            }
+        }
+        assert!(classify_external_git_path(&roots, Path::new("/elsewhere/file.rs")).is_none());
+    }
+
+    #[test]
+    fn topology_for_plain_repo_root_needs_no_external_watch() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let workdir = temp.path().join("repo");
+        std::fs::create_dir_all(workdir.join(".git")).expect("create .git");
+        let topology = resolve_git_meta_topology(&workdir);
+        assert!(topology.watch_roots.is_empty());
+        assert_eq!(topology.git_dir, workdir.join(".git"));
+    }
+
+    #[test]
+    fn topology_for_subfolder_workspace_watches_ancestor_git_dir() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let root = temp.path().join("repo");
+        let workdir = root.join("packages").join("app");
+        std::fs::create_dir_all(root.join(".git")).expect("create .git");
+        std::fs::create_dir_all(&workdir).expect("create workdir");
+        let topology = resolve_git_meta_topology(&workdir);
+        assert_eq!(topology.watch_roots, vec![root.join(".git")]);
+        assert_eq!(topology.git_dir, root.join(".git"));
+        assert!(topology.class_roots.contains(&root.join(".git")));
+    }
+
+    #[test]
+    fn topology_for_linked_worktree_watches_commondir_and_classifies_gitdir_first() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let common = temp.path().join("main").join(".git");
+        let git_dir = common.join("worktrees").join("feat");
+        let workdir = temp.path().join("feat-worktree");
+        std::fs::create_dir_all(&git_dir).expect("create gitdir");
+        std::fs::create_dir_all(&workdir).expect("create workdir");
+        std::fs::write(
+            workdir.join(".git"),
+            format!("gitdir: {}\n", git_dir.display()),
+        )
+        .expect("write .git file");
+        std::fs::write(git_dir.join("commondir"), "../..\n").expect("write commondir");
+
+        let topology = resolve_git_meta_topology(&workdir);
+        // Canonicalize expectations: the resolver canonicalizes targets (macOS
+        // tempdirs live behind the /private symlink).
+        let canonical_git_dir = std::fs::canonicalize(&git_dir).expect("canonical gitdir");
+        let canonical_common = std::fs::canonicalize(&common).expect("canonical commondir");
+        assert_eq!(topology.git_dir, canonical_git_dir);
+        // The gitdir nests inside the commondir, so one watch covers both.
+        assert_eq!(topology.watch_roots, vec![canonical_common.clone()]);
+        // Classification still knows the finer gitdir prefix, ordered first.
+        let gitdir_pos = topology
+            .class_roots
+            .iter()
+            .position(|root| root == &canonical_git_dir)
+            .expect("gitdir in class roots");
+        let common_pos = topology
+            .class_roots
+            .iter()
+            .position(|root| root == &canonical_common)
+            .expect("commondir in class roots");
+        assert!(gitdir_pos < common_pos);
+        assert!(matches!(
+            classify_external_git_path(&topology.class_roots, &canonical_git_dir.join("index")),
+            Some(PathClass::GitMeta)
+        ));
     }
 }

--- a/crates/agent-gui/src/components/project-tools/git-review/useGitReviewData.ts
+++ b/crates/agent-gui/src/components/project-tools/git-review/useGitReviewData.ts
@@ -872,7 +872,11 @@ export function useGitReviewData(options: UseGitReviewDataOptions) {
   }, [handleWorkspaceInvalidate]);
 
   // Invalidation stays keyed to the workspace folder: activity events cover
-  // subdirectory repositories because they live inside the workspace tree.
+  // subdirectory repositories because they live inside the workspace tree,
+  // and the desktop watcher additionally covers the git metadata (index,
+  // HEAD, refs) of a repository that contains the workspace folder as a
+  // subfolder or links it as a worktree (services/workspace_watch). Worktree
+  // file edits outside the workspace subtree still need a manual refresh.
   useWorkspaceInvalidation({
     client: workspaceActivityClient,
     workdir: workspaceCwd,


### PR DESCRIPTION
## 问题

深查两端(GUI/WebUI)右侧边栏 Git 审查面板后确认,"本地改动"列表存在两类漏显文件的场景:

1. **untracked 新目录被折叠**:`git status` 默认 `--untracked-files=normal`,整个未跟踪目录只输出一条 `dir/`。目录内的文件在更改列表中不逐个显示,且该折叠条目的 diff 为空(被归入 binaryFiles)。用户 `status.showUntrackedFiles=no` 配置还会让 untracked 整体消失。
2. **监听范围与采集范围不匹配**:status 采集覆盖整个仓库(`discover_repo` 向上找 toplevel),但 activity watcher 只监听工作区子树。把 monorepo 子文件夹作为工作区打开时,终端里的 `git add`/`commit`/切分支只触碰上层 `.git`,不产生任何失效事件,面板列表持续陈旧直到手动刷新(推送环境下无兜底轮询)。linked worktree(`.git` 文件)同理。

## 修复

- `git_status_sync`(两端共用的唯一 status 入口)加 `--untracked-files=all`:新目录内文件逐个列出,diff/stage/discard 全链路可用,显式参数同时覆盖用户配置。
- watcher 新增 `resolve_git_meta_topology`:纯文件系统探测(不 spawn git,`set_desired` 在命令处理路径上不能阻塞),向上找最近 `.git`(目录,或 worktree 文件→解析 gitdir + commondir),对位于工作区子树之外的 git 元数据目录加挂 recursive watch;分类前缀最长优先(gitdir 赢过包含它的 commondir)。
- 外部元数据事件只置 `git` 标志:不置 `fs`、不记 changedPaths——file tree 忽略 `fs=false` 批次,文件树零干扰。
- poll fallback 采样解析后 gitdir 的 HEAD/index,不再假设 `workdir/.git`。
- 两端镜像的 `useGitReviewData.ts` 注释同步更新(逐字节一致)。

## 有意保留的取舍

工作区子树外的**裸文件编辑**(不经任何 git 操作)仍需手动刷新:彻底覆盖需 watch 整个 repo root,当 $HOME 本身是 dotfiles 仓库时会退化成监听整个家目录。与 VSCode 的取舍一致(workspace watcher + dotgit watcher)。

## 验证

- 新增 4 个 watcher 单测(普通根/monorepo 子目录/linked worktree topology 与分类)+ 1 个真实 git 集成测试锁定 `-uall` 行为(逐文件列出、无折叠条目、diff/stage/discard 可用)。
- `cargo test --lib`:625 通过;clippy 无新增告警;rustfmt 干净(proxy.rs 既有漂移未触碰)。
- `scripts/check-mirror.mjs`:111 个镜像文件通过。