### PR TITLE
fix(chat): 修复队列"打断并执行"需点击两次才发送

### DIFF
--- a/crates/agent-gui/src/pages/chat/queue/useChatTurnQueue.ts
+++ b/crates/agent-gui/src/pages/chat/queue/useChatTurnQueue.ts
@@ -116,6 +116,12 @@ export function useChatTurnQueue(params: UseChatTurnQueueParams) {
   const queuedChatTurnsRef = useRef<QueuedChatTurn[]>([]);
   const queuedChatProcessingConversationIdsRef = useRef(new Set<string>());
   const queuedChatStopVersionsRef = useRef(new Map<string, number>());
+  // 打断并执行的恢复意图：conversationId → 触发打断那一刻的 stop-request 版本号。
+  // stopConversation 会打上 stop-requested 标记，而 drain effect 对该标记一律
+  // "消费后跳过"（普通停止不允许自动放行队列）。登记版本号让 drain effect 能
+  // 识别出"这次停止是打断并执行"，消费标记后继续自动发送；若用户随后又按了
+  // 普通停止，版本号被 bump，登记的意图自动失效，队列保持挂起。
+  const queuedChatInterruptResumeVersionsRef = useRef(new Map<string, number>());
   const queuedChatProcessingStatesRef = useRef(
     new Map<
       string,
@@ -581,11 +587,19 @@ export function useChatTurnQueue(params: UseChatTurnQueueParams) {
       ) {
         continue;
       }
+      const interruptResumeVersion =
+        queuedChatInterruptResumeVersionsRef.current.get(conversationId);
+      queuedChatInterruptResumeVersionsRef.current.delete(conversationId);
       if (isConversationStopRequested(conversationId)) {
         queuedChatProcessingConversationIdsRef.current.delete(conversationId);
         const stopRequestVersion = getConversationStopRequestVersion(conversationId);
         consumeConversationStop(conversationId, stopRequestVersion);
-        continue;
+        // 打断并执行：这次停止就是为了立刻放行队首轮次，消费掉 stop 标记后
+        // 继续向下触发处理；版本号不匹配说明打断之后用户又请求过停止，尊重
+        // 最新意图，保持队列挂起。
+        if (interruptResumeVersion !== stopRequestVersion) {
+          continue;
+        }
       }
       requestQueuedChatTurnProcessing(conversationId);
     }
@@ -597,6 +611,12 @@ export function useChatTurnQueue(params: UseChatTurnQueueParams) {
     setQueuedChatTurnsState((current) => promoteQueuedChatTurn(current, queuedTurn.id));
     if (isConversationRunning(queuedTurn.conversationId)) {
       stopConversation(queuedTurn.conversationId);
+      // 登记恢复意图（须在 stopConversation bump 版本号之后取值），运行结束后
+      // drain effect 据此消费 stop 标记并自动发送刚置顶的轮次。
+      queuedChatInterruptResumeVersionsRef.current.set(
+        queuedTurn.conversationId,
+        getConversationStopRequestVersion(queuedTurn.conversationId),
+      );
       return;
     }
     requestQueuedChatTurnProcessing(queuedTurn.conversationId);
@@ -724,14 +744,12 @@ export function useChatTurnQueue(params: UseChatTurnQueueParams) {
       },
     });
 
-    setQueuedChatTurnsState((current) => {
-      const appended = appendQueuedChatTurn(current, queuedTurn);
-      return payload.queuePolicy === "interrupt"
-        ? promoteQueuedChatTurn(appended, queuedTurn.id)
-        : appended;
-    });
+    setQueuedChatTurnsState((current) => appendQueuedChatTurn(current, queuedTurn));
     if (payload.queuePolicy === "interrupt") {
-      stopConversation(targetConversationId);
+      // 与本地"打断并执行"共用同一路径：置顶 + 运行中则打断并登记恢复意图；
+      // 空闲则直接触发队列处理（此前空闲时也会打 stop 标记且无人消费，
+      // 导致该轮次永远挂起）。
+      runQueuedTurnNow(queuedTurn.id);
     }
     return true;
   }


### PR DESCRIPTION
## 问题

GUI 与 WebUI 的提示词队列中点击"打断并执行"后，当前对话会停止，但提示词仍留在队列里不自动发送，需要再点一次才能发出。

## 根因

`useChatTurnQueue.ts` 中 `runQueuedTurnNow` 对运行中的会话走 `stopConversation` 后 return，把"停止后接力发送"寄托给 drain effect(running→not-running 转变)；但 `stopConversation` 会打上 stop-requested 标记，而 drain effect 对该标记一律**消费后跳过**——这是普通停止按钮的正确语义(停止后队列不得自动放行)，却把打断并执行的恢复意图一并吞掉。第二次点击时标记已被消费、会话已空闲，才走直发分支成功。

WebUI 面板按钮经 `chat_queue.run_now` → Rust 网关中继 → `gateway:chat-queue-request` 事件落回同一段 GUI 代码，因此两端表现一致、同源同修。

## 修复

- 新增 `queuedChatInterruptResumeVersionsRef`(conversationId → 打断时的 stop-request 版本号)：`runQueuedTurnNow` 在 `stopConversation` 之后登记；drain effect 消费 stop 标记后比对版本号，**相等才自动发送刚置顶的轮次**；打断后用户再按普通停止会 bump 版本号使意图自动失效，普通停止行为完全不变。
- 版本号匹配天然消解与 `useSendChatTurn` finally 中带版本 `consumeConversationStop` 的竞态：任一先执行结果都正确。
- 顺带修复同类缺陷：网关 `queuePolicy === "interrupt"` 分支改为复用 `runQueuedTurnNow`——旧代码在会话空闲时也无条件 `stopConversation`，打上无人消费的 stop 标记，导致该轮次永久挂起。

## 验证

- `tsc --noEmit` 无错误；`biome check` 警告与改动前基线完全一致，无新增
- `npm run test:frontend` 全量 1329 个测试通过(含 `chat-turn-queue`、`chat-stop-timing`)