### PR TITLE
fix: 启用 rquickjs 的 bindgen feature 以支持 aarch64 平台编译

### DIFF
--- a/crates/agent-gui/src-tauri/Cargo.toml
+++ b/crates/agent-gui/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ tauri-plugin-opener = "2.5.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 reqwest = { version = "0.13.4", features = ["blocking", "json", "stream", "socks"] }
-rquickjs = { version = "0.8", features = ["array-buffer", "classes"] }
+rquickjs = { version = "0.8", features = ["array-buffer", "classes", "bindgen"] }
 percent-encoding = "2.3.2"
 axum = "0.8.9"
 tokio = { version = "1.52.3", features = ["macros", "net", "sync", "time", "io-util"] }


### PR DESCRIPTION
Issue: #305

```bash
error: couldn't read `C:\Users\OseasyVM\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\rquickjs-sys-0.8.1\src\bindings/aarch64-pc-windows-msvc.rs`: 系统找不到指定的文件。 (os error 2)
  --> C:\Users\OseasyVM\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\rquickjs-sys-0.8.1\src\lib.rs:17:1
   |
17 | include!(concat!("bindings/", bindings_env!("TARGET"), ".rs"));
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: rquickjs-sys@0.8.1: rquickjs probably doesn't ship bindings for platform `aarch64-pc-windows-msvc(n/a)`. try the `bindgen` feature instead.
error: could not compile `rquickjs-sys` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

由于rquickjs没有开bindgen这个feature所以不适配aarch平台，加上之后就好了

aarch64-pc-windows-msvc平台编译通过。