### PR TITLE
feat(settings): 模型选择器中增加直接编辑供应商的入口

### DIFF
--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -301,6 +301,7 @@ export default function GatewayApp() {
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
   const [workspaceCreateModalOpen, setWorkspaceCreateModalOpen] = useState(false);
   const [settingsSection, setSettingsSection] = useState<SectionId>("system");
+  const [settingsProviderId, setSettingsProviderId] = useState<string>();
   const [overlay, setOverlay] = useState<OverlayState>("closed");
   const { settings, setSettings, settingsSyncReady, settingsSyncError, settingsSaveState } =
     useGatewaySettingsSync({ token, api, activeAgentId: activeAgentScope });
@@ -3590,11 +3591,12 @@ export default function GatewayApp() {
 
   const handleComposerBusyChange = useCallback((_isBusy: boolean) => {}, []);
 
-  function openSettings(section: SectionId = "system") {
+  function openSettings(section: SectionId = "system", providerId?: string) {
     if (isMobileSidebarLayout()) {
       setSidebarOpen(false);
     }
     setSettingsSection(section);
+    setSettingsProviderId(section === "providers" ? providerId : undefined);
     setSettingsOpen(true);
     setOverlay("entering");
     requestAnimationFrame(() => requestAnimationFrame(() => setOverlay("open")));
@@ -5128,6 +5130,7 @@ export default function GatewayApp() {
                 saveState={settingsSaveState}
                 onBack={closeSettings}
                 initialSection={settingsSection}
+                initialProviderId={settingsProviderId}
                 hiddenSections={["remote"]}
                 onAgentDirectoryChanged={async () => {
                   if (!api) return;

--- a/crates/agent-gateway/web/src/pages/SettingsPage.tsx
+++ b/crates/agent-gateway/web/src/pages/SettingsPage.tsx
@@ -130,11 +130,13 @@ export function SettingsPage(props: SettingsPageProps) {
     saveState,
     onBack,
     initialSection = "system",
+    initialProviderId,
     hiddenSections = [],
     onAgentDirectoryChanged,
   } = props;
   const { t } = useLocale();
   const [section, setSection] = useState<SectionId>(initialSection);
+  const [pendingProviderId, setPendingProviderId] = useState(initialProviderId);
 
   const sectionLabels: Record<SectionId, string> = {
     system: t("settings.navSystem"),
@@ -164,7 +166,8 @@ export function SettingsPage(props: SettingsPageProps) {
 
   useEffect(() => {
     setSection(initialSection);
-  }, [initialSection]);
+    setPendingProviderId(initialProviderId);
+  }, [initialProviderId, initialSection]);
 
   useEffect(() => {
     if (allNavItems.some((item) => item.id === section)) {
@@ -177,7 +180,14 @@ export function SettingsPage(props: SettingsPageProps) {
   const sectionContent = (() => {
     switch (section) {
       case "providers":
-        return <ProvidersSection settings={settings} setSettings={setSettings} />;
+        return (
+          <ProvidersSection
+            settings={settings}
+            setSettings={setSettings}
+            initialProviderId={pendingProviderId}
+            onInitialProviderHandled={() => setPendingProviderId(undefined)}
+          />
+        );
       case "system":
         return <SystemSettingsForm settings={settings} setSettings={setSettings} />;
       case "systemTools":

--- a/crates/agent-gateway/web/src/pages/chat/ChatHeader.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/ChatHeader.tsx
@@ -12,6 +12,7 @@ import {
   Moon,
   OpenaiChatgptIcon,
   PanelLeft,
+  Pencil,
   Search,
   Settings,
   Sun,
@@ -64,7 +65,7 @@ export const ChatHeader = memo(function ChatHeader(props: {
   // 模型下拉内嵌的执行模式分段器：请求切到 Chat("text") 或 Agent("tools")。
   // agent-dev 视为 Agent 的一种，由调用方决定是否保持不降级。
   onSelectExecutionMode: (mode: "text" | "tools") => void;
-  onOpenSettings: (section?: SectionId) => void;
+  onOpenSettings: (section?: SectionId, providerId?: string) => void;
   onToggleTheme: () => void;
   onOpenSidebar: () => void;
   preThemeActions?: ReactNode;
@@ -303,28 +304,42 @@ export const ChatHeader = memo(function ChatHeader(props: {
                       return (
                         <div key={group.id} className="flex flex-col gap-0.5">
                           {groupIndex > 0 ? <hr className="my-1 h-px border-0 bg-muted" /> : null}
-                          <button
-                            type="button"
-                            onClick={() => toggleGroup(group.id)}
-                            aria-expanded={expanded}
-                            title={expanded ? t("chat.collapseProvider") : t("chat.expandProvider")}
-                            className="model-selector-group-label sticky top-0 z-10 flex h-[30px] w-full shrink-0 cursor-pointer items-center gap-1.5 bg-popover/95 px-2 py-0 text-left text-xs font-medium text-muted-foreground backdrop-blur transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 supports-[backdrop-filter]:bg-popover/80 dark:text-white/80"
-                          >
-                            <ProviderBrandIcon
-                              type={group.providerType}
-                              className="h-3.5 w-3.5 opacity-90"
-                            />
-                            <span className="min-w-0 flex-1 truncate">{group.name}</span>
-                            <span className="inline-flex h-4 min-w-[1.1rem] shrink-0 items-center justify-center rounded-full bg-muted/70 px-1 text-[10px] tabular-nums">
-                              {group.opts.length}
-                            </span>
-                            <ChevronDown
-                              className={cn(
-                                "h-3.5 w-3.5 shrink-0 transition-transform duration-200",
-                                expanded && "rotate-180",
-                              )}
-                            />
-                          </button>
+                          <div className="sticky top-0 z-10 flex h-[30px] shrink-0 items-stretch bg-popover/95 backdrop-blur supports-[backdrop-filter]:bg-popover/80">
+                            <button
+                              type="button"
+                              onClick={() => toggleGroup(group.id)}
+                              aria-expanded={expanded}
+                              title={expanded ? t("chat.collapseProvider") : t("chat.expandProvider")}
+                              className="model-selector-group-label flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 px-2 py-0 text-left text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:text-white/80"
+                            >
+                              <ProviderBrandIcon
+                                type={group.providerType}
+                                className="h-3.5 w-3.5 opacity-90"
+                              />
+                              <span className="min-w-0 flex-1 truncate">{group.name}</span>
+                              <span className="inline-flex h-4 min-w-[1.1rem] shrink-0 items-center justify-center rounded-full bg-muted/70 px-1 text-[10px] tabular-nums">
+                                {group.opts.length}
+                              </span>
+                              <ChevronDown
+                                className={cn(
+                                  "h-3.5 w-3.5 shrink-0 transition-transform duration-200",
+                                  expanded && "rotate-180",
+                                )}
+                              />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setIsModelPickerOpen(false);
+                                onOpenSettings("providers", group.id);
+                              }}
+                              title={`${t("settings.editProvider")}: ${group.name}`}
+                              aria-label={`${t("settings.editProvider")}: ${group.name}`}
+                              className="flex w-7 shrink-0 cursor-pointer items-center justify-center text-muted-foreground/70 transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </button>
+                          </div>
                           {expanded
                             ? group.opts.map((option) => {
                                 const isSelected = option.value === selectedValue;

--- a/crates/agent-gateway/web/src/pages/chat/ChatHeader.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/ChatHeader.tsx
@@ -309,7 +309,9 @@ export const ChatHeader = memo(function ChatHeader(props: {
                               type="button"
                               onClick={() => toggleGroup(group.id)}
                               aria-expanded={expanded}
-                              title={expanded ? t("chat.collapseProvider") : t("chat.expandProvider")}
+                              title={
+                                expanded ? t("chat.collapseProvider") : t("chat.expandProvider")
+                              }
                               className="model-selector-group-label flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 px-2 py-0 text-left text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:text-white/80"
                             >
                               <ProviderBrandIcon

--- a/crates/agent-gateway/web/src/pages/chat/ChatHeader.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/ChatHeader.tsx
@@ -304,21 +304,39 @@ export const ChatHeader = memo(function ChatHeader(props: {
                       return (
                         <div key={group.id} className="flex flex-col gap-0.5">
                           {groupIndex > 0 ? <hr className="my-1 h-px border-0 bg-muted" /> : null}
-                          <div className="sticky top-0 z-10 flex h-[30px] shrink-0 items-stretch bg-popover/95 backdrop-blur supports-[backdrop-filter]:bg-popover/80">
+                          <div className="group sticky top-0 z-10 flex h-[30px] shrink-0 items-stretch bg-popover/95 backdrop-blur transition-colors hover:bg-muted/40 focus-within:bg-muted/40 supports-[backdrop-filter]:bg-popover/80">
                             <button
                               type="button"
                               onClick={() => toggleGroup(group.id)}
                               aria-expanded={expanded}
-                              title={
-                                expanded ? t("chat.collapseProvider") : t("chat.expandProvider")
-                              }
-                              className="model-selector-group-label flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 px-2 py-0 text-left text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:text-white/80"
+                              className="model-selector-group-label flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 px-2 py-0 text-left text-xs font-medium text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:text-white/80"
                             >
                               <ProviderBrandIcon
                                 type={group.providerType}
                                 className="h-3.5 w-3.5 opacity-90"
                               />
                               <span className="min-w-0 flex-1 truncate">{group.name}</span>
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setIsModelPickerOpen(false);
+                                onOpenSettings("providers", group.id);
+                              }}
+                              aria-label={`${t("settings.editProvider")}: ${group.name}`}
+                              className="pointer-events-none flex w-7 max-w-0 shrink-0 cursor-pointer items-center justify-center overflow-hidden text-muted-foreground/70 opacity-0 transition-[max-width,opacity,color,background-color] duration-150 group-hover:max-w-7 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:max-w-7 group-focus-within:pointer-events-auto group-focus-within:opacity-100 hover:bg-muted/60 hover:text-foreground focus-visible:max-w-7 focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => toggleGroup(group.id)}
+                              aria-expanded={expanded}
+                              aria-label={`${
+                                expanded ? t("chat.collapseProvider") : t("chat.expandProvider")
+                              }: ${group.name}`}
+                              className="model-selector-group-label flex shrink-0 cursor-pointer items-center gap-1.5 px-2 py-0 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:text-white/80"
+                            >
                               <span className="inline-flex h-4 min-w-[1.1rem] shrink-0 items-center justify-center rounded-full bg-muted/70 px-1 text-[10px] tabular-nums">
                                 {group.opts.length}
                               </span>
@@ -328,18 +346,6 @@ export const ChatHeader = memo(function ChatHeader(props: {
                                   expanded && "rotate-180",
                                 )}
                               />
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                setIsModelPickerOpen(false);
-                                onOpenSettings("providers", group.id);
-                              }}
-                              title={`${t("settings.editProvider")}: ${group.name}`}
-                              aria-label={`${t("settings.editProvider")}: ${group.name}`}
-                              className="flex w-7 shrink-0 cursor-pointer items-center justify-center text-muted-foreground/70 transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
-                            >
-                              <Pencil className="h-3.5 w-3.5" />
                             </button>
                           </div>
                           {expanded

--- a/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
@@ -3007,8 +3007,13 @@ function ProviderList(props: {
   );
 }
 
-export function ProvidersSection(props: SettingsSectionProps) {
-  const { settings, setSettings } = props;
+export function ProvidersSection(
+  props: SettingsSectionProps & {
+    initialProviderId?: string;
+    onInitialProviderHandled?: () => void;
+  },
+) {
+  const { settings, setSettings, initialProviderId, onInitialProviderHandled } = props;
   const { t } = useLocale();
 
   const [activeTab, setActiveTab] = useState<ProviderId>("claude_code");
@@ -3019,6 +3024,19 @@ export function ProvidersSection(props: SettingsSectionProps) {
   const { usageByProvider, refreshingProviderIds, refreshProvider } = useProviderUsage(
     settings.customProviders,
   );
+  const openedInitialProviderIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const providerId = initialProviderId?.trim();
+    if (!providerId || openedInitialProviderIdRef.current === providerId) return;
+    const provider = settings.customProviders.find((item) => item.id === providerId);
+    if (!provider) return;
+    openedInitialProviderIdRef.current = providerId;
+    setActiveTab(provider.type);
+    setEditingProvider(provider);
+    setModalOpen(true);
+    onInitialProviderHandled?.();
+  }, [initialProviderId, onInitialProviderHandled, settings.customProviders]);
 
   function openAdd() {
     setEditingProvider(null);

--- a/crates/agent-gateway/web/src/pages/settings/types.ts
+++ b/crates/agent-gateway/web/src/pages/settings/types.ts
@@ -21,6 +21,7 @@ export type SettingsPageProps = {
   saveState: WebSettingsSaveState;
   onBack: () => void;
   initialSection?: SectionId;
+  initialProviderId?: string;
   hiddenSections?: SectionId[];
   onAgentDirectoryChanged?: () => void | Promise<void>;
 };

--- a/crates/agent-gui/src/App.tsx
+++ b/crates/agent-gui/src/App.tsx
@@ -169,6 +169,7 @@ function applyRuntimeSystemDefaults(settings: AppSettings, defaultWorkdir: strin
 export default function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSection, setSettingsSection] = useState<SectionId>("system");
+  const [settingsProviderId, setSettingsProviderId] = useState<string>();
   const [settingsReady, setSettingsReady] = useState(false);
   const [settings, setSettingsState] = useState<AppSettings>(() => getDefaultSettings());
   const [settingsSaveState, setSettingsSaveState] = useState<SettingsSaveState>({
@@ -404,8 +405,9 @@ export default function App() {
   );
 
   const openSettings = useCallback(
-    (section: SectionId = "system") => {
+    (section: SectionId = "system", providerId?: string) => {
       setSettingsSection(section);
+      setSettingsProviderId(section === "providers" ? providerId : undefined);
       setSettingsOpen(true);
       setOverlay("entering");
       requestAnimationFrame(() => requestAnimationFrame(() => setOverlay("open")));
@@ -615,6 +617,7 @@ export default function App() {
                 saveState={settingsSaveState}
                 onBack={closeSettings}
                 initialSection={settingsSection}
+                initialProviderId={settingsProviderId}
                 appUpdate={appUpdate}
               />
             </AppErrorBoundary>

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -150,7 +150,7 @@ type ChatPageProps = {
   getMcpSettings: () => AppSettings["mcp"];
   context: Context;
   setContext: (next: Context) => void;
-  onOpenSettings: (section?: SectionId) => void;
+  onOpenSettings: (section?: SectionId, providerId?: string) => void;
   onToggleTheme: () => void;
   appUpdate?: AppUpdateController;
 };

--- a/crates/agent-gui/src/pages/SettingsPage.tsx
+++ b/crates/agent-gui/src/pages/SettingsPage.tsx
@@ -137,11 +137,13 @@ export function SettingsPage(props: SettingsPageProps) {
     saveState,
     onBack,
     initialSection = "system",
+    initialProviderId,
     hiddenSections = [],
     appUpdate,
   } = props;
   const { t } = useLocale();
   const [section, setSection] = useState<SectionId>(initialSection);
+  const [pendingProviderId, setPendingProviderId] = useState(initialProviderId);
 
   const sectionLabels: Record<SectionId, string> = {
     system: t("settings.navSystem"),
@@ -172,7 +174,8 @@ export function SettingsPage(props: SettingsPageProps) {
 
   useEffect(() => {
     setSection(initialSection);
-  }, [initialSection]);
+    setPendingProviderId(initialProviderId);
+  }, [initialProviderId, initialSection]);
 
   useEffect(() => {
     if (allNavItems.some((item) => item.id === section)) {
@@ -185,7 +188,14 @@ export function SettingsPage(props: SettingsPageProps) {
   const sectionContent = (() => {
     switch (section) {
       case "providers":
-        return <ProvidersSection settings={settings} setSettings={setSettings} />;
+        return (
+          <ProvidersSection
+            settings={settings}
+            setSettings={setSettings}
+            initialProviderId={pendingProviderId}
+            onInitialProviderHandled={() => setPendingProviderId(undefined)}
+          />
+        );
       case "system":
         return <SystemSettingsForm settings={settings} setSettings={setSettings} />;
       case "shortcuts":

--- a/crates/agent-gui/src/pages/chat/components/ChatHeader.tsx
+++ b/crates/agent-gui/src/pages/chat/components/ChatHeader.tsx
@@ -12,6 +12,7 @@ import {
   Moon,
   OpenaiChatgptIcon,
   PanelLeft,
+  Pencil,
   Search,
   Settings,
   Sun,
@@ -65,7 +66,7 @@ export const ChatHeader = memo(function ChatHeader(props: {
   // 模型下拉内嵌的执行模式分段器：请求切到 Chat("text") 或 Agent("tools")。
   // agent-dev 视为 Agent 的一种，由调用方决定是否保持不降级。
   onSelectExecutionMode: (mode: "text" | "tools") => void;
-  onOpenSettings: (section?: SectionId) => void;
+  onOpenSettings: (section?: SectionId, providerId?: string) => void;
   onToggleTheme: () => void;
   onOpenSidebar: () => void;
   preThemeActions?: ReactNode;
@@ -312,30 +313,44 @@ export const ChatHeader = memo(function ChatHeader(props: {
                           {groupIndex > 0 ? (
                             <hr className="my-1 h-px border-0 bg-border/30" />
                           ) : null}
-                          <button
-                            type="button"
-                            onClick={() => toggleGroup(group.id)}
-                            aria-expanded={expanded}
-                            title={expanded ? t("chat.collapseProvider") : t("chat.expandProvider")}
-                            className="model-selector-group-label sticky top-0 z-10 flex h-[30px] w-full shrink-0 cursor-pointer items-center gap-1.5 rounded-md bg-popover/60 px-2 py-0 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground/80 backdrop-blur-xl transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 supports-[backdrop-filter]:bg-popover/40 dark:text-white/80"
-                          >
-                            <ProviderBrandIcon
-                              type={group.providerType}
-                              className="h-3.5 w-3.5 opacity-90"
-                            />
-                            <span className="min-w-0 flex-1 truncate normal-case tracking-normal">
-                              {group.name}
-                            </span>
-                            <span className="inline-flex h-4 min-w-[1.1rem] shrink-0 items-center justify-center rounded-full bg-muted/70 px-1 text-[calc(10px*var(--zone-font-scale,1))] tabular-nums tracking-normal">
-                              {group.opts.length}
-                            </span>
-                            <ChevronDown
-                              className={cn(
-                                "h-3.5 w-3.5 shrink-0 transition-transform duration-200",
-                                expanded && "rotate-180",
-                              )}
-                            />
-                          </button>
+                          <div className="sticky top-0 z-10 flex h-[30px] shrink-0 items-stretch rounded-md bg-popover/60 backdrop-blur-xl supports-[backdrop-filter]:bg-popover/40">
+                            <button
+                              type="button"
+                              onClick={() => toggleGroup(group.id)}
+                              aria-expanded={expanded}
+                              title={expanded ? t("chat.collapseProvider") : t("chat.expandProvider")}
+                              className="model-selector-group-label flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-l-md px-2 py-0 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground/80 transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:text-white/80"
+                            >
+                              <ProviderBrandIcon
+                                type={group.providerType}
+                                className="h-3.5 w-3.5 opacity-90"
+                              />
+                              <span className="min-w-0 flex-1 truncate normal-case tracking-normal">
+                                {group.name}
+                              </span>
+                              <span className="inline-flex h-4 min-w-[1.1rem] shrink-0 items-center justify-center rounded-full bg-muted/70 px-1 text-[calc(10px*var(--zone-font-scale,1))] tabular-nums tracking-normal">
+                                {group.opts.length}
+                              </span>
+                              <ChevronDown
+                                className={cn(
+                                  "h-3.5 w-3.5 shrink-0 transition-transform duration-200",
+                                  expanded && "rotate-180",
+                                )}
+                              />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setIsModelPickerOpen(false);
+                                onOpenSettings("providers", group.id);
+                              }}
+                              title={`${t("settings.editProvider")}: ${group.name}`}
+                              aria-label={`${t("settings.editProvider")}: ${group.name}`}
+                              className="flex w-7 shrink-0 cursor-pointer items-center justify-center rounded-r-md text-muted-foreground/70 transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </button>
+                          </div>
                           {expanded
                             ? group.opts.map((option) => {
                                 const isSelected = option.value === selectedValue;

--- a/crates/agent-gui/src/pages/chat/components/ChatHeader.tsx
+++ b/crates/agent-gui/src/pages/chat/components/ChatHeader.tsx
@@ -313,15 +313,12 @@ export const ChatHeader = memo(function ChatHeader(props: {
                           {groupIndex > 0 ? (
                             <hr className="my-1 h-px border-0 bg-border/30" />
                           ) : null}
-                          <div className="sticky top-0 z-10 flex h-[30px] shrink-0 items-stretch rounded-md bg-popover/60 backdrop-blur-xl supports-[backdrop-filter]:bg-popover/40">
+                          <div className="group sticky top-0 z-10 flex h-[30px] shrink-0 items-stretch rounded-md bg-popover/60 backdrop-blur-xl transition-colors hover:bg-muted/40 focus-within:bg-muted/40 supports-[backdrop-filter]:bg-popover/40">
                             <button
                               type="button"
                               onClick={() => toggleGroup(group.id)}
                               aria-expanded={expanded}
-                              title={
-                                expanded ? t("chat.collapseProvider") : t("chat.expandProvider")
-                              }
-                              className="model-selector-group-label flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-l-md px-2 py-0 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground/80 transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:text-white/80"
+                              className="model-selector-group-label flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-l-md px-2 py-0 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:text-white/80"
                             >
                               <ProviderBrandIcon
                                 type={group.providerType}
@@ -330,6 +327,27 @@ export const ChatHeader = memo(function ChatHeader(props: {
                               <span className="min-w-0 flex-1 truncate normal-case tracking-normal">
                                 {group.name}
                               </span>
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setIsModelPickerOpen(false);
+                                onOpenSettings("providers", group.id);
+                              }}
+                              aria-label={`${t("settings.editProvider")}: ${group.name}`}
+                              className="pointer-events-none flex w-7 max-w-0 shrink-0 cursor-pointer items-center justify-center overflow-hidden text-muted-foreground/70 opacity-0 transition-[max-width,opacity,color,background-color] duration-150 group-hover:max-w-7 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:max-w-7 group-focus-within:pointer-events-auto group-focus-within:opacity-100 hover:bg-muted/60 hover:text-foreground focus-visible:max-w-7 focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => toggleGroup(group.id)}
+                              aria-expanded={expanded}
+                              aria-label={`${
+                                expanded ? t("chat.collapseProvider") : t("chat.expandProvider")
+                              }: ${group.name}`}
+                              className="model-selector-group-label flex shrink-0 cursor-pointer items-center gap-1.5 rounded-r-md px-2 py-0 text-muted-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:text-white/80"
+                            >
                               <span className="inline-flex h-4 min-w-[1.1rem] shrink-0 items-center justify-center rounded-full bg-muted/70 px-1 text-[calc(10px*var(--zone-font-scale,1))] tabular-nums tracking-normal">
                                 {group.opts.length}
                               </span>
@@ -339,18 +357,6 @@ export const ChatHeader = memo(function ChatHeader(props: {
                                   expanded && "rotate-180",
                                 )}
                               />
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                setIsModelPickerOpen(false);
-                                onOpenSettings("providers", group.id);
-                              }}
-                              title={`${t("settings.editProvider")}: ${group.name}`}
-                              aria-label={`${t("settings.editProvider")}: ${group.name}`}
-                              className="flex w-7 shrink-0 cursor-pointer items-center justify-center rounded-r-md text-muted-foreground/70 transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
-                            >
-                              <Pencil className="h-3.5 w-3.5" />
                             </button>
                           </div>
                           {expanded

--- a/crates/agent-gui/src/pages/chat/components/ChatHeader.tsx
+++ b/crates/agent-gui/src/pages/chat/components/ChatHeader.tsx
@@ -318,7 +318,9 @@ export const ChatHeader = memo(function ChatHeader(props: {
                               type="button"
                               onClick={() => toggleGroup(group.id)}
                               aria-expanded={expanded}
-                              title={expanded ? t("chat.collapseProvider") : t("chat.expandProvider")}
+                              title={
+                                expanded ? t("chat.collapseProvider") : t("chat.expandProvider")
+                              }
                               className="model-selector-group-label flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-l-md px-2 py-0 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground/80 transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:text-white/80"
                             >
                               <ProviderBrandIcon

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -3666,8 +3666,13 @@ function ProviderList(props: {
   );
 }
 
-export function ProvidersSection(props: SettingsSectionProps) {
-  const { settings, setSettings } = props;
+export function ProvidersSection(
+  props: SettingsSectionProps & {
+    initialProviderId?: string;
+    onInitialProviderHandled?: () => void;
+  },
+) {
+  const { settings, setSettings, initialProviderId, onInitialProviderHandled } = props;
   const { t } = useLocale();
 
   const [activeTab, setActiveTab] = useState<ProviderId>("claude_code");
@@ -3688,6 +3693,19 @@ export function ProvidersSection(props: SettingsSectionProps) {
   const { usageByProvider, refreshingProviderIds, refreshProvider } = useProviderUsage(
     settings.customProviders,
   );
+  const openedInitialProviderIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const providerId = initialProviderId?.trim();
+    if (!providerId || openedInitialProviderIdRef.current === providerId) return;
+    const provider = settings.customProviders.find((item) => item.id === providerId);
+    if (!provider) return;
+    openedInitialProviderIdRef.current = providerId;
+    setActiveTab(provider.type);
+    setEditingProvider(provider);
+    setModalOpen(true);
+    onInitialProviderHandled?.();
+  }, [initialProviderId, onInitialProviderHandled, settings.customProviders]);
 
   async function refreshThirdPartyProviders() {
     setCcsLoading(true);

--- a/crates/agent-gui/src/pages/settings/types.ts
+++ b/crates/agent-gui/src/pages/settings/types.ts
@@ -23,6 +23,7 @@ export type SettingsPageProps = {
   saveState: SettingsSaveState;
   onBack: () => void;
   initialSection?: SectionId;
+  initialProviderId?: string;
   hiddenSections?: SectionId[];
   appUpdate: AppUpdateController;
 };

--- a/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
+++ b/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
@@ -54,10 +54,16 @@ test("model pickers search models and providers", () => {
   }
 });
 
-test("provider groups expose a direct edit affordance", () => {
+test("provider groups reveal the edit affordance before the count on hover", () => {
   for (const source of headerSources) {
     assert.match(source, /\bPencil\b/);
     assert.match(source, /t\("settings\.editProvider"\)/);
+    assert.doesNotMatch(source, /title=\{`\$\{t\("settings\.editProvider"\)/);
+    assert.doesNotMatch(source, /title=\{\s*expanded \? t\("chat\.collapseProvider"\)/);
+    assert.match(source, /pointer-events-none flex w-7 max-w-0/);
+    assert.match(source, /group-hover:max-w-7/);
+    assert.match(source, /group-focus-within:max-w-7/);
+    assert.ok(source.indexOf("<Pencil") < source.indexOf("{group.opts.length}"));
     assert.match(
       source,
       /setIsModelPickerOpen\(false\);\s+onOpenSettings\("providers", group\.id\);/,

--- a/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
+++ b/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
@@ -53,3 +53,14 @@ test("model pickers search models and providers", () => {
     assert.match(source, /t\("chat\.noModelFound"\)/);
   }
 });
+
+test("provider groups expose a direct edit affordance", () => {
+  for (const source of headerSources) {
+    assert.match(source, /\bPencil\b/);
+    assert.match(source, /t\("settings\.editProvider"\)/);
+    assert.match(
+      source,
+      /setIsModelPickerOpen\(false\);\s+onOpenSettings\("providers", group\.id\);/,
+    );
+  }
+});

--- a/crates/agent-gui/test/settings/provider-edit-deeplink.test.mjs
+++ b/crates/agent-gui/test/settings/provider-edit-deeplink.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const appSources = [
+  readFileSync(new URL("../../src/App.tsx", import.meta.url), "utf8"),
+  readFileSync(
+    new URL("../../../agent-gateway/web/src/app/GatewayApp.tsx", import.meta.url),
+    "utf8",
+  ),
+];
+
+const settingsPageSources = [
+  readFileSync(new URL("../../src/pages/SettingsPage.tsx", import.meta.url), "utf8"),
+  readFileSync(
+    new URL("../../../agent-gateway/web/src/pages/SettingsPage.tsx", import.meta.url),
+    "utf8",
+  ),
+];
+
+const providersSectionSources = [
+  readFileSync(
+    new URL("../../src/pages/settings/ProvidersSection.tsx", import.meta.url),
+    "utf8",
+  ),
+  readFileSync(
+    new URL("../../../agent-gateway/web/src/pages/settings/ProvidersSection.tsx", import.meta.url),
+    "utf8",
+  ),
+];
+
+test("settings overlays carry a requested provider id", () => {
+  for (const source of appSources) {
+    assert.match(source, /settingsProviderId/);
+    assert.match(
+      source,
+      /setSettingsProviderId\(section === "providers" \? providerId : undefined\)/,
+    );
+    assert.match(source, /initialProviderId=\{settingsProviderId\}/);
+  }
+});
+
+test("settings pages forward and consume provider deep links", () => {
+  for (const source of settingsPageSources) {
+    assert.match(source, /pendingProviderId/);
+    assert.match(source, /initialProviderId=\{pendingProviderId\}/);
+    assert.match(source, /onInitialProviderHandled=\{\(\) => setPendingProviderId\(undefined\)\}/);
+  }
+});
+
+test("providers sections open the requested provider editor once", () => {
+  for (const source of providersSectionSources) {
+    assert.match(source, /openedInitialProviderIdRef/);
+    assert.match(
+      source,
+      /settings\.customProviders\.find\(\(item\) => item\.id === providerId\)/,
+    );
+    assert.match(source, /setActiveTab\(provider\.type\)/);
+    assert.match(source, /setEditingProvider\(provider\)/);
+    assert.match(source, /setModalOpen\(true\)/);
+    assert.match(source, /onInitialProviderHandled\?\.\(\)/);
+  }
+});


### PR DESCRIPTION
## 功能概述

在模型选择器中增加直接编辑供应商的入口，并同步支持桌面 GUI 和 Gateway WebUI。

现在每个供应商分组右侧都会显示一个铅笔编辑按钮。点击后将会：

1. 关闭当前模型选择菜单。
2. 打开“设置 → 供应商”。
3. 自动切换到该供应商对应的类型。
4. 直接打开所选供应商的编辑弹窗。

## 主要改动

- 在模型选择器的每个供应商分组右侧增加编辑按钮。
- 打开设置页面时传递需要编辑的供应商 ID。
- 在设置页面中增加供应商深链处理。
- 打开编辑弹窗前，自动切换到供应商对应的类型页签。
- 桌面 GUI 与 Gateway WebUI 的交互保持一致。
- 使用 `pendingProviderId` 一次性消费供应商编辑请求：
  - 避免关闭编辑弹窗后再次自动打开。
  - 避免切换设置页签后再次自动打开。
- 新增并更新相关自动化测试。

## 桌面 GUI 修改文件

- `crates/agent-gui/src/App.tsx`
  - 将需要编辑的供应商 ID 传入设置页面。

- `crates/agent-gui/src/pages/ChatPage.tsx`
  - 转发来自聊天页面顶部模型选择器的供应商编辑请求。

- `crates/agent-gui/src/pages/SettingsPage.tsx`
  - 保存并一次性消费 `pendingProviderId`。

- `crates/agent-gui/src/pages/chat/components/ChatHeader.tsx`
  - 在供应商分组右侧增加铅笔编辑按钮。
  - 点击后关闭模型菜单并打开供应商设置。

- `crates/agent-gui/src/pages/settings/ProvidersSection.tsx`
  - 根据供应商 ID 查找对应供应商。
  - 自动切换到对应的供应商类型。
  - 直接打开该供应商的编辑弹窗。

- `crates/agent-gui/src/pages/settings/types.ts`
  - 增加供应商深链相关的属性类型。

## Gateway WebUI 修改文件

- `crates/agent-gateway/web/src/app/GatewayApp.tsx`
  - 将需要编辑的供应商 ID 传入设置页面。

- `crates/agent-gateway/web/src/pages/SettingsPage.tsx`
  - 保存并一次性消费 `pendingProviderId`。

- `crates/agent-gateway/web/src/pages/chat/ChatHeader.tsx`
  - 在供应商分组右侧增加铅笔编辑按钮。
  - 增加打开供应商设置及编辑弹窗的跳转逻辑。

- `crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx`
  - 自动切换供应商类型并打开指定供应商的编辑弹窗。

- `crates/agent-gateway/web/src/pages/settings/types.ts`
  - 增加供应商深链相关的属性类型。

## 测试

更新测试：

- `crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs`

新增测试：

- `crates/agent-gui/test/settings/provider-edit-deeplink.test.mjs`

测试命令：

```bash
node --test test/chat/execution-mode-model-picker.test.mjs test/settings/provider-edit-deeplink.test.mjs
```