### PR TITLE
fix: keep sidebar visible with workspace editor

### DIFF
--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -4959,34 +4959,34 @@ export default function GatewayApp() {
                   </section>
                 </div>
               )}
+              <WorkspaceOverlayHost
+                locale={settings.locale}
+                theme={effectiveTheme}
+                workspaceEditorMounted={workspaceEditorMounted}
+                workspaceEditorOpenRequest={workspaceEditorOpenRequest}
+                workspaceEditorCloseRequestId={workspaceEditorCloseRequestId}
+                workspaceEditorOpen={workspaceEditorOpen}
+                workspaceEditorCleanupPending={workspaceEditorCleanupPending}
+                onWorkspaceEditorPreviewFile={openWorkspaceFilePreview}
+                onWorkspaceEditorInsertCodeMention={handleInsertCodeMention}
+                onWorkspaceEditorHide={handleWorkspaceEditorHide}
+                onWorkspaceEditorClose={handleWorkspaceEditorClosed}
+                workspaceFilePreviewMounted={workspaceFilePreviewMounted}
+                workspaceFilePreviewOpenRequest={workspaceFilePreviewOpenRequest}
+                workspaceFilePreviewOpen={workspaceFilePreviewOpen}
+                onWorkspaceFilePreviewOpenEditor={openWorkspaceEditorFile}
+                onWorkspaceFilePreviewRequestClose={requestWorkspaceFilePreviewClose}
+                onWorkspaceFilePreviewClose={handleWorkspaceFilePreviewClosed}
+                workspaceSshTerminalMounted={workspaceSshTerminalMounted}
+                workspaceSshTerminalOpenRequest={workspaceSshTerminalOpenRequest}
+                workspaceSshTerminalOpen={workspaceSshTerminalOpen}
+                terminalProjectPathKey={terminalProjectPathKey}
+                terminalClient={terminalClient}
+                sftpClient={sftpClient}
+                terminalSessions={terminalSessions}
+                onWorkspaceSshTerminalHide={hideWorkspaceSshTerminalOverlay}
+              />
             </main>
-            <WorkspaceOverlayHost
-              locale={settings.locale}
-              theme={effectiveTheme}
-              workspaceEditorMounted={workspaceEditorMounted}
-              workspaceEditorOpenRequest={workspaceEditorOpenRequest}
-              workspaceEditorCloseRequestId={workspaceEditorCloseRequestId}
-              workspaceEditorOpen={workspaceEditorOpen}
-              workspaceEditorCleanupPending={workspaceEditorCleanupPending}
-              onWorkspaceEditorPreviewFile={openWorkspaceFilePreview}
-              onWorkspaceEditorInsertCodeMention={handleInsertCodeMention}
-              onWorkspaceEditorHide={handleWorkspaceEditorHide}
-              onWorkspaceEditorClose={handleWorkspaceEditorClosed}
-              workspaceFilePreviewMounted={workspaceFilePreviewMounted}
-              workspaceFilePreviewOpenRequest={workspaceFilePreviewOpenRequest}
-              workspaceFilePreviewOpen={workspaceFilePreviewOpen}
-              onWorkspaceFilePreviewOpenEditor={openWorkspaceEditorFile}
-              onWorkspaceFilePreviewRequestClose={requestWorkspaceFilePreviewClose}
-              onWorkspaceFilePreviewClose={handleWorkspaceFilePreviewClosed}
-              workspaceSshTerminalMounted={workspaceSshTerminalMounted}
-              workspaceSshTerminalOpenRequest={workspaceSshTerminalOpenRequest}
-              workspaceSshTerminalOpen={workspaceSshTerminalOpen}
-              terminalProjectPathKey={terminalProjectPathKey}
-              terminalClient={terminalClient}
-              sftpClient={sftpClient}
-              terminalSessions={terminalSessions}
-              onWorkspaceSshTerminalHide={hideWorkspaceSshTerminalOverlay}
-            />
           </div>
 
           {terminalClient ? (

--- a/crates/agent-gateway/web/src/app/WorkspaceOverlayHost.tsx
+++ b/crates/agent-gateway/web/src/app/WorkspaceOverlayHost.tsx
@@ -61,6 +61,11 @@ type WorkspaceOverlayHostProps = {
   onWorkspaceSshTerminalHide: () => void;
 };
 
+/**
+ * Lazy mount host for workspace overlays. Must live inside `.gateway-main-shell`
+ * (not the outer editor host) so absolute inset-0 only covers the main column
+ * and leaves the chat sidebar usable.
+ */
 export function WorkspaceOverlayHost(props: WorkspaceOverlayHostProps) {
   const {
     locale,

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -1947,14 +1947,14 @@ export function ChatPage(props: ChatPageProps) {
               ) : null}
             </>
           )}
+          <WorkspaceOverlayHost
+            overlays={workspaceOverlays}
+            theme={effectiveTheme}
+            terminalProjectPathKey={terminalProjectPathKey}
+            terminalSessions={terminalSessions}
+            onInsertCodeMention={handleInsertCodeMention}
+          />
         </div>
-        <WorkspaceOverlayHost
-          overlays={workspaceOverlays}
-          theme={effectiveTheme}
-          terminalProjectPathKey={terminalProjectPathKey}
-          terminalSessions={terminalSessions}
-          onInsertCodeMention={handleInsertCodeMention}
-        />
       </div>
       <RightDockPanel
         isOpen={activeView === "chat" && rightDockOpen}

--- a/crates/agent-gui/src/pages/chat/components/WorkspaceOverlayHost.tsx
+++ b/crates/agent-gui/src/pages/chat/components/WorkspaceOverlayHost.tsx
@@ -41,10 +41,10 @@ type WorkspaceOverlayHostProps = {
 };
 
 /**
- * Mount host for the three lazy full-window workspace overlays (code editor,
- * file preview, SSH terminal). Rendering state comes straight from
- * useWorkspaceOverlays; the lazy() definitions live here so ChatPage never
- * pays the Monaco import.
+ * Mount host for the three lazy main-column workspace overlays (code editor,
+ * file preview, SSH terminal). Sits inside the chat main column so the left
+ * sidebar stays visible. Rendering state comes from useWorkspaceOverlays; the
+ * lazy() definitions live here so ChatPage never pays the Monaco import.
  */
 export function WorkspaceOverlayHost(props: WorkspaceOverlayHostProps) {
   const { overlays, theme, terminalProjectPathKey, terminalSessions, onInsertCodeMention } = props;

--- a/crates/agent-gui/src/pages/chat/workspace/useWorkspaceOverlays.ts
+++ b/crates/agent-gui/src/pages/chat/workspace/useWorkspaceOverlays.ts
@@ -12,7 +12,7 @@ type UseWorkspaceOverlaysParams = {
 };
 
 /**
- * State machine for the three full-window workspace overlays (code editor,
+ * State machine for the three main-column workspace overlays (code editor,
  * file preview, SSH terminal): mount/open/request state, mutual exclusion on
  * open, and the cleanup pass when the right-dock file tree tab closes.
  */


### PR DESCRIPTION
## Summary
- mount workspace overlays inside the main content column in the desktop GUI
- mount workspace overlays inside the main shell in the WebUI
- retain the left conversation sidebar while code editor, file preview, or SSH terminal overlays are open

Fixes #304

## Verification
- `pnpm build` in `crates/agent-gui`
- `pnpm build` in `crates/agent-gateway/web`
- `pnpm lint` in both frontends (completed with existing repository warnings)