### PR TITLE
refactor(chat): stack changed file names above paths

### DIFF
--- a/crates/agent-gateway/web/src/components/chat/ChangedFilesCard.tsx
+++ b/crates/agent-gateway/web/src/components/chat/ChangedFilesCard.tsx
@@ -38,6 +38,7 @@ function splitPath(path: string): { dir: string; base: string } {
 // 且没有 hover 可以显形；此时点按文件名默认用代码编辑器打开。
 const ROW_ACTION_CLASS =
   "hidden h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 opacity-0 transition-all hover:bg-foreground/[0.07] hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none group-hover/changed-file:opacity-100 md:flex";
+const MAX_VISIBLE_FILES = 5;
 
 const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFileEntry }) {
   const { t } = useLocale();
@@ -45,9 +46,15 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
   const { dir, base } = splitPath(file.path);
   const canOpen = Boolean(actions?.onOpenFile) && !file.deleted;
   const FileTypeIcon = getFileTypeIcon(file.path, "file");
+  const openLabel = `${t("chat.changedFiles.open")}: ${file.path}`;
+  const revealLabel = `${t("chat.changedFiles.reveal")}: ${file.path}`;
+  const diffLabel = `${t("chat.changedFiles.diff")}: ${file.path}`;
 
   const pathLabel = (
-    <span className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 overflow-hidden font-mono">
+    <span
+      title={file.path}
+      className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 overflow-hidden font-mono"
+    >
       <span
         className={cn(
           "min-w-0 max-w-full truncate text-[calc(11.5px*var(--zone-font-scale,1))] font-medium leading-tight text-foreground/90",
@@ -71,7 +78,8 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
         <button
           type="button"
           onClick={() => actions?.onOpenFile?.(file.path)}
-          title={t("chat.changedFiles.open")}
+          title={openLabel}
+          aria-label={openLabel}
           className="flex min-w-0 flex-1 items-stretch text-left focus-visible:outline-none"
         >
           {pathLabel}
@@ -90,8 +98,8 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
         <button
           type="button"
           onClick={() => actions.onRevealInFileTree?.(file.path)}
-          title={t("chat.changedFiles.reveal")}
-          aria-label={t("chat.changedFiles.reveal")}
+          title={revealLabel}
+          aria-label={revealLabel}
           className={ROW_ACTION_CLASS}
         >
           <FolderTree className="h-3.5 w-3.5" />
@@ -101,8 +109,8 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
         <button
           type="button"
           onClick={() => actions.onOpenDiff?.(file.path)}
-          title={t("chat.changedFiles.diff")}
-          aria-label={t("chat.changedFiles.diff")}
+          title={diffLabel}
+          aria-label={diffLabel}
           className={ROW_ACTION_CLASS}
         >
           <GitCommitHorizontal className="h-3.5 w-3.5" />
@@ -149,7 +157,13 @@ export const ChangedFilesCard = memo(function ChangedFilesCard({
         ) : null}
       </div>
       {/* 最多露出 5 行，更多文件走内部滚动条。 */}
-      <div className="flex max-h-[calc(200px*var(--zone-font-scale,1))] flex-col gap-0.5 overflow-y-auto overscroll-contain border-t border-border/35 px-1 py-1 dark:border-white/[0.05]">
+      <div
+        className={cn(
+          "flex flex-col gap-0.5 border-t border-border/35 px-1 py-1 dark:border-white/[0.05]",
+          summary.files.length > MAX_VISIBLE_FILES &&
+            "max-h-[calc(210px*var(--zone-font-scale,1))] overflow-y-auto overscroll-contain",
+        )}
+      >
         {summary.files.map((file) => (
           <ChangedFileRow key={file.lastToolCallId || file.path} file={file} />
         ))}

--- a/crates/agent-gateway/web/src/components/chat/ChangedFilesCard.tsx
+++ b/crates/agent-gateway/web/src/components/chat/ChangedFilesCard.tsx
@@ -47,15 +47,17 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
   const FileTypeIcon = getFileTypeIcon(file.path, "file");
 
   const pathLabel = (
-    <span className="flex min-w-0 flex-1 items-baseline font-mono text-[calc(11.5px*var(--zone-font-scale,1))] leading-[1.6]">
-      {dir ? <span className="truncate text-muted-foreground/70">{dir}</span> : null}
+    <span className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 overflow-hidden font-mono">
       <span
         className={cn(
-          "shrink-0 text-foreground/90",
+          "min-w-0 max-w-full truncate text-[calc(11.5px*var(--zone-font-scale,1))] font-medium leading-tight text-foreground/90",
           file.deleted && "text-muted-foreground line-through",
         )}
       >
         {base}
+      </span>
+      <span className="min-w-0 max-w-full truncate text-[calc(10px*var(--zone-font-scale,1))] leading-tight text-muted-foreground/70">
+        {dir || "."}
       </span>
     </span>
   );
@@ -70,12 +72,12 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
           type="button"
           onClick={() => actions?.onOpenFile?.(file.path)}
           title={t("chat.changedFiles.open")}
-          className="flex min-w-0 flex-1 items-center text-left focus-visible:outline-none"
+          className="flex min-w-0 flex-1 items-stretch text-left focus-visible:outline-none"
         >
           {pathLabel}
         </button>
       ) : (
-        <span className="flex min-w-0 flex-1 items-center">{pathLabel}</span>
+        <span className="flex min-w-0 flex-1 items-stretch">{pathLabel}</span>
       )}
       {file.deleted ? (
         <span className="shrink-0 rounded-full bg-muted/70 px-1.5 py-0.5 text-[calc(10px*var(--zone-font-scale,1))] leading-none text-muted-foreground">
@@ -147,7 +149,7 @@ export const ChangedFilesCard = memo(function ChangedFilesCard({
         ) : null}
       </div>
       {/* 最多露出 5 行，更多文件走内部滚动条。 */}
-      <div className="flex max-h-[calc(150px*var(--zone-font-scale,1))] flex-col gap-0.5 overflow-y-auto overscroll-contain border-t border-border/35 px-1 py-1 dark:border-white/[0.05]">
+      <div className="flex max-h-[calc(200px*var(--zone-font-scale,1))] flex-col gap-0.5 overflow-y-auto overscroll-contain border-t border-border/35 px-1 py-1 dark:border-white/[0.05]">
         {summary.files.map((file) => (
           <ChangedFileRow key={file.lastToolCallId || file.path} file={file} />
         ))}

--- a/crates/agent-gateway/web/test/changed-files-card.test.mjs
+++ b/crates/agent-gateway/web/test/changed-files-card.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createWebModuleLoader } from "../../test/helpers/load-web-module.mjs";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+
+function NullIcon() {
+  return null;
+}
+
+function createCardModule() {
+  const requireFromRoot = createRequire(path.join(rootDir, "package.json"));
+  const jsxRuntime = requireFromRoot("react/jsx-runtime");
+  const { renderToStaticMarkup } = requireFromRoot("react-dom/server");
+  const resolveSource = (relativePath) => path.join(rootDir, "src", relativePath);
+  const loader = createWebModuleLoader({
+    rootDir,
+    mocks: {
+      "react/jsx-runtime": jsxRuntime,
+      [resolveSource("i18n/index.ts")]: {
+        useLocale() {
+          return {
+            t(key) {
+              return key;
+            },
+          };
+        },
+      },
+      [resolveSource("components/icons.tsx")]: {
+        FilePenLine: NullIcon,
+      },
+      [resolveSource("components/chat/fileTypeIcons.tsx")]: {
+        getFileTypeIcon() {
+          return NullIcon;
+        },
+      },
+      [resolveSource("components/chat/FileChangeBadge.tsx")]: {
+        FileChangeBadge() {
+          return null;
+        },
+      },
+    },
+  });
+
+  return {
+    cardModule: loader.loadModule("src/components/chat/ChangedFilesCard.tsx"),
+    jsxRuntime,
+    renderToStaticMarkup,
+  };
+}
+
+function renderCard({ cardModule, jsxRuntime, renderToStaticMarkup }) {
+  const paths = [
+    { path: "src/components/ChangedFilesCard.tsx", deleted: false },
+    { path: "README.md", deleted: false },
+    { path: "src\\pages\\Settings.tsx", deleted: false },
+    { path: "tmp/removed.ts", deleted: true },
+  ];
+  const summary = {
+    files: paths.map((file, index) => ({
+      ...file,
+      added: index + 1,
+      removed: index,
+      lastToolCallId: `call-${index}`,
+    })),
+    totalAdded: 11,
+    totalRemoved: 8,
+  };
+
+  return renderToStaticMarkup(
+    jsxRuntime.jsx(cardModule.ChangedFilesCard, { summary }),
+  );
+}
+
+function assertVerticalPath(html, fileName, directory, fromIndex = 0) {
+  const fileNameIndex = html.indexOf(`>${fileName}</span>`, fromIndex);
+  const directoryIndex = html.indexOf(`>${directory}</span>`, fileNameIndex);
+  assert.notEqual(fileNameIndex, -1, `missing file name ${fileName}`);
+  assert.notEqual(directoryIndex, -1, `missing directory ${directory}`);
+  assert.ok(fileNameIndex < directoryIndex, `${fileName} must render above its directory`);
+  return directoryIndex;
+}
+
+test("WebUI changed-files rows render file names above directory paths", () => {
+  const html = renderCard(createCardModule());
+
+  let position = assertVerticalPath(html, "ChangedFilesCard.tsx", "src/components/");
+  position = assertVerticalPath(html, "README.md", ".", position);
+  assertVerticalPath(html, "Settings.tsx", "src/pages/", position);
+
+  assert.match(
+    html,
+    /class="[^"]*line-through[^"]*"[^>]*>removed\.ts<\/span><span[^>]*>tmp\/<\/span>/,
+  );
+  assert.ok(html.includes("max-h-[calc(200px*var(--zone-font-scale,1))]"));
+});

--- a/crates/agent-gateway/web/test/changed-files-card.test.mjs
+++ b/crates/agent-gateway/web/test/changed-files-card.test.mjs
@@ -31,6 +31,8 @@ function createCardModule() {
       },
       [resolveSource("components/icons.tsx")]: {
         FilePenLine: NullIcon,
+        FolderTree: NullIcon,
+        GitCommitHorizontal: NullIcon,
       },
       [resolveSource("components/chat/fileTypeIcons.tsx")]: {
         getFileTypeIcon() {
@@ -52,15 +54,20 @@ function createCardModule() {
   };
 }
 
-function renderCard({ cardModule, jsxRuntime, renderToStaticMarkup }) {
+function renderCard(
+  { cardModule, jsxRuntime, renderToStaticMarkup },
+  { withActions = false, fileCount = 4 } = {},
+) {
   const paths = [
     { path: "src/components/ChangedFilesCard.tsx", deleted: false },
     { path: "README.md", deleted: false },
     { path: "src\\pages\\Settings.tsx", deleted: false },
     { path: "tmp/removed.ts", deleted: true },
+    { path: "src/features/fifth.ts", deleted: false },
+    { path: "src/features/sixth.ts", deleted: false },
   ];
   const summary = {
-    files: paths.map((file, index) => ({
+    files: paths.slice(0, fileCount).map((file, index) => ({
       ...file,
       added: index + 1,
       removed: index,
@@ -70,8 +77,18 @@ function renderCard({ cardModule, jsxRuntime, renderToStaticMarkup }) {
     totalRemoved: 8,
   };
 
+  const card = jsxRuntime.jsx(cardModule.ChangedFilesCard, { summary });
+  if (!withActions) return renderToStaticMarkup(card);
+
   return renderToStaticMarkup(
-    jsxRuntime.jsx(cardModule.ChangedFilesCard, { summary }),
+    jsxRuntime.jsx(cardModule.ChangedFilesActionsProvider, {
+      value: {
+        onOpenFile() {},
+        onRevealInFileTree() {},
+        onOpenDiff() {},
+      },
+      children: card,
+    }),
   );
 }
 
@@ -95,5 +112,44 @@ test("WebUI changed-files rows render file names above directory paths", () => {
     html,
     /class="[^"]*line-through[^"]*"[^>]*>removed\.ts<\/span><span[^>]*>tmp\/<\/span>/,
   );
-  assert.ok(html.includes("max-h-[calc(200px*var(--zone-font-scale,1))]"));
+  for (const filePath of [
+    "src/components/ChangedFilesCard.tsx",
+    "README.md",
+    "src\\pages\\Settings.tsx",
+    "tmp/removed.ts",
+  ]) {
+    assert.ok(html.includes(`title="${filePath}"`), `missing full-path tooltip for ${filePath}`);
+  }
+  assert.doesNotMatch(html, /aria-label="chat\.changedFiles\.(?:open|reveal|diff):/);
+});
+
+test("WebUI changed-files scrolling starts with the sixth row", () => {
+  const modules = createCardModule();
+  const fiveFiles = renderCard(modules, { fileCount: 5 });
+  const sixFiles = renderCard(modules, { fileCount: 6 });
+
+  assert.ok(!fiveFiles.includes("max-h-[calc(210px*var(--zone-font-scale,1))]"));
+  assert.ok(!fiveFiles.includes("overscroll-contain"));
+  assert.ok(sixFiles.includes("max-h-[calc(210px*var(--zone-font-scale,1))]"));
+  assert.ok(sixFiles.includes("overflow-y-auto overscroll-contain"));
+});
+
+test("WebUI changed-files actions include the localized action and canonical path", () => {
+  const html = renderCard(createCardModule(), { withActions: true });
+  const nestedPath = "src/components/ChangedFilesCard.tsx";
+
+  for (const action of ["open", "reveal", "diff"]) {
+    const label = `chat.changedFiles.${action}: ${nestedPath}`;
+    assert.ok(html.includes(`aria-label="${label}"`), `missing accessible ${action} label`);
+    assert.ok(html.includes(`title="${label}"`), `missing ${action} tooltip`);
+  }
+
+  assert.ok(
+    html.includes('aria-label="chat.changedFiles.reveal: tmp/removed.ts"'),
+    "deleted files should retain their available row actions",
+  );
+  assert.ok(
+    !html.includes('aria-label="chat.changedFiles.open: tmp/removed.ts"'),
+    "deleted files must not expose the open-file action",
+  );
 });

--- a/crates/agent-gui/src/components/chat/ChangedFilesCard.tsx
+++ b/crates/agent-gui/src/components/chat/ChangedFilesCard.tsx
@@ -45,15 +45,17 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
   const FileTypeIcon = getFileTypeIcon(file.path, "file");
 
   const pathLabel = (
-    <span className="flex min-w-0 flex-1 items-baseline font-mono text-[calc(11.5px*var(--zone-font-scale,1))] leading-[1.6]">
-      {dir ? <span className="truncate text-muted-foreground/70">{dir}</span> : null}
+    <span className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 overflow-hidden font-mono">
       <span
         className={cn(
-          "shrink-0 text-foreground/90",
+          "min-w-0 max-w-full truncate text-[calc(11.5px*var(--zone-font-scale,1))] font-medium leading-tight text-foreground/90",
           file.deleted && "text-muted-foreground line-through",
         )}
       >
         {base}
+      </span>
+      <span className="min-w-0 max-w-full truncate text-[calc(10px*var(--zone-font-scale,1))] leading-tight text-muted-foreground/70">
+        {dir || "."}
       </span>
     </span>
   );
@@ -68,12 +70,12 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
           type="button"
           onClick={() => actions?.onOpenFile?.(file.path)}
           title={t("chat.changedFiles.open")}
-          className="flex min-w-0 flex-1 items-center text-left focus-visible:outline-none"
+          className="flex min-w-0 flex-1 items-stretch text-left focus-visible:outline-none"
         >
           {pathLabel}
         </button>
       ) : (
-        <span className="flex min-w-0 flex-1 items-center">{pathLabel}</span>
+        <span className="flex min-w-0 flex-1 items-stretch">{pathLabel}</span>
       )}
       {file.deleted ? (
         <span className="shrink-0 rounded-full bg-muted/70 px-1.5 py-0.5 text-[calc(10px*var(--zone-font-scale,1))] leading-none text-muted-foreground">
@@ -145,7 +147,7 @@ export const ChangedFilesCard = memo(function ChangedFilesCard({
         ) : null}
       </div>
       {/* 最多露出 5 行，更多文件走内部滚动条。 */}
-      <div className="flex max-h-[calc(150px*var(--zone-font-scale,1))] flex-col gap-0.5 overflow-y-auto overscroll-contain border-t border-border/35 px-1 py-1 dark:border-white/[0.05]">
+      <div className="flex max-h-[calc(200px*var(--zone-font-scale,1))] flex-col gap-0.5 overflow-y-auto overscroll-contain border-t border-border/35 px-1 py-1 dark:border-white/[0.05]">
         {summary.files.map((file) => (
           <ChangedFileRow key={file.lastToolCallId || file.path} file={file} />
         ))}

--- a/crates/agent-gui/src/components/chat/ChangedFilesCard.tsx
+++ b/crates/agent-gui/src/components/chat/ChangedFilesCard.tsx
@@ -36,6 +36,7 @@ function splitPath(path: string): { dir: string; base: string } {
 
 const ROW_ACTION_CLASS =
   "flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 opacity-0 transition-all hover:bg-foreground/[0.07] hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none group-hover/changed-file:opacity-100";
+const MAX_VISIBLE_FILES = 5;
 
 const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFileEntry }) {
   const { t } = useLocale();
@@ -43,9 +44,15 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
   const { dir, base } = splitPath(file.path);
   const canOpen = Boolean(actions?.onOpenFile) && !file.deleted;
   const FileTypeIcon = getFileTypeIcon(file.path, "file");
+  const openLabel = `${t("chat.changedFiles.open")}: ${file.path}`;
+  const revealLabel = `${t("chat.changedFiles.reveal")}: ${file.path}`;
+  const diffLabel = `${t("chat.changedFiles.diff")}: ${file.path}`;
 
   const pathLabel = (
-    <span className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 overflow-hidden font-mono">
+    <span
+      title={file.path}
+      className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 overflow-hidden font-mono"
+    >
       <span
         className={cn(
           "min-w-0 max-w-full truncate text-[calc(11.5px*var(--zone-font-scale,1))] font-medium leading-tight text-foreground/90",
@@ -69,7 +76,8 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
         <button
           type="button"
           onClick={() => actions?.onOpenFile?.(file.path)}
-          title={t("chat.changedFiles.open")}
+          title={openLabel}
+          aria-label={openLabel}
           className="flex min-w-0 flex-1 items-stretch text-left focus-visible:outline-none"
         >
           {pathLabel}
@@ -88,8 +96,8 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
         <button
           type="button"
           onClick={() => actions.onRevealInFileTree?.(file.path)}
-          title={t("chat.changedFiles.reveal")}
-          aria-label={t("chat.changedFiles.reveal")}
+          title={revealLabel}
+          aria-label={revealLabel}
           className={ROW_ACTION_CLASS}
         >
           <FolderTree className="h-3.5 w-3.5" />
@@ -99,8 +107,8 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
         <button
           type="button"
           onClick={() => actions.onOpenDiff?.(file.path)}
-          title={t("chat.changedFiles.diff")}
-          aria-label={t("chat.changedFiles.diff")}
+          title={diffLabel}
+          aria-label={diffLabel}
           className={ROW_ACTION_CLASS}
         >
           <GitCommitHorizontal className="h-3.5 w-3.5" />
@@ -147,7 +155,13 @@ export const ChangedFilesCard = memo(function ChangedFilesCard({
         ) : null}
       </div>
       {/* 最多露出 5 行，更多文件走内部滚动条。 */}
-      <div className="flex max-h-[calc(200px*var(--zone-font-scale,1))] flex-col gap-0.5 overflow-y-auto overscroll-contain border-t border-border/35 px-1 py-1 dark:border-white/[0.05]">
+      <div
+        className={cn(
+          "flex flex-col gap-0.5 border-t border-border/35 px-1 py-1 dark:border-white/[0.05]",
+          summary.files.length > MAX_VISIBLE_FILES &&
+            "max-h-[calc(210px*var(--zone-font-scale,1))] overflow-y-auto overscroll-contain",
+        )}
+      >
         {summary.files.map((file) => (
           <ChangedFileRow key={file.lastToolCallId || file.path} file={file} />
         ))}

--- a/crates/agent-gui/test/chat/changed-files-card.test.mjs
+++ b/crates/agent-gui/test/chat/changed-files-card.test.mjs
@@ -31,6 +31,8 @@ function createCardModule(rootDir) {
       },
       [resolveSource("components/icons.tsx")]: {
         FilePenLine: NullIcon,
+        FolderTree: NullIcon,
+        GitCommitHorizontal: NullIcon,
       },
       [resolveSource("components/chat/fileTypeIcons.tsx")]: {
         getFileTypeIcon() {
@@ -52,15 +54,20 @@ function createCardModule(rootDir) {
   };
 }
 
-function renderCard({ cardModule, jsxRuntime, renderToStaticMarkup }) {
+function renderCard(
+  { cardModule, jsxRuntime, renderToStaticMarkup },
+  { withActions = false, fileCount = 4 } = {},
+) {
   const paths = [
     { path: "src/components/ChangedFilesCard.tsx", deleted: false },
     { path: "README.md", deleted: false },
     { path: "src\\pages\\Settings.tsx", deleted: false },
     { path: "tmp/removed.ts", deleted: true },
+    { path: "src/features/fifth.ts", deleted: false },
+    { path: "src/features/sixth.ts", deleted: false },
   ];
   const summary = {
-    files: paths.map((file, index) => ({
+    files: paths.slice(0, fileCount).map((file, index) => ({
       ...file,
       added: index + 1,
       removed: index,
@@ -70,8 +77,18 @@ function renderCard({ cardModule, jsxRuntime, renderToStaticMarkup }) {
     totalRemoved: 8,
   };
 
+  const card = jsxRuntime.jsx(cardModule.ChangedFilesCard, { summary });
+  if (!withActions) return renderToStaticMarkup(card);
+
   return renderToStaticMarkup(
-    jsxRuntime.jsx(cardModule.ChangedFilesCard, { summary }),
+    jsxRuntime.jsx(cardModule.ChangedFilesActionsProvider, {
+      value: {
+        onOpenFile() {},
+        onRevealInFileTree() {},
+        onOpenDiff() {},
+      },
+      children: card,
+    }),
   );
 }
 
@@ -95,5 +112,44 @@ test("GUI changed-files rows render file names above directory paths", () => {
     html,
     /class="[^"]*line-through[^"]*"[^>]*>removed\.ts<\/span><span[^>]*>tmp\/<\/span>/,
   );
-  assert.ok(html.includes("max-h-[calc(200px*var(--zone-font-scale,1))]"));
+  for (const filePath of [
+    "src/components/ChangedFilesCard.tsx",
+    "README.md",
+    "src\\pages\\Settings.tsx",
+    "tmp/removed.ts",
+  ]) {
+    assert.ok(html.includes(`title="${filePath}"`), `missing full-path tooltip for ${filePath}`);
+  }
+  assert.doesNotMatch(html, /aria-label="chat\.changedFiles\.(?:open|reveal|diff):/);
+});
+
+test("GUI changed-files scrolling starts with the sixth row", () => {
+  const modules = createCardModule(rootDir);
+  const fiveFiles = renderCard(modules, { fileCount: 5 });
+  const sixFiles = renderCard(modules, { fileCount: 6 });
+
+  assert.ok(!fiveFiles.includes("max-h-[calc(210px*var(--zone-font-scale,1))]"));
+  assert.ok(!fiveFiles.includes("overscroll-contain"));
+  assert.ok(sixFiles.includes("max-h-[calc(210px*var(--zone-font-scale,1))]"));
+  assert.ok(sixFiles.includes("overflow-y-auto overscroll-contain"));
+});
+
+test("GUI changed-files actions include the localized action and canonical path", () => {
+  const html = renderCard(createCardModule(rootDir), { withActions: true });
+  const nestedPath = "src/components/ChangedFilesCard.tsx";
+
+  for (const action of ["open", "reveal", "diff"]) {
+    const label = `chat.changedFiles.${action}: ${nestedPath}`;
+    assert.ok(html.includes(`aria-label="${label}"`), `missing accessible ${action} label`);
+    assert.ok(html.includes(`title="${label}"`), `missing ${action} tooltip`);
+  }
+
+  assert.ok(
+    html.includes('aria-label="chat.changedFiles.reveal: tmp/removed.ts"'),
+    "deleted files should retain their available row actions",
+  );
+  assert.ok(
+    !html.includes('aria-label="chat.changedFiles.open: tmp/removed.ts"'),
+    "deleted files must not expose the open-file action",
+  );
 });

--- a/crates/agent-gui/test/chat/changed-files-card.test.mjs
+++ b/crates/agent-gui/test/chat/changed-files-card.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const rootDir = fileURLToPath(new URL("../..", import.meta.url));
+
+function NullIcon() {
+  return null;
+}
+
+function createCardModule(rootDir) {
+  const requireFromRoot = createRequire(path.join(rootDir, "package.json"));
+  const jsxRuntime = requireFromRoot("react/jsx-runtime");
+  const { renderToStaticMarkup } = requireFromRoot("react-dom/server");
+  const resolveSource = (relativePath) => path.join(rootDir, "src", relativePath);
+  const loader = createTsModuleLoader({
+    rootDir,
+    mocks: {
+      "react/jsx-runtime": jsxRuntime,
+      [resolveSource("i18n/index.ts")]: {
+        useLocale() {
+          return {
+            t(key) {
+              return key;
+            },
+          };
+        },
+      },
+      [resolveSource("components/icons.tsx")]: {
+        FilePenLine: NullIcon,
+      },
+      [resolveSource("components/chat/fileTypeIcons.tsx")]: {
+        getFileTypeIcon() {
+          return NullIcon;
+        },
+      },
+      [resolveSource("components/chat/FileChangeBadge.tsx")]: {
+        FileChangeBadge() {
+          return null;
+        },
+      },
+    },
+  });
+
+  return {
+    cardModule: loader.loadModule("src/components/chat/ChangedFilesCard.tsx"),
+    jsxRuntime,
+    renderToStaticMarkup,
+  };
+}
+
+function renderCard({ cardModule, jsxRuntime, renderToStaticMarkup }) {
+  const paths = [
+    { path: "src/components/ChangedFilesCard.tsx", deleted: false },
+    { path: "README.md", deleted: false },
+    { path: "src\\pages\\Settings.tsx", deleted: false },
+    { path: "tmp/removed.ts", deleted: true },
+  ];
+  const summary = {
+    files: paths.map((file, index) => ({
+      ...file,
+      added: index + 1,
+      removed: index,
+      lastToolCallId: `call-${index}`,
+    })),
+    totalAdded: 11,
+    totalRemoved: 8,
+  };
+
+  return renderToStaticMarkup(
+    jsxRuntime.jsx(cardModule.ChangedFilesCard, { summary }),
+  );
+}
+
+function assertVerticalPath(html, fileName, directory, fromIndex = 0) {
+  const fileNameIndex = html.indexOf(`>${fileName}</span>`, fromIndex);
+  const directoryIndex = html.indexOf(`>${directory}</span>`, fileNameIndex);
+  assert.notEqual(fileNameIndex, -1, `missing file name ${fileName}`);
+  assert.notEqual(directoryIndex, -1, `missing directory ${directory}`);
+  assert.ok(fileNameIndex < directoryIndex, `${fileName} must render above its directory`);
+  return directoryIndex;
+}
+
+test("GUI changed-files rows render file names above directory paths", () => {
+  const html = renderCard(createCardModule(rootDir));
+
+  let position = assertVerticalPath(html, "ChangedFilesCard.tsx", "src/components/");
+  position = assertVerticalPath(html, "README.md", ".", position);
+  assertVerticalPath(html, "Settings.tsx", "src/pages/", position);
+
+  assert.match(
+    html,
+    /class="[^"]*line-through[^"]*"[^>]*>removed\.ts<\/span><span[^>]*>tmp\/<\/span>/,
+  );
+  assert.ok(html.includes("max-h-[calc(200px*var(--zone-font-scale,1))]"));
+});


### PR DESCRIPTION
## Summary

- render each changed file name on a dedicated primary line with its directory path below
- show `.` for workspace-root files and retain the existing cross-platform path normalization
- expand the internal scroll viewport so roughly five two-line rows remain visible
- add package-local component regression coverage for nested, root, Windows-style, and deleted paths in both GUI and WebUI

## Why

The Edited Files card currently renders the directory and file name on one line. Deep paths compete with line-change statistics and row actions, while duplicate file names are harder to scan quickly.

The two-line hierarchy keeps the file name prominent and the directory available as secondary context without changing file tracking or row actions.

## Verification

- GUI typecheck and production Vite build
- GUI full frontend test suite
- GUI `pnpm lint` (exit 0; existing repository warnings only)
- GUI release tests: 9 passed
- WebUI typecheck and production Vite build
- WebUI test suite: 466 passed
- WebUI `pnpm lint` (exit 0; existing repository warnings only)
- package-local GUI/WebUI component render tests: 2 passed
- Playwright Chromium screenshots at 1280x800 and 360x800 in light and dark themes
- `node scripts/check-mirror.mjs`: 115 mirrored files passed
- `git diff --check`