### PR TITLE
fix(聊天): 修复提问工具启动竞态

### DIFF
--- a/crates/agent-gateway/web/src/components/chat/AskUserQuestionCard.tsx
+++ b/crates/agent-gateway/web/src/components/chat/AskUserQuestionCard.tsx
@@ -26,7 +26,8 @@ function formatCountdown(remainingMs: number) {
 /**
  * 倒计时提示：优先使用调用方传入的权威截止时间（GUI 读工具挂起表，WebUI 读
  * 网关参数上的 deadline 盖章），两端与桌面计时同源；缺失时（历史/降级数据）
- * 回退为挂载时刻近似。超时后 tool_result 会把卡片切到只读态。
+ * 回退为挂载时刻近似。倒计时归零立即禁止交互，随后 tool_result 把卡片
+ * 切到只读态。
  */
 function useAnswerCountdown(active: boolean, deadlineAt?: number) {
   const [fallbackDeadline] = useState(() => Date.now() + ASK_USER_QUESTION_TIMEOUT_MS);
@@ -98,8 +99,10 @@ export function AskUserQuestionCard({
 
   const isSettled = (answers?.length ?? 0) > 0;
   const selections = isSettled ? settledSelections : draftSelections;
-  const canInteract = interactive && !isSettled && !cancelled && !submitting;
-  const remainingMs = useAnswerCountdown(interactive && !isSettled && !cancelled, deadlineAt);
+  const countdownActive = interactive && !isSettled && !cancelled;
+  const remainingMs = useAnswerCountdown(countdownActive, deadlineAt);
+  const countdownExpired = countdownActive && remainingMs <= 0;
+  const canInteract = countdownActive && remainingMs > 0 && !submitting;
 
   // 该题是否已作答：普通选项已选，或“其他”选中且文本非空。
   const isQuestionAnswered = (questionId: string) => {
@@ -267,7 +270,9 @@ export function AskUserQuestionCard({
                     canInteract && !isSelected
                       ? "hover:border-border/70 hover:bg-foreground/[0.03] dark:hover:border-white/[0.14]"
                       : "",
-                    !canInteract && !isSelected && (isSettled || cancelled) ? "opacity-55" : "",
+                    !canInteract && !isSelected && (isSettled || cancelled || countdownExpired)
+                      ? "opacity-55"
+                      : "",
                     canInteract ? "cursor-pointer" : "cursor-default",
                   )}
                 >
@@ -323,7 +328,9 @@ export function AskUserQuestionCard({
                 canInteract && !activeCustomSelected
                   ? "hover:border-border/70 hover:bg-foreground/[0.03] dark:hover:border-white/[0.14]"
                   : "",
-                !canInteract && !activeCustomSelected && (isSettled || cancelled)
+                !canInteract &&
+                !activeCustomSelected &&
+                (isSettled || cancelled || countdownExpired)
                   ? "opacity-55"
                   : "",
                 canInteract ? "cursor-pointer" : "cursor-default",
@@ -403,7 +410,7 @@ export function AskUserQuestionCard({
             </span>
             <button
               type="button"
-              disabled={!allAnswered || submitting}
+              disabled={!allAnswered || !canInteract}
               onClick={() => void submit()}
               className="shrink-0 rounded-lg bg-primary px-3 py-1.5 text-[calc(11px*var(--zone-font-scale,1))] font-medium leading-none text-primary-foreground transition-opacity hover:opacity-90 disabled:pointer-events-none disabled:opacity-40"
             >

--- a/crates/agent-gateway/web/src/components/chat/AskUserQuestionCard.tsx
+++ b/crates/agent-gateway/web/src/components/chat/AskUserQuestionCard.tsx
@@ -28,10 +28,21 @@ function formatCountdown(remainingMs: number) {
  * 网关参数上的 deadline 盖章），两端与桌面计时同源；缺失时（历史/降级数据）
  * 回退为挂载时刻近似。倒计时归零立即禁止交互，随后 tool_result 把卡片
  * 切到只读态。
+ *
+ * 盖章用的是桌面时钟，而倒计时读本机时钟：远端浏览器时钟偏移足够大时，
+ * 一个仍在挂起的提问会在挂载瞬间就显示过期（或远超完整窗口）。因此仅当
+ * 截止时间落在“挂载时刻（不含）～挂载时刻 + 完整应答窗口（含）”内才采信，
+ * 否则视为时钟不可比、回退挂载近似，避免把可作答的卡片锁死；真正过期的
+ * 提交仍由桌面挂起表权威拒绝。
  */
 function useAnswerCountdown(active: boolean, deadlineAt?: number) {
-  const [fallbackDeadline] = useState(() => Date.now() + ASK_USER_QUESTION_TIMEOUT_MS);
-  const deadline = deadlineAt ?? fallbackDeadline;
+  const [mountedAt] = useState(() => Date.now());
+  const deadline =
+    deadlineAt !== undefined &&
+    deadlineAt > mountedAt &&
+    deadlineAt <= mountedAt + ASK_USER_QUESTION_TIMEOUT_MS
+      ? deadlineAt
+      : mountedAt + ASK_USER_QUESTION_TIMEOUT_MS;
   const [remainingMs, setRemainingMs] = useState(() => deadline - Date.now());
 
   useEffect(() => {

--- a/crates/agent-gateway/web/src/components/chat/AskUserQuestionCard.tsx
+++ b/crates/agent-gateway/web/src/components/chat/AskUserQuestionCard.tsx
@@ -329,8 +329,8 @@ export function AskUserQuestionCard({
                   ? "hover:border-border/70 hover:bg-foreground/[0.03] dark:hover:border-white/[0.14]"
                   : "",
                 !canInteract &&
-                !activeCustomSelected &&
-                (isSettled || cancelled || countdownExpired)
+                  !activeCustomSelected &&
+                  (isSettled || cancelled || countdownExpired)
                   ? "opacity-55"
                   : "",
                 canInteract ? "cursor-pointer" : "cursor-default",

--- a/crates/agent-gui/src/components/chat/AskUserQuestionCard.tsx
+++ b/crates/agent-gui/src/components/chat/AskUserQuestionCard.tsx
@@ -26,7 +26,8 @@ function formatCountdown(remainingMs: number) {
 /**
  * 倒计时提示：优先使用调用方传入的权威截止时间（GUI 读工具挂起表，WebUI 读
  * 网关参数上的 deadline 盖章），两端与桌面计时同源；缺失时（历史/降级数据）
- * 回退为挂载时刻近似。超时后 tool_result 会把卡片切到只读态。
+ * 回退为挂载时刻近似。倒计时归零立即禁止交互，随后 tool_result 把卡片
+ * 切到只读态。
  */
 function useAnswerCountdown(active: boolean, deadlineAt?: number) {
   const [fallbackDeadline] = useState(() => Date.now() + ASK_USER_QUESTION_TIMEOUT_MS);
@@ -98,8 +99,10 @@ export function AskUserQuestionCard({
 
   const isSettled = (answers?.length ?? 0) > 0;
   const selections = isSettled ? settledSelections : draftSelections;
-  const canInteract = interactive && !isSettled && !cancelled && !submitting;
-  const remainingMs = useAnswerCountdown(interactive && !isSettled && !cancelled, deadlineAt);
+  const countdownActive = interactive && !isSettled && !cancelled;
+  const remainingMs = useAnswerCountdown(countdownActive, deadlineAt);
+  const countdownExpired = countdownActive && remainingMs <= 0;
+  const canInteract = countdownActive && remainingMs > 0 && !submitting;
 
   // 该题是否已作答：普通选项已选，或“其他”选中且文本非空。
   const isQuestionAnswered = (questionId: string) => {
@@ -267,7 +270,9 @@ export function AskUserQuestionCard({
                     canInteract && !isSelected
                       ? "hover:border-border/70 hover:bg-foreground/[0.03] dark:hover:border-white/[0.14]"
                       : "",
-                    !canInteract && !isSelected && (isSettled || cancelled) ? "opacity-55" : "",
+                    !canInteract && !isSelected && (isSettled || cancelled || countdownExpired)
+                      ? "opacity-55"
+                      : "",
                     canInteract ? "cursor-pointer" : "cursor-default",
                   )}
                 >
@@ -323,7 +328,9 @@ export function AskUserQuestionCard({
                 canInteract && !activeCustomSelected
                   ? "hover:border-border/70 hover:bg-foreground/[0.03] dark:hover:border-white/[0.14]"
                   : "",
-                !canInteract && !activeCustomSelected && (isSettled || cancelled)
+                !canInteract &&
+                !activeCustomSelected &&
+                (isSettled || cancelled || countdownExpired)
                   ? "opacity-55"
                   : "",
                 canInteract ? "cursor-pointer" : "cursor-default",
@@ -403,7 +410,7 @@ export function AskUserQuestionCard({
             </span>
             <button
               type="button"
-              disabled={!allAnswered || submitting}
+              disabled={!allAnswered || !canInteract}
               onClick={() => void submit()}
               className="shrink-0 rounded-lg bg-primary px-3 py-1.5 text-[calc(11px*var(--zone-font-scale,1))] font-medium leading-none text-primary-foreground transition-opacity hover:opacity-90 disabled:pointer-events-none disabled:opacity-40"
             >

--- a/crates/agent-gui/src/components/chat/AskUserQuestionCard.tsx
+++ b/crates/agent-gui/src/components/chat/AskUserQuestionCard.tsx
@@ -28,10 +28,21 @@ function formatCountdown(remainingMs: number) {
  * 网关参数上的 deadline 盖章），两端与桌面计时同源；缺失时（历史/降级数据）
  * 回退为挂载时刻近似。倒计时归零立即禁止交互，随后 tool_result 把卡片
  * 切到只读态。
+ *
+ * 盖章用的是桌面时钟，而倒计时读本机时钟：远端浏览器时钟偏移足够大时，
+ * 一个仍在挂起的提问会在挂载瞬间就显示过期（或远超完整窗口）。因此仅当
+ * 截止时间落在“挂载时刻（不含）～挂载时刻 + 完整应答窗口（含）”内才采信，
+ * 否则视为时钟不可比、回退挂载近似，避免把可作答的卡片锁死；真正过期的
+ * 提交仍由桌面挂起表权威拒绝。
  */
 function useAnswerCountdown(active: boolean, deadlineAt?: number) {
-  const [fallbackDeadline] = useState(() => Date.now() + ASK_USER_QUESTION_TIMEOUT_MS);
-  const deadline = deadlineAt ?? fallbackDeadline;
+  const [mountedAt] = useState(() => Date.now());
+  const deadline =
+    deadlineAt !== undefined &&
+    deadlineAt > mountedAt &&
+    deadlineAt <= mountedAt + ASK_USER_QUESTION_TIMEOUT_MS
+      ? deadlineAt
+      : mountedAt + ASK_USER_QUESTION_TIMEOUT_MS;
   const [remainingMs, setRemainingMs] = useState(() => deadline - Date.now());
 
   useEffect(() => {

--- a/crates/agent-gui/src/components/chat/AskUserQuestionCard.tsx
+++ b/crates/agent-gui/src/components/chat/AskUserQuestionCard.tsx
@@ -329,8 +329,8 @@ export function AskUserQuestionCard({
                   ? "hover:border-border/70 hover:bg-foreground/[0.03] dark:hover:border-white/[0.14]"
                   : "",
                 !canInteract &&
-                !activeCustomSelected &&
-                (isSettled || cancelled || countdownExpired)
+                  !activeCustomSelected &&
+                  (isSettled || cancelled || countdownExpired)
                   ? "opacity-55"
                   : "",
                 canInteract ? "cursor-pointer" : "cursor-default",

--- a/crates/agent-gui/src/pages/chat/turns/runAgentConversationTurn.ts
+++ b/crates/agent-gui/src/pages/chat/turns/runAgentConversationTurn.ts
@@ -620,8 +620,9 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
 
   function queueToolCallDelta(toolCall: ToolCall, round: number) {
     if (!shouldShowToolEvent(toolCall)) return;
-    // 提问卡必须等问题与选项全部生成完毕再显示：跳过流式增量，双端
-    // （GUI 回合与网关 tool_call_delta）都只在 onToolCall 拿到完整参数后出现。
+    // 提问卡必须等问题与选项全部生成完毕且工具真正开始执行后再显示：
+    // 流式增量与 onToolCall 都只做内部记账，双端统一由
+    // onToolExecutionStart 发布可交互卡片。
     if (toolCall.name === ASK_USER_QUESTION_TOOL_NAME) return;
     pendingToolCallDeltas.set(toolCallDeltaKey(round, toolCall.id), { round, toolCall });
     schedulePendingToolCallDeltaFlush();
@@ -741,6 +742,10 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
         onToolCall: (toolCall, round) => {
           sawToolCallInRound = true;
           discardPendingToolCallDelta(toolCall, round);
+          // isRunning 只表示工具已出现在当前轮次，不代表提问已经进入权威
+          // pending 表。提问卡延迟到 onToolExecutionStart，避免用户在
+          // executeToolCall 建立 pending 前抢先提交。
+          if (toolCall.name === ASK_USER_QUESTION_TOOL_NAME) return;
           if (!shouldShowToolEvent(toolCall)) return;
           gatewayBridgeEvents.queueEvent({
             type: "tool_call",

--- a/crates/agent-gui/test/chat/agent-runner.test.mjs
+++ b/crates/agent-gui/test/chat/agent-runner.test.mjs
@@ -560,6 +560,106 @@ test("runAssistantWithTools calls onBeforeNextTurn only for toolUse turns with t
   );
 });
 
+test("runAssistantWithTools announces execution start before invoking the tool executor", async () => {
+  const askToolCall = createToolCall("call-ask-order", "AskUserQuestion", {
+    questions: [
+      {
+        id: "choice",
+        prompt: "Choose one",
+        options: [{ label: "First" }, { label: "Second" }],
+      },
+    ],
+  });
+  const askTool = {
+    name: "AskUserQuestion",
+    description: "Ask the user",
+    parameters: { type: "object", properties: {} },
+  };
+  const sequence = [];
+  resetFakeStreams(createToolUseAssistant(askToolCall), createTextAssistant("done"));
+  const { params } = createBaseParams({
+    context: {
+      systemPrompt: "Base system prompt",
+      messages: [{ role: "user", content: "Start", timestamp: 1 }],
+      tools: [askTool],
+    },
+    tools: [askTool],
+    onToolCall() {
+      sequence.push("tool_call");
+    },
+    onToolExecutionStart() {
+      sequence.push("execution_start");
+    },
+    async executeToolCall(toolCall) {
+      sequence.push("execute");
+      return createToolResult(toolCall);
+    },
+  });
+
+  await runAssistantWithTools(params);
+
+  const executionStartIndex = sequence.indexOf("execution_start");
+  const executeIndex = sequence.indexOf("execute");
+  assert.ok(sequence.includes("tool_call"));
+  assert.ok(executionStartIndex >= 0);
+  assert.ok(executeIndex > executionStartIndex);
+});
+
+test("AskUserQuestion is pending before the next user-event task after execution start", async () => {
+  const askTools = loader.loadModule("src/lib/tools/askUserQuestionTools.ts");
+  const bundle = askTools.createAskUserQuestionTools({
+    conversationId: "conversation-runner",
+    timeoutMs: 200,
+  });
+  const askTool = bundle.tools.find((tool) => tool.name === "AskUserQuestion");
+  assert.ok(askTool);
+  const askToolCall = createToolCall("call-ask-next-task", "AskUserQuestion", {
+    questions: [
+      {
+        id: "choice",
+        prompt: "Choose one",
+        options: [{ label: "First", recommended: true }, { label: "Second" }],
+      },
+    ],
+  });
+  resetFakeStreams(createToolUseAssistant(askToolCall), createTextAssistant("done"));
+
+  let resolveAnswerAttempt;
+  const answerAttempt = new Promise((resolve) => {
+    resolveAnswerAttempt = resolve;
+  });
+  const { params } = createBaseParams({
+    context: {
+      systemPrompt: "Base system prompt",
+      messages: [{ role: "user", content: "Start", timestamp: 1 }],
+      tools: [askTool],
+    },
+    tools: [askTool],
+    executeToolCall: bundle.executeToolCall,
+    onToolExecutionStart() {
+      // DOM clicks and Gateway deliveries cannot run inside this synchronous callback;
+      // the earliest real user event is the next task, after the runner has entered
+      // executeToolCall and synchronously populated pendingByToolCallId.
+      setImmediate(() => {
+        resolveAnswerAttempt(
+          askTools.answerAskUserQuestion("call-ask-next-task", [
+            { questionId: "choice", selectedLabel: "Second" },
+          ]),
+        );
+      });
+    },
+  });
+
+  const result = await runAssistantWithTools(params);
+  assert.deepEqual(await answerAttempt, { ok: true });
+  const toolResult = result.emittedMessages.find(
+    (message) => message.role === "toolResult" && message.toolCallId === askToolCall.id,
+  );
+  assert.ok(toolResult);
+  assert.equal(toolResult.details.answers[0].selectedLabel, "Second");
+  assert.equal("timedOut" in toolResult.details, false);
+});
+
 // Mocked turn tests (agent-turn-cancelled-history.test.mjs) replay this payload
 // shape by hand; the assertions here are what keep those replicas honest.
 test("runAssistantWithTools reports 1-based monotonic rounds and paired tool results to onBeforeNextTurn", async () => {

--- a/crates/agent-gui/test/chat/agent-turn-cancelled-history.test.mjs
+++ b/crates/agent-gui/test/chat/agent-turn-cancelled-history.test.mjs
@@ -79,6 +79,34 @@ const todoToolsPath = fileURLToPath(
   new URL("../../src/lib/tools/todoTools.ts", import.meta.url),
 );
 
+async function replayCancelledHistoryScenario(params) {
+  params.onTurnStart?.(1);
+  params.onToolCall?.(parentToolCall, 1);
+  params.onToolCall?.(cardToolCall, 1);
+  params.onToolResult?.(parentToolCall, parentToolResult, 1);
+  params.onToolResult?.(cardToolCall, cardToolResult, 1);
+  params.onAssistantMessage?.(toolUseAssistant, 1);
+  await params.onBeforeNextTurn?.({
+    round: 1,
+    assistant: toolUseAssistant,
+    toolResults: [parentToolResult, cardToolResult],
+    emittedMessages: [toolUseAssistant, parentToolResult, cardToolResult],
+    runtimeContext: params.context,
+    signal: params.signal,
+  });
+
+  params.onTurnStart?.(2);
+  params.onTextDelta?.("partial final", 2);
+  params.onAssistantMessage?.(abortedAssistant, 2);
+  return {
+    assistant: abortedAssistant,
+    messages: [toolUseAssistant, parentToolResult, cardToolResult, abortedAssistant],
+    emittedMessages: [toolUseAssistant, parentToolResult, cardToolResult, abortedAssistant],
+  };
+}
+
+let runAssistantWithToolsScenario = replayCancelledHistoryScenario;
+
 const loader = createTsModuleLoader({
   mocks: {
     [agentRunnerPath]: {
@@ -86,34 +114,7 @@ const loader = createTsModuleLoader({
       // (1-based rounds, results paired by toolCallId) is pinned against the
       // real runner in agent-runner.test.mjs.
       async runAssistantWithTools(params) {
-        params.onTurnStart?.(1);
-        params.onToolCall?.(parentToolCall, 1);
-        params.onToolCall?.(cardToolCall, 1);
-        params.onToolResult?.(parentToolCall, parentToolResult, 1);
-        params.onToolResult?.(cardToolCall, cardToolResult, 1);
-        params.onAssistantMessage?.(toolUseAssistant, 1);
-        await params.onBeforeNextTurn?.({
-          round: 1,
-          assistant: toolUseAssistant,
-          toolResults: [parentToolResult, cardToolResult],
-          emittedMessages: [toolUseAssistant, parentToolResult, cardToolResult],
-          runtimeContext: params.context,
-          signal: params.signal,
-        });
-
-        params.onTurnStart?.(2);
-        params.onTextDelta?.("partial final", 2);
-        params.onAssistantMessage?.(abortedAssistant, 2);
-        return {
-          assistant: abortedAssistant,
-          messages: [toolUseAssistant, parentToolResult, cardToolResult, abortedAssistant],
-          emittedMessages: [
-            toolUseAssistant,
-            parentToolResult,
-            cardToolResult,
-            abortedAssistant,
-          ],
-        };
+        return runAssistantWithToolsScenario(params);
       },
     },
     [builtinRegistryPath]: {
@@ -162,6 +163,7 @@ function createHookLifecycle() {
     startTurn: noOp,
     ensureMessageEnded: noOp,
     assistantMessageCompleted: noOp,
+    toolExecutionStarted: noOp,
     toolResultReceived: noOp,
   };
 }
@@ -258,4 +260,162 @@ test("agent turn preserves suppressed parent Agent trace for cancellation persis
   );
   assert.deepEqual(visibleToolCalls, [cardId]);
   assert.equal(visibleToolCalls.includes(parentId), false);
+});
+
+test("AskUserQuestion becomes visible only when execution starts while ordinary tools keep previews", async () => {
+  const askToolCall = {
+    type: "toolCall",
+    id: "call-ask-lifecycle",
+    name: "AskUserQuestion",
+    arguments: {
+      questions: [
+        {
+          id: "choice",
+          prompt: "Choose one",
+          options: [{ label: "First" }, { label: "Second", recommended: true }],
+        },
+      ],
+    },
+  };
+  const readToolCall = {
+    type: "toolCall",
+    id: "call-read-lifecycle",
+    name: "Read",
+    arguments: { path: "README.md" },
+  };
+  const finalAssistant = {
+    ...abortedAssistant,
+    content: [{ type: "text", text: "done" }],
+  };
+  const gatewayEvents = [];
+  let liveRounds = [];
+  let protectionChecks = 0;
+  let askDeadlineAt = null;
+  const state = conversationState.createConversationStateFromContext({
+    systemPrompt: "",
+    messages: [],
+  });
+  const askTools = loader.loadModule("src/lib/tools/askUserQuestionTools.ts");
+  const askShared = loader.loadModule("src/lib/chat/askUserQuestion.ts");
+
+  const visibleToolCalls = () =>
+    liveRounds.flatMap((round) =>
+      round.blocks
+        .filter((block) => block.kind === "tool")
+        .map((block) => block.item.toolCall),
+    );
+  const toolCallEvents = (name) =>
+    gatewayEvents.filter((event) => event.type === "tool_call" && event.name === name);
+
+  runAssistantWithToolsScenario = async (params) => {
+    params.onTurnStart?.(1);
+
+    params.onToolCall?.(askToolCall, 1);
+    assert.equal(toolCallEvents("AskUserQuestion").length, 0);
+    assert.equal(visibleToolCalls().some((call) => call.id === askToolCall.id), false);
+    assert.deepEqual(liveRounds[0].runningToolCallIds, []);
+    assert.equal(askTools.getAskUserQuestionDeadlineAt(askToolCall.id), null);
+
+    // onToolCall 的内部回合语义仍须生效：后续长文本不能重新触发 mid-stream 保护。
+    params.onTextDelta?.("x".repeat(200), 1);
+
+    params.onToolExecutionStart?.(askToolCall, 1);
+    const askEventsAfterStart = toolCallEvents("AskUserQuestion");
+    assert.equal(askEventsAfterStart.length, 1);
+    assert.equal(visibleToolCalls().filter((call) => call.id === askToolCall.id).length, 1);
+    assert.deepEqual(liveRounds[0].runningToolCallIds, [askToolCall.id]);
+    askDeadlineAt = askEventsAfterStart[0].arguments[askShared.ASK_USER_QUESTION_DEADLINE_ARG];
+    assert.ok(askDeadlineAt > Date.now());
+    assert.equal(askTools.getAskUserQuestionDeadlineAt(askToolCall.id), askDeadlineAt);
+
+    params.onToolCall?.(readToolCall, 1);
+    assert.equal(toolCallEvents("Read").length, 1);
+    assert.equal(visibleToolCalls().filter((call) => call.id === readToolCall.id).length, 1);
+    assert.deepEqual(liveRounds[0].runningToolCallIds, [askToolCall.id, readToolCall.id]);
+
+    params.onToolExecutionStart?.(readToolCall, 1);
+    assert.equal(toolCallEvents("Read").length, 2);
+    assert.equal(visibleToolCalls().filter((call) => call.id === readToolCall.id).length, 1);
+
+    params.onAssistantMessage?.(finalAssistant, 1);
+    return {
+      assistant: finalAssistant,
+      messages: [finalAssistant],
+      emittedMessages: [finalAssistant],
+    };
+  };
+
+  try {
+    await runAgentConversationTurn({
+      providerId: "codex",
+      model: "gpt-5",
+      runtime: {},
+      runtimeModel: {
+        provider: "codex",
+        api: "openai-responses",
+        id: "gpt-5",
+      },
+      selectedModel: { customProviderId: "codex", model: "gpt-5" },
+      effectiveWorkdir: "C:/workspace",
+      effectiveSkillsEnabled: false,
+      showSilentMemoryExtraction: false,
+      agentTemplates: [],
+      selectedSystemToolIds: [],
+      getMcpSettings: () => ({ servers: [], selected: [] }),
+      sessionId: "session-1",
+      conversationId: "conversation-lifecycle",
+      fallbackTitle: "title",
+      createdAt: 1,
+      titlePromise: null,
+      transcriptStore: {},
+      gatewayBridgeEvents: {
+        queueToken: noOp,
+        queueEvent(event) {
+          gatewayEvents.push(event);
+        },
+        queueToolStatus: noOp,
+      },
+      hookLifecycle: createHookLifecycle(),
+      conversationDebugLogger: { enabled: false, logResult: noOp },
+      getNextConversationState: () => state,
+      applyConversationState: noOp,
+      buildPreparedContext: () => ({ systemPrompt: "", messages: [] }),
+      compaction: {
+        async maybeCompactPreSend() {},
+        beginRequest: noOp,
+        shouldProtectMidStream() {
+          protectionChecks += 1;
+          return false;
+        },
+        async compactDuringRun() {
+          return { context: null, shouldDisableProtection: false };
+        },
+      },
+      cancellation: {
+        deriveScope() {
+          return { controller: new AbortController(), release: noOp };
+        },
+      },
+      resetLiveTranscript: noOp,
+      settleLiveTranscript: noOp,
+      batchLiveRoundsUpdate(updater) {
+        liveRounds = updater(liveRounds);
+      },
+      updateToolStatus: noOp,
+      updatePersistableAgentProgress: noOp,
+      commitVisibleAbortedConversation() {
+        return true;
+      },
+      updateConversationRuntimeEntry: noOp,
+      async persistConversationWithHistorySync() {
+        return true;
+      },
+    });
+  } finally {
+    runAssistantWithToolsScenario = replayCancelledHistoryScenario;
+  }
+
+  assert.equal(protectionChecks, 0);
+  assert.equal(toolCallEvents("AskUserQuestion").length, 1);
+  assert.equal(askTools.getAskUserQuestionDeadlineAt(askToolCall.id), askDeadlineAt);
 });

--- a/crates/agent-gui/test/chat/ask-user-question-card.test.mjs
+++ b/crates/agent-gui/test/chat/ask-user-question-card.test.mjs
@@ -8,6 +8,10 @@ const i18nPath = fileURLToPath(new URL("../../src/i18n/index.ts", import.meta.ur
 const iconsPath = fileURLToPath(new URL("../../src/components/icons/index.ts", import.meta.url));
 const utilsPath = fileURLToPath(new URL("../../src/lib/shared/utils.ts", import.meta.url));
 
+const { ASK_USER_QUESTION_TIMEOUT_MS } = createTsModuleLoader().loadModule(
+  "src/lib/chat/askUserQuestion.ts",
+);
+
 const questions = [
   {
     id: "choice",
@@ -30,6 +34,11 @@ function createHookHarness(initialState = {}) {
     [4, initialState.customTexts ?? {}],
     [5, initialState.submitting ?? false],
   ]);
+  // useAnswerCountdown 的 remainingMs（挂载后由 interval tick 驱动）；
+  // 测试用它模拟“采信的截止时间随后归零”。
+  if (initialState.remainingMs !== undefined) {
+    stateOverrides.set(8, initialState.remainingMs);
+  }
 
   const react = {
     useState(initialValue) {
@@ -146,9 +155,11 @@ test("expired countdown disables options, custom input, and submit before tool_r
   const card = createCardHarness({
     customSelected: { choice: true },
     customTexts: { choice: "My answer" },
+    // 采信的截止时间（挂载时仍在窗口内）随 interval tick 归零。
+    remainingMs: 0,
   });
   const tree = card.render({
-    deadlineAt: Date.now() - 1,
+    deadlineAt: Date.now() + 60_000,
     onSubmit: async () => {
       submitCalls += 1;
       return { ok: true };
@@ -189,6 +200,57 @@ test("expired countdown disables options, custom input, and submit before tool_r
   await flushPromises();
   assert.equal(card.hooks.setters.length, setterCountBeforeBlockedActions);
   assert.equal(submitCalls, 0);
+});
+
+// 截止时间由桌面时钟盖章、倒计时读本机时钟：偏移超界时必须回退挂载近似，
+// 不能把仍在挂起的提问卡一挂载就锁死（过期提交由桌面挂起表权威拒绝）。
+test("a deadline already past at mount is distrusted and the pending card stays answerable", async () => {
+  const submitted = [];
+  const card = createCardHarness({ draftSelections: { choice: "Second" } });
+  const tree = card.render({
+    // 本机时钟快于桌面盖章时钟：卡片挂载时截止时间看似早已过去。
+    deadlineAt: Date.now() - 5 * 60 * 1000,
+    onSubmit: async (answers) => {
+      submitted.push(answers);
+      return { ok: true };
+    },
+  });
+
+  const optionButtons = findAll(
+    tree,
+    (node) => node.type === "button" && node.props?.role === "radio",
+  );
+  assert.equal(optionButtons.length, 2);
+  assert.equal(optionButtons.every((button) => button.props.disabled === false), true);
+  const customOption = findAll(
+    tree,
+    (node) => node.type === "div" && node.props?.role === "radio",
+  )[0];
+  assert.equal(customOption.props["aria-disabled"], false);
+
+  const submitButton = findSubmitButton(tree);
+  assert.equal(submitButton.props.disabled, false);
+  submitButton.props.onClick();
+  await flushPromises();
+  assert.equal(submitted.length, 1);
+  assert.equal(submitted[0][0].selectedLabel, "Second");
+});
+
+test("a deadline beyond the full answer window is distrusted and clamps the countdown", () => {
+  const card = createCardHarness();
+  const tree = card.render({
+    // 本机时钟慢于桌面盖章时钟：截止时间看似远超完整应答窗口。
+    deadlineAt: Date.now() + ASK_USER_QUESTION_TIMEOUT_MS + 5 * 60 * 1000,
+    onSubmit: async () => ({ ok: true }),
+  });
+
+  const optionButtons = findAll(
+    tree,
+    (node) => node.type === "button" && node.props?.role === "radio",
+  );
+  assert.equal(optionButtons.every((button) => button.props.disabled === false), true);
+  // 倒计时按挂载近似显示完整窗口，而不是把偏移量当剩余时间。
+  assert.match(treeText(tree), /(?:3:00|2:59) chat\.askUser\.timeoutHint/);
 });
 
 test("a complete answer before the deadline submits the selected non-first option", async () => {

--- a/crates/agent-gui/test/chat/ask-user-question-card.test.mjs
+++ b/crates/agent-gui/test/chat/ask-user-question-card.test.mjs
@@ -1,0 +1,359 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const i18nPath = fileURLToPath(new URL("../../src/i18n/index.ts", import.meta.url));
+const iconsPath = fileURLToPath(new URL("../../src/components/icons/index.ts", import.meta.url));
+const utilsPath = fileURLToPath(new URL("../../src/lib/shared/utils.ts", import.meta.url));
+
+const questions = [
+  {
+    id: "choice",
+    header: "Choice",
+    prompt: "Choose one option",
+    options: [
+      { label: "First", description: "The first option" },
+      { label: "Second", description: "The second option", recommended: true },
+    ],
+  },
+];
+
+function createHookHarness(initialState = {}) {
+  const states = [];
+  const setters = [];
+  let stateIndex = 0;
+  const stateOverrides = new Map([
+    [2, initialState.draftSelections ?? {}],
+    [3, initialState.customSelected ?? {}],
+    [4, initialState.customTexts ?? {}],
+    [5, initialState.submitting ?? false],
+  ]);
+
+  const react = {
+    useState(initialValue) {
+      const index = stateIndex++;
+      if (!(index in states)) {
+        states[index] = stateOverrides.has(index)
+          ? stateOverrides.get(index)
+          : typeof initialValue === "function"
+            ? initialValue()
+            : initialValue;
+      }
+      const setState = (next) => {
+        setters.push(index);
+        states[index] = typeof next === "function" ? next(states[index]) : next;
+      };
+      return [states[index], setState];
+    },
+    useMemo(factory) {
+      return factory();
+    },
+    useEffect() {},
+  };
+
+  return {
+    react,
+    setters,
+    render(run) {
+      stateIndex = 0;
+      return run();
+    },
+  };
+}
+
+function createCardHarness(initialState = {}) {
+  const hooks = createHookHarness(initialState);
+  const loader = createTsModuleLoader({
+    mocks: {
+      react: hooks.react,
+      [i18nPath]: {
+        useLocale() {
+          return { t: (key) => key };
+        },
+      },
+      [iconsPath]: {
+        Check: (props) => ({ type: "Check", props }),
+        Sparkles: (props) => ({ type: "Sparkles", props }),
+      },
+      [utilsPath]: {
+        cn(...values) {
+          return values.filter(Boolean).join(" ");
+        },
+      },
+    },
+  });
+  const { AskUserQuestionCard } = loader.loadModule(
+    "src/components/chat/AskUserQuestionCard.tsx",
+  );
+  return {
+    hooks,
+    render(props) {
+      return hooks.render(() =>
+        AskUserQuestionCard({
+          questions,
+          interactive: true,
+          ...props,
+        }),
+      );
+    },
+  };
+}
+
+function findAll(node, predicate, matches = []) {
+  if (Array.isArray(node)) {
+    for (const child of node) findAll(child, predicate, matches);
+    return matches;
+  }
+  if (!node || typeof node !== "object") return matches;
+  if (predicate(node)) matches.push(node);
+  findAll(node.props?.children, predicate, matches);
+  return matches;
+}
+
+function findSubmitButton(tree) {
+  return findAll(
+    tree,
+    (node) =>
+      node.type === "button" &&
+      ["chat.askUser.submit", "chat.askUser.submitting"].includes(node.props?.children),
+  )[0];
+}
+
+function treeText(node) {
+  if (Array.isArray(node)) return node.map(treeText).join("");
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (!node || typeof node !== "object") return "";
+  return treeText(node.props?.children);
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+test("expired countdown disables options, custom input, and submit before tool_result arrives", async () => {
+  let submitCalls = 0;
+  const card = createCardHarness({
+    customSelected: { choice: true },
+    customTexts: { choice: "My answer" },
+  });
+  const tree = card.render({
+    deadlineAt: Date.now() - 1,
+    onSubmit: async () => {
+      submitCalls += 1;
+      return { ok: true };
+    },
+  });
+
+  const optionButtons = findAll(
+    tree,
+    (node) => node.type === "button" && node.props?.role === "radio",
+  );
+  assert.equal(optionButtons.length, 2);
+  assert.equal(optionButtons.every((button) => button.props.disabled === true), true);
+  assert.equal(optionButtons.every((button) => button.props.className.includes("opacity-55")), true);
+
+  const customOption = findAll(
+    tree,
+    (node) => node.type === "div" && node.props?.role === "radio",
+  )[0];
+  assert.equal(customOption.props["aria-disabled"], true);
+  assert.equal(customOption.props.tabIndex, -1);
+
+  const customInput = findAll(tree, (node) => node.type === "input")[0];
+  assert.ok(customInput);
+  assert.equal(customInput.props.disabled, true);
+
+  const submitButton = findSubmitButton(tree);
+  assert.ok(submitButton);
+  assert.equal(submitButton.props.disabled, true);
+  const setterCountBeforeBlockedActions = card.hooks.setters.length;
+  optionButtons[0].props.onClick();
+  customOption.props.onClick();
+  submitButton.props.onClick();
+  customInput.props.onKeyDown({
+    key: "Enter",
+    stopPropagation() {},
+    preventDefault() {},
+  });
+  await flushPromises();
+  assert.equal(card.hooks.setters.length, setterCountBeforeBlockedActions);
+  assert.equal(submitCalls, 0);
+});
+
+test("a complete answer before the deadline submits the selected non-first option", async () => {
+  const submitted = [];
+  const card = createCardHarness({ draftSelections: { choice: "Second" } });
+  const tree = card.render({
+    deadlineAt: Date.now() + 60_000,
+    onSubmit: async (answers) => {
+      submitted.push(answers);
+      return { ok: true };
+    },
+  });
+
+  const optionButtons = findAll(
+    tree,
+    (node) => node.type === "button" && node.props?.role === "radio",
+  );
+  assert.equal(optionButtons.every((button) => button.props.disabled === false), true);
+  const submitButton = findSubmitButton(tree);
+  assert.equal(submitButton.props.disabled, false);
+  submitButton.props.onClick();
+  await flushPromises();
+
+  assert.equal(submitted.length, 1);
+  assert.deepEqual(submitted[0], [
+    {
+      questionId: "choice",
+      prompt: "Choose one option",
+      selectedLabel: "Second",
+    },
+  ]);
+});
+
+test("multi-question selection auto-advances and preserves a mixed custom payload", async () => {
+  const multiQuestions = [
+    {
+      id: "q1",
+      header: "One",
+      prompt: "Question one",
+      options: [{ label: "A1" }, { label: "A2" }],
+    },
+    {
+      id: "q2",
+      header: "Two",
+      prompt: "Question two",
+      options: [{ label: "B1" }, { label: "B2" }],
+    },
+    {
+      id: "q3",
+      header: "Three",
+      prompt: "Question three",
+      options: [{ label: "C1" }, { label: "C2" }],
+    },
+  ];
+  const submitted = [];
+  const card = createCardHarness();
+  const props = {
+    questions: multiQuestions,
+    deadlineAt: Date.now() + 60_000,
+    onSubmit: async (answers) => {
+      submitted.push(answers);
+      return { ok: true };
+    },
+  };
+
+  let tree = card.render(props);
+  assert.equal(
+    findAll(
+      tree,
+      (node) =>
+        node.type === "button" && ["One", "Two", "Three"].includes(treeText(node)),
+    ).length,
+    3,
+  );
+  findAll(tree, (node) => node.type === "button" && node.props?.role === "radio")[1].props.onClick();
+
+  tree = card.render(props);
+  assert.match(treeText(tree), /Question two/);
+  findAll(tree, (node) => node.type === "button" && node.props?.role === "radio")[0].props.onClick();
+
+  tree = card.render(props);
+  assert.match(treeText(tree), /Question three/);
+  findAll(tree, (node) => node.type === "div" && node.props?.role === "radio")[0].props.onClick();
+
+  tree = card.render(props);
+  const customInput = findAll(tree, (node) => node.type === "input")[0];
+  assert.ok(customInput);
+  customInput.props.onChange({ currentTarget: { value: "Typed third answer" } });
+
+  tree = card.render(props);
+  const submitButton = findSubmitButton(tree);
+  assert.equal(submitButton.props.disabled, false);
+  submitButton.props.onClick();
+  await flushPromises();
+
+  assert.deepEqual(submitted, [
+    [
+      { questionId: "q1", prompt: "Question one", selectedLabel: "A2" },
+      { questionId: "q2", prompt: "Question two", selectedLabel: "B1" },
+      {
+        questionId: "q3",
+        prompt: "Question three",
+        selectedLabel: "Typed third answer",
+        custom: true,
+      },
+    ],
+  ]);
+});
+
+test("submitting state blocks a second click until the first request settles", async () => {
+  const gate = deferred();
+  let submitCalls = 0;
+  const card = createCardHarness({ draftSelections: { choice: "Second" } });
+  const props = {
+    deadlineAt: Date.now() + 60_000,
+    onSubmit: async () => {
+      submitCalls += 1;
+      await gate.promise;
+      return { ok: true };
+    },
+  };
+
+  findSubmitButton(card.render(props)).props.onClick();
+  await Promise.resolve();
+  const submittingButton = findSubmitButton(card.render(props));
+  assert.equal(submittingButton.props.disabled, true);
+  assert.equal(submittingButton.props.children, "chat.askUser.submitting");
+  submittingButton.props.onClick();
+  assert.equal(submitCalls, 1);
+
+  gate.resolve();
+  await flushPromises();
+  assert.equal(findSubmitButton(card.render(props)).props.disabled, false);
+});
+
+test("settled and cancelled cards remain read-only", () => {
+  const settledCard = createCardHarness();
+  const settled = settledCard.render({
+    deadlineAt: Date.now() + 60_000,
+    answers: [
+      {
+        questionId: "choice",
+        prompt: "Choose one option",
+        selectedLabel: "Second",
+      },
+    ],
+  });
+  assert.equal(
+    findAll(settled, (node) => node.type === "button" && node.props?.role === "radio").every(
+      (button) => button.props.disabled === true,
+    ),
+    true,
+  );
+  assert.equal(findSubmitButton(settled), undefined);
+
+  const cancelledCard = createCardHarness();
+  const cancelled = cancelledCard.render({
+    deadlineAt: Date.now() + 60_000,
+    cancelled: true,
+  });
+  assert.equal(
+    findAll(cancelled, (node) => node.type === "button" && node.props?.role === "radio").every(
+      (button) => button.props.disabled === true,
+    ),
+    true,
+  );
+  assert.equal(findSubmitButton(cancelled), undefined);
+});

--- a/crates/agent-gui/test/chat/chat-stop-timing.test.mjs
+++ b/crates/agent-gui/test/chat/chat-stop-timing.test.mjs
@@ -341,6 +341,176 @@ test("a direct queue stop pauses processing until composer Stop resumes it", asy
   hookHarness.cleanup();
 });
 
+test("gateway tool_answer forwards validated JSON with conversation isolation", async () => {
+  const hookHarness = createHookHarness();
+  const listeners = new Map();
+  const responses = [];
+  const answerCalls = [];
+  const loader = createTsModuleLoader({
+    mocks: {
+      react: hookHarness.react,
+      "@tauri-apps/api/core": {
+        async invoke(command, args) {
+          if (command === "gateway_chat_queue_respond") {
+            responses.push(args);
+          }
+          return undefined;
+        },
+      },
+      "@tauri-apps/api/event": {
+        async listen(eventName, callback) {
+          listeners.set(eventName, callback);
+          return () => listeners.delete(eventName);
+        },
+      },
+      "../../../lib/settings": {
+        isAgentExecutionMode() {
+          return false;
+        },
+        normalizeChatRuntimeControls(value) {
+          return value ?? {};
+        },
+        normalizeSystemToolSelection(value) {
+          return Array.isArray(value) ? value : [];
+        },
+      },
+      "../../../lib/tools/askUserQuestionTools": {
+        answerAskUserQuestion(toolCallId, answers, options) {
+          answerCalls.push({ toolCallId, answers, options });
+          if (options.conversationId !== "conversation-owner") {
+            return { ok: false, message: "Question belongs to a different conversation." };
+          }
+          return { ok: true };
+        },
+      },
+      "../composer/composerDraftText": {
+        createTextComposerDraft(text) {
+          return { text, isEmpty: !text.trim(), segments: [{ type: "text", text }] };
+        },
+      },
+      "../gateway/gatewayBridgeTypes": {
+        normalizeGatewayExecutionMode(value) {
+          return value;
+        },
+        normalizeGatewayWorkdir(value) {
+          return value;
+        },
+      },
+    },
+  });
+  const { useChatTurnQueue } = loader.loadModule(
+    "src/pages/chat/queue/useChatTurnQueue.ts",
+  );
+
+  hookHarness.render(() =>
+    useChatTurnQueue({
+      settings: {
+        system: { executionMode: "chat", workdir: "", selectedSystemTools: [] },
+        chatRuntimeControls: {},
+      },
+      currentConversationId: "conversation-owner",
+      currentConversationIdRef: { current: "conversation-owner" },
+      conversationRuntimeCacheRef: { current: new Map() },
+      buildRuntimeEntryFromVisibleState() {
+        return { workdir: "" };
+      },
+      isConversationRunning() {
+        return false;
+      },
+      runningConversationIds: new Set(),
+      getConversationAbortController() {
+        return null;
+      },
+      setConversationAbortController() {},
+      setConversationSendingState() {},
+      requestConversationStop() {
+        return false;
+      },
+      getConversationStopRequestVersion() {
+        return 0;
+      },
+      isConversationStopRequested() {
+        return false;
+      },
+      consumeConversationStop() {
+        return false;
+      },
+      requestActiveConversationStop() {
+        return false;
+      },
+      getConversationLiveTranscriptStore() {
+        return {};
+      },
+      captureAbortSnapshot() {},
+      updateToolStatus() {},
+      composerRef: { current: null },
+      pendingUploadedFiles: [],
+      setPendingUploadsForConversation() {},
+      clearCachedComposerDraft() {},
+      displayedConversationWorkdir: "",
+      sendActionRef: { current: async () => true },
+    }),
+  );
+
+  const listener = listeners.get("gateway:chat-queue-request");
+  assert.ok(listener);
+  const answers = [{ questionId: "choice", selectedLabel: "Second" }];
+
+  listener({
+    payload: {
+      requestId: "request-accepted",
+      action: "tool_answer",
+      conversationId: "conversation-owner",
+      itemId: "call-ask-remote",
+      requestJson: JSON.stringify(answers),
+    },
+  });
+  await flushPromises();
+  assert.deepEqual(answerCalls[0], {
+    toolCallId: "call-ask-remote",
+    answers,
+    options: { conversationId: "conversation-owner" },
+  });
+  assert.equal(
+    responses.find((response) => response.input.requestId === "request-accepted").input.accepted,
+    true,
+  );
+
+  listener({
+    payload: {
+      requestId: "request-mismatch",
+      action: "tool_answer",
+      conversationId: "conversation-other",
+      itemId: "call-ask-remote",
+      requestJson: JSON.stringify(answers),
+    },
+  });
+  await flushPromises();
+  const mismatch = responses.find((response) => response.input.requestId === "request-mismatch");
+  assert.equal(mismatch.input.accepted, false);
+  assert.equal(mismatch.input.errorCode, "not_found");
+  assert.match(mismatch.input.message, /different conversation/);
+
+  listener({
+    payload: {
+      requestId: "request-invalid-json",
+      action: "tool_answer",
+      conversationId: "conversation-owner",
+      itemId: "call-ask-remote",
+      requestJson: "{broken",
+    },
+  });
+  await flushPromises();
+  const invalid = responses.find(
+    (response) => response.input.requestId === "request-invalid-json",
+  );
+  assert.equal(invalid.input.accepted, false);
+  assert.equal(invalid.input.errorCode, "invalid_payload");
+  assert.equal(answerCalls.length, 2);
+
+  hookHarness.cleanup();
+});
+
 test("slow chat finalization cannot delay synchronous UI release", async () => {
   const loader = createTsModuleLoader();
   const { releaseChatRunUi, settleChatRunFinalization } = loader.loadModule(

--- a/crates/agent-gui/test/chat/gateway-runtime-snapshot.test.mjs
+++ b/crates/agent-gui/test/chat/gateway-runtime-snapshot.test.mjs
@@ -12,6 +12,8 @@ const { buildGatewayToolCallPreviewArguments } = loader.loadModule(
   "src/pages/chat/turns/gatewayToolPreview.ts",
 );
 const toolPreview = loader.loadModule("src/lib/chat/messages/toolPreview.ts");
+const askTools = loader.loadModule("src/lib/tools/askUserQuestionTools.ts");
+const askShared = loader.loadModule("src/lib/chat/askUserQuestion.ts");
 
 test("gateway runtime snapshot projects live rounds into chat entries", () => {
   const entries = buildGatewayRuntimeSnapshotEntries({
@@ -101,6 +103,66 @@ test("gateway runtime snapshot carries the same tool preview shape as bridge del
   const metadata = entry.toolCall.arguments[toolPreview.LIVE_TOOL_PREVIEW_META_KEY];
   assert.equal(metadata.progress, content.length);
   assert.equal(metadata.fields.content.chars, content.length);
+});
+
+test("gateway runtime snapshots preserve an AskUserQuestion deadline across reconnects", async () => {
+  const toolCall = {
+    type: "toolCall",
+    id: "tool-ask-snapshot",
+    name: "AskUserQuestion",
+    arguments: {
+      questions: [
+        {
+          id: "choice",
+          prompt: "Choose one",
+          options: [{ label: "First" }, { label: "Second" }],
+        },
+      ],
+    },
+  };
+  const liveTranscript = {
+    draftAssistantText: "",
+    toolStatus: null,
+    liveRounds: [
+      {
+        key: "round-1",
+        round: 1,
+        runningToolCallIds: [toolCall.id],
+        thinkingOpen: false,
+        blocks: [{ kind: "tool", item: { toolCall } }],
+      },
+    ],
+  };
+
+  const first = buildGatewayRuntimeSnapshotEntries({ userMessage: null, liveTranscript });
+  const firstToolCall = first.find((entry) => entry.kind === "tool_call");
+  assert.ok(firstToolCall);
+  const deadlineAt =
+    firstToolCall.toolCall.arguments[askShared.ASK_USER_QUESTION_DEADLINE_ARG];
+  assert.ok(deadlineAt > Date.now());
+
+  const reconnected = buildGatewayRuntimeSnapshotEntries({ userMessage: null, liveTranscript });
+  const reconnectedToolCalls = reconnected.filter((entry) => entry.kind === "tool_call");
+  assert.equal(reconnectedToolCalls.length, 1);
+  assert.equal(
+    reconnectedToolCalls[0].toolCall.arguments[askShared.ASK_USER_QUESTION_DEADLINE_ARG],
+    deadlineAt,
+  );
+  assert.equal(askTools.getAskUserQuestionDeadlineAt(toolCall.id), deadlineAt);
+
+  // Consume the preset through the real pending lifecycle and clean it up.
+  const bundle = askTools.createAskUserQuestionTools({ conversationId: "conv-snapshot" });
+  const resultPromise = bundle.executeToolCall(toolCall);
+  assert.equal(askTools.hasPendingAskUserQuestion(toolCall.id), true);
+  assert.equal(
+    askTools.answerAskUserQuestion(toolCall.id, [
+      { questionId: "choice", selectedLabel: "Second" },
+    ]).ok,
+    true,
+  );
+  const result = await resultPromise;
+  assert.equal(result.details.answers[0].selectedLabel, "Second");
+  assert.equal(askTools.getAskUserQuestionDeadlineAt(toolCall.id), null);
 });
 
 test("gateway runtime snapshot falls back to draft assistant text", () => {

--- a/crates/agent-gui/test/tools/ask-user-question-tools.test.mjs
+++ b/crates/agent-gui/test/tools/ask-user-question-tools.test.mjs
@@ -61,8 +61,19 @@ test("parseAskUserQuestionItems enforces limits, ids, and single recommendation"
       ),
     /at most 4 questions/,
   );
+  assert.throws(() => shared.parseAskUserQuestionItems(undefined), /non-empty/);
   assert.throws(
     () => shared.parseAskUserQuestionItems([{ prompt: "只有一个选项？", options: [{ label: "a" }] }]),
+    /needs 2-6 options/,
+  );
+  assert.throws(
+    () =>
+      shared.parseAskUserQuestionItems([
+        {
+          prompt: "选项过多？",
+          options: Array.from({ length: 7 }, (_, index) => ({ label: `o${index}` })),
+        },
+      ]),
     /needs 2-6 options/,
   );
   assert.throws(
@@ -178,9 +189,11 @@ test("execute suspends until the user answers, then returns the selections", asy
   ]);
   assert.equal(wrongLabel.ok, false);
 
+  // 乱序提交每题的非推荐、非第一项，结果仍按问题定义对齐；这也确保超时
+  // 默认答案不能掩盖用户真实选择。
   const accepted = tools.answerAskUserQuestion("call-ask-answer", [
-    { questionId: "storage", selectedLabel: "应用数据目录" },
-    { questionId: "q2", selectedLabel: "不迁移" },
+    { questionId: "q2", selectedLabel: "稍后再说" },
+    { questionId: "storage", selectedLabel: "工作区根目录" },
   ]);
   assert.equal(accepted.ok, true);
 
@@ -189,10 +202,11 @@ test("execute suspends until the user answers, then returns the selections", asy
   assert.equal(result.details.kind, "ask_user_question");
   assert.deepEqual(
     result.details.answers.map((answer) => answer.selectedLabel),
-    ["应用数据目录", "不迁移"],
+    ["工作区根目录", "稍后再说"],
   );
+  assert.equal("timedOut" in result.details, false);
   assert.match(result.content[0].text, /proceed accordingly/);
-  assert.match(result.content[0].text, /应用数据目录/);
+  assert.match(result.content[0].text, /工作区根目录/);
   assert.equal(tools.hasPendingAskUserQuestion("call-ask-answer"), false);
 
   // 已落定的提问不能再次应答。
@@ -223,6 +237,79 @@ test("timeout auto-selects the recommended options and continues", async () => {
   assert.equal(late.ok, false);
 });
 
+test("timeout falls back to the first option when no recommendation exists", async () => {
+  const { tools } = loadModules();
+  const bundle = tools.createAskUserQuestionTools({ conversationId: "conv-1", timeoutMs: 25 });
+  const result = await bundle.executeToolCall(
+    createToolCall(
+      {
+        questions: [
+          {
+            id: "plain",
+            prompt: "No recommendation",
+            options: [{ label: "First" }, { label: "Second" }],
+          },
+        ],
+      },
+      "call-ask-first-fallback",
+    ),
+  );
+
+  assert.equal(result.details.timedOut, true);
+  assert.deepEqual(
+    result.details.answers.map((answer) => answer.selectedLabel),
+    ["First"],
+  );
+  assert.equal(tools.hasPendingAskUserQuestion("call-ask-first-fallback"), false);
+});
+
+test("immediate answers are pending synchronously and never fall through to timeout defaults", async () => {
+  const { tools } = loadModules();
+  const bundle = tools.createAskUserQuestionTools({ conversationId: "conv-fast", timeoutMs: 100 });
+
+  for (let index = 0; index < 20; index += 1) {
+    const toolCallId = `call-ask-fast-${index}`;
+    const resultPromise = bundle.executeToolCall(createToolCall(buildQuestionsArgs(), toolCallId));
+    assert.equal(tools.hasPendingAskUserQuestion(toolCallId), true);
+
+    const accepted = tools.answerAskUserQuestion(toolCallId, [
+      { questionId: "storage", selectedLabel: "工作区根目录" },
+      { questionId: "q2", selectedLabel: "稍后再说" },
+    ]);
+    assert.deepEqual(accepted, { ok: true });
+
+    const result = await resultPromise;
+    assert.equal("timedOut" in result.details, false);
+    assert.deepEqual(
+      result.details.answers.map((answer) => answer.selectedLabel),
+      ["工作区根目录", "稍后再说"],
+    );
+  }
+});
+
+test("an answer accepted before the deadline is not overwritten when the old timeout passes", async () => {
+  const { tools } = loadModules();
+  const bundle = tools.createAskUserQuestionTools({ conversationId: "conv-1", timeoutMs: 35 });
+  const toolCallId = "call-ask-before-deadline";
+  const resultPromise = bundle.executeToolCall(createToolCall(buildQuestionsArgs(), toolCallId));
+
+  const accepted = tools.answerAskUserQuestion(toolCallId, [
+    { questionId: "storage", selectedLabel: "工作区根目录" },
+    { questionId: "q2", selectedLabel: "稍后再说" },
+  ]);
+  assert.equal(accepted.ok, true);
+  const result = await resultPromise;
+
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  assert.equal("timedOut" in result.details, false);
+  assert.deepEqual(
+    result.details.answers.map((answer) => answer.selectedLabel),
+    ["工作区根目录", "稍后再说"],
+  );
+  assert.equal(tools.hasPendingAskUserQuestion(toolCallId), false);
+  assert.equal(tools.answerAskUserQuestion(toolCallId, []).ok, false);
+});
+
 test("abort settles a pending question as cancelled", async () => {
   const { tools } = loadModules();
   const bundle = tools.createAskUserQuestionTools({ conversationId: "conv-1" });
@@ -239,6 +326,14 @@ test("abort settles a pending question as cancelled", async () => {
   assert.deepEqual(result.details.answers, []);
   assert.match(result.content[0].text, /stopped the turn/);
   assert.equal(tools.hasPendingAskUserQuestion("call-ask-abort"), false);
+  assert.equal(tools.getAskUserQuestionDeadlineAt("call-ask-abort"), null);
+  assert.equal(
+    tools.answerAskUserQuestion("call-ask-abort", [
+      { questionId: "storage", selectedLabel: "工作区根目录" },
+      { questionId: "q2", selectedLabel: "迁移" },
+    ]).ok,
+    false,
+  );
 });
 
 test("conversation disposal cancels its pending questions only", async () => {
@@ -267,6 +362,11 @@ test("conversation disposal cancels its pending questions only", async () => {
 test("invalid arguments fail fast with a validation error result", async () => {
   const { tools } = loadModules();
   const bundle = tools.createAskUserQuestionTools({ conversationId: "conv-1" });
+  const missing = await bundle.executeToolCall(createToolCall({}, "call-ask-missing"));
+  assert.equal(missing.isError, true);
+  assert.match(missing.content[0].text, /non-empty `questions` array/);
+  assert.equal(tools.hasPendingAskUserQuestion("call-ask-missing"), false);
+
   const result = await bundle.executeToolCall(
     createToolCall({ questions: [{ prompt: "选项不足", options: [{ label: "唯一" }] }] }),
   );


### PR DESCRIPTION
Depends-On: none
Stack-Root: #327

## 改动说明

- 将 AskUserQuestion 的可见发布时机延后到工具执行开始，确保用户看到卡片时挂起应答状态已经建立
- 倒计时归零后统一禁用普通选项、其他输入和提交，避免过期答案覆盖超时结果
- 保持桌面 GUI 与 Gateway WebUI 卡片逐字节镜像
- 补充生命周期、Gateway 重连、超时回退、取消、立即应答、多问题和防重复提交回归测试

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新

## 测试说明

- [x] 定向回归测试：75/75
- [x] GUI production build
- [x] Gateway WebUI production build
- [x] Gateway WebUI 全量测试：493/493
- [x] 本次文件定向 Biome 检查
- [x] Mirror Check：116 个镜像文件通过
- [x] `git diff --check`
- [x] Playwright 390px / 412px 响应式与过期交互验证
- [x] Tauri 调试客户端手动验证 AskUserQuestion 立即应答、多问题和自定义答案

## 已知基线问题

- GUI 全量前端测试为 1390/1395；5 项失败位于 mention 源码抽取和 provider preset 同步测试，与本 PR 文件无交集
- GUI/WebUI 全量 lint 被仓库现有 CRLF formatter 基线拦截；本次修改文件的定向检查通过，仅保留组件原有的 2 条 ARIA 建议

## 关联 Issue

无
