### PR TITLE
fix(webui): 修复模型选择器文字下伸部被裁切

### DIFF
--- a/crates/agent-gateway/web/src/styles.css
+++ b/crates/agent-gateway/web/src/styles.css
@@ -32,19 +32,19 @@ html[data-liveagent-webui="gateway"] .model-selector-item {
 html[data-liveagent-webui="gateway"] .model-selector-trigger,
 html[data-liveagent-webui="gateway"] .model-selector-current-label {
   font-size: 15px;
-  line-height: 1.1;
+  line-height: 1.3;
 }
 
 html[data-liveagent-webui="gateway"] .model-selector-dropdown,
 html[data-liveagent-webui="gateway"] .model-selector-item {
   font-size: 14px;
-  line-height: 1.15;
+  line-height: 1.3;
 }
 
 html[data-liveagent-webui="gateway"] .model-selector-menu-title,
 html[data-liveagent-webui="gateway"] .model-selector-group-label {
   font-size: 14px;
-  line-height: 1.15;
+  line-height: 1.3;
 }
 
 html[data-liveagent-webui="gateway"] .chat-history-sidebar {


### PR DESCRIPTION
## 问题

WebUI 顶栏模型选择器中,部分模型名称字母的下伸部(descender)会被底部裁切,例如 `grok-4.5` 的 **g** 底部缺失(见 issue 截图)。

## 原因

`styles.css` 中 gateway WebUI 专属的模型选择器排版规则将 line-height 收得过紧(trigger/label 为 1.1,dropdown/item/标题为 1.15)。文本节点同时带有 `truncate`(`overflow: hidden`),行盒高度小于字形实际高度时,g、y、p 等字母的下伸部就会被裁掉。

## 修复

将三组规则的 line-height 统一放宽为 1.3,为下伸部留出空间:

- `.model-selector-trigger` / `.model-selector-current-label`:1.1 → 1.3
- `.model-selector-dropdown` / `.model-selector-item`:1.15 → 1.3
- `.model-selector-menu-title` / `.model-selector-group-label`:1.15 → 1.3

trigger 高度由 `h-8` 固定、下拉项高度由 `h-[30px]` 固定,行高放宽不会改变整体布局尺寸。此文件为 gateway WebUI 专属覆盖(桌面 GUI 无对应规则,不在 mirror-manifest 范围内),无需镜像同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)