### PR TITLE
docs: correct LLM tech-stack deps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Expand the Development Guide below for the full set of Make commands.
 | **Agent GUI** · Styling | Tailwind CSS 4 + Radix UI |
 | **Agent GUI** · Rendering | streamdown + KaTeX + Mermaid + Monaco Editor |
 | **Agent GUI** · Backend | Rust + Tokio + SQLite (rusqlite) + WebSocket (tokio-tungstenite) |
-| **Agent GUI** · LLM | @earendil-works/pi-ai · @openai/codex-sdk · claude-agent-sdk |
+| **Agent GUI** · LLM | @earendil-works/pi-ai · @earendil-works/pi-agent-core |
 | **Gateway** · Language | Go 1.25 |
 | **Gateway** · Protocols | WebSocket + Protobuf + HTTP |
 | **Gateway** · Web UI | React + Vite + Tailwind CSS (embedded) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -279,7 +279,7 @@ location / {
 | **Agent GUI** · 样式 | Tailwind CSS 4 + Radix UI |
 | **Agent GUI** · 渲染 | streamdown + KaTeX + Mermaid + Monaco Editor |
 | **Agent GUI** · 后端 | Rust + Tokio + SQLite (rusqlite) + WebSocket (tokio-tungstenite) |
-| **Agent GUI** · LLM | @earendil-works/pi-ai · @openai/codex-sdk · claude-agent-sdk |
+| **Agent GUI** · LLM | @earendil-works/pi-ai · @earendil-works/pi-agent-core |
 | **Gateway** · 语言 | Go 1.25 |
 | **Gateway** · 协议 | WebSocket + Protobuf + HTTP |
 | **Gateway** · Web UI | React + Vite + Tailwind CSS(嵌入式) |


### PR DESCRIPTION
## Summary

The **Agent GUI · LLM** row in the Tech Stack table listed two dependencies that are not actually used:

- `@openai/codex-sdk` — not present in `package.json`, `package-lock.json`, or `node_modules`
- `claude-agent-sdk` — same

The only LLM/agent runtime dependencies are:

- `@earendil-works/pi-ai` (unified LLM API)
- `@earendil-works/pi-agent-core` (agent runtime)

Codex here is a protocol provider (OpenAI Responses / Completions) driven by `pi-ai`, not a separate SDK dependency.

## Changes

| File | Change |
|---|---|
| `README.md` | Replace fake LLM deps row with real ones |
| `README.zh-CN.md` | Same |

## Verification

- `package.json` / `package-lock.json` / `node_modules/@openai/` contain no `codex-sdk` or `claude-agent-sdk`
- `grep` confirms both docs now list only real deps

Closes #374