### PR TITLE
feat(sidebar): distinct styling for pinned workspaces and conversations

### DIFF
--- a/crates/agent-gateway/web/src/components/chat/ChatHistorySidebar.tsx
+++ b/crates/agent-gateway/web/src/components/chat/ChatHistorySidebar.tsx
@@ -2,6 +2,7 @@ import { Tooltip } from "@base-ui/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   type CSSProperties,
+  Fragment,
   memo,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
@@ -709,7 +710,7 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
               className={cn(
                 "relative flex items-center justify-end overflow-hidden transition-[max-width,opacity] duration-200 ease-out",
                 isSelectionMode && "hidden",
-                isRunning
+                isRunning || item.isPinned
                   ? // Mobile rows render no inline action buttons, so this flex
                     // box has zero content width AND zero height — max-w alone
                     // leaves the absolutely-positioned spinner fully clipped by
@@ -739,11 +740,26 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
                 >
                   <Loader2 className="h-4 w-4 animate-spin" />
                 </span>
+              ) : item.isPinned ? (
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "pointer-events-none absolute right-1.5 flex h-4 w-4 items-center justify-center text-amber-500/90 transition-opacity duration-200",
+                    isMobileMenuLayout
+                      ? "opacity-100"
+                      : [
+                          "opacity-100 group-hover/item:opacity-0 group-focus-within/item:opacity-0",
+                          menuOpen && "opacity-0",
+                        ],
+                  )}
+                >
+                  <Pin className="h-3 w-3" />
+                </span>
               ) : null}
               <div
                 className={cn(
                   "flex items-center gap-0.5 transition-opacity duration-200",
-                  isRunning
+                  isRunning || item.isPinned
                     ? "opacity-0 group-hover/item:opacity-100 group-focus-within/item:opacity-100"
                     : "opacity-100",
                   menuOpen && "opacity-100",
@@ -1155,7 +1171,7 @@ const ProjectRow = memo(function ProjectRow(props: {
             "relative flex items-center justify-end overflow-hidden transition-[max-width,opacity] duration-200 ease-out",
             isMissing
               ? "max-w-8 opacity-100"
-              : isRunning
+              : isRunning || (isPinned && !isArchived)
                 ? "max-w-7 opacity-100 group-hover/project:max-w-16 group-focus-within/project:max-w-16"
                 : "max-w-0 opacity-0 group-hover/project:max-w-16 group-hover/project:opacity-100 group-focus-within/project:max-w-16 group-focus-within/project:opacity-100",
             menuOpen && "max-w-16 opacity-100",
@@ -1174,11 +1190,22 @@ const ProjectRow = memo(function ProjectRow(props: {
             >
               <Loader2 className="h-4 w-4 animate-spin" />
             </span>
+          ) : !isMissing && !isArchived && isPinned ? (
+            <span
+              aria-hidden="true"
+              className={cn(
+                "pointer-events-none absolute right-1.5 flex h-4 w-4 items-center justify-center text-amber-500/80 transition-opacity duration-200",
+                "opacity-100 group-hover/project:opacity-0 group-focus-within/project:opacity-0",
+                menuOpen && "opacity-0",
+              )}
+            >
+              <Pin className="h-3 w-3" />
+            </span>
           ) : null}
           <div
             className={cn(
               "flex items-center gap-0.5 transition-opacity duration-200",
-              isRunning && !isMissing
+              (isRunning || (isPinned && !isArchived)) && !isMissing
                 ? "opacity-0 group-hover/project:opacity-100 group-focus-within/project:opacity-100"
                 : "opacity-100",
               menuOpen && "opacity-100",
@@ -1714,6 +1741,14 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
     () => (showAllProjects ? activeProjects : activeProjects.slice(0, SIDEBAR_PROJECT_RENDER_CAP)),
     [activeProjects, showAllProjects],
   );
+  // Divider slot between the pinned block and the rest of the projects.
+  const firstUnpinnedProjectIndex = useMemo(() => {
+    if (renderedProjects[0]?.isPinned !== true) {
+      return -1;
+    }
+    const index = renderedProjects.findIndex((project) => project.isPinned !== true);
+    return index > 0 ? index : -1;
+  }, [renderedProjects]);
   // Archiving must always leave at least one active workspace behind.
   const canArchiveProjects = Boolean(onArchiveProject) && activeProjects.length > 1;
   const [archivedGroupOpen, setArchivedGroupOpen] = useState(false);
@@ -1927,6 +1962,15 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
 
   const menuSide = isMobileMenuLayout ? "bottom" : "right";
   const historyScrollRef = useRef<HTMLDivElement | null>(null);
+  // Divider slot between the pinned block and the rest: index of the first
+  // unpinned row, only when at least one pinned row sits above it.
+  const firstUnpinnedHistoryIndex = useMemo(() => {
+    if (items[0]?.isPinned !== true) {
+      return -1;
+    }
+    const index = items.findIndex((item) => item.isPinned !== true);
+    return index > 0 ? index : -1;
+  }, [items]);
   const getHistoryItemKey = useCallback((index: number) => items[index]?.id ?? index, [items]);
   const historyVirtualizer = useVirtualizer({
     count: items.length,
@@ -2355,37 +2399,44 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
                 )}
               >
                 <div ref={projectsBodyRef} className="space-y-0.5 px-2 pb-0.5">
-                  {renderedProjects.map((project) => {
+                  {renderedProjects.map((project, projectIndex) => {
                     const pathKey = workspaceProjectPathKey(project.path);
                     return (
-                      <ProjectRow
-                        key={project.id}
-                        project={project}
-                        isActive={activeProjectId === project.id}
-                        isMissing={missingProjectPathKeys.has(pathKey)}
-                        isRunning={runningProjectPathKeys.has(pathKey)}
-                        isRenaming={projectRenamingId === project.id}
-                        isPendingRemove={pendingProjectRemoveId === project.id}
-                        isInteractionDisabled={sectionsDisabled}
-                        renameDraft={projectRenameDraft}
-                        onSelectProject={handleSelectProject}
-                        onBrowseProjectInFileTree={
-                          onBrowseProjectInFileTree ? handleBrowseProjectInFileTree : undefined
-                        }
-                        onStartRenamingProject={handleStartRenamingProject}
-                        onProjectRenameDraftChange={handleProjectRenameDraftChange}
-                        onCommitProjectRename={handleCommitProjectRename}
-                        onCancelProjectRename={handleCancelProjectRename}
-                        onSetProjectPinned={handleSetProjectPinned}
-                        onRemoveProject={handleRemoveProject}
-                        isArchived={false}
-                        canArchive={canArchiveProjects}
-                        onArchiveProject={handleArchiveProject}
-                        onUnarchiveProject={handleUnarchiveProject}
-                        onSetPendingRemove={handleSetPendingProjectRemove}
-                        menuOpen={!sectionsDisabled && openProjectMenuId === project.id}
-                        onMenuOpenChange={handleProjectMenuOpenChange}
-                      />
+                      <Fragment key={project.id}>
+                        {projectIndex === firstUnpinnedProjectIndex ? (
+                          <div
+                            aria-hidden="true"
+                            className="mx-2 !my-1.5 h-px bg-gradient-to-r from-border/80 via-border/45 to-transparent"
+                          />
+                        ) : null}
+                        <ProjectRow
+                          project={project}
+                          isActive={activeProjectId === project.id}
+                          isMissing={missingProjectPathKeys.has(pathKey)}
+                          isRunning={runningProjectPathKeys.has(pathKey)}
+                          isRenaming={projectRenamingId === project.id}
+                          isPendingRemove={pendingProjectRemoveId === project.id}
+                          isInteractionDisabled={sectionsDisabled}
+                          renameDraft={projectRenameDraft}
+                          onSelectProject={handleSelectProject}
+                          onBrowseProjectInFileTree={
+                            onBrowseProjectInFileTree ? handleBrowseProjectInFileTree : undefined
+                          }
+                          onStartRenamingProject={handleStartRenamingProject}
+                          onProjectRenameDraftChange={handleProjectRenameDraftChange}
+                          onCommitProjectRename={handleCommitProjectRename}
+                          onCancelProjectRename={handleCancelProjectRename}
+                          onSetProjectPinned={handleSetProjectPinned}
+                          onRemoveProject={handleRemoveProject}
+                          isArchived={false}
+                          canArchive={canArchiveProjects}
+                          onArchiveProject={handleArchiveProject}
+                          onUnarchiveProject={handleUnarchiveProject}
+                          onSetPendingRemove={handleSetPendingProjectRemove}
+                          menuOpen={!sectionsDisabled && openProjectMenuId === project.id}
+                          onMenuOpenChange={handleProjectMenuOpenChange}
+                        />
+                      </Fragment>
                     );
                   })}
                   {hasCappedProjects ? (
@@ -2679,6 +2730,12 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
                         className="absolute inset-x-0 top-0 pb-0.5"
                         style={{ transform: `translateY(${virtualRow.start}px)` }}
                       >
+                        {virtualRow.index === firstUnpinnedHistoryIndex ? (
+                          <div
+                            aria-hidden="true"
+                            className="mx-2 mb-1.5 mt-1 h-px bg-gradient-to-r from-border/80 via-border/45 to-transparent"
+                          />
+                        ) : null}
                         {renderHistoryRow(item)}
                       </div>
                     );

--- a/crates/agent-gui/src/components/chat/ChatHistorySidebar.tsx
+++ b/crates/agent-gui/src/components/chat/ChatHistorySidebar.tsx
@@ -1,6 +1,15 @@
 import { Tooltip } from "@base-ui/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { type CSSProperties, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type CSSProperties,
+  Fragment,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import iconSimpleUrl from "../../../src-tauri/icons/icon-simple.png";
 import { useLocale } from "../../i18n";
 import type { AppUpdateController } from "../../lib/appUpdates";
@@ -390,7 +399,7 @@ const HistoryRow = memo(function HistoryRow(props: {
         <div
           className={cn(
             "relative flex items-center justify-end overflow-hidden transition-[max-width,opacity] duration-200 ease-out",
-            isRunning
+            isRunning || item.isPinned
               ? "max-w-7 opacity-100 group-hover/item:max-w-16 group-focus-within/item:max-w-16"
               : "max-w-0 opacity-0 group-hover/item:max-w-16 group-hover/item:opacity-100 group-focus-within/item:max-w-16 group-focus-within/item:opacity-100",
             menuOpen && "max-w-16 opacity-100",
@@ -409,11 +418,22 @@ const HistoryRow = memo(function HistoryRow(props: {
             >
               <Loader2 className="h-4 w-4 animate-spin" />
             </span>
+          ) : item.isPinned ? (
+            <span
+              aria-hidden="true"
+              className={cn(
+                "pointer-events-none absolute right-1.5 flex h-4 w-4 items-center justify-center text-amber-500/90 transition-opacity duration-200",
+                "opacity-100 group-hover/item:opacity-0 group-focus-within/item:opacity-0",
+                menuOpen && "opacity-0",
+              )}
+            >
+              <Pin className="h-3 w-3" />
+            </span>
           ) : null}
           <div
             className={cn(
               "flex items-center gap-0.5 transition-opacity duration-200",
-              isRunning
+              isRunning || item.isPinned
                 ? "opacity-0 group-hover/item:opacity-100 group-focus-within/item:opacity-100"
                 : "opacity-100",
               menuOpen && "opacity-100",
@@ -760,7 +780,7 @@ const ProjectRow = memo(function ProjectRow(props: {
             "relative flex items-center justify-end overflow-hidden transition-[max-width,opacity] duration-200 ease-out",
             isMissing
               ? "max-w-8 opacity-100"
-              : isRunning
+              : isRunning || (isPinned && !isArchived)
                 ? "max-w-7 opacity-100 group-hover/project:max-w-16 group-focus-within/project:max-w-16"
                 : "max-w-0 opacity-0 group-hover/project:max-w-16 group-hover/project:opacity-100 group-focus-within/project:max-w-16 group-focus-within/project:opacity-100",
             menuOpen && "max-w-16 opacity-100",
@@ -779,11 +799,22 @@ const ProjectRow = memo(function ProjectRow(props: {
             >
               <Loader2 className="h-4 w-4 animate-spin" />
             </span>
+          ) : !isMissing && !isArchived && isPinned ? (
+            <span
+              aria-hidden="true"
+              className={cn(
+                "pointer-events-none absolute right-1.5 flex h-4 w-4 items-center justify-center text-amber-500/80 transition-opacity duration-200",
+                "opacity-100 group-hover/project:opacity-0 group-focus-within/project:opacity-0",
+                menuOpen && "opacity-0",
+              )}
+            >
+              <Pin className="h-3 w-3" />
+            </span>
           ) : null}
           <div
             className={cn(
               "flex items-center gap-0.5 transition-opacity duration-200",
-              isRunning && !isMissing
+              (isRunning || (isPinned && !isArchived)) && !isMissing
                 ? "opacity-0 group-hover/project:opacity-100 group-focus-within/project:opacity-100"
                 : "opacity-100",
               menuOpen && "opacity-100",
@@ -1257,6 +1288,14 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
     () => (showAllProjects ? activeProjects : activeProjects.slice(0, PROJECT_LIST_COLLAPSED_MAX)),
     [activeProjects, showAllProjects],
   );
+  // Divider slot between the pinned block and the rest of the projects.
+  const firstUnpinnedProjectIndex = useMemo(() => {
+    if (renderedProjects[0]?.isPinned !== true) {
+      return -1;
+    }
+    const index = renderedProjects.findIndex((project) => project.isPinned !== true);
+    return index > 0 ? index : -1;
+  }, [renderedProjects]);
   // Archiving must always leave at least one active workspace behind.
   const canArchiveProjects = Boolean(onArchiveProject) && activeProjects.length > 1;
   const [archivedGroupOpen, setArchivedGroupOpen] = useState(false);
@@ -1340,6 +1379,15 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
     resizeMaxHeight: sidebarSectionLayout.resizeMaxHeight,
   };
   const historyScrollRef = useRef<HTMLDivElement | null>(null);
+  // Divider slot between the pinned block and the rest: index of the first
+  // unpinned row, only when at least one pinned row sits above it.
+  const firstUnpinnedHistoryIndex = useMemo(() => {
+    if (items[0]?.isPinned !== true) {
+      return -1;
+    }
+    const index = items.findIndex((item) => item.isPinned !== true);
+    return index > 0 ? index : -1;
+  }, [items]);
   const getHistoryItemKey = useCallback((index: number) => items[index]?.id ?? index, [items]);
   const historyVirtualizer = useVirtualizer({
     count: items.length,
@@ -1802,39 +1850,46 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
                 )}
               >
                 <div ref={projectsBodyRef} className="space-y-0.5 px-2 pb-0.5">
-                  {renderedProjects.map((project) => {
+                  {renderedProjects.map((project, projectIndex) => {
                     const pathKey = workspaceProjectPathKey(project.path);
                     return (
-                      <ProjectRow
-                        key={project.id}
-                        project={project}
-                        isActive={activeProjectId === project.id}
-                        isMissing={missingProjectPathKeys.has(pathKey)}
-                        isRunning={runningProjectPathKeys.has(pathKey)}
-                        isRenaming={projectRenamingId === project.id}
-                        isPendingRemove={pendingProjectRemoveId === project.id}
-                        renameDraft={projectRenameDraft}
-                        onSelectProject={handleSelectProject}
-                        onBrowseProjectInFileTree={
-                          onBrowseProjectInFileTree ? handleBrowseProjectInFileTree : undefined
-                        }
-                        onBrowseProjectInSystemFileManager={
-                          onBrowseProjectInSystemFileManager
-                            ? handleBrowseProjectInSystemFileManager
-                            : undefined
-                        }
-                        onStartRenamingProject={handleStartRenamingProject}
-                        onProjectRenameDraftChange={handleProjectRenameDraftChange}
-                        onCommitProjectRename={handleCommitProjectRename}
-                        onCancelProjectRename={handleCancelProjectRename}
-                        onSetProjectPinned={handleSetProjectPinned}
-                        onRemoveProject={handleRemoveProject}
-                        isArchived={false}
-                        canArchive={canArchiveProjects}
-                        onArchiveProject={handleArchiveProject}
-                        onUnarchiveProject={handleUnarchiveProject}
-                        onSetPendingRemove={setPendingProjectRemoveId}
-                      />
+                      <Fragment key={project.id}>
+                        {projectIndex === firstUnpinnedProjectIndex ? (
+                          <div
+                            aria-hidden="true"
+                            className="mx-2 !my-1.5 h-px bg-gradient-to-r from-border/80 via-border/45 to-transparent"
+                          />
+                        ) : null}
+                        <ProjectRow
+                          project={project}
+                          isActive={activeProjectId === project.id}
+                          isMissing={missingProjectPathKeys.has(pathKey)}
+                          isRunning={runningProjectPathKeys.has(pathKey)}
+                          isRenaming={projectRenamingId === project.id}
+                          isPendingRemove={pendingProjectRemoveId === project.id}
+                          renameDraft={projectRenameDraft}
+                          onSelectProject={handleSelectProject}
+                          onBrowseProjectInFileTree={
+                            onBrowseProjectInFileTree ? handleBrowseProjectInFileTree : undefined
+                          }
+                          onBrowseProjectInSystemFileManager={
+                            onBrowseProjectInSystemFileManager
+                              ? handleBrowseProjectInSystemFileManager
+                              : undefined
+                          }
+                          onStartRenamingProject={handleStartRenamingProject}
+                          onProjectRenameDraftChange={handleProjectRenameDraftChange}
+                          onCommitProjectRename={handleCommitProjectRename}
+                          onCancelProjectRename={handleCancelProjectRename}
+                          onSetProjectPinned={handleSetProjectPinned}
+                          onRemoveProject={handleRemoveProject}
+                          isArchived={false}
+                          canArchive={canArchiveProjects}
+                          onArchiveProject={handleArchiveProject}
+                          onUnarchiveProject={handleUnarchiveProject}
+                          onSetPendingRemove={setPendingProjectRemoveId}
+                        />
+                      </Fragment>
                     );
                   })}
                   {hiddenProjectCount > 0 || showAllProjects ? (
@@ -2112,6 +2167,12 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
                             className="absolute inset-x-0 top-0 pb-0.5"
                             style={{ transform: `translateY(${virtualRow.start}px)` }}
                           >
+                            {virtualRow.index === firstUnpinnedHistoryIndex ? (
+                              <div
+                                aria-hidden="true"
+                                className="mx-2 mb-1.5 mt-1 h-px bg-gradient-to-r from-border/80 via-border/45 to-transparent"
+                              />
+                            ) : null}
                             {renderHistoryRow(item)}
                           </div>
                         );


### PR DESCRIPTION
## Summary

Addresses the pin-visibility part of #388 — pinned rows in the sidebar were visually indistinguishable from normal rows.

- **Persistent pin badge**: pinned conversations and workspaces show a small amber `Pin` icon in the row's trailing slot. It reuses the running-spinner slot mechanism: visible at rest, cross-fades to the pin/more action buttons on hover or when the row menu opens. The running spinner still takes priority; archived/missing workspace rows are excluded.
- **Pinned-block divider**: a gradient hairline separates the pinned block from the rest of the list, rendered only when at least one pinned row sits above the first unpinned one. In the virtualized history list the divider lives inside the measured row element, so `measureElement` absorbs its height.
- **WebUI mobile**: mobile rows have no inline action buttons, so the badge stays visible via the reserved `h-7 w-7` spinner slot (same pattern the spinner already uses).

Both frontends (`crates/agent-gui` and `crates/agent-gateway/web`) are updated in step; the byte-mirrored `lib/sidebar/*` modules are untouched.

Deliberately restrained: no background tint on pinned rows (would fight the active-row highlight), amber echoes the sidebar's active-folder accent.

## Out of scope

The sticky-note color tags proposed in #388 need a persisted per-conversation field plus protocol changes — left for a follow-up.

## Verification

- `tsc --noEmit` passes in both frontends
- `biome check` clean on both changed files
- `node scripts/check-mirror.mjs` passes (122 files)

## Screenshots / preview
<img width="290" height="802" alt="image" src="https://github.com/user-attachments/assets/e43a5ca4-2f10-41cf-82af-8b6c60d1165c" />


Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)