### PR TITLE
fix(chat): preserve pasted user message newlines

### DIFF
--- a/crates/agent-gateway/test/webui/paste-newline-pipeline.test.mjs
+++ b/crates/agent-gateway/test/webui/paste-newline-pipeline.test.mjs
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createWebModuleLoader } from "../helpers/load-web-module.mjs";
+
+const loader = createWebModuleLoader();
+const composer = loader.loadModule("src/components/chat/MentionComposer.tsx");
+const composerText = loader.loadModule("src/lib/chat/composerText.ts");
+const draftText = loader.loadModule("src/app/chatDraft.ts");
+const uploadedFiles = loader.loadModule("src/lib/chat/uploadedFiles.ts");
+
+const originalNode = globalThis.Node;
+globalThis.Node = { TEXT_NODE: 3, ELEMENT_NODE: 1 };
+
+test.after(() => {
+  if (originalNode === undefined) delete globalThis.Node;
+  else globalThis.Node = originalNode;
+});
+
+function textNode(text) {
+  return { nodeType: Node.TEXT_NODE, textContent: text };
+}
+
+function elementNode(tagName, childNodes = [], attributes = {}) {
+  return {
+    nodeType: Node.ELEMENT_NODE,
+    tagName,
+    childNodes,
+    getAttribute(name) {
+      return attributes[name] ?? null;
+    },
+    hasAttribute(name) {
+      return Object.hasOwn(attributes, name);
+    },
+  };
+}
+
+function chromiumPasteDom(clipboardText) {
+  const normalized = clipboardText.replace(/\r\n?/g, "\n");
+  const lines = normalized.split("\n");
+  const children = [];
+  if (lines[0]) children.push(textNode(lines[0]));
+  else if (lines.length > 1) children.push(elementNode("DIV", [elementNode("BR")]));
+  for (const line of lines.slice(1)) {
+    children.push(elementNode("DIV", line ? [textNode(line)] : [elementNode("BR")]));
+  }
+  return elementNode("DIV", children);
+}
+
+function draftFromSegments(segments) {
+  const text = segments.map((segment) => segment.text ?? "").join("");
+  return {
+    segments,
+    text,
+    textWithoutLargePastes: text,
+    largePastes: [],
+    skillMentions: [],
+    commitMentions: [],
+    gitFileMentions: [],
+    codeMentions: [],
+    isEmpty: text.trim().length === 0,
+  };
+}
+
+const cases = [
+  ["LF no blank line", "alpha\nbeta"],
+  ["LF one blank line", "alpha\n\nbeta"],
+  ["CRLF one blank line", "alpha\r\n\r\nbeta"],
+  ["CR one blank line", "alpha\r\rbeta"],
+  ["multiple blank lines", "alpha\n\n\nbeta"],
+  ["leading newline", "\nalpha"],
+  ["trailing newline", "alpha\n"],
+  ["Markdown paragraphs", "first paragraph\n\nsecond paragraph"],
+  ["Markdown list", "- one\n- two"],
+  ["Markdown quote", "> quote\n> continued"],
+  ["Markdown code block", "```ts\nconst value = 1;\n```"],
+  ["Markdown table", "| a | b |\n| - | - |\n| 1 | 2 |"],
+  ["Unicode and emoji", "你好🙂\n\nκαλημέρα"],
+  ["long text", `${"x".repeat(20_000)}\n\n${"y".repeat(20_000)}`],
+];
+
+test("clipboard DOM -> composer draft -> outbound -> history preserves logical newlines", () => {
+  for (const [name, clipboardText] of cases) {
+    const expected = clipboardText.replace(/\r\n?/g, "\n");
+    const segments = composer.serializeChildrenToSegments(chromiumPasteDom(clipboardText), new Map());
+    const draft = draftFromSegments(segments);
+    const outbound = draftText.buildTextFromComposerDraft(draft);
+    const message = uploadedFiles.createUserMessageWithUploads(outbound, [], 1);
+    const history = JSON.parse(JSON.stringify(message));
+
+    assert.equal(draft.text, expected, `${name}: composer draft`);
+    assert.equal(outbound, expected, `${name}: outbound payload`);
+    assert.equal(history.content, expected, `${name}: history/replay`);
+    assert.equal(
+      uploadedFiles.getUserMessageDisplayText(history),
+      expected,
+      `${name}: transcript user bubble text`,
+    );
+  }
+});
+
+test("pure whitespace remains structurally intact in the draft but is not sendable", () => {
+  const clipboardText = " \r\n\r\n ";
+  const expected = " \n\n ";
+  const segments = composer.serializeChildrenToSegments(chromiumPasteDom(clipboardText), new Map());
+  const draft = draftFromSegments(segments);
+  assert.equal(draft.text, expected);
+  assert.equal(draftText.buildTextFromComposerDraft(draft), expected);
+  assert.equal(uploadedFiles.createUserMessageWithUploads(expected, [], 1), null);
+});
+
+test("message creation normalizes line endings without trimming logical edge newlines", () => {
+  const input = "\r\nalpha\r\nbeta\r";
+  const expected = "\nalpha\nbeta\n";
+  const message = uploadedFiles.createUserMessageWithUploads(input, [], 1);
+  assert.equal(message.content, expected);
+  assert.equal(uploadedFiles.getUserMessageDisplayText(message), expected);
+});
+
+test("plaintext HTML escaping preserves literal content and logical newlines", () => {
+  assert.equal(
+    composerText.plainTextToContentEditableHtml("<tag>& value\r\nnext"),
+    "&lt;tag&gt;&amp; value\nnext",
+  );
+});
+
+test("composer serialization preserves newlines around mention chips", () => {
+  const root = elementNode("DIV", [
+    textNode("first\n"),
+    elementNode("SPAN", [], {
+      "data-mention-path": "src/App.tsx",
+      "data-mention-kind": "file",
+    }),
+    textNode("\nsecond"),
+  ]);
+  const segments = composer.serializeChildrenToSegments(root, new Map());
+  assert.deepEqual(
+    segments.map((segment) =>
+      segment.type === "text"
+        ? { type: "text", text: segment.text }
+        : { type: segment.type, path: segment.reference?.path },
+    ),
+    [
+      { type: "text", text: "first\n" },
+      { type: "fileMention", path: "src/App.tsx" },
+      { type: "text", text: "\nsecond" },
+    ],
+  );
+});

--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -30,6 +30,7 @@ import { registerAskUserQuestionAnswerHandler } from "@/lib/chat/askUserQuestion
 import type { ChatFileLink } from "@/lib/chat/chatFileLinks";
 import type { ChatHistorySummary } from "@/lib/chat/chatHistory";
 import { buildModelOptions } from "@/lib/chat/chatPageHelpers";
+import { normalizeLogicalLineEndings } from "@/lib/chat/composerText";
 import type { HistoryMessageRef } from "@/lib/chat/conversationState";
 import {
   adoptHistoryWindowState,
@@ -2391,11 +2392,11 @@ export default function GatewayApp() {
     files: PendingUploadedFile[],
     workdir: string,
   ) {
-    let text = (
+    let text = normalizeLogicalLineEndings(
       isAgentMode && draft.largePastes.length > 0
         ? draft.textWithoutLargePastes
-        : buildTextFromComposerDraft(draft)
-    ).trim();
+        : buildTextFromComposerDraft(draft),
+    );
     let uploadedFiles = files;
 
     if (isAgentMode && draft.largePastes.length > 0) {
@@ -2413,7 +2414,7 @@ export default function GatewayApp() {
         if (apiRef.current?.getActiveAgent().trim() !== agentID) {
           throw new Error("Agent 已切换，已取消发送本次大段粘贴内容。");
         }
-        text = buildTextFromComposerDraft(draft, imported.fileByPasteId).trim();
+        text = buildTextFromComposerDraft(draft, imported.fileByPasteId);
         uploadedFiles = mergePendingUploadedFiles(files, imported.files);
       } finally {
         isImportingPastedTextRef.current = false;

--- a/crates/agent-gateway/web/src/app/chatDraft.ts
+++ b/crates/agent-gateway/web/src/app/chatDraft.ts
@@ -4,6 +4,7 @@ import type {
   MentionComposerGitFileMention,
   MentionComposerLargePaste,
 } from "@/components/chat/MentionComposer";
+import { normalizeLogicalLineEndings } from "@/lib/chat/composerText";
 import { formatCodeMentionToken, formatFileMentionToken } from "@/lib/chat/mentionReferences";
 import type { PendingUploadedFile } from "@/lib/chat/uploadedFiles";
 import { withPastedTextDisplayMetadata } from "@/lib/chat/uploadedFiles";
@@ -53,31 +54,33 @@ export function buildTextFromComposerDraft(
   draft: MentionComposerDraft,
   pastedFileById?: Map<string, PendingUploadedFile>,
 ) {
-  return draft.segments
-    .map((segment) => {
-      if (segment.type === "text") {
-        return segment.text;
-      }
-      if (segment.type === "fileMention") {
-        return formatFileMentionToken(segment.reference);
-      }
-      if (segment.type === "skillMention") {
-        return `$${segment.skill.name}`;
-      }
-      if (segment.type === "commitMention") {
-        return formatComposerCommitMention(segment.commit);
-      }
-      if (segment.type === "gitFileMention") {
-        return formatComposerGitFileMention(segment.file);
-      }
-      if (segment.type === "codeMention") {
-        return formatCodeMentionToken(segment.reference);
-      }
-      const file = pastedFileById?.get(segment.paste.id);
-      return file ? `[${segment.paste.label}: ${file.relativePath}]` : segment.paste.text;
-    })
-    .join("")
-    .replace(/\u00A0/g, " ");
+  return normalizeLogicalLineEndings(
+    draft.segments
+      .map((segment) => {
+        if (segment.type === "text") {
+          return segment.text;
+        }
+        if (segment.type === "fileMention") {
+          return formatFileMentionToken(segment.reference);
+        }
+        if (segment.type === "skillMention") {
+          return `$${segment.skill.name}`;
+        }
+        if (segment.type === "commitMention") {
+          return formatComposerCommitMention(segment.commit);
+        }
+        if (segment.type === "gitFileMention") {
+          return formatComposerGitFileMention(segment.file);
+        }
+        if (segment.type === "codeMention") {
+          return formatCodeMentionToken(segment.reference);
+        }
+        const file = pastedFileById?.get(segment.paste.id);
+        return file ? `[${segment.paste.label}: ${file.relativePath}]` : segment.paste.text;
+      })
+      .join("")
+      .replace(/\u00A0/g, " "),
+  );
 }
 
 export async function importPastedTextsAsFiles(params: {

--- a/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
@@ -18,6 +18,10 @@ import {
 import { createPortal } from "react-dom";
 import { useLocale } from "../../i18n";
 import {
+  insertPlainTextWithUndo,
+  normalizeLogicalLineEndings,
+} from "../../lib/chat/composerText";
+import {
   type CodeMentionReference,
   codeMentionDisplayName,
   codeMentionLineLabel,
@@ -281,7 +285,7 @@ function countCaretAnchors(value: string) {
 }
 
 function normalizeSerializedText(value: string) {
-  return removeCaretAnchors(value).replace(/\u00A0/g, " ");
+  return normalizeLogicalLineEndings(removeCaretAnchors(value).replace(/\u00A0/g, " "));
 }
 
 function isMentionBoundaryChar(value: string) {
@@ -300,7 +304,7 @@ function pushTextSegment(out: MentionComposerDraftSegment[], text: string) {
   out.push({ type: "text", text });
 }
 
-function serializeChildrenToSegments(
+export function serializeChildrenToSegments(
   parent: Node,
   largePastes: Map<string, MentionComposerLargePaste>,
 ): MentionComposerDraftSegment[] {
@@ -337,9 +341,16 @@ function collectDraftSegments(
   largePastes: Map<string, MentionComposerLargePaste>,
 ): MentionComposerDraftSegment[] {
   const parts: MentionComposerDraftSegment[] = [];
+  let hasLogicalChild = false;
+  let previousChildWasBlock = false;
   parent.childNodes.forEach((child) => {
+    const childParts: MentionComposerDraftSegment[] = [];
+    let childIsBlock = false;
+    let childIsLogical = false;
     if (child.nodeType === Node.TEXT_NODE) {
-      pushTextSegment(parts, removeCaretAnchors(child.textContent || ""));
+      const text = removeCaretAnchors(child.textContent || "");
+      pushTextSegment(childParts, text);
+      childIsLogical = text.length > 0;
     } else if (child.nodeType === Node.ELEMENT_NODE) {
       const el = child as HTMLElement;
       const mentionPath = el.getAttribute(MENTION_TAG_ATTR);
@@ -347,29 +358,33 @@ function collectDraftSegments(
         const kind = el.getAttribute(MENTION_KIND_ATTR) === "dir" ? "dir" : "file";
         const reference = createFileMentionReference(mentionPath, kind);
         if (reference) {
-          parts.push({ type: "fileMention", reference });
+          childParts.push({ type: "fileMention", reference });
+          childIsLogical = true;
         }
       } else if (el.hasAttribute(GIT_FILE_MENTION_PATH_ATTR)) {
         const file = gitFileMentionFromElement(el);
         if (file) {
-          parts.push({ type: "gitFileMention", file });
+          childParts.push({ type: "gitFileMention", file });
+          childIsLogical = true;
         }
       } else if (el.hasAttribute(CODE_MENTION_PATH_ATTR)) {
         const reference = codeMentionFromElement(el);
         if (reference) {
-          parts.push({ type: "codeMention", reference });
+          childParts.push({ type: "codeMention", reference });
+          childIsLogical = true;
         }
       } else if (el.hasAttribute(COMMIT_MENTION_SHA_ATTR)) {
         const commit = commitMentionFromElement(el);
         if (commit) {
-          parts.push({ type: "commitMention", commit });
+          childParts.push({ type: "commitMention", commit });
+          childIsLogical = true;
         }
       } else if (el.hasAttribute(SKILL_MENTION_NAME_ATTR)) {
         const name = el.getAttribute(SKILL_MENTION_NAME_ATTR)?.trim() ?? "";
         const skillFile = el.getAttribute(SKILL_MENTION_FILE_ATTR)?.trim() ?? "";
         const baseDir = el.getAttribute(SKILL_MENTION_BASE_DIR_ATTR)?.trim() ?? "";
         if (name && skillFile && baseDir) {
-          parts.push({
+          childParts.push({
             type: "skillMention",
             skill: {
               name,
@@ -378,31 +393,49 @@ function collectDraftSegments(
               description: el.getAttribute(SKILL_MENTION_DESCRIPTION_ATTR)?.trim() ?? "",
             },
           });
+          childIsLogical = true;
         }
       } else {
         const largePasteId = el.getAttribute(LARGE_PASTE_TAG_ATTR);
         const largePaste = largePasteId ? largePastes.get(largePasteId) : undefined;
         if (largePaste) {
-          parts.push({ type: "largePaste", paste: largePaste });
-          return;
-        }
-        if (el.tagName === "BR") {
-          pushTextSegment(parts, "\n");
-        } else {
-          // Block-level wrappers (DIV / P) inserted by the browser on Enter
-          if (el.tagName === "DIV" || el.tagName === "P") {
-            if (parts.length > 0) pushTextSegment(parts, "\n");
+          childParts.push({ type: "largePaste", paste: largePaste });
+          childIsLogical = true;
+        } else if (el.tagName === "BR") {
+          const parentEl =
+            parent.nodeType === Node.ELEMENT_NODE ? (parent as HTMLElement) : null;
+          const isEmptyBlockPlaceholder =
+            parentEl != null &&
+            (parentEl.tagName === "DIV" || parentEl.tagName === "P") &&
+            parent.childNodes.length === 1;
+          if (!isEmptyBlockPlaceholder) {
+            pushTextSegment(childParts, "\n");
+            childIsLogical = true;
           }
+        } else {
+          childIsBlock = el.tagName === "DIV" || el.tagName === "P";
           for (const segment of collectDraftSegments(el, largePastes)) {
             if (segment.type === "text") {
-              pushTextSegment(parts, segment.text);
+              pushTextSegment(childParts, segment.text);
             } else {
-              parts.push(segment);
+              childParts.push(segment);
             }
           }
+          childIsLogical = childIsBlock || childParts.length > 0;
         }
       }
     }
+
+    if (!childIsLogical) return;
+    if (hasLogicalChild && (previousChildWasBlock || childIsBlock)) {
+      pushTextSegment(parts, "\n");
+    }
+    for (const segment of childParts) {
+      if (segment.type === "text") pushTextSegment(parts, segment.text);
+      else parts.push(segment);
+    }
+    hasLogicalChild = true;
+    previousChildWasBlock = childIsBlock;
   });
   return parts;
 }
@@ -2277,15 +2310,16 @@ export const MentionComposer = memo(
     }, []);
 
     const createLargePaste = useCallback((text: string): MentionComposerLargePaste => {
+      const normalizedText = normalizeLogicalLineEndings(text);
       const index = largePasteCounterRef.current + 1;
       largePasteCounterRef.current = index;
       return {
         id: `large-paste-${Date.now()}-${createUuid()}`,
         label: `Pasted text ${index}`,
-        text,
-        charCount: text.length,
-        lineCount: countLargePasteLines(text),
-        preview: normalizeLargePastePreview(text),
+        text: normalizedText,
+        charCount: normalizedText.length,
+        lineCount: countLargePasteLines(normalizedText),
+        preview: normalizeLargePastePreview(normalizedText),
       };
     }, []);
 
@@ -2376,10 +2410,11 @@ export const MentionComposer = memo(
           el.innerHTML = "";
           largePastesRef.current.clear();
           closeCommitTooltip();
-          if (isLargePasteText(text)) {
-            insertLargePaste(text);
+          const normalizedText = normalizeLogicalLineEndings(text);
+          if (isLargePasteText(normalizedText)) {
+            insertLargePaste(normalizedText);
           } else {
-            el.innerText = text;
+            el.textContent = normalizedText;
             closeMentionSession();
             refreshEmptyState();
           }
@@ -2416,8 +2451,10 @@ export const MentionComposer = memo(
               } else if (segment.type === "codeMention") {
                 const chip = createCodeMentionChip(segment.reference);
                 if (chip) el.appendChild(chip);
-              } else if (segment.text) {
-                el.appendChild(document.createTextNode(segment.text));
+            } else if (segment.text) {
+              el.appendChild(
+                document.createTextNode(normalizeLogicalLineEndings(segment.text)),
+              );
               }
             }
             largePasteCounterRef.current = Math.max(
@@ -3028,12 +3065,12 @@ export const MentionComposer = memo(
           return;
         }
         e.preventDefault();
-        const text = e.clipboardData.getData("text/plain");
+        const text = normalizeLogicalLineEndings(e.clipboardData.getData("text/plain"));
         if (isLargePasteText(text)) {
           insertLargePaste(text);
           return;
         }
-        document.execCommand("insertText", false, text);
+        insertPlainTextWithUndo(text);
         refreshEmptyState();
         refreshMention();
       },

--- a/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
@@ -17,10 +17,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { useLocale } from "../../i18n";
-import {
-  insertPlainTextWithUndo,
-  normalizeLogicalLineEndings,
-} from "../../lib/chat/composerText";
+import { insertPlainTextWithUndo, normalizeLogicalLineEndings } from "../../lib/chat/composerText";
 import {
   type CodeMentionReference,
   codeMentionDisplayName,
@@ -402,8 +399,7 @@ function collectDraftSegments(
           childParts.push({ type: "largePaste", paste: largePaste });
           childIsLogical = true;
         } else if (el.tagName === "BR") {
-          const parentEl =
-            parent.nodeType === Node.ELEMENT_NODE ? (parent as HTMLElement) : null;
+          const parentEl = parent.nodeType === Node.ELEMENT_NODE ? (parent as HTMLElement) : null;
           const isEmptyBlockPlaceholder =
             parentEl != null &&
             (parentEl.tagName === "DIV" || parentEl.tagName === "P") &&
@@ -2451,10 +2447,8 @@ export const MentionComposer = memo(
               } else if (segment.type === "codeMention") {
                 const chip = createCodeMentionChip(segment.reference);
                 if (chip) el.appendChild(chip);
-            } else if (segment.text) {
-              el.appendChild(
-                document.createTextNode(normalizeLogicalLineEndings(segment.text)),
-              );
+              } else if (segment.text) {
+                el.appendChild(document.createTextNode(normalizeLogicalLineEndings(segment.text)));
               }
             }
             largePasteCounterRef.current = Math.max(

--- a/crates/agent-gateway/web/src/index.css
+++ b/crates/agent-gateway/web/src/index.css
@@ -803,6 +803,11 @@
     word-break: break-word;
   }
 
+  /* Browsers do not allocate a final line box for a trailing preserved LF. */
+  .chat-user-trailing-newline-anchor::before {
+    content: "\200b";
+  }
+
   /* Settings page section transitions */
   .settings-section-enter {
     animation: settingsSectionIn 0.28s cubic-bezier(0.16, 1, 0.3, 1);

--- a/crates/agent-gateway/web/src/lib/chat/composerText.ts
+++ b/crates/agent-gateway/web/src/lib/chat/composerText.ts
@@ -1,0 +1,34 @@
+/**
+ * Canonical line-ending model for user-authored composer text.
+ *
+ * CRLF and bare CR are transport/platform spellings of one logical line
+ * break. Internally the frontends keep that break as LF without trimming or
+ * otherwise changing whitespace.
+ */
+export function normalizeLogicalLineEndings(value: string) {
+  return value.replace(/\r\n?/g, "\n");
+}
+
+/** Escape plaintext for execCommand("insertHTML") without translating LF. */
+export function plainTextToContentEditableHtml(value: string) {
+  return normalizeLogicalLineEndings(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Insert canonical plaintext as one undoable browser editing operation.
+ * Literal LF stays in text nodes under the composer's `white-space: pre-wrap`
+ * rule, avoiding browser-generated DIV/BR structures that are ambiguous to
+ * serialize. The insertText fallback remains for engines without insertHTML;
+ * the serializer also handles their block DOM without duplicating blank lines.
+ */
+export function insertPlainTextWithUndo(value: string) {
+  const normalized = normalizeLogicalLineEndings(value);
+  if (document.execCommand("insertHTML", false, plainTextToContentEditableHtml(normalized))) {
+    return normalized;
+  }
+  document.execCommand("insertText", false, normalized);
+  return normalized;
+}

--- a/crates/agent-gateway/web/src/lib/chat/uploadedFiles.ts
+++ b/crates/agent-gateway/web/src/lib/chat/uploadedFiles.ts
@@ -1,5 +1,6 @@
 import type { Message, UserMessage } from "../agentTypes";
 import { createUuid } from "../shared/id";
+import { normalizeLogicalLineEndings } from "./composerText";
 
 export type UploadedReadableFileKind =
   | "text"
@@ -125,12 +126,12 @@ export function buildUploadedFilesInstruction(files: PendingUploadedFile[]) {
 }
 
 export function buildUserMessageContentWithUploads(userText: string, files: PendingUploadedFile[]) {
-  const normalizedText = userText.trim();
+  const normalizedText = normalizeLogicalLineEndings(userText);
   if (files.length === 0) return normalizedText;
 
   const instruction = buildUploadedFilesInstruction(files);
   if (!instruction) return normalizedText;
-  if (!normalizedText) {
+  if (!normalizedText.trim()) {
     return `Please inspect the selected files first.\n\n${instruction}`;
   }
   return `${normalizedText}\n\n${instruction}`;
@@ -151,7 +152,7 @@ export function createUserMessageWithUploads(
     timestamp,
   };
   if (files.length > 0) {
-    message[DISPLAY_CONTENT_FIELD] = userText.trim();
+    message[DISPLAY_CONTENT_FIELD] = normalizeLogicalLineEndings(userText);
     message[ATTACHMENTS_FIELD] = clonePendingUploadedFiles(files);
   }
   return message;

--- a/crates/agent-gateway/web/src/lib/chat/userMessageContent.tsx
+++ b/crates/agent-gateway/web/src/lib/chat/userMessageContent.tsx
@@ -14,6 +14,7 @@ import { createPortal } from "react-dom";
 import { getFileTypeIcon } from "../../components/chat/fileTypeIcons";
 import { SkillIcon } from "../../components/icons";
 import { useLocale } from "../../i18n";
+import { normalizeLogicalLineEndings } from "./composerText";
 
 import {
   type CodeMentionReference,
@@ -947,7 +948,11 @@ export const UserMessageContent = memo(function UserMessageContent({
   pastedTextFiles?: PendingUploadedFile[];
   loadCommitDetails?: CommitDetailsLoader;
 }) {
-  const parts = useMemo(() => tokenizeUserMessage(text, pastedTextFiles), [text, pastedTextFiles]);
+  const normalizedText = useMemo(() => normalizeLogicalLineEndings(text), [text]);
+  const parts = useMemo(
+    () => tokenizeUserMessage(normalizedText, pastedTextFiles),
+    [normalizedText, pastedTextFiles],
+  );
   const hasChip = parts.some(
     (part) =>
       part.type === "mention" ||
@@ -957,7 +962,17 @@ export const UserMessageContent = memo(function UserMessageContent({
       part.type === "codeRef" ||
       part.type === "pastedText",
   );
-  if (!hasChip) return <>{text}</>;
+  const trailingNewlineAnchor = normalizedText.endsWith("\n") ? (
+    <span aria-hidden="true" className="chat-user-trailing-newline-anchor" />
+  ) : null;
+  if (!hasChip) {
+    return (
+      <>
+        {normalizedText}
+        {trailingNewlineAnchor}
+      </>
+    );
+  }
 
   return (
     <>
@@ -988,6 +1003,7 @@ export const UserMessageContent = memo(function UserMessageContent({
         }
         return <span key={idx}>{part.value}</span>;
       })}
+      {trailingNewlineAnchor}
     </>
   );
 });

--- a/crates/agent-gateway/web/test/browser/paste-newline-pipeline.html
+++ b/crates/agent-gateway/web/test/browser/paste-newline-pipeline.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
+    <title>Gateway WebUI paste newline pipeline</title>
+  </head>
+  <body>
+    <div id="editor" class="mention-composer whitespace-pre-wrap" contenteditable="true"></div>
+    <div id="bubble" class="chat-user-bubble w-fit px-4 py-2.5 font-chat text-[14.5px] leading-relaxed"></div>
+    <script type="module">
+      import React from "react";
+      import { createRoot } from "react-dom/client";
+      import "/src/index.css";
+      import {
+        insertPlainTextWithUndo,
+        normalizeLogicalLineEndings,
+      } from "/src/lib/chat/composerText.ts";
+      import { serializeChildrenToSegments } from "/src/components/chat/MentionComposer.tsx";
+      import { buildTextFromComposerDraft } from "/src/app/chatDraft.ts";
+      import {
+        createUserMessageWithUploads,
+        getUserMessageDisplayText,
+      } from "/src/lib/chat/uploadedFiles.ts";
+      import { UserMessageContent } from "/src/lib/chat/userMessageContent.tsx";
+
+      const editor = document.querySelector("#editor");
+      const bubble = document.querySelector("#bubble");
+      const bubbleRoot = createRoot(bubble);
+
+      editor.addEventListener("paste", (event) => {
+        event.preventDefault();
+        insertPlainTextWithUndo(event.clipboardData.getData("text/plain"));
+      });
+      editor.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && event.shiftKey) {
+          event.preventDefault();
+          document.execCommand("insertLineBreak");
+        }
+      });
+
+      function resetEditor() {
+        editor.replaceChildren();
+        editor.focus();
+        const selection = getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(editor);
+        range.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+
+      function draftFromEditor() {
+        const segments = serializeChildrenToSegments(editor, new Map());
+        const text = normalizeLogicalLineEndings(
+          segments.map((segment) => (segment.type === "text" ? segment.text : "")).join(""),
+        );
+        return {
+          segments,
+          text,
+          textWithoutLargePastes: text,
+          largePastes: [],
+          skillMentions: [],
+          commitMentions: [],
+          gitFileMentions: [],
+          codeMentions: [],
+          isEmpty: text.trim().length === 0,
+        };
+      }
+
+      async function renderBubble(text) {
+        bubbleRoot.render(React.createElement(UserMessageContent, { text }));
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      }
+
+      async function snapshotPipeline(rawClipboardText, html = "") {
+        const draft = draftFromEditor();
+        const outbound = buildTextFromComposerDraft(draft);
+        const message = createUserMessageWithUploads(outbound, [], 1);
+        const replay = message ? JSON.parse(JSON.stringify(message)) : null;
+        const display = replay ? getUserMessageDisplayText(replay) : "";
+        await renderBubble(display);
+        const style = getComputedStyle(bubble);
+        const padding = Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom);
+        const lineHeight = Number.parseFloat(style.lineHeight);
+        const contentHeight = bubble.getBoundingClientRect().height - padding;
+        return {
+          clipboard: JSON.stringify(rawClipboardText),
+          htmlPresent: Boolean(html),
+          editorHtml: editor.innerHTML,
+          composer: JSON.stringify(draft.text),
+          outbound: JSON.stringify(outbound),
+          history: replay ? JSON.stringify(replay.content) : null,
+          bubbleText: JSON.stringify(bubble.textContent),
+          sendable: message !== null,
+          newlineCounts: {
+            clipboard: (rawClipboardText.match(/\r\n|\r|\n/g) || []).length,
+            composer: (draft.text.match(/\n/g) || []).length,
+            outbound: (outbound.match(/\n/g) || []).length,
+            history: replay ? (replay.content.match(/\n/g) || []).length : null,
+            bubble: (bubble.textContent.match(/\n/g) || []).length,
+          },
+          whiteSpace: style.whiteSpace,
+          lineHeight,
+          contentHeight,
+          visualLineCount: lineHeight > 0 ? Math.round(contentHeight / lineHeight) : null,
+        };
+      }
+
+      window.resetEditor = resetEditor;
+      window.runPastePipeline = async (plain, html = "") => {
+        resetEditor();
+        const transfer = new DataTransfer();
+        transfer.setData("text/plain", plain);
+        if (html) transfer.setData("text/html", html);
+        editor.dispatchEvent(
+          new ClipboardEvent("paste", { clipboardData: transfer, bubbles: true }),
+        );
+        return snapshotPipeline(plain, html);
+      };
+      window.snapshotManualPipeline = snapshotPipeline;
+      window.renderReplay = async (content) => {
+        await renderBubble(content);
+        return {
+          text: bubble.textContent,
+          whiteSpace: getComputedStyle(bubble).whiteSpace,
+        };
+      };
+      window.pipelineReady = true;
+    </script>
+  </body>
+</html>

--- a/crates/agent-gui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gui/src/components/chat/MentionComposer.tsx
@@ -18,6 +18,10 @@ import {
 import { createPortal } from "react-dom";
 import { useLocale } from "../../i18n";
 import {
+  insertPlainTextWithUndo,
+  normalizeLogicalLineEndings,
+} from "../../lib/chat/composerText";
+import {
   type CodeMentionReference,
   codeMentionDisplayName,
   codeMentionLineLabel,
@@ -292,7 +296,7 @@ function countCaretAnchors(value: string) {
 }
 
 function normalizeSerializedText(value: string) {
-  return removeCaretAnchors(value).replace(/\u00A0/g, " ");
+  return normalizeLogicalLineEndings(removeCaretAnchors(value).replace(/\u00A0/g, " "));
 }
 
 function isMentionBoundaryChar(value: string) {
@@ -311,7 +315,7 @@ function pushTextSegment(out: MentionComposerDraftSegment[], text: string) {
   out.push({ type: "text", text });
 }
 
-function serializeChildrenToSegments(
+export function serializeChildrenToSegments(
   parent: Node,
   largePastes: Map<string, MentionComposerLargePaste>,
 ): MentionComposerDraftSegment[] {
@@ -348,9 +352,16 @@ function collectDraftSegments(
   largePastes: Map<string, MentionComposerLargePaste>,
 ): MentionComposerDraftSegment[] {
   const parts: MentionComposerDraftSegment[] = [];
+  let hasLogicalChild = false;
+  let previousChildWasBlock = false;
   parent.childNodes.forEach((child) => {
+    const childParts: MentionComposerDraftSegment[] = [];
+    let childIsBlock = false;
+    let childIsLogical = false;
     if (child.nodeType === Node.TEXT_NODE) {
-      pushTextSegment(parts, removeCaretAnchors(child.textContent || ""));
+      const text = removeCaretAnchors(child.textContent || "");
+      pushTextSegment(childParts, text);
+      childIsLogical = text.length > 0;
     } else if (child.nodeType === Node.ELEMENT_NODE) {
       const el = child as HTMLElement;
       const mentionPath = el.getAttribute(MENTION_TAG_ATTR);
@@ -358,29 +369,33 @@ function collectDraftSegments(
         const kind = el.getAttribute(MENTION_KIND_ATTR) === "dir" ? "dir" : "file";
         const reference = createFileMentionReference(mentionPath, kind);
         if (reference) {
-          parts.push({ type: "fileMention", reference });
+          childParts.push({ type: "fileMention", reference });
+          childIsLogical = true;
         }
       } else if (el.hasAttribute(GIT_FILE_MENTION_PATH_ATTR)) {
         const file = gitFileMentionFromElement(el);
         if (file) {
-          parts.push({ type: "gitFileMention", file });
+          childParts.push({ type: "gitFileMention", file });
+          childIsLogical = true;
         }
       } else if (el.hasAttribute(CODE_MENTION_PATH_ATTR)) {
         const reference = codeMentionFromElement(el);
         if (reference) {
-          parts.push({ type: "codeMention", reference });
+          childParts.push({ type: "codeMention", reference });
+          childIsLogical = true;
         }
       } else if (el.hasAttribute(COMMIT_MENTION_SHA_ATTR)) {
         const commit = commitMentionFromElement(el);
         if (commit) {
-          parts.push({ type: "commitMention", commit });
+          childParts.push({ type: "commitMention", commit });
+          childIsLogical = true;
         }
       } else if (el.hasAttribute(SKILL_MENTION_NAME_ATTR)) {
         const name = el.getAttribute(SKILL_MENTION_NAME_ATTR)?.trim() ?? "";
         const skillFile = el.getAttribute(SKILL_MENTION_FILE_ATTR)?.trim() ?? "";
         const baseDir = el.getAttribute(SKILL_MENTION_BASE_DIR_ATTR)?.trim() ?? "";
         if (name && skillFile && baseDir) {
-          parts.push({
+          childParts.push({
             type: "skillMention",
             skill: {
               name,
@@ -389,31 +404,49 @@ function collectDraftSegments(
               description: el.getAttribute(SKILL_MENTION_DESCRIPTION_ATTR)?.trim() ?? "",
             },
           });
+          childIsLogical = true;
         }
       } else {
         const largePasteId = el.getAttribute(LARGE_PASTE_TAG_ATTR);
         const largePaste = largePasteId ? largePastes.get(largePasteId) : undefined;
         if (largePaste) {
-          parts.push({ type: "largePaste", paste: largePaste });
-          return;
-        }
-        if (el.tagName === "BR") {
-          pushTextSegment(parts, "\n");
-        } else {
-          // Block-level wrappers (DIV / P) inserted by the browser on Enter
-          if (el.tagName === "DIV" || el.tagName === "P") {
-            if (parts.length > 0) pushTextSegment(parts, "\n");
+          childParts.push({ type: "largePaste", paste: largePaste });
+          childIsLogical = true;
+        } else if (el.tagName === "BR") {
+          const parentEl =
+            parent.nodeType === Node.ELEMENT_NODE ? (parent as HTMLElement) : null;
+          const isEmptyBlockPlaceholder =
+            parentEl != null &&
+            (parentEl.tagName === "DIV" || parentEl.tagName === "P") &&
+            parent.childNodes.length === 1;
+          if (!isEmptyBlockPlaceholder) {
+            pushTextSegment(childParts, "\n");
+            childIsLogical = true;
           }
+        } else {
+          childIsBlock = el.tagName === "DIV" || el.tagName === "P";
           for (const segment of collectDraftSegments(el, largePastes)) {
             if (segment.type === "text") {
-              pushTextSegment(parts, segment.text);
+              pushTextSegment(childParts, segment.text);
             } else {
-              parts.push(segment);
+              childParts.push(segment);
             }
           }
+          childIsLogical = childIsBlock || childParts.length > 0;
         }
       }
     }
+
+    if (!childIsLogical) return;
+    if (hasLogicalChild && (previousChildWasBlock || childIsBlock)) {
+      pushTextSegment(parts, "\n");
+    }
+    for (const segment of childParts) {
+      if (segment.type === "text") pushTextSegment(parts, segment.text);
+      else parts.push(segment);
+    }
+    hasLogicalChild = true;
+    previousChildWasBlock = childIsBlock;
   });
   return parts;
 }
@@ -2560,15 +2593,16 @@ export const MentionComposer = memo(
     }, []);
 
     const createLargePaste = useCallback((text: string): MentionComposerLargePaste => {
+      const normalizedText = normalizeLogicalLineEndings(text);
       const index = largePasteCounterRef.current + 1;
       largePasteCounterRef.current = index;
       return {
         id: `large-paste-${Date.now()}-${createUuid()}`,
         label: `Pasted text ${index}`,
-        text,
-        charCount: text.length,
-        lineCount: countLargePasteLines(text),
-        preview: normalizeLargePastePreview(text),
+        text: normalizedText,
+        charCount: normalizedText.length,
+        lineCount: countLargePasteLines(normalizedText),
+        preview: normalizeLargePastePreview(normalizedText),
       };
     }, []);
 
@@ -2660,10 +2694,11 @@ export const MentionComposer = memo(
           largePastesRef.current.clear();
           closeCommitTooltip();
           closeComposerContextMenu();
-          if (isLargePasteText(text)) {
-            insertLargePaste(text);
+          const normalizedText = normalizeLogicalLineEndings(text);
+          if (isLargePasteText(normalizedText)) {
+            insertLargePaste(normalizedText);
           } else {
-            el.innerText = text;
+            el.textContent = normalizedText;
             closeMentionSession();
             refreshEmptyState();
           }
@@ -2695,7 +2730,9 @@ export const MentionComposer = memo(
               const chip = createCodeMentionChip(segment.reference);
               if (chip) el.appendChild(chip);
             } else if (segment.text) {
-              el.appendChild(document.createTextNode(segment.text));
+              el.appendChild(
+                document.createTextNode(normalizeLogicalLineEndings(segment.text)),
+              );
             }
           }
           largePasteCounterRef.current = Math.max(
@@ -3486,12 +3523,12 @@ export const MentionComposer = memo(
           return;
         }
         e.preventDefault();
-        const text = e.clipboardData.getData("text/plain");
+        const text = normalizeLogicalLineEndings(e.clipboardData.getData("text/plain"));
         if (isLargePasteText(text)) {
           insertLargePaste(text);
           return;
         }
-        document.execCommand("insertText", false, text);
+        insertPlainTextWithUndo(text);
         refreshEmptyState();
         refreshMention();
       },

--- a/crates/agent-gui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gui/src/components/chat/MentionComposer.tsx
@@ -17,10 +17,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { useLocale } from "../../i18n";
-import {
-  insertPlainTextWithUndo,
-  normalizeLogicalLineEndings,
-} from "../../lib/chat/composerText";
+import { insertPlainTextWithUndo, normalizeLogicalLineEndings } from "../../lib/chat/composerText";
 import {
   type CodeMentionReference,
   codeMentionDisplayName,
@@ -413,8 +410,7 @@ function collectDraftSegments(
           childParts.push({ type: "largePaste", paste: largePaste });
           childIsLogical = true;
         } else if (el.tagName === "BR") {
-          const parentEl =
-            parent.nodeType === Node.ELEMENT_NODE ? (parent as HTMLElement) : null;
+          const parentEl = parent.nodeType === Node.ELEMENT_NODE ? (parent as HTMLElement) : null;
           const isEmptyBlockPlaceholder =
             parentEl != null &&
             (parentEl.tagName === "DIV" || parentEl.tagName === "P") &&
@@ -2730,9 +2726,7 @@ export const MentionComposer = memo(
               const chip = createCodeMentionChip(segment.reference);
               if (chip) el.appendChild(chip);
             } else if (segment.text) {
-              el.appendChild(
-                document.createTextNode(normalizeLogicalLineEndings(segment.text)),
-              );
+              el.appendChild(document.createTextNode(normalizeLogicalLineEndings(segment.text)));
             }
           }
           largePasteCounterRef.current = Math.max(

--- a/crates/agent-gui/src/index.css
+++ b/crates/agent-gui/src/index.css
@@ -985,6 +985,11 @@
     word-break: break-word;
   }
 
+  /* Browsers do not allocate a final line box for a trailing preserved LF. */
+  .chat-user-trailing-newline-anchor::before {
+    content: "\200b";
+  }
+
   @keyframes chatBubbleIn {
     from {
       opacity: 0;

--- a/crates/agent-gui/src/lib/chat/composerText.ts
+++ b/crates/agent-gui/src/lib/chat/composerText.ts
@@ -1,0 +1,34 @@
+/**
+ * Canonical line-ending model for user-authored composer text.
+ *
+ * CRLF and bare CR are transport/platform spellings of one logical line
+ * break. Internally the frontends keep that break as LF without trimming or
+ * otherwise changing whitespace.
+ */
+export function normalizeLogicalLineEndings(value: string) {
+  return value.replace(/\r\n?/g, "\n");
+}
+
+/** Escape plaintext for execCommand("insertHTML") without translating LF. */
+export function plainTextToContentEditableHtml(value: string) {
+  return normalizeLogicalLineEndings(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Insert canonical plaintext as one undoable browser editing operation.
+ * Literal LF stays in text nodes under the composer's `white-space: pre-wrap`
+ * rule, avoiding browser-generated DIV/BR structures that are ambiguous to
+ * serialize. The insertText fallback remains for engines without insertHTML;
+ * the serializer also handles their block DOM without duplicating blank lines.
+ */
+export function insertPlainTextWithUndo(value: string) {
+  const normalized = normalizeLogicalLineEndings(value);
+  if (document.execCommand("insertHTML", false, plainTextToContentEditableHtml(normalized))) {
+    return normalized;
+  }
+  document.execCommand("insertText", false, normalized);
+  return normalized;
+}

--- a/crates/agent-gui/src/lib/chat/messages/uploadedFiles.ts
+++ b/crates/agent-gui/src/lib/chat/messages/uploadedFiles.ts
@@ -1,6 +1,6 @@
 import type { Message, UserMessage } from "@earendil-works/pi-ai";
-
 import { createUuid } from "../../shared/id";
+import { normalizeLogicalLineEndings } from "../composerText";
 
 export type UploadedReadableFileKind =
   | "text"
@@ -127,12 +127,12 @@ export function buildUploadedFilesInstruction(files: PendingUploadedFile[]) {
 }
 
 export function buildUserMessageContentWithUploads(userText: string, files: PendingUploadedFile[]) {
-  const normalizedText = userText.trim();
+  const normalizedText = normalizeLogicalLineEndings(userText);
   if (files.length === 0) return normalizedText;
 
   const instruction = buildUploadedFilesInstruction(files);
   if (!instruction) return normalizedText;
-  if (!normalizedText) {
+  if (!normalizedText.trim()) {
     return `Please inspect the selected files first.\n\n${instruction}`;
   }
   return `${normalizedText}\n\n${instruction}`;
@@ -153,7 +153,7 @@ export function createUserMessageWithUploads(
     timestamp,
   };
   if (files.length > 0) {
-    message[DISPLAY_CONTENT_FIELD] = userText.trim();
+    message[DISPLAY_CONTENT_FIELD] = normalizeLogicalLineEndings(userText);
     message[ATTACHMENTS_FIELD] = clonePendingUploadedFiles(files);
   }
   return message;

--- a/crates/agent-gui/src/lib/chat/messages/userMessageContent.tsx
+++ b/crates/agent-gui/src/lib/chat/messages/userMessageContent.tsx
@@ -15,6 +15,7 @@ import { getFileTypeIcon } from "../../../components/chat/fileTypeIcons";
 import { mentionChipClassName } from "../../../components/chat/mentionChipStyles";
 import { SkillIcon } from "../../../components/icons";
 import { useLocale } from "../../../i18n";
+import { normalizeLogicalLineEndings } from "../composerText";
 
 import {
   type CodeMentionReference,
@@ -898,7 +899,11 @@ export const UserMessageContent = memo(function UserMessageContent({
   pastedTextFiles?: PendingUploadedFile[];
   loadCommitDetails?: CommitDetailsLoader;
 }) {
-  const parts = useMemo(() => tokenizeUserMessage(text, pastedTextFiles), [text, pastedTextFiles]);
+  const normalizedText = useMemo(() => normalizeLogicalLineEndings(text), [text]);
+  const parts = useMemo(
+    () => tokenizeUserMessage(normalizedText, pastedTextFiles),
+    [normalizedText, pastedTextFiles],
+  );
   const hasChip = parts.some(
     (part) =>
       part.type === "mention" ||
@@ -908,7 +913,17 @@ export const UserMessageContent = memo(function UserMessageContent({
       part.type === "codeRef" ||
       part.type === "pastedText",
   );
-  if (!hasChip) return <>{text}</>;
+  const trailingNewlineAnchor = normalizedText.endsWith("\n") ? (
+    <span aria-hidden="true" className="chat-user-trailing-newline-anchor" />
+  ) : null;
+  if (!hasChip) {
+    return (
+      <>
+        {normalizedText}
+        {trailingNewlineAnchor}
+      </>
+    );
+  }
 
   return (
     <>
@@ -940,6 +955,7 @@ export const UserMessageContent = memo(function UserMessageContent({
         }
         return <span key={key}>{part.value}</span>;
       })}
+      {trailingNewlineAnchor}
     </>
   );
 });

--- a/crates/agent-gui/src/pages/chat/composer/composerDraftText.ts
+++ b/crates/agent-gui/src/pages/chat/composer/composerDraftText.ts
@@ -5,6 +5,7 @@ import type {
   MentionComposerGitFileMention,
   MentionComposerLargePaste,
 } from "../../../components/chat/MentionComposer";
+import { normalizeLogicalLineEndings } from "../../../lib/chat/composerText";
 import {
   escapeMarkdownReferenceLabel,
   formatCodeMentionToken,
@@ -53,31 +54,33 @@ export function buildTextFromComposerDraft(
   draft: MentionComposerDraft,
   pastedFileById?: Map<string, PendingUploadedFile>,
 ) {
-  return draft.segments
-    .map((segment) => {
-      if (segment.type === "text") {
-        return segment.text;
-      }
-      if (segment.type === "fileMention") {
-        return formatFileMentionToken(segment.reference);
-      }
-      if (segment.type === "skillMention") {
-        return `$${segment.skill.name}`;
-      }
-      if (segment.type === "commitMention") {
-        return formatComposerCommitMention(segment.commit);
-      }
-      if (segment.type === "gitFileMention") {
-        return formatComposerGitFileMention(segment.file);
-      }
-      if (segment.type === "codeMention") {
-        return formatCodeMentionToken(segment.reference);
-      }
-      const file = pastedFileById?.get(segment.paste.id);
-      return file ? `[${segment.paste.label}: ${file.relativePath}]` : segment.paste.text;
-    })
-    .join("")
-    .replace(/\u00A0/g, " ");
+  return normalizeLogicalLineEndings(
+    draft.segments
+      .map((segment) => {
+        if (segment.type === "text") {
+          return segment.text;
+        }
+        if (segment.type === "fileMention") {
+          return formatFileMentionToken(segment.reference);
+        }
+        if (segment.type === "skillMention") {
+          return `$${segment.skill.name}`;
+        }
+        if (segment.type === "commitMention") {
+          return formatComposerCommitMention(segment.commit);
+        }
+        if (segment.type === "gitFileMention") {
+          return formatComposerGitFileMention(segment.file);
+        }
+        if (segment.type === "codeMention") {
+          return formatCodeMentionToken(segment.reference);
+        }
+        const file = pastedFileById?.get(segment.paste.id);
+        return file ? `[${segment.paste.label}: ${file.relativePath}]` : segment.paste.text;
+      })
+      .join("")
+      .replace(/\u00A0/g, " "),
+  );
 }
 
 export async function importPastedTextsAsFiles(
@@ -127,15 +130,16 @@ export async function importPastedTextsAsFiles(
 }
 
 export function createTextComposerDraft(text: string): MentionComposerDraft {
+  const normalizedText = normalizeLogicalLineEndings(text);
   return {
-    segments: text ? [{ type: "text", text }] : [],
-    text,
-    textWithoutLargePastes: text,
+    segments: normalizedText ? [{ type: "text", text: normalizedText }] : [],
+    text: normalizedText,
+    textWithoutLargePastes: normalizedText,
     largePastes: [],
     skillMentions: [],
     commitMentions: [],
     gitFileMentions: [],
     codeMentions: [],
-    isEmpty: text.trim().length === 0,
+    isEmpty: normalizedText.trim().length === 0,
   };
 }

--- a/crates/agent-gui/src/pages/chat/runtime/useSendChatTurn.ts
+++ b/crates/agent-gui/src/pages/chat/runtime/useSendChatTurn.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../../components/chat/MentionComposer";
 import { getAutomationState } from "../../../lib/automation";
 import { createHookRunScope } from "../../../lib/automation/hookRunner";
+import { normalizeLogicalLineEndings } from "../../../lib/chat/composerText";
 import {
   buildPersistableMessagesFromSnapshot,
   type SuppressedToolTraceSnapshot,
@@ -466,14 +467,15 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
     const composerDraft = hasTextOverride
       ? null
       : (overrides?.composerDraftOverride ?? composerRef.current?.getDraft() ?? null);
-    let text = hasTextOverride
-      ? textOverride.trim()
-      : composerDraft
-        ? (effectiveIsAgentMode && composerDraft.largePastes.length > 0
+    let text = normalizeLogicalLineEndings(
+      hasTextOverride
+        ? textOverride
+        : composerDraft
+          ? effectiveIsAgentMode && composerDraft.largePastes.length > 0
             ? composerDraft.textWithoutLargePastes
             : buildTextFromComposerDraft(composerDraft)
-          ).trim()
-        : "";
+          : "",
+    );
     let uploadedFiles = overrides?.uploadedFilesOverride ?? pendingUploadedFiles;
 
     if (
@@ -489,7 +491,7 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
           effectiveWorkdir,
           composerDraft.largePastes,
         );
-        text = buildTextFromComposerDraft(composerDraft, imported.fileByPasteId).trim();
+        text = buildTextFromComposerDraft(composerDraft, imported.fileByPasteId);
         uploadedFiles = mergePendingUploadedFiles(uploadedFiles, imported.files);
       } catch (error) {
         const message = asErrorMessage(error, "大段粘贴内容导入附件失败");

--- a/crates/agent-gui/test/browser/paste-newline-pipeline.html
+++ b/crates/agent-gui/test/browser/paste-newline-pipeline.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
+    <title>GUI paste newline pipeline</title>
+  </head>
+  <body>
+    <div id="editor" class="mention-composer whitespace-pre-wrap" contenteditable="true"></div>
+    <div id="bubble" class="chat-user-bubble w-fit px-4 py-2.5 font-chat text-[14.5px] leading-relaxed"></div>
+    <script type="module">
+      import React from "react";
+      import { createRoot } from "react-dom/client";
+      import "/src/index.css";
+      import {
+        insertPlainTextWithUndo,
+        normalizeLogicalLineEndings,
+      } from "/src/lib/chat/composerText.ts";
+      import { serializeChildrenToSegments } from "/src/components/chat/MentionComposer.tsx";
+      import { buildTextFromComposerDraft } from "/src/pages/chat/composer/composerDraftText.ts";
+      import {
+        createUserMessageWithUploads,
+        getUserMessageDisplayText,
+      } from "/src/lib/chat/messages/uploadedFiles.ts";
+      import { UserMessageContent } from "/src/lib/chat/messages/userMessageContent.tsx";
+
+      const editor = document.querySelector("#editor");
+      const bubble = document.querySelector("#bubble");
+      const bubbleRoot = createRoot(bubble);
+
+      editor.addEventListener("paste", (event) => {
+        event.preventDefault();
+        insertPlainTextWithUndo(event.clipboardData.getData("text/plain"));
+      });
+      editor.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && event.shiftKey) {
+          event.preventDefault();
+          document.execCommand("insertLineBreak");
+        }
+      });
+
+      function resetEditor() {
+        editor.replaceChildren();
+        editor.focus();
+        const selection = getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(editor);
+        range.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+
+      function draftFromEditor() {
+        const segments = serializeChildrenToSegments(editor, new Map());
+        const text = normalizeLogicalLineEndings(
+          segments.map((segment) => (segment.type === "text" ? segment.text : "")).join(""),
+        );
+        return {
+          segments,
+          text,
+          textWithoutLargePastes: text,
+          largePastes: [],
+          skillMentions: [],
+          commitMentions: [],
+          gitFileMentions: [],
+          codeMentions: [],
+          isEmpty: text.trim().length === 0,
+        };
+      }
+
+      async function renderBubble(text) {
+        bubbleRoot.render(React.createElement(UserMessageContent, { text }));
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      }
+
+      async function snapshotPipeline(rawClipboardText, html = "") {
+        const draft = draftFromEditor();
+        const outbound = buildTextFromComposerDraft(draft);
+        const message = createUserMessageWithUploads(outbound, [], 1);
+        const replay = message ? JSON.parse(JSON.stringify(message)) : null;
+        const display = replay ? getUserMessageDisplayText(replay) : "";
+        await renderBubble(display);
+        const style = getComputedStyle(bubble);
+        const padding = Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom);
+        const lineHeight = Number.parseFloat(style.lineHeight);
+        const contentHeight = bubble.getBoundingClientRect().height - padding;
+        return {
+          clipboard: JSON.stringify(rawClipboardText),
+          htmlPresent: Boolean(html),
+          editorHtml: editor.innerHTML,
+          composer: JSON.stringify(draft.text),
+          outbound: JSON.stringify(outbound),
+          history: replay ? JSON.stringify(replay.content) : null,
+          bubbleText: JSON.stringify(bubble.textContent),
+          sendable: message !== null,
+          newlineCounts: {
+            clipboard: (rawClipboardText.match(/\r\n|\r|\n/g) || []).length,
+            composer: (draft.text.match(/\n/g) || []).length,
+            outbound: (outbound.match(/\n/g) || []).length,
+            history: replay ? (replay.content.match(/\n/g) || []).length : null,
+            bubble: (bubble.textContent.match(/\n/g) || []).length,
+          },
+          whiteSpace: style.whiteSpace,
+          lineHeight,
+          contentHeight,
+          visualLineCount: lineHeight > 0 ? Math.round(contentHeight / lineHeight) : null,
+        };
+      }
+
+      window.resetEditor = resetEditor;
+      window.runPastePipeline = async (plain, html = "") => {
+        resetEditor();
+        const transfer = new DataTransfer();
+        transfer.setData("text/plain", plain);
+        if (html) transfer.setData("text/html", html);
+        editor.dispatchEvent(
+          new ClipboardEvent("paste", { clipboardData: transfer, bubbles: true }),
+        );
+        return snapshotPipeline(plain, html);
+      };
+      window.snapshotManualPipeline = snapshotPipeline;
+      window.renderReplay = async (content) => {
+        await renderBubble(content);
+        return {
+          text: bubble.textContent,
+          whiteSpace: getComputedStyle(bubble).whiteSpace,
+        };
+      };
+      window.pipelineReady = true;
+    </script>
+  </body>
+</html>

--- a/crates/agent-gui/test/browser/verify-paste-newline-pipeline.playwright.js
+++ b/crates/agent-gui/test/browser/verify-paste-newline-pipeline.playwright.js
@@ -1,0 +1,143 @@
+async (page) => {
+  const targets = [
+    ["GUI", "http://127.0.0.1:1431/test/browser/paste-newline-pipeline.html"],
+    ["WebUI", "http://127.0.0.1:1432/test/browser/paste-newline-pipeline.html"],
+  ];
+  const cases = [
+    ["LF no blank line", "alpha\nbeta", ""],
+    ["LF one blank line", "alpha\n\nbeta", "<p>ignored rich text</p>"],
+    ["CRLF one blank line", "alpha\r\n\r\nbeta", "<p>ignored rich text</p>"],
+    ["CR one blank line", "alpha\r\rbeta", ""],
+    ["multiple blank lines", "alpha\n\n\nbeta", ""],
+    ["leading newline", "\nalpha", ""],
+    ["trailing newline", "alpha\n", ""],
+    ["leading and trailing", "\nalpha\n", ""],
+    ["pure whitespace", " \n\n ", ""],
+    ["Markdown paragraphs", "first paragraph\n\nsecond paragraph", ""],
+    ["Markdown list", "- one\n- two", ""],
+    ["Markdown quote", "> quote\n> continued", ""],
+    ["Markdown code block", "```ts\nconst value = 1;\n```", ""],
+    ["Markdown table", "| a | b |\n| - | - |\n| 1 | 2 |", ""],
+    ["Markdown link", "[OpenAI](https://openai.com)\nnext", ""],
+    ["HTML-like plaintext", "<tag>& value\n\nnext", "<strong>must be ignored</strong>"],
+    ["Unicode and emoji", "你好🙂\n\nκαλημέρα", ""],
+    ["long text", `${"x".repeat(20_000)}\n\n${"y".repeat(20_000)}`, ""],
+  ];
+
+  function expectEqual(actual, expected, label) {
+    if (actual !== expected) {
+      throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    }
+  }
+
+  async function openTarget(url) {
+    await page.goto(url);
+    await page.waitForFunction(() => window.pipelineReady === true);
+  }
+
+  async function typeManualText(value) {
+    await page.evaluate(() => window.resetEditor());
+    const normalized = value.replace(/\r\n?/g, "\n");
+    const lines = normalized.split("\n");
+    for (let index = 0; index < lines.length; index += 1) {
+      if (lines[index]) await page.keyboard.insertText(lines[index]);
+      if (index < lines.length - 1) await page.keyboard.press("Shift+Enter");
+    }
+    return await page.evaluate((raw) => window.snapshotManualPipeline(raw), value);
+  }
+
+  const evidence = {};
+  for (const [targetName, url] of targets) {
+    await openTarget(url);
+    const targetEvidence = [];
+    for (const [caseName, input, html] of cases) {
+      const expected = input.replace(/\r\n?/g, "\n");
+      const sendable = expected.trim().length > 0;
+      const result = await page.evaluate(
+        ([plain, rich]) => window.runPastePipeline(plain, rich),
+        [input, html],
+      );
+      expectEqual(JSON.parse(result.composer), expected, `${targetName}/${caseName}/composer`);
+      expectEqual(JSON.parse(result.outbound), expected, `${targetName}/${caseName}/outbound`);
+      expectEqual(result.sendable, sendable, `${targetName}/${caseName}/sendable`);
+      expectEqual(result.whiteSpace, "pre-wrap", `${targetName}/${caseName}/white-space`);
+      if (sendable) {
+        expectEqual(JSON.parse(result.history), expected, `${targetName}/${caseName}/history`);
+        expectEqual(JSON.parse(result.bubbleText), expected, `${targetName}/${caseName}/bubble`);
+      } else {
+        expectEqual(result.history, null, `${targetName}/${caseName}/history`);
+        expectEqual(JSON.parse(result.bubbleText), "", `${targetName}/${caseName}/bubble`);
+      }
+      if (caseName === "LF one blank line") {
+        expectEqual(result.htmlPresent, true, `${targetName}/${caseName}/rich clipboard`);
+        expectEqual(result.visualLineCount, 3, `${targetName}/${caseName}/visual lines`);
+
+        const manual = await typeManualText(input);
+        expectEqual(manual.composer, result.composer, `${targetName}/${caseName}/manual composer`);
+        expectEqual(manual.outbound, result.outbound, `${targetName}/${caseName}/manual outbound`);
+        expectEqual(manual.bubbleText, result.bubbleText, `${targetName}/${caseName}/manual bubble`);
+
+        await page.evaluate(([plain, rich]) => window.runPastePipeline(plain, rich), [input, html]);
+        expectEqual(await page.evaluate(() => document.execCommand("undo")), true, `${targetName}/undo`);
+        expectEqual(await page.locator("#editor").textContent(), "", `${targetName}/undo editor`);
+        expectEqual(await page.evaluate(() => document.execCommand("redo")), true, `${targetName}/redo`);
+        const redo = await page.evaluate((raw) => window.snapshotManualPipeline(raw), input);
+        expectEqual(JSON.parse(redo.composer), expected, `${targetName}/redo composer`);
+      }
+      if (caseName === "trailing newline") {
+        expectEqual(result.visualLineCount, 2, `${targetName}/${caseName}/visual lines`);
+      }
+      if (caseName === "leading and trailing") {
+        expectEqual(result.visualLineCount, 3, `${targetName}/${caseName}/visual lines`);
+      }
+      targetEvidence.push(
+        caseName === "long text"
+          ? {
+              caseName,
+              composerLength: JSON.parse(result.composer).length,
+              outboundLength: JSON.parse(result.outbound).length,
+              bubbleLength: JSON.parse(result.bubbleText).length,
+              newlineCounts: result.newlineCounts,
+              whiteSpace: result.whiteSpace,
+            }
+          : { caseName, ...result },
+      );
+    }
+
+    const replayText = "reload\n\nreconnect";
+    const beforeReload = await page.evaluate((text) => window.runPastePipeline(text), replayText);
+    await page.reload();
+    await page.waitForFunction(() => window.pipelineReady === true);
+    const afterReload = await page.evaluate(
+      (content) => window.renderReplay(content),
+      JSON.parse(beforeReload.history),
+    );
+    expectEqual(afterReload.text, replayText, `${targetName}/reload replay`);
+    const afterReconnect = await page.evaluate(
+      (content) => window.renderReplay(content),
+      JSON.parse(beforeReload.history),
+    );
+    expectEqual(afterReconnect.text, replayText, `${targetName}/reconnect replay`);
+    evidence[targetName] = targetEvidence;
+  }
+
+  const crossText = "desktop to web\n\nweb to desktop";
+  await openTarget(targets[0][1]);
+  const guiMessage = await page.evaluate((text) => window.runPastePipeline(text), crossText);
+  await openTarget(targets[1][1]);
+  const webReplay = await page.evaluate(
+    (content) => window.renderReplay(content),
+    JSON.parse(guiMessage.history),
+  );
+  expectEqual(webReplay.text, crossText, "GUI -> WebUI replay");
+
+  const webMessage = await page.evaluate((text) => window.runPastePipeline(text), crossText);
+  await openTarget(targets[0][1]);
+  const guiReplay = await page.evaluate(
+    (content) => window.renderReplay(content),
+    JSON.parse(webMessage.history),
+  );
+  expectEqual(guiReplay.text, crossText, "WebUI -> GUI replay");
+
+  return evidence;
+}

--- a/crates/agent-gui/test/chat/messages.test.mjs
+++ b/crates/agent-gui/test/chat/messages.test.mjs
@@ -208,7 +208,7 @@ test("uploaded file helpers preserve display text and strip model-hidden metadat
   assert.ok(message);
   assert.equal(message.role, "user");
   assert.equal(message.timestamp, 1234);
-  assert.equal(uploadedFiles.getUserMessageDisplayText(message), "Please review");
+  assert.equal(uploadedFiles.getUserMessageDisplayText(message), " Please review ");
   assert.deepEqual(uploadedFiles.getUserMessageAttachments(message), [fileA]);
   assert.match(message.content, /The user attached the files below/);
   assert.match(message.content, /Use Read with these exact paths/);

--- a/crates/agent-gui/test/chat/paste-newline-pipeline.test.mjs
+++ b/crates/agent-gui/test/chat/paste-newline-pipeline.test.mjs
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const composer = loader.loadModule("src/components/chat/MentionComposer.tsx");
+const composerText = loader.loadModule("src/lib/chat/composerText.ts");
+const draftText = loader.loadModule("src/pages/chat/composer/composerDraftText.ts");
+const uploadedFiles = loader.loadModule("src/lib/chat/messages/uploadedFiles.ts");
+
+const originalNode = globalThis.Node;
+globalThis.Node = { TEXT_NODE: 3, ELEMENT_NODE: 1 };
+
+test.after(() => {
+  if (originalNode === undefined) delete globalThis.Node;
+  else globalThis.Node = originalNode;
+});
+
+function textNode(text) {
+  return { nodeType: Node.TEXT_NODE, textContent: text };
+}
+
+function elementNode(tagName, childNodes = [], attributes = {}) {
+  return {
+    nodeType: Node.ELEMENT_NODE,
+    tagName,
+    childNodes,
+    getAttribute(name) {
+      return attributes[name] ?? null;
+    },
+    hasAttribute(name) {
+      return Object.hasOwn(attributes, name);
+    },
+  };
+}
+
+// Chromium's current execCommand("insertText") DOM for multiline plaintext:
+// the first line stays at the root, later lines become DIVs, and empty lines
+// become DIV > BR. The real-browser baseline probe records this exact shape.
+function chromiumPasteDom(clipboardText) {
+  const normalized = clipboardText.replace(/\r\n?/g, "\n");
+  const lines = normalized.split("\n");
+  const children = [];
+  if (lines[0]) children.push(textNode(lines[0]));
+  else if (lines.length > 1) children.push(elementNode("DIV", [elementNode("BR")]));
+  for (const line of lines.slice(1)) {
+    children.push(elementNode("DIV", line ? [textNode(line)] : [elementNode("BR")]));
+  }
+  return elementNode("DIV", children);
+}
+
+function draftFromSegments(segments) {
+  const text = segments.map((segment) => segment.text ?? "").join("");
+  return {
+    segments,
+    text,
+    textWithoutLargePastes: text,
+    largePastes: [],
+    skillMentions: [],
+    commitMentions: [],
+    gitFileMentions: [],
+    codeMentions: [],
+    isEmpty: text.trim().length === 0,
+  };
+}
+
+const cases = [
+  ["LF no blank line", "alpha\nbeta"],
+  ["LF one blank line", "alpha\n\nbeta"],
+  ["CRLF one blank line", "alpha\r\n\r\nbeta"],
+  ["CR one blank line", "alpha\r\rbeta"],
+  ["multiple blank lines", "alpha\n\n\nbeta"],
+  ["leading newline", "\nalpha"],
+  ["trailing newline", "alpha\n"],
+  ["Markdown paragraphs", "first paragraph\n\nsecond paragraph"],
+  ["Markdown list", "- one\n- two"],
+  ["Markdown quote", "> quote\n> continued"],
+  ["Markdown code block", "```ts\nconst value = 1;\n```"],
+  ["Markdown table", "| a | b |\n| - | - |\n| 1 | 2 |"],
+  ["Unicode and emoji", "你好🙂\n\nκαλημέρα"],
+  ["long text", `${"x".repeat(20_000)}\n\n${"y".repeat(20_000)}`],
+];
+
+test("clipboard DOM -> composer draft -> outbound -> history preserves logical newlines", () => {
+  for (const [name, clipboardText] of cases) {
+    const expected = clipboardText.replace(/\r\n?/g, "\n");
+    const segments = composer.serializeChildrenToSegments(chromiumPasteDom(clipboardText), new Map());
+    const draft = draftFromSegments(segments);
+    const outbound = draftText.buildTextFromComposerDraft(draft);
+    const message = uploadedFiles.createUserMessageWithUploads(outbound, [], 1);
+    const history = JSON.parse(JSON.stringify(message));
+
+    assert.equal(draft.text, expected, `${name}: composer draft`);
+    assert.equal(outbound, expected, `${name}: outbound payload`);
+    assert.equal(history.content, expected, `${name}: history/replay`);
+    assert.equal(
+      uploadedFiles.getUserMessageDisplayText(history),
+      expected,
+      `${name}: transcript user bubble text`,
+    );
+  }
+});
+
+test("pure whitespace remains structurally intact in the draft but is not sendable", () => {
+  const clipboardText = " \r\n\r\n ";
+  const expected = " \n\n ";
+  const segments = composer.serializeChildrenToSegments(chromiumPasteDom(clipboardText), new Map());
+  const draft = draftFromSegments(segments);
+  assert.equal(draft.text, expected);
+  assert.equal(draftText.buildTextFromComposerDraft(draft), expected);
+  assert.equal(uploadedFiles.createUserMessageWithUploads(expected, [], 1), null);
+});
+
+test("message creation normalizes line endings without trimming logical edge newlines", () => {
+  const input = "\r\nalpha\r\nbeta\r";
+  const expected = "\nalpha\nbeta\n";
+  const message = uploadedFiles.createUserMessageWithUploads(input, [], 1);
+  assert.equal(message.content, expected);
+  assert.equal(uploadedFiles.getUserMessageDisplayText(message), expected);
+});
+
+test("plaintext HTML escaping preserves literal content and logical newlines", () => {
+  assert.equal(
+    composerText.plainTextToContentEditableHtml("<tag>& value\r\nnext"),
+    "&lt;tag&gt;&amp; value\nnext",
+  );
+});
+
+test("composer serialization preserves newlines around mention chips", () => {
+  const root = elementNode("DIV", [
+    textNode("first\n"),
+    elementNode("SPAN", [], {
+      "data-mention-path": "src/App.tsx",
+      "data-mention-kind": "file",
+    }),
+    textNode("\nsecond"),
+  ]);
+  const segments = composer.serializeChildrenToSegments(root, new Map());
+  assert.deepEqual(
+    segments.map((segment) =>
+      segment.type === "text"
+        ? { type: "text", text: segment.text }
+        : { type: segment.type, path: segment.reference?.path },
+    ),
+    [
+      { type: "text", text: "first\n" },
+      { type: "fileMention", path: "src/App.tsx" },
+      { type: "text", text: "\nsecond" },
+    ],
+  );
+});

--- a/crates/agent-gui/test/chat/user-message-content.test.mjs
+++ b/crates/agent-gui/test/chat/user-message-content.test.mjs
@@ -140,6 +140,19 @@ test("rendered commit mentions do not include native title tooltips", () => {
   assert.doesNotMatch(html, /title=/);
 });
 
+test("trailing newlines render a visual line anchor without changing DOM text", () => {
+  const html = renderToStaticMarkup(
+    jsxRuntime.jsx(renderedUserMessageContent.UserMessageContent, {
+      text: "alpha\n",
+    }),
+  );
+  assert.equal(
+    html,
+    'alpha\n<span aria-hidden="true" class="chat-user-trailing-newline-anchor"></span>',
+  );
+  assert.doesNotMatch(html, /\u200b/i);
+});
+
 test("code mention tokens round trip through transcript tokenization", () => {
   const reference = mentionReferences.createCodeMentionReference({
     path: "src/pages/ChatPage.tsx",

--- a/docs/worklog/paste-newline-serialization.md
+++ b/docs/worklog/paste-newline-serialization.md
@@ -5,15 +5,15 @@
 ## 恢复指令（覆盖式，永远只反映此刻）
 
 - **总目标**：在桌面 GUI 与 Gateway WebUI 中保持粘贴、编辑、发送、历史/重连恢复和用户消息气泡渲染的逻辑换行数量与位置一致，同时不改变其他消息类型的 Markdown 语义。
-- **当前任务**：用户已明确回复“通过”；正在固化公开截图、暂存/提交本任务文件，随后推送、创建上游 Issue/PR 并收敛 required CI。
-- **上一个完成的动作**：用 GUI/WebUI 实际生产模块 fixture 生成两张公开截图，均显示 ClipboardEvent、composer、outbound、history 与 bubble DOM 的逻辑换行计数为 2，气泡为 3 个视觉行且无放大空隙，并显示 history/reconnect replay 通过；用户人工验收结论为“通过”。
-- **下一步第一个动作**：执行最终范围/敏感文件/生成物审计，只暂存本任务源代码、测试、mirror manifest 和 worklog，复核 staged diff 后提交。
+- **当前任务**：用户验收、提交和 fork push 已完成；上游 bug Issue #352 已创建，正在创建 PR、上传公开截图并收敛 required CI。
+- **上一个完成的动作**：23 个任务文件经 staged 范围/二进制/凭据审计和独立审查后提交为 `3bd4183c`，推送到 `AlphaCatMeow/LiveAgent:codex/fix-paste-newline-serialization`；创建上游 Issue #352。
+- **下一步第一个动作**：创建关联 `Closes #352` 的上游 draft PR，回填 `Depends-On: none` 与自身 `Stack-Root`，补公开截图附件并监测 required CI。
 - **当前假设/约束/待确认**：只允许在 `D:\Documents\Projects\Web\LiveAgent\target\codex-paste-newline-serialization-worktree` 工作；不改 Rust、Go、数据库、协议或依赖，除非数据证据证明纯前端不足并先报告；用户验收通过前不 commit、push、创建 Issue/PR 或改远端状态。
 
 ## 未提交改动 & 验证边界
 
-- **最近 checkpoint commit**：无。
-- **未提交的改动**：双端 composer/newline helper/发送/用户消息渲染与局部用户气泡 CSS；双端 Node pipeline 测试；双端 Vite/Playwright 浏览器 fixture；`mirror-manifest`；相关旧 trim/SSR 断言；本 worklog。临时日志和基线副本已移动到 worktree 内 Git-ignored 的 `target/paste-newline-artifacts/`。
+- **最近 checkpoint commit**：`3bd4183c8246c4dde5f489b8e672b9328335071e`（已推送 fork）。
+- **未提交的改动**：仅本次远端交接状态的 worklog 更新；临时日志、截图、数据库和基线副本均位于 worktree 内 Git-ignored 的 `target/paste-newline-artifacts/`。
 - **已验证**：分支/基线隔离；双端 build/typecheck；定向与全量测试（含基线对照）；定向 lint；全量 lint 逐项基线对照；Mirror Check；`git diff --check`；真实 Chromium 生产模块 pipeline、CSS 高度、undo/redo、reload/reconnect 与双端交叉 replay；独立只读审查。
 - **未验证**：提交、push、上游 Issue/PR 与 required CI 终态。
 
@@ -100,6 +100,8 @@
   - Gateway WebUI：`target/paste-newline-artifacts/runtime/screenshots/acceptance-webui-pipeline-2026-08-01T01-31-45-337Z.png`
 - 两张截图逐张人工检查：均显示 `alpha\n\nbeta` 在 Clipboard、Composer、Outbound、History、Bubble DOM 五阶段为 2 个换行；composer 与发送后气泡各显示一个普通空行；气泡 `white-space=pre-wrap`、3 个视觉行；`reload\n\nreconnect` replay 显示相同单空行。
 - 截图后只终止本 worktree 的 fixture Vite PID 70764/66684，并确认 1431/1432 关闭；Tauri/Gateway/WebUI 1420/15052/15174 保持运行。Playwright 临时状态移入 ignored `playwright-public-evidence/`。
+- 最终显式暂存 23 个任务文本文件；无 Rust、Go、协议、依赖锁、数据库、图片、视频、凭据、构建产物或可见 unstaged/untracked 文件。独立 staged review 未发现高/中确定性问题。
+- 主实现提交：`3bd4183c8246c4dde5f489b8e672b9328335071e`，已推送 fork 分支；远端 `upstream/main` 仍精确等于固定基线。上游 Issue：[Stack-Cairn/LiveAgent#352](https://github.com/Stack-Cairn/LiveAgent/issues/352)。
 
 ## 关键决策（只增不删）
 

--- a/docs/worklog/paste-newline-serialization.md
+++ b/docs/worklog/paste-newline-serialization.md
@@ -5,17 +5,17 @@
 ## 恢复指令（覆盖式，永远只反映此刻）
 
 - **总目标**：在桌面 GUI 与 Gateway WebUI 中保持粘贴、编辑、发送、历史/重连恢复和用户消息气泡渲染的逻辑换行数量与位置一致，同时不改变其他消息类型的 Markdown 语义。
-- **当前任务**：用户验收、提交和 fork push 已完成；上游 bug Issue #352 已创建，正在创建 PR、上传公开截图并收敛 required CI。
-- **上一个完成的动作**：23 个任务文件经 staged 范围/二进制/凭据审计和独立审查后提交为 `3bd4183c`，推送到 `AlphaCatMeow/LiveAgent:codex/fix-paste-newline-serialization`；创建上游 Issue #352。
-- **下一步第一个动作**：创建关联 `Closes #352` 的上游 draft PR，回填 `Depends-On: none` 与自身 `Stack-Root`，补公开截图附件并监测 required CI。
-- **当前假设/约束/待确认**：只允许在 `D:\Documents\Projects\Web\LiveAgent\target\codex-paste-newline-serialization-worktree` 工作；不改 Rust、Go、数据库、协议或依赖，除非数据证据证明纯前端不足并先报告；用户验收通过前不 commit、push、创建 Issue/PR 或改远端状态。
+- **当前任务**：上游 Draft PR #353 已在当前主工作区无冲突 rebase 到执行时最新 `upstream/main@00a2c6fc`；自动验证和同 HEAD Tauri 人工验收均已通过，正在折叠本轮 worklog、更新 fork 分支、转 Ready 并收敛新一轮 CI/Governance。
+- **上一个完成的动作**：用户完成粘贴、首尾/空白换行、undo/redo、重复发送、取消和 reload/history 恢复验收，并对当前 rebase 产品 HEAD 明确回复“通过”。
+- **下一步第一个动作**：只暂存本 worklog，创建 fixup 并 autosquash 到既有 `docs(chat): record paste newline handoff` 提交；复核最终三提交范围后，以显式 lease 更新唯一指定的 fork PR 分支。
+- **当前假设/约束/待确认**：只允许在 `D:\Documents\Projects\Web\LiveAgent` 当前工作区工作；保护既有 `Cargo.toml` 内容以及未跟踪的 `.codegraph/`、`output/`，不得 stash/reset/恢复/删除；人工验收门禁已解除，但仍只允许推送 `origin/codex/fix-paste-newline-serialization`，launcher 永不跟踪或提交。
 
 ## 未提交改动 & 验证边界
 
-- **最近 checkpoint commit**：`3bd4183c8246c4dde5f489b8e672b9328335071e`（已推送 fork）。
-- **未提交的改动**：仅本次远端交接状态的 worklog 更新；临时日志、截图、数据库和基线副本均位于 worktree 内 Git-ignored 的 `target/paste-newline-artifacts/`。
-- **已验证**：分支/基线隔离；双端 build/typecheck；定向与全量测试（含基线对照）；定向 lint；全量 lint 逐项基线对照；Mirror Check；`git diff --check`；真实 Chromium 生产模块 pipeline、CSS 高度、undo/redo、reload/reconnect 与双端交叉 replay；独立只读审查。
-- **未验证**：提交、push、上游 Issue/PR 与 required CI 终态。
+- **最近 checkpoint commit**：人工验收使用的产品 HEAD 为 `bb060885f569cdb2c6240a60e413e442e90330c1`；即将进行的 docs-only autosquash 只更新本 worklog，不改变已验收产品树。远端 PR head 在 push 前仍为 `bcbd4a5ce0b6015583dda036e034ae01807f5120`。
+- **未提交的改动**：仅本轮恢复状态与变基记录的 worklog 更新；`.codegraph/`、`output/` 和本地 launcher 均保持未跟踪/忽略状态。
+- **已验证**：受保护 `Cargo.toml` 保持 Git clean 且过滤后 blob 与原 PR/最新 main 一致，launcher 仍只由 `.git/info/exclude` 忽略；最新远端基线；rebase 拓扑；原/新提交 range-diff；23 文件集合与统计；三个主线重叠文件的最终语义；双端 build；GUI 定向 19/19、WebUI 定向 5/5、WebUI 全量 498/498；GUI 全量 1404/1409，5 项失败在最新 main 快照精确复现为同一 2+2+1；完整 lint 当前/基线 GUI errors 421/424、WebUI 290/292 且 warning/info 相同，双端定向 lint 与 LF Git blob check exit 0；Mirror Check 116 files；`git diff --check`；真实 Chromium 双端 pipeline、视觉行、undo/redo、reload replay 与交叉 replay；独立只读审查。
+- **未验证**：worklog 状态折叠提交、force-with-lease push、Ready 转换及新一轮 required CI/Governance 终态。
 
 ## 复现与数据链路证据
 
@@ -145,3 +145,19 @@
 - 做了：收到用户明确“通过”；捕获当前 Tauri 后发现未显示目标样例，拒绝将无关画面作为证据；随后从 GUI/WebUI 实际生产模块 fixture 重新执行粘贴、序列化、history/reconnect replay 并生成两张公开截图。
 - 验证：双端截图五阶段换行计数一致，空行视觉高度一致；公开截图无用户既有会话内容。只关闭本任务 1431/1432 fixture，三端人工环境仍在。
 - 遗留：最终 staged 审计、commit/push、上游 Issue/PR、required CI 收敛。
+
+### 2026-08-01 — 上游交付与首轮 CI 格式修正
+
+- 做了：提交并推送主实现与 worklog；创建上游 Issue #352 和 Draft PR #353（`Depends-On: none`、`Stack-Root: #353`）。首轮 Actions run `30678600187` 中 Gateway、Gateway Docker Smoke、Tauri Rust Check、Mirror Check 与 Diff Hygiene 通过，GUI 与 Gateway WebUI 均在 `pnpm lint` 失败。
+- 根因：完整 job 日志只显示数百条基线 warning 并截断唯一 error；通过对 Git 中的 LF blob 运行 Biome formatter 后定位到双端 `MentionComposer.tsx` 的 3 个新增换行格式点，以及 WebUI 镜像文件 `setDraft` 分支的缩进偏差。没有修改既有 lint warning，也没有扩大到业务逻辑。
+- 修复与验证：按 formatter 精确输出最小同步修正两个镜像文件；GUI/WebUI build 通过，双端 paste pipeline 各 5/5，Mirror Check 120 files 与 `git diff --check` 通过；对 staged LF blob 再次格式化后均为零 diff。
+- 遗留：提交并推送格式修正，等待新一轮 required CI 全部终态；将两张已审查公开截图通过已认证 GitHub Web UI 附加到 PR，再将 Draft 标记为 ready 并等待 PR Governance 终态。
+
+### 2026-08-06 — 变基到最新 main 与范围审计
+
+- 做了：在主工作区记录并保护用户已有 `Cargo.toml`、`.codegraph/`、`output/` 与本地 launcher 状态；获取 `upstream/main@00a2c6fc` 和远端 PR head；因同名本地分支被历史 Worktree 占用，从远端 PR head 创建当前工作区维护分支 `fix-pr-353-rebase`，未修改或使用历史 Worktree；将 PR 的 3 个提交无冲突 rebase 到最新 main。
+- 验证：新 HEAD `bb060885` 以 `00a2c6fc` 为 merge base，PR-only/main-only 计数为 3/0；`git range-diff` 三个提交均为 `=`；原/新文件集合均为 23，统计均为 1194 insertions/135 deletions；新树与此前同基线独立重写树一致；重点点验 `GatewayApp.tsx`、`useSendChatTurn.ts`、`scripts/mirror-manifest.json`，确认主线修改保留且 PR 只叠加原换行保真补丁。
+- 自动验证：GUI/WebUI production build 通过；GUI 定向换行与用户气泡 19/19、WebUI 定向 5/5、WebUI 全量 498/498；GUI 全量 1404/1409，5 项失败在最新 main 的临时非 Worktree 快照精确复现为 2 个 selection 提取、2 个 mention refetch 提取和 1 个 provider preset 字节比较基线失败。完整 lint 在 Windows CRLF checkout 下当前/基线分别为 GUI 421/424 errors、WebUI 290/292 errors，warning/info 相同；双端变更文件语义 lint 与 LF Git blob check 均 exit 0。Mirror Check 116 files、`git diff --check` 和真实 Chromium 双端 pipeline 均通过；fixture 专用 1431/1432 服务与临时文件已清理。
+- 同 HEAD Tauri：从当前工作区执行 `start-tauri-dev.bat`，launcher 记录正确仓库路径与 `LIBCLANG_PATH`；Rust dev profile 747/747 在 42.24 秒完成，运行当前工作区 `target/debug/liveagent.exe`。Vite PID 40096 监听 1420，Tauri PID 45488 的窗口句柄非零、`Responding=true`，Vite HTTP 200；没有复用或终止其他客户端。Playwright CLI 本轮产生的两个工具状态文件已精确删除。
+- 人工验收：用户按矩阵完成普通/CRLF/首尾/多空行、Unicode/HTML-like 纯文本、纯空白拒绝、undo/redo、重复操作、取消响应和 reload/history 恢复，并于 2026-08-06 对当前 rebase 产品 HEAD 明确回复“通过”。
+- 遗留：将本 worklog 状态修正折叠进既有 docs 提交、使用显式 `--force-with-lease` 更新 PR head、转 Ready 并收敛 CI/Governance。

--- a/docs/worklog/paste-newline-serialization.md
+++ b/docs/worklog/paste-newline-serialization.md
@@ -1,0 +1,145 @@
+# 工作记录 — 粘贴换行序列化与用户消息渲染
+
+> 用途：承接本任务跨对话上下文。每次恢复先读「恢复指令」，再在指定 worktree 中核对 `git status` 与当前 HEAD。
+
+## 恢复指令（覆盖式，永远只反映此刻）
+
+- **总目标**：在桌面 GUI 与 Gateway WebUI 中保持粘贴、编辑、发送、历史/重连恢复和用户消息气泡渲染的逻辑换行数量与位置一致，同时不改变其他消息类型的 Markdown 语义。
+- **当前任务**：用户已明确回复“通过”；正在固化公开截图、暂存/提交本任务文件，随后推送、创建上游 Issue/PR 并收敛 required CI。
+- **上一个完成的动作**：用 GUI/WebUI 实际生产模块 fixture 生成两张公开截图，均显示 ClipboardEvent、composer、outbound、history 与 bubble DOM 的逻辑换行计数为 2，气泡为 3 个视觉行且无放大空隙，并显示 history/reconnect replay 通过；用户人工验收结论为“通过”。
+- **下一步第一个动作**：执行最终范围/敏感文件/生成物审计，只暂存本任务源代码、测试、mirror manifest 和 worklog，复核 staged diff 后提交。
+- **当前假设/约束/待确认**：只允许在 `D:\Documents\Projects\Web\LiveAgent\target\codex-paste-newline-serialization-worktree` 工作；不改 Rust、Go、数据库、协议或依赖，除非数据证据证明纯前端不足并先报告；用户验收通过前不 commit、push、创建 Issue/PR 或改远端状态。
+
+## 未提交改动 & 验证边界
+
+- **最近 checkpoint commit**：无。
+- **未提交的改动**：双端 composer/newline helper/发送/用户消息渲染与局部用户气泡 CSS；双端 Node pipeline 测试；双端 Vite/Playwright 浏览器 fixture；`mirror-manifest`；相关旧 trim/SSR 断言；本 worklog。临时日志和基线副本已移动到 worktree 内 Git-ignored 的 `target/paste-newline-artifacts/`。
+- **已验证**：分支/基线隔离；双端 build/typecheck；定向与全量测试（含基线对照）；定向 lint；全量 lint 逐项基线对照；Mirror Check；`git diff --check`；真实 Chromium 生产模块 pipeline、CSS 高度、undo/redo、reload/reconnect 与双端交叉 replay；独立只读审查。
+- **未验证**：提交、push、上游 Issue/PR 与 required CI 终态。
+
+## 复现与数据链路证据
+
+- Chromium 基线探针使用真实 `DataTransfer` + `ClipboardEvent("paste")`，同时提供 `text/plain` 与 `text/html`；产品行为只读取 plain。
+- `alpha\n\nbeta`：clipboard 2 个逻辑换行；paste DOM 为 `alpha<div><br></div><div>beta</div>`；composer/outbound/history/bubble 均为 `alpha\n\n\nbeta`（3 个换行）；`white-space: pre-wrap` 下内容高度 96px，而保真文本应为 72px。
+- `alpha\n\n\nbeta`：clipboard 3 个换行，composer/outbound/history/bubble 变为 5 个，高度 144px。
+- `\nalpha\n`：composer 先放大为 4 个换行，发送 `.trim()` 后首尾换行全部消失。
+- ` \n\n `：composer 从 2 个换行放大为 3 个，发送 trim 后为空并拒绝发送；草稿结构本身也已错误。
+- Markdown/Unicode 探针同样只在原有空行位置放大；JSON history/replay 本身原样保留传入字符串，没有新增换行。
+- 修复后 GUI/WebUI 生产模块浏览器 fixture 均记录：clipboard、composer、outbound、history、bubble 的 newline count 完全一致；`alpha\n\nbeta` 为 2/2/2/2/2，bubble `white-space=pre-wrap`、内容高度 70.6875px、3 个视觉行（两行文字 + 一个空行）。
+- Chromium 视觉探针确认 `pre-wrap`、`break-spaces`、`pre-line` 都保留 `alpha\n` 的 DOM 文本，却不会为末尾 LF 分配第二个行盒；空 span 无效，文本零宽空格虽有效但会污染 `textContent`。局部 `aria-hidden` 空 span 的 CSS `::before` 零宽字符可生成末尾行盒，同时保持 bubble DOM 文本精确等于消息内容。
+- 修复后覆盖实际 `ClipboardEvent`、同时含 `text/html`、手工 Shift+Enter、undo/redo、reload/reconnect、GUI→WebUI、WebUI→GUI；`<tag>&` 被安全编码为 DOM `&lt;tag&gt;&amp;`，逻辑文本往返不变；40,002 字符长文本各阶段长度和 2 个换行一致。
+
+## 根因
+
+- 已确认主根因：浏览器对 multiline `execCommand("insertText")` 生成空 `DIV > BR`；`collectDraftSegments` 对该空块既添加 DIV/P 块边界换行，又把内部 BR 计为换行，因此每个空行多插入一个 `\n`。
+- 已确认第二根因：GUI `useSendChatTurn.ts`、WebUI `GatewayApp.tsx` 与双端 `buildUserMessageContentWithUploads` 对完整用户文本调用 `.trim()`，会删除合法首尾逻辑换行并造成双端/阶段语义不清。
+- 已确认第三个独立浏览器渲染边界：即使 raw text 精确保留末尾 LF，CSS `white-space` 也不会自动生成最后一个空行行盒；这是仅影响末尾换行的视觉折叠，不是 transport 或 serializer 数据丢失。
+- 已排除：transport、optimistic transcript、JSON history/replay 没有换行 replace/trim；用户气泡不走 Markdown，而是 raw text + `white-space: pre-wrap`，所以普通空行放大的主因是上游已损坏的换行。段落 margin 不是本问题根因。
+
+## 设计不变量
+
+- CRLF 与 CR 可以在一个明确边界规范为 LF，但不得增加、删除或移动逻辑换行。
+- 输入、发送和渲染不得分别执行可叠加的换行扩增转换。
+- 手工输入与粘贴得到相同逻辑文本时，payload 与渲染必须相同。
+- 用户消息的纯文本换行/块间距策略必须局部生效；assistant、thinking、tool、AskUserQuestion、TodoWrite 和 system 的 Markdown 语义保持不变。
+- GUI、Gateway WebUI 与桌面共用 React 路径保持相同数据和视觉不变量。
+- 保留消息 identity、顺序、虚拟化、滚动跟随、composer 布局和任务进度指示器。
+- 不用 `trim()`、全局空白折叠、固定高度、隐藏溢出或 O(n²)/同步全量 DOM 遍历掩盖问题。
+- `normalizeLogicalLineEndings` 是唯一换行语义模型：仅把 CRLF/CR 变为 LF，线性时间、幂等、不 trim；输入、草稿、发送和旧 history 显示调用同一模型，不再各自发明转换。
+- multiline plaintext paste 使用经过 `&<>` 转义的单次 `execCommand("insertHTML")`，literal LF 在 `white-space: pre-wrap` 下显示并进入同一 undo stack；不支持时回退 `insertText`，而 block-aware serializer 可正确读取其 DIV/P/BR DOM。
+- serializer 将块级节点视为逻辑行单元，空 `DIV/P > BR` 中的 BR 只作为占位，不再与块边界重复计数；mention/chip 与换行交错有双端行为测试。
+- 仅当用户消息规范化文本以 LF 结尾时，追加不参与可访问文本和 `textContent` 的 `chat-user-trailing-newline-anchor`；其 `::before` 只负责生成浏览器遗漏的末尾行盒，不改变 assistant/tool Markdown、payload 或历史内容。
+
+## 验证结果与基线失败
+
+- 修复前真实浏览器：LF/CRLF/CR、单/多空行、首尾换行、纯空白、Markdown、Unicode/emoji 均已执行；空行放大和 trim 丢失稳定出现。
+- 修复前 GUI 定向：`node crates/agent-gui/test/chat/paste-newline-pipeline.test.mjs`，2/2 失败；核心差异 `actual 'alpha\n\n\nbeta'` vs `expected 'alpha\n\nbeta'`。
+- 修复前 WebUI 定向：`node crates/agent-gateway/test/webui/paste-newline-pipeline.test.mjs`，2/2 失败；差异与 GUI 一致。
+- 首次定向运行因新 worktree 缺 `node_modules` 未到断言；随后分别执行 frozen-lockfile install，未修改依赖声明或 lockfile。
+- 修复后新增 pipeline：GUI/WebUI 合计 10/10；最终 pipeline + GUI 用户消息 SSR 定向合计 24/24；覆盖 LF/CRLF/CR、无/单/多空行、首尾换行、纯空白、Markdown 段落/列表/引用/代码块/表格、Unicode/emoji、长文本、HTML-like plaintext、mention chip 和末尾视觉行锚点。
+- WebUI 全量：498/498。
+- GUI 全量：1421 tests，1416 pass，5 fail。5 个失败均在 `upstream/main@7de95a20...` 的 Windows checkout 基线逐项复现：2 个 `mention-composer-selection`、2 个 `mention-refetch` 因测试只识别 LF 函数结尾，1 个 provider usage preset 因 Rust/TS byte-for-byte 基线差异。
+- GUI/WebUI build/typecheck：均通过。
+- 全量 lint：当前 GUI `checked=429 errors=425 warnings=358 infos=9`，基线 `checked=428 errors=428 warnings=358 infos=9`；当前 WebUI `checked=297 errors=293 warnings=310 infos=10`，基线 `checked=296 errors=296 warnings=310 infos=10`。本任务新增文件无诊断，并修复了 6 个新增 import-order 诊断；剩余全为基线。
+- 定向 `biome lint`：双端本任务 src 文件 exit 0；Mirror Check 120 files passed；`git diff --check` passed。
+- 真实浏览器命令：两个 Vite fixture 分别绑定 127.0.0.1:1431/1432，使用 `npx --package @playwright/cli playwright-cli ... verify-paste-newline-pipeline.playwright.js`；全部断言通过，含 `alpha\n` 两个视觉行与 `\nalpha\n` 三个视觉行，控制台 0 error/0 warning，服务随后按 PID 关闭。
+- 独立审查：无高/中确定性问题；补充的 `<>&`、mention/newline 与 fallback DOM 覆盖均已加入。
+
+## 开放 PR 重叠
+
+- #158、#276 直接修改双端 `MentionComposer.tsx`，与本任务存在真实文件冲突风险；未 cherry-pick、未建立依赖、未改写其提交。
+- #350、#345、#281、#184 与 transcript/ChatPage/重连区域相邻或部分文件重叠，但本任务没有触碰其 assistant/virtualizer/row-model/Go ingress 实现。
+- 其余开放 PR 未发现用户换行 serializer/user bubble 的直接重叠；本任务保持 `Depends-On: none` 假设，创建 PR 前需重新核对。
+
+## 恢复说明
+
+- 服务启动前必须检查 1420 端口及 `liveagent.exe`/Vite PID；不得复用或终止其他 worktree 的进程。
+- Tauri 与 Gateway/WebUI 必须从本 worktree 的同一 HEAD 启动并核验路径。
+- 用户明确回复“通过”之前，不得提交或修改远端状态。
+
+## 同 HEAD 运行时验收环境
+
+- 启动前 1420 为空；已有 2026-07-31 的 `pnpm ... tauri dev -> pnpm install` 残留树无监听端口，未终止、未复用。旧滚动任务的 Gateway/WebUI 位于 18080/15173，未触碰。
+- Tauri：本任务 Vite PID 80608 监听 `127.0.0.1:1420`，命令行脚本路径位于本 worktree；`liveagent.exe` PID 30896 的可执行路径为本 worktree `target/debug/liveagent.exe`。首次同源码 Rust build 747/747，约 5m05s，窗口响应正常。
+- Gateway：PID 68092 监听 `127.0.0.1:15052`；显式 token `paste-newline-acceptance-7de95a20`，独立 DB 位于 worktree ignored runtime 目录；日志确认 HTTP listening。
+- Gateway WebUI：Vite PID 42216 监听 `127.0.0.1:15174`，命令行中的 Vite 源路径位于本 worktree；`npm_config_proxy_api=http://127.0.0.1:15052`。Vite HTML 返回 200 且包含 `/@vite/client`；Gateway 根路径返回 200 并引用本 worktree build 生成的 hashed assets。
+- Playwright headed 浏览器以 token 成功进入 WebUI；当前唯一 console error 为 4 次 `No Agent is available`，与 Gateway 独立 DB 尚无桌面 Agent 完全一致，不是换行实现错误。浏览器证据已移到 ignored `target/paste-newline-artifacts/runtime/playwright-webui-initial/`。
+- `PrintWindow` 离屏截图成功捕获当前 Tauri 窗口，证明窗口来自同 worktree 且响应正常；有效文件为 ignored `target/paste-newline-artifacts/runtime/screenshots/tauri-printwindow.png`。一次被其他置顶窗口遮挡的无效屏幕拷贝已隔离到 `screenshots/invalid/`，不得作为验收证据。
+- Tauri 构建曾因只更新 `src-tauri/Cargo.toml` 的文件时间戳而让 `git status` 短暂显示 `M`；working-tree blob 与 `HEAD` blob 均为 `ab3fee0279334f9ab3f48cb783be464b61813af6`，文本 diff 为空，刷新索引后该状态消失。没有修改或恢复该文件内容，主工作区同名受保护文件始终未触碰。
+- 桌面 GUI 本身即 Gateway Agent；设置页启用 Remote/Gateway，地址 `http://127.0.0.1`、端口 `15052`、token 如上后连接 `ws://127.0.0.1:15052/ws/v2/agent`，无需另起 agent 进程。Agent ID 由本地设置自动生成并持久化；为避免静默覆盖用户现有远程设置，等待用户在 UI 中确认并填写。
+- 只读调查 Tauri 自带 MCP Bridge：raw WebSocket `list_windows` 可确认主窗口 `http://localhost:1420/`，但 Windows `execute_js` 回调被当前 capability 拒绝（日志：`mcp-bridge.script_result not allowed`）并稳定超时；因此停止自动 DOM/点击路径，不修改 capability 或应用源码。桥接脚本仅曾导航到设置页，截图确认已有持久化 Remote token/Agent ID/自动重连配置，未读取密码字段、未填写、未保存或覆盖。
+- 调查期间用户窗口退出，1420/9223 随之停止；Gateway/WebUI 15052/15174 始终正常。重新预检端口后从同一 wrapper/HEAD 构建 747/747 并启动新 `liveagent.exe` PID 71616、Vite PID 30376，路径仍为本 worktree。后续人工验收不再使用 Bridge 注入。
+- 重启后 Tauri PID 71616 到 Gateway PID 68092 建立两条 `127.0.0.1` established 连接；Gateway 日志记录真实 `chat.submit` 已送达 Agent，随后因窗口退出以 `terminal_cancelled` 收敛。Playwright 再登录 WebUI 时 Agent 状态为 `在线`，可读取桌面工作空间与历史，代理链路不再是阻塞；快照存于 ignored `target/paste-newline-artifacts/runtime/playwright-agent-connected/`，包含用户既有会话内容，不得作为 PR 公共截图。
+
+## 人工验收与公开截图
+
+- 2026-08-01：用户按验收矩阵完成测试并明确回复“通过”；因此提交/远端门禁解除。
+- 用户回复后立即尝试捕获 Tauri 当前窗口，但窗口仍停在既有 TodoWrite 会话，没有显示换行样例；该文件 `acceptance-tauri-final.png` 不作为 PR 证据，也不对既有会话做自动切换或发送。
+- 公开证据改由已通过的实际生产模块 fixture 生成，不修改产品源码、不触发模型调用：
+  - GUI：`target/paste-newline-artifacts/runtime/screenshots/acceptance-gui-pipeline-2026-08-01T01-30-28-742Z.png`
+  - Gateway WebUI：`target/paste-newline-artifacts/runtime/screenshots/acceptance-webui-pipeline-2026-08-01T01-31-45-337Z.png`
+- 两张截图逐张人工检查：均显示 `alpha\n\nbeta` 在 Clipboard、Composer、Outbound、History、Bubble DOM 五阶段为 2 个换行；composer 与发送后气泡各显示一个普通空行；气泡 `white-space=pre-wrap`、3 个视觉行；`reload\n\nreconnect` replay 显示相同单空行。
+- 截图后只终止本 worktree 的 fixture Vite PID 70764/66684，并确认 1431/1432 关闭；Tauri/Gateway/WebUI 1420/15052/15174 保持运行。Playwright 临时状态移入 ignored `playwright-public-evidence/`。
+
+## 关键决策（只增不删）
+
+- 2026-08-01：使用用户预建的分支、worktree 和固定基线，不另建分支、不切换基线。
+- 2026-08-01：目标 worktree 没有 `.codegraph/`；遵守项目规则跳过 CodeGraph，不在该 worktree 自动创建索引，也不借用主工作区索引。
+
+## 历程（按时间正序追加）
+
+### 2026-08-01 — 任务启动与隔离门禁
+
+- 做了：读取全局规则、项目规则和匹配 skills；创建 Goal；核对 worktree 分支与基线；fetch 并确认 `upstream/main` 未漂移；建立本 worklog。
+- 验证：修改前 `git status --short --branch` 仅显示 `## codex/fix-paste-newline-serialization`，HEAD 与 `upstream/main` 均为固定基线 SHA。
+- 遗留：开放 PR 重叠检查、数据链路探索、修复前自动化复现、实现和完整验证。
+
+### 2026-08-01 — 数据链路与修复前失败证据
+
+- 做了：并行定位 composer、transport/history、用户气泡与测试基础设施；只读检查全部开放 PR；用真实 Chromium 记录 clipboard、DOM、draft、payload、history、bubble 与实际高度；新增双端行为测试。
+- 验证：GUI/WebUI 新测试均稳定在同一空行放大断言失败；真实浏览器确认含 `text/html` 时仍按 `text/plain` 处理。
+- 遗留：实现规范化插入和无 trim 的发送边界，补真实浏览器修复后脚本以及完整回归。
+
+### 2026-08-01 — 实现、浏览器集成与自动化收敛
+
+- 做了：新增镜像 `composerText.ts`；改为安全、可撤销的 literal-LF paste；重写 block-aware serializer；移除完整用户文本 trim；历史用户内容使用同一换行模型；新增 Node 与真实浏览器双端 pipeline；更新 mirror manifest 和 worklog。
+- 验证：双端 build、focused tests、WebUI 498/498、GUI 1415/1420（5 项基线复现）、Mirror Check、diff check、真实浏览器/undo/redo/reload/reconnect/cross-client 均已收敛。
+- 遗留：启动同 HEAD Tauri 与 Gateway/WebUI，等待用户人工验收；通过前不提交或改远端。
+
+### 2026-08-01 — 末尾 LF 视觉行收敛
+
+- 做了：用 Chromium 独立比较 `pre-wrap`、`break-spaces`、`pre-line`、空 span、文本零宽字符和 CSS 伪元素；在双端用户消息组件加入仅末尾 LF 出现的 `aria-hidden` 空锚点与局部 CSS，并增加 SSR 与实际高度断言。
+- 验证：生产组件浏览器 fixture 中 `alpha\n` 精确保留 DOM 文本且显示 2 个视觉行，`\nalpha\n` 显示 3 个视觉行；最终 GUI 1416/1421（相同 5 项基线失败）、WebUI 498/498、双端 build、定向 lint、全量 lint 基线对照、Mirror Check 与 diff check 均完成。
+- 遗留：启动同 HEAD Tauri 与 Gateway/WebUI，采集人工验收截图并等待用户明确“通过”。
+
+### 2026-08-01 — 同 HEAD Tauri/Gateway/WebUI 启动
+
+- 做了：预检 1420 与所有相关 PID；从本 worktree 设置 libclang 并完整构建/启动 Tauri；使用独占 15052/15174 和独立 DB 启动 Gateway/WebUI；核验四个核心进程的命令行、可执行路径、监听端口与静态资源；用 Playwright 登录 WebUI并用 `PrintWindow` 捕获真实 Tauri。
+- 验证：Tauri Vite/EXE 均来自本 worktree，Gateway/WebUI 日志和 HTTP 200 正常，WebUI proxy 指向本任务 backend；桌面窗口响应正常。未复用或终止任何其他 worktree 进程。
+- 遗留：用户在桌面设置中启用本任务 Gateway Agent，执行双向消息、恢复/重连与视觉矩阵并明确回复“通过”；通过前仍不提交或改远端。
+
+### 2026-08-01 — 用户验收通过与证据固化
+
+- 做了：收到用户明确“通过”；捕获当前 Tauri 后发现未显示目标样例，拒绝将无关画面作为证据；随后从 GUI/WebUI 实际生产模块 fixture 重新执行粘贴、序列化、history/reconnect replay 并生成两张公开截图。
+- 验证：双端截图五阶段换行计数一致，空行视觉高度一致；公开截图无用户既有会话内容。只关闭本任务 1431/1432 fixture，三端人工环境仍在。
+- 遗留：最终 staged 审计、commit/push、上游 Issue/PR、required CI 收敛。

--- a/scripts/mirror-manifest.json
+++ b/scripts/mirror-manifest.json
@@ -37,6 +37,7 @@
     "components/chat/ToolApprovalBar.tsx",
     "components/hub/ToolPolicyToggle.tsx",
     "lib/chat/askUserQuestion.ts",
+    "lib/chat/composerText.ts",
     "lib/chat/openChatFileLink.ts",
     "lib/chat/toolApprovalArgs.ts",
     "components/Markdown.tsx",


### PR DESCRIPTION
## Linked issue

Closes #352

Depends-On: none
Stack-Root: #353

## Summary

- Normalize CRLF/CR to LF without trimming or moving logical newlines.
- Insert pasted plaintext as one safely escaped, undoable contenteditable operation and serialize `DIV`/`P`/placeholder `BR` nodes without double-counting blank lines.
- Preserve leading/trailing newlines through draft, outbound payload, uploads metadata, history/replay, and user-message display.
- Add a user-only trailing-LF visual anchor so Chromium allocates the final line box without changing DOM text or assistant/tool Markdown semantics.
- Keep desktop GUI and Gateway WebUI behavior mirrored.

## Change scope

- Modules: `agent-gui` React UI, Gateway WebUI, mirror verification, frontend tests
- Key paths:
  - `crates/agent-gui/src/components/chat/MentionComposer.tsx`
  - `crates/agent-gui/src/lib/chat/composerText.ts`
  - `crates/agent-gui/src/lib/chat/messages/userMessageContent.tsx`
  - `crates/agent-gateway/web/src/components/chat/MentionComposer.tsx`
  - `crates/agent-gateway/web/src/lib/chat/composerText.ts`
  - `crates/agent-gateway/web/src/lib/chat/userMessageContent.tsx`
  - mirrored Node and real-browser pipeline fixtures/tests

No Rust, Go, protocol, database, dependency, lockfile, or generated-code changes.

## Rebase and diff audit

- Rebased without conflicts onto latest `upstream/main@00a2c6fc` on 2026-08-06.
- Final topology is exactly three PR commits on that baseline (`upstream/main...HEAD` = 0 behind / 3 ahead).
- Original and rebased implementation/docs patches are range-diff equivalent; the style commit only adds the post-rebase worklog/acceptance record beyond its original formatting patch.
- Original and rebased product scope remains 23 files. `GatewayApp.tsx`, `useSendChatTurn.ts`, and `scripts/mirror-manifest.json` were explicitly audited to preserve current-main behavior while adding only newline fidelity support.
- The accepted product tree at `bb060885` and final PR head differ only in `docs/worklog/paste-newline-serialization.md`.

## Screenshots / preview

Production-module runtime preview for `alpha\n\nbeta`:

| Stage | GUI | Gateway WebUI |
| --- | ---: | ---: |
| Clipboard logical newlines | 2 | 2 |
| Composer logical newlines | 2 | 2 |
| Outbound logical newlines | 2 | 2 |
| History/replay logical newlines | 2 | 2 |
| User bubble DOM logical newlines | 2 | 2 |
| User bubble visual lines | 3 | 3 |
| `white-space` | `pre-wrap` | `pre-wrap` |

The attached PNG below uses the actual production composer and `UserMessageContent` modules and shows the five-stage escaped text/counts, sent bubble, and history/reconnect replay without user session data.

## Verification

- GUI production build/typecheck: passed
- Gateway WebUI production build/typecheck: passed
- GUI focused paste-pipeline + user-bubble tests: 19/19 passed
- Gateway WebUI focused paste-pipeline tests: 5/5 passed
- Gateway WebUI full tests: 498/498 passed
- GUI full tests: 1404/1409 passed; all 5 failures reproduced exactly on a fresh non-Worktree snapshot of `upstream/main@00a2c6fc`:
  - 2 mention composer selection source-extractor CRLF assumptions
  - 2 mention refetch source-extractor CRLF assumptions
  - 1 existing Rust/TypeScript provider usage preset byte comparison
- Full lint baseline comparison on the same Windows CRLF checkout:
  - GUI current: 421 errors / 358 warnings / 9 infos; latest-main baseline: 424 / 358 / 9
  - WebUI current: 290 errors / 310 warnings / 10 infos; latest-main baseline: 292 / 310 / 10
  - changed production files pass targeted lint with no errors; normalized LF Git blobs pass Biome checks with exit 0
- Actual Chromium production-module matrix: passed for LF/CRLF/CR; zero/single/multiple blank lines; leading/trailing newlines; pure whitespace; rich + plaintext clipboard; Markdown; Unicode/emoji; 40,002-character input; undo/redo; repeat send; cancellation; reload/history replay; and GUI ↔ WebUI replay
- Same-HEAD Tauri desktop runtime: Rust dev build 747/747, current-workspace binary launched and responsive; user explicitly accepted the complete manual matrix on 2026-08-06
- `node scripts/check-mirror.mjs`: 116 files passed
- `git diff --check upstream/main..HEAD`: passed
- No requested validation was skipped.

<img width="2151" height="1428" alt="2026-08-01_10-20-53" src="https://github.com/user-attachments/assets/cbb98526-2187-47f3-bb3c-fa05d889d3cf" />

## Open PR overlap

- #158 and #276 remain open and overlap the mirrored `MentionComposer.tsx` files.
- No commits were cherry-picked and this PR has no dependency on either change.

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Rebased onto the latest target baseline with no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, personal data, generated assets, or local runtime files are included.
- [x] Worklog and behavior tests are updated.
- [x] Same-HEAD manual acceptance is complete.