### PR TITLE
fix(chat): resume queued prompt after stopping

### DIFF
--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -4930,6 +4930,13 @@ export default function GatewayApp() {
                         })();
                       }}
                       onStop={() => {
+                        const nextQueuedTurn = queuedChatTurnsForDisplayedConversation[0];
+                        if (nextQueuedTurn) {
+                          // Keep WebUI's stop button aligned with the desktop
+                          // composer: stop the active run, then drain the queue.
+                          runQueuedTurnNow(nextQueuedTurn.id);
+                          return;
+                        }
                         void cancelChat(displayedConversationId);
                       }}
                       onPrepareChatRuntime={() => {

--- a/crates/agent-gui/src/pages/chat/queue/useChatTurnQueue.ts
+++ b/crates/agent-gui/src/pages/chat/queue/useChatTurnQueue.ts
@@ -353,6 +353,16 @@ export function useChatTurnQueue(params: UseChatTurnQueueParams) {
   function stopSending() {
     const conversationId = resolveStopConversationId();
     if (!conversationId) return;
+    const nextQueuedTurn = queuedChatTurnsRef.current.find(
+      (item) => item.conversationId === conversationId,
+    );
+    if (nextQueuedTurn) {
+      // Composer Stop is stop-and-continue when this conversation already
+      // has queued work; runQueuedTurnNow records the resume intent before
+      // aborting the current run.
+      runQueuedTurnNow(nextQueuedTurn.id);
+      return;
+    }
     stopConversation(conversationId);
   }
 

--- a/crates/agent-gui/test/chat/chat-stop-timing.test.mjs
+++ b/crates/agent-gui/test/chat/chat-stop-timing.test.mjs
@@ -172,7 +172,7 @@ test("a stop intent aborts a controller and handler registered later", () => {
   hookHarness.cleanup();
 });
 
-test("a stop during queued processing never auto-starts the next turn", async () => {
+test("a direct queue stop pauses processing until composer Stop resumes it", async () => {
   const hookHarness = createHookHarness();
   const sendGate = deferred();
   const sendCalls = [];
@@ -332,6 +332,12 @@ test("a stop during queued processing never auto-starts the next turn", async ()
 
   assert.equal(sendCalls.length, 1, "the second queued turn must remain paused after Stop");
   assert.equal(queue.queuedChatTurnsRef.current.length, 1);
+
+  queue.stopSending();
+  await flushPromises();
+
+  assert.equal(sendCalls.length, 2, "composer Stop must continue with the queued turn");
+  assert.equal(queue.queuedChatTurnsRef.current.length, 0);
   hookHarness.cleanup();
 });
 


### PR DESCRIPTION
## Summary
- resume the first queued prompt when stopping from the GUI composer
- keep WebUI stop behavior consistent with the desktop composer
- preserve ordinary queue-stop pause semantics and add regression coverage

## Validation
- targeted GUI stop timing tests pass
- WebUI chat queue tests pass
- GUI and WebUI TypeScript checks pass