### PR TITLE
fix(providers): show custom header values in plaintext

### DIFF
--- a/crates/agent-gateway/web/src/i18n/config.ts
+++ b/crates/agent-gateway/web/src/i18n/config.ts
@@ -1384,8 +1384,6 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.noCustomHeaders": "暂无自定义请求头",
     "settings.noCustomHeadersHint": "点击此处新增，输入名称时会自动联想常用请求头。",
     "settings.customHeaderReservedTitle": "保留头，由系统管理",
-    "settings.showCustomHeaderValue": "显示请求头值",
-    "settings.hideCustomHeaderValue": "隐藏请求头值",
     "settings.manualAddModel": "手动添加",
     "settings.customHeaderKeyPlaceholder": "请求头名称",
     "settings.addCustomHeader": "添加",
@@ -3610,8 +3608,6 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.noCustomHeadersHint":
       "Click to add one — common header names are suggested as you type.",
     "settings.customHeaderReservedTitle": "Reserved header managed by the system",
-    "settings.showCustomHeaderValue": "Show header value",
-    "settings.hideCustomHeaderValue": "Hide header value",
     "settings.manualAddModel": "Add manually",
     "settings.customHeaderKeyPlaceholder": "Header name",
     "settings.addCustomHeader": "Add",

--- a/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/ProvidersSection.tsx
@@ -402,7 +402,6 @@ function ProviderModal({
   const [editingModel, setEditingModel] = useState<ModelEditDraft | null>(null);
   const [showApiKey, setShowApiKey] = useState(false);
   const [activePanel, setActivePanel] = useState<ProviderDialogPanel>("general");
-  const [visibleHeaderValues, setVisibleHeaderValues] = useState<Set<number>>(new Set());
   const [headerValidationSubmitted, setHeaderValidationSubmitted] = useState(false);
   const [headerSuggest, setHeaderSuggest] = useState<{
     index: number;
@@ -764,24 +763,7 @@ function ProviderModal({
 
   function removeCustomHeader(index: number) {
     setCustomHeaders((prev) => prev.filter((_, headerIndex) => headerIndex !== index));
-    setVisibleHeaderValues((prev) => {
-      const next = new Set<number>();
-      for (const visibleIndex of prev) {
-        if (visibleIndex < index) next.add(visibleIndex);
-        if (visibleIndex > index) next.add(visibleIndex - 1);
-      }
-      return next;
-    });
     setHeaderValidationSubmitted(false);
-  }
-
-  function toggleCustomHeaderValue(index: number) {
-    setVisibleHeaderValues((prev) => {
-      const next = new Set(prev);
-      if (next.has(index)) next.delete(index);
-      else next.add(index);
-      return next;
-    });
   }
 
   function openHeaderSuggest(index: number) {
@@ -824,7 +806,6 @@ function ProviderModal({
       }
       const merged = mergeImportedCustomHeaders(customHeaders, parsed.headers);
       setCustomHeaders(merged.headers);
-      setVisibleHeaderValues(new Set());
       setHeaderSuggest(null);
       setHeaderValidationSubmitted(false);
       setHeaderImportSummary({
@@ -1816,7 +1797,6 @@ function ProviderModal({
                         const issueTitle = issue ? customHeaderIssueMessage(issue, t) : undefined;
                         const valueIssue = issue === "invalid-value";
                         const keyIssue = issue !== null && !valueIssue;
-                        const valueVisible = visibleHeaderValues.has(index);
                         const suggestOpen =
                           headerSuggest?.index === index && headerSuggestItems.length > 0;
 
@@ -1895,10 +1875,10 @@ function ProviderModal({
                                 ref={(element) => {
                                   headerValueRefs.current[index] = element;
                                 }}
-                                type={valueVisible ? "text" : "password"}
+                                type="text"
                                 value={header.value}
                                 className={cn(
-                                  "h-10 w-full rounded-none border-0 bg-transparent pl-3 pr-[4.5rem] font-mono text-xs shadow-none focus-visible:ring-0",
+                                  "h-10 w-full rounded-none border-0 bg-transparent pl-3 pr-11 font-mono text-xs shadow-none focus-visible:ring-0",
                                   valueIssue && "text-destructive",
                                 )}
                                 placeholder={t("settings.customHeaderValue")}
@@ -1918,29 +1898,6 @@ function ProviderModal({
                                 }}
                               />
                               <div className="settings-hover-actions absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 max-[720px]:opacity-100">
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="icon"
-                                  className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground"
-                                  onClick={() => toggleCustomHeaderValue(index)}
-                                  title={
-                                    valueVisible
-                                      ? t("settings.hideCustomHeaderValue")
-                                      : t("settings.showCustomHeaderValue")
-                                  }
-                                  aria-label={
-                                    valueVisible
-                                      ? t("settings.hideCustomHeaderValue")
-                                      : t("settings.showCustomHeaderValue")
-                                  }
-                                >
-                                  {valueVisible ? (
-                                    <EyeOff className="h-3.5 w-3.5" />
-                                  ) : (
-                                    <Eye className="h-3.5 w-3.5" />
-                                  )}
-                                </Button>
                                 <Button
                                   type="button"
                                   variant="ghost"

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -1454,8 +1454,6 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.noCustomHeaders": "暂无自定义请求头",
     "settings.noCustomHeadersHint": "点击此处新增，输入名称时会自动联想常用请求头。",
     "settings.customHeaderReservedTitle": "保留头，由系统管理",
-    "settings.showCustomHeaderValue": "显示请求头值",
-    "settings.hideCustomHeaderValue": "隐藏请求头值",
     "settings.manualAddModel": "手动添加",
     "settings.customHeaderKeyPlaceholder": "请求头名称",
     "settings.addCustomHeader": "添加",
@@ -3773,8 +3771,6 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.noCustomHeadersHint":
       "Click to add one — common header names are suggested as you type.",
     "settings.customHeaderReservedTitle": "Reserved header managed by the system",
-    "settings.showCustomHeaderValue": "Show header value",
-    "settings.hideCustomHeaderValue": "Hide header value",
     "settings.manualAddModel": "Add manually",
     "settings.customHeaderKeyPlaceholder": "Header name",
     "settings.addCustomHeader": "Add",

--- a/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-gui/src/pages/settings/ProvidersSection.tsx
@@ -458,7 +458,6 @@ function ProviderModal({
   );
   const [editingModel, setEditingModel] = useState<ModelEditDraft | null>(null);
   const [activePanel, setActivePanel] = useState<ProviderDialogPanel>("general");
-  const [visibleHeaderValues, setVisibleHeaderValues] = useState<Set<number>>(new Set());
   const [headerValidationSubmitted, setHeaderValidationSubmitted] = useState(false);
   const [headerSuggest, setHeaderSuggest] = useState<{
     index: number;
@@ -820,24 +819,7 @@ function ProviderModal({
 
   function removeCustomHeader(index: number) {
     setCustomHeaders((prev) => prev.filter((_, headerIndex) => headerIndex !== index));
-    setVisibleHeaderValues((prev) => {
-      const next = new Set<number>();
-      for (const visibleIndex of prev) {
-        if (visibleIndex < index) next.add(visibleIndex);
-        if (visibleIndex > index) next.add(visibleIndex - 1);
-      }
-      return next;
-    });
     setHeaderValidationSubmitted(false);
-  }
-
-  function toggleCustomHeaderValue(index: number) {
-    setVisibleHeaderValues((prev) => {
-      const next = new Set(prev);
-      if (next.has(index)) next.delete(index);
-      else next.add(index);
-      return next;
-    });
   }
 
   function openHeaderSuggest(index: number) {
@@ -880,7 +862,6 @@ function ProviderModal({
       }
       const merged = mergeImportedCustomHeaders(customHeaders, parsed.headers);
       setCustomHeaders(merged.headers);
-      setVisibleHeaderValues(new Set());
       setHeaderSuggest(null);
       setHeaderValidationSubmitted(false);
       setHeaderImportSummary({
@@ -1868,7 +1849,6 @@ function ProviderModal({
                         const issueTitle = issue ? customHeaderIssueMessage(issue, t) : undefined;
                         const valueIssue = issue === "invalid-value";
                         const keyIssue = issue !== null && !valueIssue;
-                        const valueVisible = visibleHeaderValues.has(index);
                         const suggestOpen =
                           headerSuggest?.index === index && headerSuggestItems.length > 0;
 
@@ -1947,10 +1927,10 @@ function ProviderModal({
                                 ref={(element) => {
                                   headerValueRefs.current[index] = element;
                                 }}
-                                type={valueVisible ? "text" : "password"}
+                                type="text"
                                 value={header.value}
                                 className={cn(
-                                  "h-10 w-full rounded-none border-0 bg-transparent pl-3 pr-[4.5rem] font-mono text-xs shadow-none focus-visible:ring-0",
+                                  "h-10 w-full rounded-none border-0 bg-transparent pl-3 pr-11 font-mono text-xs shadow-none focus-visible:ring-0",
                                   valueIssue && "text-destructive",
                                 )}
                                 placeholder={t("settings.customHeaderValue")}
@@ -1970,29 +1950,6 @@ function ProviderModal({
                                 }}
                               />
                               <div className="settings-hover-actions absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 max-[720px]:opacity-100">
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="icon"
-                                  className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground"
-                                  onClick={() => toggleCustomHeaderValue(index)}
-                                  title={
-                                    valueVisible
-                                      ? t("settings.hideCustomHeaderValue")
-                                      : t("settings.showCustomHeaderValue")
-                                  }
-                                  aria-label={
-                                    valueVisible
-                                      ? t("settings.hideCustomHeaderValue")
-                                      : t("settings.showCustomHeaderValue")
-                                  }
-                                >
-                                  {valueVisible ? (
-                                    <EyeOff className="h-3.5 w-3.5" />
-                                  ) : (
-                                    <Eye className="h-3.5 w-3.5" />
-                                  )}
-                                </Button>
                                 <Button
                                   type="button"
                                   variant="ghost"


### PR DESCRIPTION
## 改动说明

- 桌面 GUI 与 Gateway WebUI 的自定义请求头 value 默认并持续明文展示
- 移除逐行显示/隐藏状态、眼睛按钮和无用中英文文案
- 缩小 value 输入框右侧留白，仅保留删除按钮空间
- 保持 API Key、Usage Query 凭据的原有脱敏行为，以及请求头保存、同步、转发、校验和安全过滤逻辑

## 自动验证

- `node --test crates/agent-gui/test/providers/custom-headers.test.mjs crates/agent-gateway/test/webui/custom-headers.test.mjs`：20/20 通过
- `pnpm --dir crates/agent-gui build`：通过
- `pnpm --dir crates/agent-gateway/web build`：通过
- `pnpm --dir crates/agent-gateway/web test`：493/493 通过
- `pnpm --dir crates/agent-gui lint --line-ending=crlf`：通过（仅现有 warnings/infos）
- `pnpm --dir crates/agent-gateway/web lint --line-ending=crlf`：通过（仅现有 warnings/infos）
- `node scripts/check-mirror.mjs`：通过，116 个镜像文件
- `git diff --check`：通过

## 环境说明与未运行项

- 原始双端 `pnpm ... lint` 在本机 Git `core.autocrlf=true` 且仓库未声明 EOL 时，会把完整检出树的 CRLF 视为格式差异；使用匹配工作树的 `--line-ending=crlf` 后全量检查为 0 错误
- 额外运行 `pnpm --dir crates/agent-gui test:frontend`，有 2 项既有的 EOL-sensitive byte-for-byte 测试失败；本次目标请求头测试全部通过
- 未运行 Rust `cargo check` 与 Gateway Go 测试：本次未修改后端、协议、数据模型或代理层
- 未单独进行 Gateway WebUI 浏览器人工会话；已通过双端对称 diff、WebUI build/lint/test 与独立代码审查覆盖

## 人工验收

- 从本任务独立 worktree 的当前源码启动 `pnpm --dir crates/agent-gui tauri dev`
- 用户已验证新增、编辑、JSON/cURL 导入、删除、连续添加、保存重开、非法/保留头校验，以及 API Key/Usage Query 脱敏回归，并明确授权提交与创建 PR

Depends-On: none
Stack-Root: #331