### PR TITLE
fix: reduce IME composition end Enter tail window from 80ms to 20ms

### DIFF
--- a/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
@@ -232,7 +232,7 @@ const LARGE_PASTE_LINE_THRESHOLD = 200;
 const LARGE_PASTE_PREVIEW_CHARS = 160;
 const CARET_ANCHOR_TEXT = "\u200B";
 const IME_ENTER_SUPPRESS_WINDOW_MS = 300;
-const IME_COMPOSITION_END_ENTER_TAIL_MS = 80;
+const IME_COMPOSITION_END_ENTER_TAIL_MS = 20;
 // Must match the .composer-typewriter-char animation duration in index.css.
 const TYPEWRITER_CHAR_FADE_MS = 220;
 const GITHUB_ICON_SVG =

--- a/crates/agent-gui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gui/src/components/chat/MentionComposer.tsx
@@ -243,7 +243,7 @@ const COMPOSER_CONTEXT_MENU_HEIGHT = 154;
 const COMPOSER_CONTEXT_MENU_MARGIN = 12;
 const CARET_ANCHOR_TEXT = "\u200B";
 const IME_ENTER_SUPPRESS_WINDOW_MS = 300;
-const IME_COMPOSITION_END_ENTER_TAIL_MS = 80;
+const IME_COMPOSITION_END_ENTER_TAIL_MS = 20;
 // Must match the .composer-typewriter-char animation duration in index.css.
 const TYPEWRITER_CHAR_FADE_MS = 220;
 const GITHUB_ICON_SVG =


### PR DESCRIPTION
## Linked issue

Closes #21

## Summary

The 80ms unconditional suppression window after compositionend was too aggressive — it blocked Enter when users selected IME candidates with non-Enter keys (e.g. number keys) and immediately pressed Enter to send.

20ms is tight enough to still catch the inseparable compositionend→Enter keydown pairs in problematic IME implementations, while avoiding false positives from fast typists.

## Change scope

- Modules: agent-gui (desktop frontend), agent-gateway (WebUI mirror)
- Key paths:
  - `crates/agent-gui/src/components/chat/MentionComposer.tsx`
  - `crates/agent-gateway/web/src/components/chat/MentionComposer.tsx`

## Screenshots / preview

N/A — this is a single-constant timing change (80ms → 20ms) with no visual effect. The behavior difference is only perceptible by fast typists using IME number-key selection followed immediately by Enter.

<img width="1400" height="800" alt="image" src="https://github.com/user-attachments/assets/4623b1ed-9430-4a0d-b9a4-76030a0794ed" />

## Verification

- [x] `git diff --check` — clean, no trailing whitespace
- [x] `node scripts/check-mirror.mjs` — 115 files pass, GUI/WebUI mirrors byte-identical
- [x] `cargo check --manifest-path crates/agent-gui/src-tauri/Cargo.toml --tests` — pass (no new warnings)
- [x] `pnpm test:frontend` — 2 pre-existing failures unrelated to this change (mention-refetch, presets sync)
- [ ] `pnpm lint` — pre-existing errors, none introduced by this change
- [ ] Gateway Go tests — skipped, no Go code changed

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.