### PR TITLE
test(tauri): stabilize background stdio timing

### DIFF
--- a/crates/agent-gui/src-tauri/src/runtime/shell_runner.rs
+++ b/crates/agent-gui/src-tauri/src/runtime/shell_runner.rs
@@ -1018,7 +1018,7 @@ mod tests {
         let started = Instant::now();
         let result = run_shell_script(
             temp_dir.display().to_string(),
-            "sleep 5 & echo ready".to_string(),
+            "sleep 15 & background_pid=$!; echo ready:$background_pid".to_string(),
             None,
             Some(60_000),
             None,
@@ -1026,16 +1026,26 @@ mod tests {
             None,
         )
         .expect("shell run should return a response");
+        let elapsed = started.elapsed();
+        let background_pid = result
+            .stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("ready:"))
+            .expect("shell should report the background process id")
+            .trim();
+        let _ = std::process::Command::new("kill")
+            .arg(background_pid)
+            .status();
 
         let _ = fs::remove_dir_all(&temp_dir);
 
         assert_eq!(result.exit_code, 0);
         assert!(result.stdio_open_after_exit);
-        assert!(result.stdout.contains("ready"));
+        assert!(result.stdout.contains("ready:"));
         assert!(result.stderr.contains("stdout/stderr remained open"));
         assert!(
-            started.elapsed() < Duration::from_secs(3),
-            "background stdio leak should not block until the background process exits"
+            elapsed < Duration::from_secs(10),
+            "background stdio leak should not block until the background process exits; elapsed: {elapsed:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Stabilize the background stdio leak regression test under loaded Linux runners.
- Keep the background process alive for 15 seconds while allowing a 10-second detection window, so the test still proves the shell runner returns before the leaked stdio process exits.
- Capture and terminate the spawned background process after the assertion data is collected.

## Root cause

The latest `main` workflow run [30447875966](https://github.com/Stack-Cairn/LiveAgent/actions/runs/30447875966) failed only in `Tauri Rust Check`. The background stdio test returned correctly in about 4.06 seconds, but its fixed 3-second timing threshold was too strict for a loaded Linux runner.

## Validation

- Full local CI matrix passed: Gateway, Gateway WebUI, GUI, Tauri, Docker, proto generation/checks, GUI/WebUI mirror check, and diff hygiene.
- Focused macOS regression test passed 10/10 consecutive runs.
- Ubuntu 24.04 `shell_runner` test suite passed 11/11 tests.
- Workflow-equivalent five-step `Tauri Rust Check` validation passed.
- `git diff --check` passed.