### PR TITLE
fix(project-tools): prevent Git review action menu drift

### DIFF
--- a/crates/agent-gateway/web/src/components/project-tools/git-review/StatusView.tsx
+++ b/crates/agent-gateway/web/src/components/project-tools/git-review/StatusView.tsx
@@ -156,7 +156,11 @@ export function GitReviewStatusView(props: {
       8,
     );
     if (dx !== 0 || dy !== 0) {
-      setChangesMenu({ ...changesMenu, x: changesMenu.x + dx, y: changesMenu.y + dy });
+      setChangesMenu({
+        ...changesMenu,
+        right: changesMenu.right - dx,
+        y: changesMenu.y + dy,
+      });
     }
   }, [changesMenu, panelRef]);
 
@@ -293,10 +297,13 @@ export function GitReviewStatusView(props: {
       setChangeContextMenu(null);
       const panelRect = panelRef.current?.getBoundingClientRect();
       const buttonRect = event.currentTarget.getBoundingClientRect();
-      // Anchor at the button's bottom-right corner; the menu right-aligns via
-      // translateX(-100%) and the measured-clamp layout effect corrects it.
+      // Anchor at the button's bottom-right corner. A stable outer positioning
+      // layer keeps the inner menu's transform animation out of coordinate
+      // measurement and boundary correction.
       setChangesMenu({
-        x: panelRect ? buttonRect.right - panelRect.left : buttonRect.right,
+        right: panelRect
+          ? panelRect.right - buttonRect.right
+          : window.innerWidth - buttonRect.right,
         y: panelRect ? buttonRect.bottom - panelRect.top + 4 : buttonRect.bottom + 4,
         section,
       });
@@ -681,61 +688,66 @@ export function GitReviewStatusView(props: {
       {changesMenu ? (
         <div
           ref={changesMenuRef}
-          role="menu"
-          className={cn("absolute z-[75] min-w-56", CONTEXT_MENU_CONTAINER_CLASS)}
-          style={{ left: changesMenu.x, top: changesMenu.y, transform: "translateX(-100%)" }}
-          onClick={(event) => event.stopPropagation()}
-          onContextMenu={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-          }}
+          className="absolute z-[75] min-w-56"
+          style={{ right: changesMenu.right, top: changesMenu.y }}
         >
-          {changesMenu.section === "changes" ? (
-            <button
-              type="button"
-              role="menuitem"
-              className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
-              disabled={writeDisabled || busy !== "" || !hasStageableChanges}
-              onClick={stageAllChanges}
-            >
-              <FilePenLine className="h-3.5 w-3.5" />
-              <span>{t("projectTools.gitReview.stageAllChanges")}</span>
-            </button>
-          ) : (
-            <button
-              type="button"
-              role="menuitem"
-              className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
-              disabled={writeDisabled || busy !== "" || !hasStagedChanges}
-              onClick={unstageAllChanges}
-            >
-              <GitCommitHorizontal className="h-3.5 w-3.5" />
-              <span>{t("projectTools.gitReview.unstageAllChanges")}</span>
-            </button>
-          )}
-          <button
-            type="button"
-            role="menuitem"
-            className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
-            disabled={writeDisabled || busy !== "" || !hasDiscardableChanges}
-            onClick={discardAllChanges}
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            <span>{t("projectTools.gitReview.discardAllChanges")}</span>
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
-            disabled={loading}
-            onClick={() => {
-              setChangesMenu(null);
-              void refresh();
+          <div
+            role="menu"
+            className={cn("w-full", CONTEXT_MENU_CONTAINER_CLASS)}
+            style={{ transformOrigin: "top right" }}
+            onClick={(event) => event.stopPropagation()}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
             }}
           >
-            <RefreshCw className="h-3.5 w-3.5" />
-            <span>{t("projectTools.gitReview.refreshChanges")}</span>
-          </button>
+            {changesMenu.section === "changes" ? (
+              <button
+                type="button"
+                role="menuitem"
+                className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
+                disabled={writeDisabled || busy !== "" || !hasStageableChanges}
+                onClick={stageAllChanges}
+              >
+                <FilePenLine className="h-3.5 w-3.5" />
+                <span>{t("projectTools.gitReview.stageAllChanges")}</span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                role="menuitem"
+                className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
+                disabled={writeDisabled || busy !== "" || !hasStagedChanges}
+                onClick={unstageAllChanges}
+              >
+                <GitCommitHorizontal className="h-3.5 w-3.5" />
+                <span>{t("projectTools.gitReview.unstageAllChanges")}</span>
+              </button>
+            )}
+            <button
+              type="button"
+              role="menuitem"
+              className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
+              disabled={writeDisabled || busy !== "" || !hasDiscardableChanges}
+              onClick={discardAllChanges}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              <span>{t("projectTools.gitReview.discardAllChanges")}</span>
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
+              disabled={loading}
+              onClick={() => {
+                setChangesMenu(null);
+                void refresh();
+              }}
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              <span>{t("projectTools.gitReview.refreshChanges")}</span>
+            </button>
+          </div>
         </div>
       ) : null}
       {changeContextMenu && contextEntry ? (

--- a/crates/agent-gateway/web/src/components/project-tools/git-review/model.ts
+++ b/crates/agent-gateway/web/src/components/project-tools/git-review/model.ts
@@ -118,7 +118,7 @@ export type HistoryContextMenuState =
     };
 
 export type ChangesMenuState = {
-  x: number;
+  right: number;
   y: number;
   section: ChangeListSection;
 };

--- a/crates/agent-gui/src/components/project-tools/git-review/StatusView.tsx
+++ b/crates/agent-gui/src/components/project-tools/git-review/StatusView.tsx
@@ -156,7 +156,11 @@ export function GitReviewStatusView(props: {
       8,
     );
     if (dx !== 0 || dy !== 0) {
-      setChangesMenu({ ...changesMenu, x: changesMenu.x + dx, y: changesMenu.y + dy });
+      setChangesMenu({
+        ...changesMenu,
+        right: changesMenu.right - dx,
+        y: changesMenu.y + dy,
+      });
     }
   }, [changesMenu, panelRef]);
 
@@ -293,10 +297,13 @@ export function GitReviewStatusView(props: {
       setChangeContextMenu(null);
       const panelRect = panelRef.current?.getBoundingClientRect();
       const buttonRect = event.currentTarget.getBoundingClientRect();
-      // Anchor at the button's bottom-right corner; the menu right-aligns via
-      // translateX(-100%) and the measured-clamp layout effect corrects it.
+      // Anchor at the button's bottom-right corner. A stable outer positioning
+      // layer keeps the inner menu's transform animation out of coordinate
+      // measurement and boundary correction.
       setChangesMenu({
-        x: panelRect ? buttonRect.right - panelRect.left : buttonRect.right,
+        right: panelRect
+          ? panelRect.right - buttonRect.right
+          : window.innerWidth - buttonRect.right,
         y: panelRect ? buttonRect.bottom - panelRect.top + 4 : buttonRect.bottom + 4,
         section,
       });
@@ -681,61 +688,66 @@ export function GitReviewStatusView(props: {
       {changesMenu ? (
         <div
           ref={changesMenuRef}
-          role="menu"
-          className={cn("absolute z-[75] min-w-56", CONTEXT_MENU_CONTAINER_CLASS)}
-          style={{ left: changesMenu.x, top: changesMenu.y, transform: "translateX(-100%)" }}
-          onClick={(event) => event.stopPropagation()}
-          onContextMenu={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-          }}
+          className="absolute z-[75] min-w-56"
+          style={{ right: changesMenu.right, top: changesMenu.y }}
         >
-          {changesMenu.section === "changes" ? (
-            <button
-              type="button"
-              role="menuitem"
-              className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
-              disabled={writeDisabled || busy !== "" || !hasStageableChanges}
-              onClick={stageAllChanges}
-            >
-              <FilePenLine className="h-3.5 w-3.5" />
-              <span>{t("projectTools.gitReview.stageAllChanges")}</span>
-            </button>
-          ) : (
-            <button
-              type="button"
-              role="menuitem"
-              className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
-              disabled={writeDisabled || busy !== "" || !hasStagedChanges}
-              onClick={unstageAllChanges}
-            >
-              <GitCommitHorizontal className="h-3.5 w-3.5" />
-              <span>{t("projectTools.gitReview.unstageAllChanges")}</span>
-            </button>
-          )}
-          <button
-            type="button"
-            role="menuitem"
-            className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
-            disabled={writeDisabled || busy !== "" || !hasDiscardableChanges}
-            onClick={discardAllChanges}
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            <span>{t("projectTools.gitReview.discardAllChanges")}</span>
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
-            disabled={loading}
-            onClick={() => {
-              setChangesMenu(null);
-              void refresh();
+          <div
+            role="menu"
+            className={cn("w-full", CONTEXT_MENU_CONTAINER_CLASS)}
+            style={{ transformOrigin: "top right" }}
+            onClick={(event) => event.stopPropagation()}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
             }}
           >
-            <RefreshCw className="h-3.5 w-3.5" />
-            <span>{t("projectTools.gitReview.refreshChanges")}</span>
-          </button>
+            {changesMenu.section === "changes" ? (
+              <button
+                type="button"
+                role="menuitem"
+                className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
+                disabled={writeDisabled || busy !== "" || !hasStageableChanges}
+                onClick={stageAllChanges}
+              >
+                <FilePenLine className="h-3.5 w-3.5" />
+                <span>{t("projectTools.gitReview.stageAllChanges")}</span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                role="menuitem"
+                className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
+                disabled={writeDisabled || busy !== "" || !hasStagedChanges}
+                onClick={unstageAllChanges}
+              >
+                <GitCommitHorizontal className="h-3.5 w-3.5" />
+                <span>{t("projectTools.gitReview.unstageAllChanges")}</span>
+              </button>
+            )}
+            <button
+              type="button"
+              role="menuitem"
+              className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
+              disabled={writeDisabled || busy !== "" || !hasDiscardableChanges}
+              onClick={discardAllChanges}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              <span>{t("projectTools.gitReview.discardAllChanges")}</span>
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className={CHANGE_CONTEXT_MENU_ITEM_CLASS}
+              disabled={loading}
+              onClick={() => {
+                setChangesMenu(null);
+                void refresh();
+              }}
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              <span>{t("projectTools.gitReview.refreshChanges")}</span>
+            </button>
+          </div>
         </div>
       ) : null}
       {changeContextMenu && contextEntry ? (

--- a/crates/agent-gui/src/components/project-tools/git-review/model.ts
+++ b/crates/agent-gui/src/components/project-tools/git-review/model.ts
@@ -118,7 +118,7 @@ export type HistoryContextMenuState =
     };
 
 export type ChangesMenuState = {
-  x: number;
+  right: number;
   y: number;
   section: ChangeListSection;
 };

--- a/crates/agent-gui/test/settings/git-review-menu-position.test.mjs
+++ b/crates/agent-gui/test/settings/git-review-menu-position.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const sourceRoots = [
+  new URL("../../src/components/project-tools/git-review/", import.meta.url),
+  new URL("../../../agent-gateway/web/src/components/project-tools/git-review/", import.meta.url),
+];
+
+function source(root, relativePath) {
+  return readFileSync(new URL(relativePath, root), "utf8");
+}
+
+test("git review section menus isolate animation transforms from positioning", () => {
+  for (const root of sourceRoots) {
+    const model = source(root, "model.ts");
+    const statusView = source(root, "StatusView.tsx");
+
+    assert.match(model, /type ChangesMenuState = \{\s+right: number;/);
+    assert.match(statusView, /style=\{\{ right: changesMenu\.right, top: changesMenu\.y \}\}/);
+    assert.match(statusView, /style=\{\{ transformOrigin: "top right" \}\}/);
+    assert.doesNotMatch(statusView, /translateX\(-100%\)/);
+  }
+});


### PR DESCRIPTION
## Summary
- decouple Git review section-menu positioning from its scale animation
- anchor staged and working-change action menus to the trigger right edge with stable boundary correction
- add GUI and WebUI regression coverage that prevents transform-based positioning from returning

## Root cause
The menu used translateX for right alignment on the same element whose entry animation also controlled transform. During the animation, layout measurement observed the temporary scale-only transform and applied an incorrect clamp correction; when the animation ended, translateX returned and shifted the menu again.

## Validation
- node --test crates/agent-gui/test/settings/git-review-menu-position.test.mjs
- node scripts/check-mirror.mjs
- GUI: npm run build -- --logLevel error
- WebUI: npm run build -- --logLevel error
- git diff --check