### PR TITLE
fix(settings): avoid unsolicited local font permission prompt

### DIFF
--- a/crates/agent-gateway/test/webui/font-family.test.mjs
+++ b/crates/agent-gateway/test/webui/font-family.test.mjs
@@ -5,6 +5,24 @@ import { createWebModuleLoader } from "../helpers/load-web-module.mjs";
 const loader = createWebModuleLoader();
 const fontFamily = loader.loadModule("src/lib/shared/fontFamily.ts");
 
+async function withNavigator(value, task) {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    enumerable: true,
+    value,
+  });
+  try {
+    return await task();
+  } finally {
+    if (previous) {
+      Object.defineProperty(globalThis, "navigator", previous);
+    } else {
+      delete globalThis.navigator;
+    }
+  }
+}
+
 test("font family normalizer keeps freeform stacks and rejects unsafe values", () => {
   assert.equal(fontFamily.normalizeFontFamily(""), "");
   assert.equal(fontFamily.normalizeFontFamily("system"), "system");
@@ -125,7 +143,38 @@ test("applying font families updates CSS variables and only emits code changes",
   }
 });
 
-test("listLocalFontFamilies uses queryLocalFonts when available", async () => {
+test("listLocalFontFamilies does not trigger a local-fonts permission prompt", async () => {
+  const previous = globalThis.queryLocalFonts;
+  let queryCount = 0;
+  globalThis.queryLocalFonts = async () => {
+    queryCount += 1;
+    return [{ family: "Inter" }];
+  };
+  try {
+    await withNavigator(
+      {
+        permissions: {
+          query: async (descriptor) => {
+            assert.deepEqual(descriptor, { name: "local-fonts" });
+            return { state: "prompt" };
+          },
+        },
+      },
+      async () => {
+        assert.deepEqual(await fontFamily.listLocalFontFamilies(), []);
+      },
+    );
+    assert.equal(queryCount, 0);
+  } finally {
+    if (previous === undefined) {
+      delete globalThis.queryLocalFonts;
+    } else {
+      globalThis.queryLocalFonts = previous;
+    }
+  }
+});
+
+test("listLocalFontFamilies uses queryLocalFonts when permission is already granted", async () => {
   const previous = globalThis.queryLocalFonts;
   globalThis.queryLocalFonts = async () => [
     { family: "Inter" },
@@ -134,7 +183,16 @@ test("listLocalFontFamilies uses queryLocalFonts when available", async () => {
     { family: "  " },
   ];
   try {
-    assert.deepEqual(await fontFamily.listLocalFontFamilies(), ["Inter", "PingFang SC"]);
+    await withNavigator(
+      {
+        permissions: {
+          query: async () => ({ state: "granted" }),
+        },
+      },
+      async () => {
+        assert.deepEqual(await fontFamily.listLocalFontFamilies(), ["Inter", "PingFang SC"]);
+      },
+    );
   } finally {
     if (previous === undefined) {
       delete globalThis.queryLocalFonts;

--- a/crates/agent-gateway/web/src/lib/shared/fontFamily.ts
+++ b/crates/agent-gateway/web/src/lib/shared/fontFamily.ts
@@ -61,6 +61,26 @@ type LocalFontData = {
 
 type QueryLocalFonts = () => Promise<LocalFontData[]>;
 
+type LocalFontPermissions = {
+  query: (descriptor: { name: "local-fonts" }) => Promise<{ state?: string }>;
+};
+
+async function hasGrantedLocalFontPermission(): Promise<boolean> {
+  const permissions = (
+    globalThis as typeof globalThis & {
+      navigator?: { permissions?: LocalFontPermissions };
+    }
+  ).navigator?.permissions;
+  if (!permissions || typeof permissions.query !== "function") return false;
+
+  try {
+    const status = await permissions.query({ name: "local-fonts" });
+    return status.state === "granted";
+  } catch {
+    return false;
+  }
+}
+
 export function normalizeFontFamily(value: unknown): string {
   if (typeof value !== "string") return "";
   const trimmed = value.trim().replace(/\s+/g, " ");
@@ -186,6 +206,7 @@ export async function listLocalFontFamilies(): Promise<string[]> {
     }
   ).queryLocalFonts;
   if (typeof queryLocalFonts !== "function") return [];
+  if (!(await hasGrantedLocalFontPermission())) return [];
 
   try {
     const fonts = await queryLocalFonts();

--- a/crates/agent-gui/src/lib/shared/fontFamily.ts
+++ b/crates/agent-gui/src/lib/shared/fontFamily.ts
@@ -61,6 +61,26 @@ type LocalFontData = {
 
 type QueryLocalFonts = () => Promise<LocalFontData[]>;
 
+type LocalFontPermissions = {
+  query: (descriptor: { name: "local-fonts" }) => Promise<{ state?: string }>;
+};
+
+async function hasGrantedLocalFontPermission(): Promise<boolean> {
+  const permissions = (
+    globalThis as typeof globalThis & {
+      navigator?: { permissions?: LocalFontPermissions };
+    }
+  ).navigator?.permissions;
+  if (!permissions || typeof permissions.query !== "function") return false;
+
+  try {
+    const status = await permissions.query({ name: "local-fonts" });
+    return status.state === "granted";
+  } catch {
+    return false;
+  }
+}
+
 export function normalizeFontFamily(value: unknown): string {
   if (typeof value !== "string") return "";
   const trimmed = value.trim().replace(/\s+/g, " ");
@@ -186,6 +206,7 @@ export async function listLocalFontFamilies(): Promise<string[]> {
     }
   ).queryLocalFonts;
   if (typeof queryLocalFonts !== "function") return [];
+  if (!(await hasGrantedLocalFontPermission())) return [];
 
   try {
     const fonts = await queryLocalFonts();

--- a/crates/agent-gui/test/system/font-family.test.mjs
+++ b/crates/agent-gui/test/system/font-family.test.mjs
@@ -5,6 +5,24 @@ import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 const loader = createTsModuleLoader();
 const fontFamily = loader.loadModule("src/lib/shared/fontFamily.ts");
 
+async function withNavigator(value, task) {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    enumerable: true,
+    value,
+  });
+  try {
+    return await task();
+  } finally {
+    if (previous) {
+      Object.defineProperty(globalThis, "navigator", previous);
+    } else {
+      delete globalThis.navigator;
+    }
+  }
+}
+
 test("font family normalizer keeps freeform stacks and rejects unsafe values", () => {
   assert.equal(fontFamily.normalizeFontFamily(""), "");
   assert.equal(fontFamily.normalizeFontFamily("system"), "system");
@@ -125,7 +143,38 @@ test("applying font families updates CSS variables and only emits code changes",
   }
 });
 
-test("listLocalFontFamilies uses queryLocalFonts when available", async () => {
+test("listLocalFontFamilies does not trigger a local-fonts permission prompt", async () => {
+  const previous = globalThis.queryLocalFonts;
+  let queryCount = 0;
+  globalThis.queryLocalFonts = async () => {
+    queryCount += 1;
+    return [{ family: "Inter" }];
+  };
+  try {
+    await withNavigator(
+      {
+        permissions: {
+          query: async (descriptor) => {
+            assert.deepEqual(descriptor, { name: "local-fonts" });
+            return { state: "prompt" };
+          },
+        },
+      },
+      async () => {
+        assert.deepEqual(await fontFamily.listLocalFontFamilies(), []);
+      },
+    );
+    assert.equal(queryCount, 0);
+  } finally {
+    if (previous === undefined) {
+      delete globalThis.queryLocalFonts;
+    } else {
+      globalThis.queryLocalFonts = previous;
+    }
+  }
+});
+
+test("listLocalFontFamilies uses queryLocalFonts when permission is already granted", async () => {
   const previous = globalThis.queryLocalFonts;
   globalThis.queryLocalFonts = async () => [
     { family: "Inter" },
@@ -134,7 +183,16 @@ test("listLocalFontFamilies uses queryLocalFonts when available", async () => {
     { family: "  " },
   ];
   try {
-    assert.deepEqual(await fontFamily.listLocalFontFamilies(), ["Inter", "PingFang SC"]);
+    await withNavigator(
+      {
+        permissions: {
+          query: async () => ({ state: "granted" }),
+        },
+      },
+      async () => {
+        assert.deepEqual(await fontFamily.listLocalFontFamilies(), ["Inter", "PingFang SC"]);
+      },
+    );
   } finally {
     if (previous === undefined) {
       delete globalThis.queryLocalFonts;


### PR DESCRIPTION
## Summary

- avoid triggering the local-fonts permission prompt when settings first opens
- enumerate installed fonts only when local-font access is already granted
- keep the desktop GUI and gateway WebUI behavior mirrored
- add regression coverage for prompt and granted permission states

## Validation

- GUI focused font-family tests
- WebUI focused font-family tests
- GUI and WebUI TypeScript checks
- Biome checks for both shared font helpers
- mirror check for 115 mirrored files
- git diff check