### PR TITLE
fix(gateway): recover compacted chat ingress gaps

### DIFF
--- a/crates/agent-gateway/internal/session/conversation_reliable_ingress.go
+++ b/crates/agent-gateway/internal/session/conversation_reliable_ingress.go
@@ -150,9 +150,14 @@ func (m *Manager) ingestChatIngressRecords(
 			return checkpointChatIngressAck(runID, conversationID, state)
 		}
 		if !state.checkpointRequested || !isChatIngressProjectionRecord(records[0]) {
-			noteChatIngressGap(agentID, runID, conversationID, state, expected, "producer_sequence_gap")
-			noteChatIngressReplay(agentID, runID, conversationID, state, expected, "producer_sequence_gap")
-			return replayChatIngressAck(runID, conversationID, state)
+			return recoverChatIngressGap(
+				agentID,
+				runID,
+				conversationID,
+				state,
+				expected,
+				"producer_sequence_gap",
+			)
 		}
 		projection := projectionFromRecord(records[0])
 		if projection == nil || projection.GetCoversThroughSeq() < firstSeq-1 {
@@ -578,10 +583,16 @@ func (m *Manager) ingestChatIngressFragment(agentID string, fragment *gatewayv2.
 			return continueChatIngressAck(runID, conversationID, state)
 		}
 		if fragment.GetSourceSeq() > expected && !state.checkpointRequested {
-			noteChatIngressGap(agentID, runID, conversationID, state, expected, "fragment_sequence_gap")
-			noteChatIngressReplay(agentID, runID, conversationID, state, expected, "fragment_sequence_gap")
+			ack := recoverChatIngressGap(
+				agentID,
+				runID,
+				conversationID,
+				state,
+				expected,
+				"fragment_sequence_gap",
+			)
 			s.mu.Unlock()
-			return replayChatIngressAck(runID, conversationID, state)
+			return ack
 		}
 	}
 	assembly := s.ingressFragments[key]
@@ -677,6 +688,23 @@ func noteChatIngressGap(
 		"seq", expected,
 		"reason", reason,
 	)
+}
+
+func recoverChatIngressGap(
+	agentID string,
+	runID string,
+	conversationID string,
+	state *chatIngressRunState,
+	expected uint64,
+	reason string,
+) *gatewayv2.ChatIngressAck {
+	noteChatIngressGap(agentID, runID, conversationID, state, expected, reason)
+	if state.checkpointRequested || state.replayRequestedAt == expected {
+		requestChatIngressCheckpoint(agentID, runID, conversationID, state, expected, reason)
+		return checkpointChatIngressAck(runID, conversationID, state)
+	}
+	noteChatIngressReplay(agentID, runID, conversationID, state, expected, reason)
+	return replayChatIngressAck(runID, conversationID, state)
 }
 
 func requestChatIngressCheckpoint(

--- a/crates/agent-gateway/internal/session/conversation_reliable_ingress_test.go
+++ b/crates/agent-gateway/internal/session/conversation_reliable_ingress_test.go
@@ -149,6 +149,49 @@ func TestChatIngressGapAndInvalidTerminalDoNotAdvanceCursor(t *testing.T) {
 	}
 }
 
+func TestChatIngressRepeatedGapEscalatesToCheckpoint(t *testing.T) {
+	manager := NewManager()
+	first := manager.ingestChatIngressBatch("agent-1", &gatewayv2.ChatIngressBatch{
+		RunId:          "run-gap",
+		ConversationId: "conv-1",
+		FirstSeq:       1,
+		Records:        []*gatewayv2.ChatIngressRecord{reliableIngressDelta(`{"type":"token","text":"a"}`)},
+	})
+	if first.GetAction() != gatewayv2.ChatIngressAck_CONTINUE || first.GetCommittedThrough() != 1 {
+		t.Fatalf("first ack = %#v", first)
+	}
+
+	late := &gatewayv2.ChatIngressBatch{
+		RunId:          "run-gap",
+		ConversationId: "conv-1",
+		FirstSeq:       3,
+		Records:        []*gatewayv2.ChatIngressRecord{reliableIngressDelta(`{"type":"token","text":"late"}`)},
+	}
+	firstGap := manager.ingestChatIngressBatch("agent-1", late)
+	if firstGap.GetAction() != gatewayv2.ChatIngressAck_REPLAY_FROM_EXPECTED || firstGap.GetExpectedNext() != 2 {
+		t.Fatalf("first gap ack = %#v", firstGap)
+	}
+	secondGap := manager.ingestChatIngressBatch("agent-1", late)
+	if secondGap.GetAction() != gatewayv2.ChatIngressAck_SEND_CHECKPOINT || secondGap.GetExpectedNext() != 2 {
+		t.Fatalf("repeated gap ack = %#v", secondGap)
+	}
+	stillMissing := manager.ingestChatIngressBatch("agent-1", late)
+	if stillMissing.GetAction() != gatewayv2.ChatIngressAck_SEND_CHECKPOINT || stillMissing.GetExpectedNext() != 2 {
+		t.Fatalf("post-request gap ack = %#v", stillMissing)
+	}
+
+	projection := reliableIngressProjection(t, `[]`)
+	recovered := manager.ingestChatIngressBatch("agent-1", &gatewayv2.ChatIngressBatch{
+		RunId:          "run-gap",
+		ConversationId: "conv-1",
+		FirstSeq:       4,
+		Records:        []*gatewayv2.ChatIngressRecord{reliableIngressCheckpoint(projection, 3, 1)},
+	})
+	if recovered.GetAction() != gatewayv2.ChatIngressAck_CONTINUE || recovered.GetCommittedThrough() != 4 || recovered.GetExpectedNext() != 5 {
+		t.Fatalf("checkpoint recovery ack = %#v", recovered)
+	}
+}
+
 func TestChatIngressResumeRequestsAndAcceptsCheckpointBaseline(t *testing.T) {
 	manager := NewManager()
 	acks := manager.ingestChatIngressResume("agent-1", &gatewayv2.ChatIngressResume{
@@ -291,6 +334,46 @@ func TestChatIngressFragmentReassemblesOneLogicalRecord(t *testing.T) {
 	defer subscription.Cleanup()
 	if got := eventTypes(subscription.Events); strings.Join(got, ",") != "run_started,token" {
 		t.Fatalf("fragment events = %v", got)
+	}
+}
+
+func TestChatIngressRepeatedFragmentGapEscalatesToCheckpoint(t *testing.T) {
+	manager := NewManager()
+	first := manager.ingestChatIngressBatch("agent-1", &gatewayv2.ChatIngressBatch{
+		RunId:          "run-fragment-gap",
+		ConversationId: "conv-1",
+		FirstSeq:       1,
+		Records:        []*gatewayv2.ChatIngressRecord{reliableIngressDelta(`{"type":"token","text":"a"}`)},
+	})
+	if first.GetAction() != gatewayv2.ChatIngressAck_CONTINUE || first.GetCommittedThrough() != 1 {
+		t.Fatalf("first ack = %#v", first)
+	}
+
+	late := reliableIngressFragment(t, "run-fragment-gap", "conv-1", 3, reliableIngressDelta(`{"type":"token","text":"late"}`))
+	firstGap := manager.ingestChatIngressFragment("agent-1", late)
+	if firstGap.GetAction() != gatewayv2.ChatIngressAck_REPLAY_FROM_EXPECTED || firstGap.GetExpectedNext() != 2 {
+		t.Fatalf("first fragment gap ack = %#v", firstGap)
+	}
+	secondGap := manager.ingestChatIngressFragment("agent-1", late)
+	if secondGap.GetAction() != gatewayv2.ChatIngressAck_SEND_CHECKPOINT || secondGap.GetExpectedNext() != 2 {
+		t.Fatalf("repeated fragment gap ack = %#v", secondGap)
+	}
+
+	projection := reliableIngressProjection(t, `[]`)
+	checkpointFragments := reliableIngressFragments(
+		t,
+		"run-fragment-gap",
+		"conv-1",
+		4,
+		reliableIngressCheckpoint(projection, 3, 1),
+		2,
+	)
+	if incomplete := manager.ingestChatIngressFragment("agent-1", checkpointFragments[1]); incomplete != nil {
+		t.Fatalf("incomplete checkpoint fragment ack = %#v", incomplete)
+	}
+	recovered := manager.ingestChatIngressFragment("agent-1", checkpointFragments[0])
+	if recovered.GetAction() != gatewayv2.ChatIngressAck_CONTINUE || recovered.GetCommittedThrough() != 4 || recovered.GetExpectedNext() != 5 {
+		t.Fatalf("fragment checkpoint recovery ack = %#v", recovered)
 	}
 }
 
@@ -596,8 +679,8 @@ func TestReliableIngressObservabilityCountsStateTransitionsOnce(t *testing.T) {
 	if got := observability.Usage.ChatIngressReplayRequestsTotal.Load() - replayBefore; got != 1 {
 		t.Fatalf("replay metric delta = %d, want 1", got)
 	}
-	if got := observability.Usage.ChatIngressCheckpointRequestsTotal.Load() - checkpointRequestBefore; got != 1 {
-		t.Fatalf("checkpoint request metric delta = %d, want 1", got)
+	if got := observability.Usage.ChatIngressCheckpointRequestsTotal.Load() - checkpointRequestBefore; got != 2 {
+		t.Fatalf("checkpoint request metric delta = %d, want 2", got)
 	}
 	if got := observability.Usage.ChatIngressCheckpointsCommittedTotal.Load() - checkpointCommittedBefore; got != 1 {
 		t.Fatalf("checkpoint committed metric delta = %d, want 1", got)
@@ -639,6 +722,52 @@ func reliableIngressDelta(eventJSON string) *gatewayv2.ChatIngressRecord {
 			Delta: &gatewayv2.ChatIngressDelta{EventJson: eventJSON},
 		},
 	}
+}
+
+func reliableIngressFragment(
+	t *testing.T,
+	runID string,
+	conversationID string,
+	sourceSeq uint64,
+	record *gatewayv2.ChatIngressRecord,
+) *gatewayv2.ChatIngressFragment {
+	t.Helper()
+	return reliableIngressFragments(t, runID, conversationID, sourceSeq, record, 1)[0]
+}
+
+func reliableIngressFragments(
+	t *testing.T,
+	runID string,
+	conversationID string,
+	sourceSeq uint64,
+	record *gatewayv2.ChatIngressRecord,
+	fragmentCount int,
+) []*gatewayv2.ChatIngressFragment {
+	t.Helper()
+	encoded, err := proto.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fragmentCount <= 0 || fragmentCount > len(encoded) {
+		t.Fatalf("invalid fragment count %d for %d encoded bytes", fragmentCount, len(encoded))
+	}
+	hash := sha256.Sum256(encoded)
+	fragments := make([]*gatewayv2.ChatIngressFragment, 0, fragmentCount)
+	for index := 0; index < fragmentCount; index++ {
+		start := len(encoded) * index / fragmentCount
+		end := len(encoded) * (index + 1) / fragmentCount
+		fragments = append(fragments, &gatewayv2.ChatIngressFragment{
+			RunId:              runID,
+			ConversationId:     conversationID,
+			SourceSeq:          sourceSeq,
+			FragmentIndex:      uint32(index),
+			FragmentCount:      uint32(fragmentCount),
+			EncodedRecordChunk: encoded[start:end],
+			EncodedRecordBytes: uint64(len(encoded)),
+			Sha256:             hex.EncodeToString(hash[:]),
+		})
+	}
+	return fragments
 }
 
 func reliableIngressTerminal(projection reliableIngressProjectionData, coversThrough uint64, state string) *gatewayv2.ChatIngressRecord {

--- a/crates/agent-gateway/test/websocket/v2_test.go
+++ b/crates/agent-gateway/test/websocket/v2_test.go
@@ -4,6 +4,8 @@ package websocket_test
 // 直通转发（白名单/限额/关联 id 命名空间化）、chat 订阅与事件推送。
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -11,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/klauspost/compress/zstd"
 	"google.golang.org/protobuf/proto"
 
 	gatewayv2 "github.com/liveagent/agent-gateway/internal/proto/v2"
@@ -327,6 +330,122 @@ func TestV2EndToEndBinaryPath(t *testing.T) {
 	}
 }
 
+func TestV2ChatIngressRepeatedGapEscalatesToCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	sm := session.NewManager()
+	store := newAgentTokenStore(t)
+	agentToken, err := store.Issue("desktop-agent", "")
+	if err != nil {
+		t.Fatalf("issue desktop agent token: %v", err)
+	}
+	srv := pbws.NewServer(newV2TestConfig(), sm, store)
+
+	mux := http.NewServeMux()
+	mux.Handle("/ws/v2/agent", srv.AgentHandler())
+	agentConn, agentCleanup := dialV2Path(t, mux, "/ws/v2/agent")
+	defer agentCleanup()
+	sendProtoFrame(t, agentConn, &gatewayv2.AgentClientFrame{
+		Payload: &gatewayv2.AgentClientFrame_Hello{
+			Hello: &gatewayv2.ClientHello{
+				ProtocolVersion: pbws.ProtocolVersion,
+				Role:            gatewayv2.ClientRole_CLIENT_ROLE_AGENT,
+				Token:           agentToken,
+				AgentId:         "desktop-agent",
+				AgentVersion:    "1.0.0",
+			},
+		},
+	})
+	agentHello := receiveAgentServerFrame(t, agentConn).GetHello()
+	if agentHello == nil || !agentHello.GetOk() {
+		t.Fatalf("agent hello reply = %#v, want ok", agentHello)
+	}
+
+	sendBatch := func(requestID string, firstSeq uint64, text string) {
+		t.Helper()
+		sendProtoFrame(t, agentConn, &gatewayv2.AgentClientFrame{
+			Payload: &gatewayv2.AgentClientFrame_Envelope{
+				Envelope: &gatewayv2.AgentEnvelope{
+					RequestId: requestID,
+					Payload: &gatewayv2.AgentEnvelope_ChatIngressBatch{
+						ChatIngressBatch: &gatewayv2.ChatIngressBatch{
+							RunId:          "run-gap",
+							ConversationId: "conv-gap",
+							FirstSeq:       firstSeq,
+							Records: []*gatewayv2.ChatIngressRecord{{
+								Payload: &gatewayv2.ChatIngressRecord_Delta{
+									Delta: &gatewayv2.ChatIngressDelta{EventJson: `{"type":"token","text":"` + text + `"}`},
+								},
+							}},
+						},
+					},
+				},
+			},
+		})
+	}
+
+	sendBatch("ingress-1", 1, "one")
+	first := receiveAgentChatIngressAck(t, agentConn, "ingress-1")
+	if first.GetAction() != gatewayv2.ChatIngressAck_CONTINUE || first.GetExpectedNext() != 2 {
+		t.Fatalf("first ack = %#v, want CONTINUE expected_next=2", first)
+	}
+
+	sendBatch("ingress-gap-1", 3, "three")
+	firstGap := receiveAgentChatIngressAck(t, agentConn, "ingress-gap-1")
+	if firstGap.GetAction() != gatewayv2.ChatIngressAck_REPLAY_FROM_EXPECTED || firstGap.GetExpectedNext() != 2 {
+		t.Fatalf("first gap ack = %#v, want REPLAY_FROM_EXPECTED expected_next=2", firstGap)
+	}
+
+	sendBatch("ingress-gap-2", 3, "three")
+	secondGap := receiveAgentChatIngressAck(t, agentConn, "ingress-gap-2")
+	if secondGap.GetAction() != gatewayv2.ChatIngressAck_SEND_CHECKPOINT || secondGap.GetExpectedNext() != 2 {
+		t.Fatalf("repeated gap ack = %#v, want SEND_CHECKPOINT expected_next=2", secondGap)
+	}
+
+	projectionJSON := []byte(`[]`)
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatalf("create projection encoder: %v", err)
+	}
+	defer encoder.Close()
+	projectionHash := sha256.Sum256(projectionJSON)
+	sendProtoFrame(t, agentConn, &gatewayv2.AgentClientFrame{
+		Payload: &gatewayv2.AgentClientFrame_Envelope{
+			Envelope: &gatewayv2.AgentEnvelope{
+				RequestId: "ingress-checkpoint",
+				Payload: &gatewayv2.AgentEnvelope_ChatIngressBatch{
+					ChatIngressBatch: &gatewayv2.ChatIngressBatch{
+						RunId:          "run-gap",
+						ConversationId: "conv-gap",
+						FirstSeq:       4,
+						Records: []*gatewayv2.ChatIngressRecord{{
+							Payload: &gatewayv2.ChatIngressRecord_Checkpoint{
+								Checkpoint: &gatewayv2.ChatIngressCheckpoint{
+									CoversThroughSeq:     3,
+									Revision:             1,
+									CompressedProjection: encoder.EncodeAll(projectionJSON, nil),
+									UncompressedBytes:    uint64(len(projectionJSON)),
+									Sha256:               hex.EncodeToString(projectionHash[:]),
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+	})
+	checkpoint := receiveAgentChatIngressAck(t, agentConn, "ingress-checkpoint")
+	if checkpoint.GetAction() != gatewayv2.ChatIngressAck_CONTINUE || checkpoint.GetCommittedThrough() != 4 || checkpoint.GetExpectedNext() != 5 {
+		t.Fatalf("checkpoint ack = %#v, want CONTINUE committed_through=4 expected_next=5", checkpoint)
+	}
+
+	sendBatch("ingress-after-checkpoint", 5, "five")
+	afterCheckpoint := receiveAgentChatIngressAck(t, agentConn, "ingress-after-checkpoint")
+	if afterCheckpoint.GetAction() != gatewayv2.ChatIngressAck_CONTINUE || afterCheckpoint.GetCommittedThrough() != 5 || afterCheckpoint.GetExpectedNext() != 6 {
+		t.Fatalf("post-checkpoint ack = %#v, want CONTINUE committed_through=5 expected_next=6", afterCheckpoint)
+	}
+}
+
 // dialV2Path 对多路由 mux 的指定路径拨号。
 func dialV2Path(t *testing.T, handler http.Handler, path string) (*websocket.Conn, func()) {
 	t.Helper()
@@ -353,4 +472,23 @@ func receiveAgentServerFrame(t *testing.T, conn *websocket.Conn) *gatewayv2.Agen
 		t.Fatalf("unmarshal agent frame: %v", err)
 	}
 	return &frame
+}
+
+func receiveAgentChatIngressAck(t *testing.T, conn *websocket.Conn, requestID string) *gatewayv2.ChatIngressAck {
+	t.Helper()
+	for attempt := 0; attempt < 8; attempt++ {
+		envelope := receiveAgentServerFrame(t, conn).GetEnvelope()
+		if envelope == nil || envelope.GetPing() != nil {
+			continue
+		}
+		if envelope.GetRequestId() != requestID {
+			t.Fatalf("agent envelope request_id = %q, want %q", envelope.GetRequestId(), requestID)
+		}
+		if ack := envelope.GetChatIngressAck(); ack != nil {
+			return ack
+		}
+		t.Fatalf("agent envelope = %#v, want chat_ingress_ack", envelope)
+	}
+	t.Fatalf("timed out waiting for chat_ingress_ack request_id=%q", requestID)
+	return nil
 }


### PR DESCRIPTION
## Summary

- stop reliable chat ingress from repeating the same replay request forever when the retained producer journal starts after the Gateway cursor
- escalate a repeated gap to the existing checkpoint recovery path for both batches and fragments
- cover replay escalation, checkpoint recovery, fragmented recovery, and the real agent WebSocket ACK path

## Root cause

When the Gateway expected a sequence that the client had already compacted away, it returned REPLAY_FROM_EXPECTED. The client immediately flushed its retained floor again, so the same gap produced an unthrottled ACK/flush loop. A repeated gap now requests a fresh checkpoint, which lets the producer rebase the Gateway cursor and continue.

## Validation

- `go test ./internal/session -run TestChatIngressRepeated -count=10`
- `go test ./test/websocket -run TestV2ChatIngressRepeatedGapEscalatesToCheckpoint -count=10`
- `go test ./internal/session ./test/websocket -count=1`
- `go vet ./...`
- `pnpm --dir crates/agent-gateway/web build`
- `git diff --check`
- same-worktree Gateway and Tauri runtime: reconnect succeeded; 30-second sampling showed stable handles, near-idle CPU, no replay log growth, and a responsive desktop window
- manual acceptance passed on 2026-07-31

## Baseline exception

`go test ./... -count=1` passes every package except `internal/auth/agenttoken.TestDBFilePermissionsAndNoPlaintext` on Windows (`0666`, expected `0600`). The same failure reproduces on an unmodified worktree at upstream/main `849daf269762846557cc8243c5fe6e7fb155ed72`.

`go test -race ./internal/session` was not run because this Windows environment has CGO disabled and Go reports that `-race` requires CGO.

Fixes #344

Depends-On: none
Stack-Root: #343