### PR TITLE
chore(github): governance draft conversion via optional PAT + stale workflow

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -19,6 +19,8 @@ jobs:
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.state == 'open' }}
     steps:
       - uses: actions/github-script@v8
+        env:
+          DRAFT_PAT: ${{ secrets.PR_GOVERNANCE_PAT }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -97,17 +99,45 @@ jobs:
               );
             }
 
-            // 汇总:更新置顶报告评论;不合规则转为 draft。
+            // 汇总:不合规先尝试转 draft,再按实际结果生成报告,避免文案与真实状态不符。
             const passed = problems.length === 0;
+
+            // 转失败(未配 PAT / token 失效)只警告:下面的 setFailed 会把检查置红,
+            // 配合 main 的 required status check 仍能阻止合并,治理不会失效。
+            let drafted = false;
+            if (!passed) {
+              try {
+                const pat = process.env.DRAFT_PAT;
+                await github.graphql(
+                  `mutation ($id: ID!) {
+                    convertPullRequestToDraft(input: { pullRequestId: $id }) {
+                      pullRequest { isDraft }
+                    }
+                  }`,
+                  {
+                    id: pr.node_id,
+                    ...(pat ? { headers: { authorization: `Bearer ${pat}` } } : {}),
+                  },
+                );
+                drafted = true;
+              } catch (e) {
+                core.warning(`Failed to convert to draft (${e.message}); the check is still red and merge blocking is unaffected.`);
+              }
+            }
+
             const report = passed
               ? `${MARKER}\n**PR governance checks passed.** Awaiting human review.`
               : [
                   MARKER,
-                  '**PR governance checks failed — this PR has been converted to draft.**',
+                  drafted
+                    ? '**PR governance checks failed — this PR has been converted to draft.**'
+                    : '**PR governance checks failed.**',
                   '',
                   ...problems.map((p) => `- ${p}`),
                   '',
-                  'Fix the items above, then click **Ready for review** to re-run the checks.',
+                  drafted
+                    ? 'Fix the items above, then click **Ready for review** to re-run the checks.'
+                    : 'Fix the items above — pushing new commits or editing the PR body will re-run the checks.',
                 ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -138,19 +168,5 @@ jobs:
             }
 
             if (!passed) {
-              // 即便转 draft 失败(token 权限不足),下面的 setFailed 也会把检查置红,
-              // 配合 main 的 required status check 仍能阻止合并,治理不会失效。
-              try {
-                await github.graphql(
-                  `mutation ($id: ID!) {
-                    convertPullRequestToDraft(input: { pullRequestId: $id }) {
-                      pullRequest { isDraft }
-                    }
-                  }`,
-                  { id: pr.node_id },
-                );
-              } catch (e) {
-                core.warning(`Failed to convert to draft (${e.message}); the check is still red and merge blocking is unaffected.`);
-              }
               core.setFailed(`PR governance checks failed:\n- ${problems.join('\n- ')}`);
             }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,36 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "23 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 14
+          days-before-issue-close: 14
+          days-before-pr-stale: 14
+          days-before-pr-close: 14
+          stale-issue-message: >-
+            This issue has been inactive for 14 days and is marked stale.
+            It will be closed in 14 days if there is no further activity.
+          close-issue-message: >-
+            Closed due to inactivity. Comment or reopen if this is still relevant.
+          stale-pr-message: >-
+            This PR has been inactive for 14 days and is marked stale.
+            It will be closed in 14 days if there is no further activity.
+            Push an update or comment to keep it open.
+          close-pr-message: >-
+            Closed due to inactivity. Reopen and push an update if you want to
+            continue this work.
+          exempt-issue-labels: "pinned,roadmap,help wanted,good first issue"
+          exempt-pr-labels: "pinned,governance-exempt"
+          exempt-all-milestones: true


### PR DESCRIPTION
## Summary

  Two governance/automation improvements:

  1. **Make the draft conversion in PR Governance actually work.** `convertPullRequestToDraft`
     does not accept the Actions `GITHUB_TOKEN` (integration token), so the conversion has been
     silently failing since the workflow landed — while the report comment claimed
     "has been converted to draft". Now the mutation authenticates with an optional
     `PR_GOVERNANCE_PAT` secret when configured; the conversion attempt runs **before** the
     report is generated, and the comment wording reflects what actually happened
     (converted → "click Ready for review"; not converted → "push commits / edit the body
     to re-run"). Without the secret, behavior gracefully degrades to today's red-check-only
     blocking. Check logic itself is unchanged.

  2. **Add a stale workflow** (`actions/stale@v9`, daily at 02:23 UTC + manual dispatch):
     issues/PRs go stale after 14 days of inactivity and close 14 days later. Exempt:
     issues labeled `pinned` / `roadmap` / `help wanted` / `good first issue`, PRs labeled
     `pinned` / `governance-exempt` (aligned with PR Governance's exemption semantics), and
     anything assigned to a milestone. Complements governance: abandoned draft-converted PRs
     get cleaned up automatically instead of lingering forever.

  ## Change scope
  
  - Modules: GitHub workflows (repo governance, no product code)
  - Key paths:
    - `.github/workflows/pr-governance.yml`
    - `.github/workflows/stale.yml` (new)

  ## Screenshots / preview

  N/A — CI/workflow-only change, no runtime surface. Behavior is observable on the next
  governance run after merge (both `pull_request_target` and `schedule` execute the
  workflow file from `main`).

  ## Verification
  
  - YAML structure and embedded github-script reviewed; mutation/header logic follows the
    documented `github.graphql(query, { headers })` override pattern.
  - Full effect requires merge to `main` first. Post-merge verification plan:
    1. add the `PR_GOVERNANCE_PAT` repo secret (fine-grained PAT, this repo only,
       Pull requests: Read & write);
    2. edit the body of a non-compliant PR (e.g. #333) to re-trigger governance and confirm
       it is actually converted to draft;
    3. `workflow_dispatch` the stale workflow once and review what it marks.
  - Without the secret configured, governance behaves exactly as today (red check blocks
    merge), so this is safe to merge before the secret exists.

  ## Pre-submit checklist

  - [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
  - [x] Synced with the target branch; no merge conflicts.
  - [x] The change is focused, with no unrelated modifications.
  - [x] No secrets, tokens, or personal data included.
  - [x] Docs are updated for changes affecting user behavior, deployment, or configuration.