### PR TITLE
feat(skills): support AGENTS global skills import

### DIFF
--- a/crates/agent-gateway/web/src/i18n/config.ts
+++ b/crates/agent-gateway/web/src/i18n/config.ts
@@ -1977,7 +1977,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.skillsHubStoreTab": "技能商店",
     "settings.skillsHubImportTab": "本地导入",
     "settings.skillsImportDesc":
-      "扫描本机 Claude Code、Codex、CodeBuddy 的技能目录，勾选后导入到 LiveAgent。",
+      "扫描本机 Claude Code、Codex、CodeBuddy 与 AGENTS 的技能目录，勾选后导入到 LiveAgent。",
     "settings.skillsImportOverwriteHint": "同名技能将自动备份后覆盖。",
     "settings.skillsImportScanning": "正在扫描本地技能...",
     "settings.skillsImportRescan": "重新扫描",
@@ -4230,7 +4230,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.skillsHubStoreTab": "Skills Store",
     "settings.skillsHubImportTab": "Local Import",
     "settings.skillsImportDesc":
-      "Scan local Claude Code, Codex, and CodeBuddy skill directories, then pick skills to import into LiveAgent.",
+      "Scan local Claude Code, Codex, CodeBuddy, and AGENTS skill directories, then pick skills to import into LiveAgent.",
     "settings.skillsImportOverwriteHint":
       "Skills with the same name are backed up, then overwritten.",
     "settings.skillsImportScanning": "Scanning local skills...",

--- a/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx
@@ -119,6 +119,7 @@ const EXTERNAL_TOOL_LABELS: Record<string, string> = {
   "claude-code": "Claude Code",
   codex: "Codex",
   codebuddy: "CodeBuddy",
+  agents: "Agent Skills",
 };
 
 const STORE_PAGE_LIMIT = 24;

--- a/crates/agent-gui/src-tauri/src/services/skills/external.rs
+++ b/crates/agent-gui/src-tauri/src/services/skills/external.rs
@@ -1,5 +1,5 @@
-//! 扫描本机其他 CLI 工具（Claude Code / Codex / CodeBuddy）已安装的 Skills，
-//! 供 UI 展示后由用户勾选导入（导入本身复用既有 install 动作，source = 技能目录）。
+//! 扫描本机其他 CLI 工具（Claude Code / Codex / CodeBuddy）与 AGENTS 规范
+//! 已安装的 Skills，供 UI 展示后由用户勾选导入（导入本身复用既有 install 动作，source = 技能目录）。
 
 use super::library::discover_skill_dirs;
 use super::metadata::{read_skill_metadata_from_dir, standard_metadata_file_for};
@@ -11,6 +11,8 @@ const EXTERNAL_TOOL_ROOTS: &[(&str, &str)] = &[
     ("codex", "~/.codex/skills"),
     // CodeBuddy 的技能市场缓存目录：可能包含未安装的技能，由 UI 提示用户。
     ("codebuddy", "~/.codebuddy/skills-marketplace/skills"),
+    // AGENTS 规范定义的通用全局技能目录，不绑定单一编码工具。
+    ("agents", "~/.agents/skills"),
 ];
 
 pub(crate) fn scan_external_skills() -> Vec<SystemExternalToolScan> {

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -2046,7 +2046,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.skillsHubStoreTab": "技能商店",
     "settings.skillsHubImportTab": "本地导入",
     "settings.skillsImportDesc":
-      "扫描本机 Claude Code、Codex、CodeBuddy 的技能目录，勾选后导入到 LiveAgent。",
+      "扫描本机 Claude Code、Codex、CodeBuddy 与 AGENTS 的技能目录，勾选后导入到 LiveAgent。",
     "settings.skillsImportOverwriteHint": "同名技能将自动备份后覆盖。",
     "settings.skillsImportScanning": "正在扫描本地技能...",
     "settings.skillsImportRescan": "重新扫描",
@@ -4393,7 +4393,7 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.skillsHubStoreTab": "Skills Store",
     "settings.skillsHubImportTab": "Local Import",
     "settings.skillsImportDesc":
-      "Scan local Claude Code, Codex, and CodeBuddy skill directories, then pick skills to import into LiveAgent.",
+      "Scan local Claude Code, Codex, CodeBuddy, and AGENTS skill directories, then pick skills to import into LiveAgent.",
     "settings.skillsImportOverwriteHint":
       "Skills with the same name are backed up, then overwritten.",
     "settings.skillsImportScanning": "Scanning local skills...",

--- a/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx
@@ -131,6 +131,7 @@ const EXTERNAL_TOOL_LABELS: Record<string, string> = {
   "claude-code": "Claude Code",
   codex: "Codex",
   codebuddy: "CodeBuddy",
+  agents: "Agent Skills",
 };
 
 const STORE_PAGE_LIMIT = 24;


### PR DESCRIPTION
### Linked issue

Closes #371 

### Summary

在 Skills Hub 本地导入中新增 AGENTS 全局技能目录 `~/.agents/skills`。改动复用现有外部技能扫描和安装流程，在 GUI 与 WebUI 的本地导入标签中加入 `Agent Skills`，并更新本地导入描述以提到 AGENTS。

### Change scope

- Modules: `agent-gui` / `agent-gateway` / `src-tauri`
- Key paths:
  - `crates/agent-gui/src-tauri/src/services/skills/external.rs`
  - `crates/agent-gui/src/pages/skills-hub/SkillsHubPage.tsx`
  - `crates/agent-gateway/web/src/pages/skills-hub/SkillsHubPage.tsx`
  - `crates/agent-gui/src/i18n/config.ts`
  - `crates/agent-gateway/web/src/i18n/config.ts`

### Screenshots / preview

可见变化是 Skills Hub 本地导入页新增一个 `Agent Skills` 选项。
<img width="1076" height="328" alt="image" src="https://github.com/user-attachments/assets/abfaa8d3-f480-4d8b-b18b-fdc3cc026f4a" />


### Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `node scripts/check-mirror.mjs`
- 未新增 Rust 测试，只在 `EXTERNAL_TOOL_ROOTS` 增加一项，并复用现有扫描器。

### Pre-submit checklist

- [x] 已关联 issue。
- [x] 已同步目标分支，无合并冲突。
- [x] 改动聚焦，没有无关重构。
- [x] 未包含密钥、Token 或个人数据。
- [x] UI 文案和 i18n 已更新；不涉及部署或配置文档。
