### PR TITLE
fix(composer): preserve structured tags across copy/cut/paste

### DIFF
--- a/crates/agent-gateway/test/webui/paste-newline-pipeline.test.mjs
+++ b/crates/agent-gateway/test/webui/paste-newline-pipeline.test.mjs
@@ -146,3 +146,148 @@ test("composer serialization preserves newlines around mention chips", () => {
     ],
   );
 });
+
+const reviewerSkill = {
+  name: "reviewer",
+  description: "Review changed code",
+  skillFile: "reviewer/SKILL.md",
+  baseDir: "reviewer",
+};
+
+function structuredClipboardSegments() {
+  return [
+    { type: "text", text: "Inspect " },
+    {
+      type: "fileMention",
+      reference: { path: "src/App.tsx", kind: "file" },
+    },
+    {
+      type: "fileMention",
+      reference: { path: "docs/guides", kind: "dir" },
+    },
+    { type: "skillMention", skill: reviewerSkill },
+    {
+      type: "commitMention",
+      commit: {
+        sha: "abcdef1234567890",
+        shortSha: "abcdef1",
+        subject: "Preserve tags",
+        body: "Full commit body",
+        authorName: "Author",
+        authorEmail: "author@example.com",
+        authorDate: "2026-08-08T00:00:00Z",
+        fileCount: 2,
+        filesChanged: 2,
+        insertions: 12,
+        deletions: 3,
+        stat: "2 files changed",
+        remoteName: "origin",
+        remoteUrl: "https://github.com/example/repo.git",
+        githubUrl: "https://github.com/example/repo/commit/abcdef1234567890",
+      },
+    },
+    {
+      type: "gitFileMention",
+      file: {
+        path: "src/App.tsx",
+        oldPath: "src/OldApp.tsx",
+        status: "M",
+        commitSha: "abcdef1234567890",
+        shortSha: "abcdef1",
+        refName: "main",
+        remoteName: "origin",
+        remoteUrl: "https://github.com/example/repo.git",
+        githubUrl:
+          "https://github.com/example/repo/blob/abcdef1234567890/src/App.tsx",
+      },
+    },
+    {
+      type: "codeMention",
+      reference: { path: "src/App.tsx", startLine: 4, endLine: 9 },
+    },
+    {
+      type: "largePaste",
+      paste: {
+        id: "large-paste-copy",
+        label: "Pasted text 1",
+        text: "large\nclipboard\nbody",
+        charCount: 999,
+        lineCount: 999,
+        preview: "stale preview",
+      },
+    },
+  ];
+}
+
+test("composer clipboard payload round trips every structured tag", () => {
+  const payload = composer.serializeComposerClipboardPayload(structuredClipboardSegments());
+  const restored = composer.parseComposerClipboardPayload(payload, [reviewerSkill]);
+
+  assert.deepEqual(
+    restored.map((segment) => segment.type),
+    [
+      "text",
+      "fileMention",
+      "fileMention",
+      "skillMention",
+      "commitMention",
+      "gitFileMention",
+      "codeMention",
+      "largePaste",
+    ],
+  );
+  assert.equal(restored[1].reference.path, "src/App.tsx");
+  assert.equal(restored[2].reference.kind, "dir");
+  assert.deepEqual(restored[3].skill, reviewerSkill);
+  assert.equal(restored[4].commit.body, "Full commit body");
+  assert.equal(restored[5].file.oldPath, "src/OldApp.tsx");
+  assert.deepEqual(restored[6].reference, {
+    path: "src/App.tsx",
+    startLine: 4,
+    endLine: 9,
+  });
+  assert.equal(restored[7].paste.charCount, "large\nclipboard\nbody".length);
+  assert.equal(restored[7].paste.lineCount, 3);
+});
+
+test("clipboard skill metadata cannot escape the currently enabled skill", () => {
+  const payload = composer.serializeComposerClipboardPayload([
+    {
+      type: "skillMention",
+      skill: { ...reviewerSkill, baseDir: "another-skill" },
+    },
+  ]);
+  assert.deepEqual(composer.parseComposerClipboardPayload(payload, [reviewerSkill]), [
+    { type: "text", text: "/reviewer" },
+  ]);
+});
+
+test("serialized user bubble tokens restore composer tags as a plain-text fallback", () => {
+  const text = [
+    "Inspect",
+    "[App.tsx](src/App.tsx)",
+    "[guides](docs/guides/)",
+    "/reviewer",
+    "[commit abcdef1: Preserve tags](https://github.com/example/repo/commit/abcdef1234567890)",
+    "[git file main: src/App.tsx](https://github.com/example/repo/blob/abcdef1234567890/src/App.tsx)",
+    "[App.tsx:4-9](src/App.tsx#L4-L9)",
+  ].join(" ");
+  const restored = composer.parseSerializedComposerText(text, [reviewerSkill]);
+  assert.deepEqual(
+    restored.filter((segment) => segment.type !== "text").map((segment) => segment.type),
+    [
+      "fileMention",
+      "fileMention",
+      "skillMention",
+      "commitMention",
+      "gitFileMention",
+      "codeMention",
+    ],
+  );
+  assert.equal(composer.parseSerializedComposerText("[OpenAI](https://openai.com)", []), null);
+});
+
+test("outbound skill tokens use the same slash contract as composer and user bubbles", () => {
+  const draft = draftFromSegments([{ type: "skillMention", skill: reviewerSkill }]);
+  assert.equal(draftText.buildTextFromComposerDraft(draft), "/reviewer");
+});

--- a/crates/agent-gateway/test/webui/paste-newline-pipeline.test.mjs
+++ b/crates/agent-gateway/test/webui/paste-newline-pipeline.test.mjs
@@ -240,7 +240,15 @@ test("composer clipboard payload round trips every structured tag", () => {
   assert.equal(restored[2].reference.kind, "dir");
   assert.deepEqual(restored[3].skill, reviewerSkill);
   assert.equal(restored[4].commit.body, "Full commit body");
+  assert.equal(
+    restored[4].commit.githubUrl,
+    "https://github.com/example/repo/commit/abcdef1234567890",
+  );
   assert.equal(restored[5].file.oldPath, "src/OldApp.tsx");
+  assert.equal(
+    restored[5].file.githubUrl,
+    "https://github.com/example/repo/blob/abcdef1234567890/src/App.tsx",
+  );
   assert.deepEqual(restored[6].reference, {
     path: "src/App.tsx",
     startLine: 4,
@@ -260,6 +268,75 @@ test("clipboard skill metadata cannot escape the currently enabled skill", () =>
   assert.deepEqual(composer.parseComposerClipboardPayload(payload, [reviewerSkill]), [
     { type: "text", text: "/reviewer" },
   ]);
+});
+
+test("clipboard github URLs that fail the plain-text channel validation are dropped", () => {
+  const segments = structuredClipboardSegments();
+  const commit = segments.find((segment) => segment.type === "commitMention").commit;
+  const file = segments.find((segment) => segment.type === "gitFileMention").file;
+  const hostileUrls = [
+    "javascript:alert(1)",
+    "liveagent://internal/action",
+    "ftp://github.com/example/repo/commit/abcdef1234567890",
+    "https://evil.example/example/repo/commit/abcdef1234567890",
+    "https://github.com.evil.example/example/repo/commit/abcdef1234567890",
+    "https://github.com/example/repo",
+  ];
+  for (const githubUrl of hostileUrls) {
+    const payload = composer.serializeComposerClipboardPayload([
+      { type: "commitMention", commit: { ...commit, githubUrl } },
+      { type: "gitFileMention", file: { ...file, githubUrl } },
+    ]);
+    const restored = composer.parseComposerClipboardPayload(payload, []);
+    assert.deepEqual(
+      restored.map((segment) => segment.type),
+      ["commitMention", "gitFileMention"],
+      githubUrl,
+    );
+    assert.equal(restored[0].commit.githubUrl, undefined, githubUrl);
+    assert.equal(restored[1].file.githubUrl, undefined, githubUrl);
+  }
+});
+
+test("oversized text segments restored from the clipboard collapse into large-paste chips", () => {
+  let counter = 0;
+  const createLargePaste = (text) => ({
+    id: `fresh-${++counter}`,
+    label: `Pasted text ${counter}`,
+    text,
+    charCount: text.length,
+    lineCount: text.split("\n").length,
+    preview: text.slice(0, 160),
+  });
+  const overCharLimit = "x".repeat(8_000);
+  const overLineLimit = "line\n".repeat(200);
+  const rebuilt = composer.rebuildClipboardSegmentsForPaste(
+    [
+      { type: "text", text: "small" },
+      { type: "text", text: overCharLimit },
+      { type: "text", text: overLineLimit },
+      {
+        type: "largePaste",
+        paste: {
+          id: "stale-id",
+          label: "Pasted text 9",
+          text: "chunk",
+          charCount: 5,
+          lineCount: 1,
+          preview: "chunk",
+        },
+      },
+    ],
+    createLargePaste,
+  );
+  assert.deepEqual(
+    rebuilt.map((segment) => segment.type),
+    ["text", "largePaste", "largePaste", "largePaste"],
+  );
+  assert.equal(rebuilt[1].paste.text, overCharLimit);
+  assert.equal(rebuilt[2].paste.text, overLineLimit);
+  assert.equal(rebuilt[3].paste.text, "chunk");
+  assert.notEqual(rebuilt[3].paste.id, "stale-id");
 });
 
 test("serialized user bubble tokens restore composer tags as a plain-text fallback", () => {

--- a/crates/agent-gateway/web/src/app/chatDraft.ts
+++ b/crates/agent-gateway/web/src/app/chatDraft.ts
@@ -64,7 +64,7 @@ export function buildTextFromComposerDraft(
           return formatFileMentionToken(segment.reference);
         }
         if (segment.type === "skillMention") {
-          return `$${segment.skill.name}`;
+          return `/${segment.skill.name}`;
         }
         if (segment.type === "commitMention") {
           return formatComposerCommitMention(segment.commit);

--- a/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
@@ -33,7 +33,11 @@ import {
   formatFileMentionToken,
   formatMarkdownReferenceDestination,
 } from "../../lib/chat/mentionReferences";
-import { tokenizeUserMessage } from "../../lib/chat/userMessageContent";
+import {
+  extractGitHubCommitSha,
+  extractGitHubFileReference,
+  tokenizeUserMessage,
+} from "../../lib/chat/userMessageContent";
 import { extractClipboardFiles } from "../../lib/clipboardFiles";
 import { createUuid } from "../../lib/shared/id";
 import { cn } from "../../lib/shared/utils";
@@ -745,6 +749,11 @@ function normalizeClipboardCommit(
 ): MentionComposerCommitMention | null {
   const sha = clipboardString(rawCommit, "sha").trim();
   if (!/^[0-9a-f]{7,64}$/i.test(sha)) return null;
+  // Clipboard payloads are untrusted — the text/html fallback channel reads
+  // the payload attribute out of any copied page — and githubUrl feeds the
+  // chip's open-on-GitHub action, so it must pass the same GitHub URL
+  // validation as the plain-text token channel or drop to a link-less chip.
+  const githubUrl = clipboardString(rawCommit, "githubUrl").trim();
   return normalizeCommitMention({
     sha,
     shortSha: clipboardString(rawCommit, "shortSha", sha.slice(0, 7)),
@@ -760,7 +769,7 @@ function normalizeClipboardCommit(
     stat: clipboardString(rawCommit, "stat"),
     remoteName: clipboardString(rawCommit, "remoteName"),
     remoteUrl: clipboardString(rawCommit, "remoteUrl"),
-    githubUrl: clipboardString(rawCommit, "githubUrl") || undefined,
+    githubUrl: extractGitHubCommitSha(githubUrl) ? githubUrl : undefined,
   });
 }
 
@@ -770,6 +779,9 @@ function normalizeClipboardGitFile(
   const path = clipboardString(rawFile, "path").trim().replace(/\\/g, "/");
   const commitSha = clipboardString(rawFile, "commitSha").trim();
   if (!createFileMentionReference(path, "file") || !commitSha) return null;
+  // Same trust boundary as normalizeClipboardCommit: only a real GitHub blob
+  // URL may reach the chip's open action.
+  const githubUrl = clipboardString(rawFile, "githubUrl").trim();
   return normalizeGitFileMention({
     path,
     oldPath: clipboardString(rawFile, "oldPath") || undefined,
@@ -779,7 +791,7 @@ function normalizeClipboardGitFile(
     refName: clipboardString(rawFile, "refName"),
     remoteName: clipboardString(rawFile, "remoteName"),
     remoteUrl: clipboardString(rawFile, "remoteUrl"),
-    githubUrl: clipboardString(rawFile, "githubUrl") || undefined,
+    githubUrl: extractGitHubFileReference(githubUrl) ? githubUrl : undefined,
   });
 }
 
@@ -868,6 +880,24 @@ export function parseComposerClipboardPayload(
   } catch {
     return null;
   }
+}
+
+// Restored segments must obey the same large-paste threshold as direct input:
+// text over the limit collapses into a chip, and carried-over largePaste
+// segments are rebuilt with fresh ids so they cannot collide in the map.
+export function rebuildClipboardSegmentsForPaste(
+  segments: MentionComposerDraftSegment[],
+  createLargePaste: (text: string) => MentionComposerLargePaste,
+): MentionComposerDraftSegment[] {
+  return segments.map((segment) => {
+    if (segment.type === "largePaste") {
+      return { type: "largePaste" as const, paste: createLargePaste(segment.paste.text) };
+    }
+    if (segment.type === "text" && isLargePasteText(segment.text)) {
+      return { type: "largePaste" as const, paste: createLargePaste(segment.text) };
+    }
+    return segment;
+  });
 }
 
 export function parseSerializedComposerText(
@@ -3472,7 +3502,16 @@ export const MentionComposer = memo(
         event.preventDefault();
         writeComposerClipboardSnapshot(event.clipboardData, snapshot);
         resetPromptHistoryRecall();
-        if (!deleteComposerSelection(editor, largePastesRef.current)) return;
+        // execCommand routes the removal through the browser editing pipeline
+        // so Ctrl+Z still restores the cut content — native cut was undoable
+        // before this interception. Its synchronous input event runs
+        // handleInput, which prunes detached large-paste map entries.
+        if (
+          !document.execCommand("delete") &&
+          !deleteComposerSelection(editor, largePastesRef.current)
+        ) {
+          return;
+        }
         closeMentionSession();
         refreshEmptyState();
         refreshMention();
@@ -3499,10 +3538,9 @@ export const MentionComposer = memo(
         const clipboardSegments = readComposerClipboardSegments(e.clipboardData, enabledSkills);
         if (clipboardSegments) {
           e.preventDefault();
-          const restoredSegments = clipboardSegments.map((segment) =>
-            segment.type === "largePaste"
-              ? { type: "largePaste" as const, paste: createLargePaste(segment.paste.text) }
-              : segment,
+          const restoredSegments = rebuildClipboardSegmentsForPaste(
+            clipboardSegments,
+            createLargePaste,
           );
           const editor = editorRef.current;
           if (editor) {

--- a/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gateway/web/src/components/chat/MentionComposer.tsx
@@ -33,6 +33,7 @@ import {
   formatFileMentionToken,
   formatMarkdownReferenceDestination,
 } from "../../lib/chat/mentionReferences";
+import { tokenizeUserMessage } from "../../lib/chat/userMessageContent";
 import { extractClipboardFiles } from "../../lib/clipboardFiles";
 import { createUuid } from "../../lib/shared/id";
 import { cn } from "../../lib/shared/utils";
@@ -167,6 +168,12 @@ export type MentionComposerDraft = {
   isEmpty: boolean;
 };
 
+type ComposerClipboardSnapshot = {
+  text: string;
+  html: string;
+  payload: string;
+};
+
 export interface MentionComposerProps {
   /** Called when user presses Enter (without Shift). */
   onSend: () => void;
@@ -228,6 +235,9 @@ const CODE_MENTION_PATH_ATTR = "data-code-mention-path";
 const CODE_MENTION_START_ATTR = "data-code-mention-start";
 const CODE_MENTION_END_ATTR = "data-code-mention-end";
 const LARGE_PASTE_TAG_ATTR = "data-large-paste-id";
+export const COMPOSER_CLIPBOARD_MIME = "application/x-liveagent-composer-draft+json";
+const COMPOSER_CLIPBOARD_HTML_ATTR = "data-liveagent-composer-clipboard";
+const COMPOSER_CLIPBOARD_VERSION = 1;
 const LARGE_PASTE_CHAR_THRESHOLD = 8_000;
 const LARGE_PASTE_LINE_THRESHOLD = 200;
 const LARGE_PASTE_PREVIEW_CHARS = 160;
@@ -440,7 +450,11 @@ function serializeChildren(
   parent: Node,
   largePastes: Map<string, MentionComposerLargePaste>,
 ): string {
-  return serializeChildrenToSegments(parent, largePastes)
+  return serializeDraftSegments(serializeChildrenToSegments(parent, largePastes));
+}
+
+function serializeDraftSegments(segments: MentionComposerDraftSegment[]) {
+  return segments
     .map((segment) => {
       if (segment.type === "fileMention") return formatFileMentionToken(segment.reference);
       if (segment.type === "largePaste") return segment.paste.text;
@@ -475,6 +489,39 @@ function editorSelectionRange(root: HTMLElement) {
   if (!selection || selection.rangeCount === 0) return null;
   const range = selection.getRangeAt(0);
   return editorRangeIsInsideRoot(root, range) ? range : null;
+}
+
+export function serializeComposerClipboardPayload(segments: MentionComposerDraftSegment[]) {
+  return JSON.stringify({ version: COMPOSER_CLIPBOARD_VERSION, segments });
+}
+
+function resolveComposerSelection(
+  root: HTMLElement | null,
+  largePastes: Map<string, MentionComposerLargePaste>,
+): ComposerClipboardSnapshot | null {
+  if (!root) return null;
+
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return null;
+  }
+
+  const range = selection.getRangeAt(0);
+  if (!editorRangeIsInsideRoot(root, range)) {
+    return null;
+  }
+
+  const fragment = range.cloneContents();
+  const segments = serializeChildrenToSegments(fragment, largePastes);
+  const payload = serializeComposerClipboardPayload(segments);
+  const htmlWrapper = document.createElement("div");
+  htmlWrapper.setAttribute(COMPOSER_CLIPBOARD_HTML_ATTR, payload);
+  htmlWrapper.appendChild(fragment);
+  return {
+    text: normalizeSerializedText(serializeDraftSegments(segments)),
+    html: htmlWrapper.outerHTML,
+    payload,
+  };
 }
 
 function normalizeMentionQuery(query: string) {
@@ -654,6 +701,261 @@ function codeMentionFromElement(el: HTMLElement): CodeMentionReference | null {
     startLine: Number(el.getAttribute(CODE_MENTION_START_ATTR) ?? "1"),
     endLine: Number(el.getAttribute(CODE_MENTION_END_ATTR) ?? "1"),
   });
+}
+
+function clipboardRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function clipboardString(record: Record<string, unknown>, key: string, fallback = "") {
+  const value = record[key];
+  return typeof value === "string" ? value : fallback;
+}
+
+function clipboardNumber(record: Record<string, unknown>, key: string) {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function normalizeClipboardSkill(
+  rawSkill: Record<string, unknown>,
+  enabledSkills: readonly MentionComposerSkill[],
+): MentionComposerDraftSegment | null {
+  const name = clipboardString(rawSkill, "name").trim();
+  const skillFile = clipboardString(rawSkill, "skillFile").trim().replace(/\\/g, "/");
+  const baseDir = clipboardString(rawSkill, "baseDir").trim().replace(/\\/g, "/");
+  if (!name || !skillFile || !baseDir) return null;
+
+  const enabledSkill = enabledSkills.find(
+    (candidate) =>
+      candidate.name === name &&
+      candidate.skillFile.trim().replace(/\\/g, "/") === skillFile &&
+      candidate.baseDir.trim().replace(/\\/g, "/") === baseDir,
+  );
+  if (!enabledSkill) {
+    return { type: "text", text: `/${name}` };
+  }
+  return { type: "skillMention", skill: enabledSkill };
+}
+
+function normalizeClipboardCommit(
+  rawCommit: Record<string, unknown>,
+): MentionComposerCommitMention | null {
+  const sha = clipboardString(rawCommit, "sha").trim();
+  if (!/^[0-9a-f]{7,64}$/i.test(sha)) return null;
+  return normalizeCommitMention({
+    sha,
+    shortSha: clipboardString(rawCommit, "shortSha", sha.slice(0, 7)),
+    subject: clipboardString(rawCommit, "subject"),
+    body: clipboardString(rawCommit, "body"),
+    authorName: clipboardString(rawCommit, "authorName"),
+    authorEmail: clipboardString(rawCommit, "authorEmail"),
+    authorDate: clipboardString(rawCommit, "authorDate"),
+    fileCount: clipboardNumber(rawCommit, "fileCount"),
+    filesChanged: clipboardNumber(rawCommit, "filesChanged"),
+    insertions: clipboardNumber(rawCommit, "insertions"),
+    deletions: clipboardNumber(rawCommit, "deletions"),
+    stat: clipboardString(rawCommit, "stat"),
+    remoteName: clipboardString(rawCommit, "remoteName"),
+    remoteUrl: clipboardString(rawCommit, "remoteUrl"),
+    githubUrl: clipboardString(rawCommit, "githubUrl") || undefined,
+  });
+}
+
+function normalizeClipboardGitFile(
+  rawFile: Record<string, unknown>,
+): MentionComposerGitFileMention | null {
+  const path = clipboardString(rawFile, "path").trim().replace(/\\/g, "/");
+  const commitSha = clipboardString(rawFile, "commitSha").trim();
+  if (!createFileMentionReference(path, "file") || !commitSha) return null;
+  return normalizeGitFileMention({
+    path,
+    oldPath: clipboardString(rawFile, "oldPath") || undefined,
+    status: clipboardString(rawFile, "status"),
+    commitSha,
+    shortSha: clipboardString(rawFile, "shortSha", commitSha.slice(0, 7)),
+    refName: clipboardString(rawFile, "refName"),
+    remoteName: clipboardString(rawFile, "remoteName"),
+    remoteUrl: clipboardString(rawFile, "remoteUrl"),
+    githubUrl: clipboardString(rawFile, "githubUrl") || undefined,
+  });
+}
+
+function normalizeComposerClipboardSegment(
+  rawSegment: unknown,
+  enabledSkills: readonly MentionComposerSkill[],
+): MentionComposerDraftSegment | null {
+  const segment = clipboardRecord(rawSegment);
+  if (!segment) return null;
+  const type = clipboardString(segment, "type");
+
+  if (type === "text") {
+    return { type, text: normalizeLogicalLineEndings(clipboardString(segment, "text")) };
+  }
+  if (type === "fileMention") {
+    const rawReference = clipboardRecord(segment.reference);
+    if (!rawReference) return null;
+    const kind = clipboardString(rawReference, "kind") === "dir" ? "dir" : "file";
+    const reference = createFileMentionReference(clipboardString(rawReference, "path"), kind);
+    return reference ? { type, reference } : null;
+  }
+  if (type === "largePaste") {
+    const rawPaste = clipboardRecord(segment.paste);
+    if (!rawPaste) return null;
+    const id = clipboardString(rawPaste, "id").trim();
+    const label = clipboardString(rawPaste, "label").trim();
+    const text = normalizeLogicalLineEndings(clipboardString(rawPaste, "text"));
+    if (!id || !label || !text) return null;
+    return {
+      type,
+      paste: {
+        id,
+        label,
+        text,
+        charCount: text.length,
+        lineCount: countLargePasteLines(text),
+        preview: normalizeLargePastePreview(text),
+      },
+    };
+  }
+  if (type === "skillMention") {
+    const rawSkill = clipboardRecord(segment.skill);
+    return rawSkill ? normalizeClipboardSkill(rawSkill, enabledSkills) : null;
+  }
+  if (type === "commitMention") {
+    const rawCommit = clipboardRecord(segment.commit);
+    const commit = rawCommit ? normalizeClipboardCommit(rawCommit) : null;
+    return commit ? { type, commit } : null;
+  }
+  if (type === "gitFileMention") {
+    const rawFile = clipboardRecord(segment.file);
+    const file = rawFile ? normalizeClipboardGitFile(rawFile) : null;
+    return file ? { type, file } : null;
+  }
+  if (type === "codeMention") {
+    const rawReference = clipboardRecord(segment.reference);
+    if (!rawReference) return null;
+    const reference = createCodeMentionReference({
+      path: clipboardString(rawReference, "path"),
+      startLine: clipboardNumber(rawReference, "startLine"),
+      endLine: clipboardNumber(rawReference, "endLine"),
+    });
+    return reference ? { type, reference } : null;
+  }
+  return null;
+}
+
+export function parseComposerClipboardPayload(
+  rawPayload: string,
+  enabledSkills: readonly MentionComposerSkill[] = [],
+): MentionComposerDraftSegment[] | null {
+  if (!rawPayload) return null;
+  try {
+    const payload = clipboardRecord(JSON.parse(rawPayload));
+    if (!payload || payload.version !== COMPOSER_CLIPBOARD_VERSION) return null;
+    if (!Array.isArray(payload.segments) || payload.segments.length > 10_000) return null;
+    const segments: MentionComposerDraftSegment[] = [];
+    for (const rawSegment of payload.segments) {
+      const segment = normalizeComposerClipboardSegment(rawSegment, enabledSkills);
+      if (!segment) return null;
+      if (segment.type !== "text" || segment.text) {
+        segments.push(segment);
+      }
+    }
+    return segments.length > 0 ? segments : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseSerializedComposerText(
+  value: string,
+  enabledSkills: readonly MentionComposerSkill[] = [],
+): MentionComposerDraftSegment[] | null {
+  const segments: MentionComposerDraftSegment[] = [];
+  let matched = false;
+  for (const segment of tokenizeUserMessage(normalizeLogicalLineEndings(value), [])) {
+    if (segment.type === "text") {
+      pushTextSegment(segments, segment.value);
+    } else if (segment.type === "mention") {
+      const reference = createFileMentionReference(segment.path, segment.isDir ? "dir" : "file");
+      if (!reference) return null;
+      segments.push({ type: "fileMention", reference });
+      matched = true;
+    } else if (segment.type === "skill") {
+      const enabledSkill = enabledSkills.find((skill) => skill.name === segment.name);
+      if (enabledSkill) {
+        segments.push({ type: "skillMention", skill: enabledSkill });
+        matched = true;
+      } else {
+        pushTextSegment(segments, `/${segment.name}`);
+      }
+    } else if (segment.type === "commit") {
+      segments.push({
+        type: "commitMention",
+        commit: normalizeCommitMention({
+          body: "",
+          authorName: "",
+          authorEmail: "",
+          authorDate: "",
+          fileCount: 0,
+          filesChanged: 0,
+          insertions: 0,
+          deletions: 0,
+          stat: "",
+          remoteName: "",
+          remoteUrl: "",
+          ...segment.commit,
+        }),
+      });
+      matched = true;
+    } else if (segment.type === "gitFile") {
+      segments.push({
+        type: "gitFileMention",
+        file: normalizeGitFileMention({
+          status: "",
+          remoteName: "",
+          remoteUrl: "",
+          ...segment.file,
+        }),
+      });
+      matched = true;
+    } else if (segment.type === "codeRef") {
+      segments.push({ type: "codeMention", reference: segment.reference });
+      matched = true;
+    }
+  }
+  return matched ? segments : null;
+}
+
+function readComposerClipboardSegments(
+  data: DataTransfer,
+  enabledSkills: readonly MentionComposerSkill[],
+) {
+  const privatePayload = data.getData(COMPOSER_CLIPBOARD_MIME);
+  const privateSegments = parseComposerClipboardPayload(privatePayload, enabledSkills);
+  if (privateSegments) return privateSegments;
+
+  const html = data.getData("text/html");
+  if (!html) return null;
+  const wrapper = new DOMParser()
+    .parseFromString(html, "text/html")
+    .querySelector<HTMLElement>(`[${COMPOSER_CLIPBOARD_HTML_ATTR}]`);
+  return parseComposerClipboardPayload(
+    wrapper?.getAttribute(COMPOSER_CLIPBOARD_HTML_ATTR) ?? "",
+    enabledSkills,
+  );
+}
+
+function writeComposerClipboardSnapshot(data: DataTransfer, snapshot: ComposerClipboardSnapshot) {
+  data.clearData();
+  data.setData("text/plain", snapshot.text);
+  data.setData("text/html", snapshot.html);
+  try {
+    data.setData(COMPOSER_CLIPBOARD_MIME, snapshot.payload);
+  } catch {}
 }
 
 function createMentionIcon(svgMarkup: string) {
@@ -850,6 +1152,38 @@ function ensureTrailingCaretAnchor(root: HTMLElement) {
   if (isComposerChipElement(last)) {
     ensureCaretAnchorAfterChip(last);
   }
+}
+
+function pruneLargePastesInRange(
+  range: Range,
+  largePastes: Map<string, MentionComposerLargePaste>,
+) {
+  range
+    .cloneContents()
+    .querySelectorAll<HTMLElement>(`[${LARGE_PASTE_TAG_ATTR}]`)
+    .forEach((chip) => {
+      const largePasteId = chip.getAttribute(LARGE_PASTE_TAG_ATTR);
+      if (largePasteId) largePastes.delete(largePasteId);
+    });
+}
+
+function deleteComposerSelection(
+  root: HTMLElement,
+  largePastes: Map<string, MentionComposerLargePaste>,
+) {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return false;
+
+  const range = selection.getRangeAt(0);
+  if (!editorRangeIsInsideRoot(root, range)) return false;
+
+  pruneLargePastesInRange(range, largePastes);
+  range.deleteContents();
+  selection.removeAllRanges();
+  selection.addRange(range);
+  normalizeCaretAfterChip(root);
+  ensureTrailingCaretAnchor(root);
+  return true;
 }
 
 /** Find the nearest previous leaf node (for checking what precedes @). */
@@ -1153,6 +1487,89 @@ function createLargePasteChip(paste: MentionComposerLargePaste) {
     ),
   );
   return chip;
+}
+
+function createComposerSegmentNode(
+  segment: MentionComposerDraftSegment,
+  largePastes: Map<string, MentionComposerLargePaste>,
+): Node | null {
+  if (segment.type === "text") {
+    return segment.text ? document.createTextNode(normalizeLogicalLineEndings(segment.text)) : null;
+  }
+  if (segment.type === "fileMention") {
+    return createFileMentionChip(segment.reference.path, segment.reference.kind);
+  }
+  if (segment.type === "largePaste") {
+    largePastes.set(segment.paste.id, segment.paste);
+    return createLargePasteChip(segment.paste);
+  }
+  if (segment.type === "skillMention") {
+    return createSkillMentionChip(segment.skill);
+  }
+  if (segment.type === "commitMention") {
+    return createCommitMentionChip(segment.commit);
+  }
+  if (segment.type === "gitFileMention") {
+    return createGitFileMentionChip(segment.file);
+  }
+  return createCodeMentionChip(segment.reference);
+}
+
+function insertComposerSegmentsAtSelection(
+  root: HTMLElement,
+  segments: MentionComposerDraftSegment[],
+  largePastes: Map<string, MentionComposerLargePaste>,
+) {
+  const nodes = segments
+    .map((segment) => createComposerSegmentNode(segment, largePastes))
+    .filter((node): node is Node => node !== null);
+  if (nodes.length === 0) return false;
+
+  const selection = window.getSelection();
+  let range = editorSelectionRange(root);
+  if (!range) {
+    range = document.createRange();
+    range.selectNodeContents(root);
+    range.collapse(false);
+  }
+
+  // A caret parked inside a non-editable chip (WebKit drops clicks there)
+  // must hop after the chip instead of letting the boundary extension below
+  // swallow the chip into the replaced range.
+  if (range.collapsed) {
+    const chip = closestComposerChipFromNode(root, range.startContainer);
+    if (chip) {
+      range.setStartAfter(chip);
+      range.collapse(true);
+    }
+  } else {
+    const startChip = closestComposerChipFromNode(root, range.startContainer);
+    if (startChip) range.setStartBefore(startChip);
+    const endChip = closestComposerChipFromNode(root, range.endContainer);
+    if (endChip) range.setEndAfter(endChip);
+    pruneLargePastesInRange(range, largePastes);
+    range.deleteContents();
+  }
+
+  const fragment = document.createDocumentFragment();
+  for (const node of nodes) fragment.appendChild(node);
+  const lastNode = nodes[nodes.length - 1];
+  range.insertNode(fragment);
+
+  if (lastNode.nodeType === Node.TEXT_NODE) {
+    placeCaretInTextNode(lastNode as Text, (lastNode.textContent ?? "").length);
+  } else if (isComposerChipElement(lastNode)) {
+    const anchor = ensureCaretAnchorAfterChip(lastNode);
+    if (anchor) placeCaretInTextNode(anchor.textNode, anchor.offset);
+  } else if (selection) {
+    const caret = document.createRange();
+    caret.setStartAfter(lastNode);
+    caret.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(caret);
+  }
+  ensureTrailingCaretAnchor(root);
+  return true;
 }
 
 function insertNodeAtCursor(root: HTMLElement, node: HTMLElement) {
@@ -3036,6 +3453,33 @@ export const MentionComposer = memo(
       ],
     );
 
+    const handleCopy = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
+      const snapshot = resolveComposerSelection(editorRef.current, largePastesRef.current);
+      if (!snapshot) return;
+      event.preventDefault();
+      writeComposerClipboardSnapshot(event.clipboardData, snapshot);
+    }, []);
+
+    const handleCut = useCallback(
+      (event: ClipboardEvent<HTMLDivElement>) => {
+        if (disabled || typewriterRef.current) {
+          event.preventDefault();
+          return;
+        }
+        const editor = editorRef.current;
+        const snapshot = resolveComposerSelection(editor, largePastesRef.current);
+        if (!editor || !snapshot) return;
+        event.preventDefault();
+        writeComposerClipboardSnapshot(event.clipboardData, snapshot);
+        resetPromptHistoryRecall();
+        if (!deleteComposerSelection(editor, largePastesRef.current)) return;
+        closeMentionSession();
+        refreshEmptyState();
+        refreshMention();
+      },
+      [closeMentionSession, disabled, refreshEmptyState, refreshMention, resetPromptHistoryRecall],
+    );
+
     const handlePaste = useCallback(
       (e: ClipboardEvent<HTMLDivElement>) => {
         if (e.defaultPrevented) {
@@ -3052,6 +3496,23 @@ export const MentionComposer = memo(
         // The large-paste chip path mutates the DOM without an input event,
         // so the recall session must reset here as well.
         resetPromptHistoryRecall();
+        const clipboardSegments = readComposerClipboardSegments(e.clipboardData, enabledSkills);
+        if (clipboardSegments) {
+          e.preventDefault();
+          const restoredSegments = clipboardSegments.map((segment) =>
+            segment.type === "largePaste"
+              ? { type: "largePaste" as const, paste: createLargePaste(segment.paste.text) }
+              : segment,
+          );
+          const editor = editorRef.current;
+          if (editor) {
+            insertComposerSegmentsAtSelection(editor, restoredSegments, largePastesRef.current);
+          }
+          closeMentionSession();
+          refreshEmptyState();
+          refreshMention();
+          return;
+        }
         const clipboardFiles = extractClipboardFiles(e.clipboardData);
         if (clipboardFiles.length > 0) {
           e.preventDefault();
@@ -3064,12 +3525,27 @@ export const MentionComposer = memo(
           insertLargePaste(text);
           return;
         }
+        const serializedSegments = parseSerializedComposerText(text, enabledSkills);
+        const editor = editorRef.current;
+        if (
+          serializedSegments &&
+          editor &&
+          insertComposerSegmentsAtSelection(editor, serializedSegments, largePastesRef.current)
+        ) {
+          closeMentionSession();
+          refreshEmptyState();
+          refreshMention();
+          return;
+        }
         insertPlainTextWithUndo(text);
         refreshEmptyState();
         refreshMention();
       },
       [
         disabled,
+        closeMentionSession,
+        createLargePaste,
+        enabledSkills,
         insertLargePaste,
         onPasteFiles,
         refreshEmptyState,
@@ -3166,6 +3642,8 @@ export const MentionComposer = memo(
           onMouseLeave={scheduleCommitTooltipClose}
           onMouseMove={handleMouseMove}
           onMouseUp={handleMouseUp}
+          onCopy={handleCopy}
+          onCut={handleCut}
           onPaste={handlePaste}
           onCompositionStart={handleCompositionStart}
           onCompositionEnd={handleCompositionEnd}

--- a/crates/agent-gateway/web/src/lib/chat/userMessageContent.tsx
+++ b/crates/agent-gateway/web/src/lib/chat/userMessageContent.tsx
@@ -65,7 +65,7 @@ export function isSkillMentionToken(token: string) {
   return Boolean(name) && isSkillMentionName(name) && !isCommonSkillMentionEnvVar(name);
 }
 
-type UserMessageSegment =
+export type UserMessageSegment =
   | { type: "text"; value: string }
   | { type: "mention"; path: string; isDir: boolean }
   | { type: "skill"; name: string }
@@ -163,8 +163,7 @@ function markdownFileReference(label: string, rawDestination: string) {
   if (!reference) return null;
 
   const fileName = reference.path.split("/").pop() || reference.path;
-  const expectedLabel = reference.isDir ? `${fileName}/` : fileName;
-  if (unescapeMarkdown(label.trim()) !== expectedLabel) return null;
+  if (unescapeMarkdown(label.trim()) !== fileName) return null;
 
   return reference;
 }
@@ -479,7 +478,7 @@ function tokenizeMentions(text: string): UserMessageSegment[] {
   return segments.length > 0 ? segments : tokenizeInlineMentions(text);
 }
 
-function tokenizeUserMessage(
+export function tokenizeUserMessage(
   text: string,
   pastedTextFiles: PendingUploadedFile[],
 ): UserMessageSegment[] {

--- a/crates/agent-gateway/web/src/lib/chat/userMessageContent.tsx
+++ b/crates/agent-gateway/web/src/lib/chat/userMessageContent.tsx
@@ -168,10 +168,17 @@ function markdownFileReference(label: string, rawDestination: string) {
   return reference;
 }
 
-function extractGitHubCommitSha(value: string) {
+function isGitHubHttpUrl(url: URL) {
+  return (
+    (url.protocol === "https:" || url.protocol === "http:") &&
+    ["github.com", "www.github.com"].includes(url.hostname.toLowerCase())
+  );
+}
+
+export function extractGitHubCommitSha(value: string) {
   try {
     const url = new URL(value);
-    if (!["github.com", "www.github.com"].includes(url.hostname.toLowerCase())) return "";
+    if (!isGitHubHttpUrl(url)) return "";
     const parts = url.pathname.split("/").filter(Boolean);
     const commitIndex = parts.findIndex((part) => part.toLowerCase() === "commit");
     const sha = commitIndex >= 0 ? (parts[commitIndex + 1] ?? "") : "";
@@ -205,10 +212,10 @@ export function buildGitHubCommitUrl(remoteUrl: string, sha: string) {
   }
 }
 
-function extractGitHubFileReference(value: string) {
+export function extractGitHubFileReference(value: string) {
   try {
     const url = new URL(value);
-    if (!["github.com", "www.github.com"].includes(url.hostname.toLowerCase())) return null;
+    if (!isGitHubHttpUrl(url)) return null;
     const parts = url.pathname.split("/").filter(Boolean);
     const blobIndex = parts.findIndex((part) => part.toLowerCase() === "blob");
     const ref = blobIndex >= 0 ? (parts[blobIndex + 1] ?? "") : "";

--- a/crates/agent-gateway/web/test/browser/paste-newline-pipeline.html
+++ b/crates/agent-gateway/web/test/browser/paste-newline-pipeline.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="editor" class="mention-composer whitespace-pre-wrap" contenteditable="true"></div>
+    <div id="tag-composer"></div>
     <div id="bubble" class="chat-user-bubble w-fit px-4 py-2.5 font-chat text-[14.5px] leading-relaxed"></div>
     <script type="module">
       import React from "react";
@@ -17,7 +18,11 @@
         insertPlainTextWithUndo,
         normalizeLogicalLineEndings,
       } from "/src/lib/chat/composerText.ts";
-      import { serializeChildrenToSegments } from "/src/components/chat/MentionComposer.tsx";
+      import {
+        COMPOSER_CLIPBOARD_MIME,
+        MentionComposer,
+        serializeChildrenToSegments,
+      } from "/src/components/chat/MentionComposer.tsx";
       import { buildTextFromComposerDraft } from "/src/app/chatDraft.ts";
       import {
         createUserMessageWithUploads,
@@ -26,8 +31,26 @@
       import { UserMessageContent } from "/src/lib/chat/userMessageContent.tsx";
 
       const editor = document.querySelector("#editor");
+      const tagComposerHost = document.querySelector("#tag-composer");
       const bubble = document.querySelector("#bubble");
+      const tagComposerRef = React.createRef();
+      const tagComposerRoot = createRoot(tagComposerHost);
       const bubbleRoot = createRoot(bubble);
+      const reviewerSkill = {
+        name: "reviewer",
+        description: "Review changed code",
+        skillFile: "reviewer/SKILL.md",
+        baseDir: "reviewer",
+      };
+
+      tagComposerRoot.render(
+        React.createElement(MentionComposer, {
+          ref: tagComposerRef,
+          onSend() {},
+          workdir: "",
+          enabledSkills: [reviewerSkill],
+        }),
+      );
 
       editor.addEventListener("paste", (event) => {
         event.preventDefault();
@@ -127,6 +150,139 @@
           whiteSpace: getComputedStyle(bubble).whiteSpace,
         };
       };
+      window.runTagClipboardRoundTrip = () => {
+        const segments = [
+          { type: "text", text: "Inspect " },
+          { type: "fileMention", reference: { path: "src/App.tsx", kind: "file" } },
+          { type: "fileMention", reference: { path: "docs/guides", kind: "dir" } },
+          { type: "skillMention", skill: reviewerSkill },
+          {
+            type: "commitMention",
+            commit: {
+              sha: "abcdef1234567890",
+              shortSha: "abcdef1",
+              subject: "Preserve tags",
+              body: "Full commit body",
+              authorName: "Author",
+              authorEmail: "author@example.com",
+              authorDate: "2026-08-08T00:00:00Z",
+              fileCount: 2,
+              filesChanged: 2,
+              insertions: 12,
+              deletions: 3,
+              stat: "2 files changed",
+              remoteName: "origin",
+              remoteUrl: "https://github.com/example/repo.git",
+              githubUrl: "https://github.com/example/repo/commit/abcdef1234567890",
+            },
+          },
+          {
+            type: "gitFileMention",
+            file: {
+              path: "src/App.tsx",
+              status: "M",
+              commitSha: "abcdef1234567890",
+              shortSha: "abcdef1",
+              refName: "main",
+              remoteName: "origin",
+              remoteUrl: "https://github.com/example/repo.git",
+              githubUrl:
+                "https://github.com/example/repo/blob/abcdef1234567890/src/App.tsx",
+            },
+          },
+          {
+            type: "codeMention",
+            reference: { path: "src/App.tsx", startLine: 4, endLine: 9 },
+          },
+          {
+            type: "largePaste",
+            paste: {
+              id: "browser-large-paste",
+              label: "Pasted text 1",
+              text: "large\nbody",
+              charCount: 10,
+              lineCount: 2,
+              preview: "large body",
+            },
+          },
+        ];
+        tagComposerRef.current.setDraft({
+          segments,
+          text: "",
+          textWithoutLargePastes: "",
+          largePastes: [],
+          skillMentions: [],
+          commitMentions: [],
+          gitFileMentions: [],
+          codeMentions: [],
+          isEmpty: false,
+        });
+
+        const tagEditor = tagComposerHost.querySelector(".mention-composer");
+        const selection = getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(tagEditor);
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const transfer = new DataTransfer();
+        const copyEvent = new ClipboardEvent("copy", {
+          clipboardData: transfer,
+          bubbles: true,
+          cancelable: true,
+        });
+        tagEditor.dispatchEvent(copyEvent);
+
+        tagComposerRef.current.setText("");
+        tagEditor.focus();
+        const pasteRange = document.createRange();
+        pasteRange.selectNodeContents(tagEditor);
+        pasteRange.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(pasteRange);
+        const pasteEvent = new ClipboardEvent("paste", {
+          clipboardData: transfer,
+          bubbles: true,
+          cancelable: true,
+        });
+        tagEditor.dispatchEvent(pasteEvent);
+        const restoredDraft = tagComposerRef.current.getDraft();
+
+        const plainTransfer = new DataTransfer();
+        plainTransfer.setData("text/plain", transfer.getData("text/plain"));
+        tagComposerRef.current.setText("");
+        tagEditor.focus();
+        const plainRange = document.createRange();
+        plainRange.selectNodeContents(tagEditor);
+        plainRange.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(plainRange);
+        tagEditor.dispatchEvent(
+          new ClipboardEvent("paste", {
+            clipboardData: plainTransfer,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+        const plainRestoredDraft = tagComposerRef.current.getDraft();
+
+        return {
+          copyPrevented: copyEvent.defaultPrevented,
+          pastePrevented: pasteEvent.defaultPrevented,
+          plainText: transfer.getData("text/plain"),
+          hasHtmlPayload: transfer
+            .getData("text/html")
+            .includes("data-liveagent-composer-clipboard"),
+          hasPrivatePayload: transfer.getData(COMPOSER_CLIPBOARD_MIME).length > 0,
+          restoredTypes: restoredDraft.segments
+            .filter((segment) => segment.type !== "text")
+            .map((segment) => segment.type),
+          plainRestoredTypes: plainRestoredDraft.segments
+            .filter((segment) => segment.type !== "text")
+            .map((segment) => segment.type),
+        };
+      };
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
       window.pipelineReady = true;
     </script>
   </body>

--- a/crates/agent-gui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gui/src/components/chat/MentionComposer.tsx
@@ -33,7 +33,11 @@ import {
   formatFileMentionToken,
   formatMarkdownReferenceDestination,
 } from "../../lib/chat/messages/mentionReferences";
-import { tokenizeUserMessage } from "../../lib/chat/messages/userMessageContent";
+import {
+  extractGitHubCommitSha,
+  extractGitHubFileReference,
+  tokenizeUserMessage,
+} from "../../lib/chat/messages/userMessageContent";
 import { createUuid } from "../../lib/shared/id";
 import { cn } from "../../lib/shared/utils";
 import { readClipboardText } from "../../lib/system/clipboardText";
@@ -983,6 +987,11 @@ function normalizeClipboardCommit(
 ): MentionComposerCommitMention | null {
   const sha = clipboardString(rawCommit, "sha").trim();
   if (!/^[0-9a-f]{7,64}$/i.test(sha)) return null;
+  // Clipboard payloads are untrusted — the text/html fallback channel reads
+  // the payload attribute out of any copied page — and githubUrl feeds the
+  // chip's open-on-GitHub action, so it must pass the same GitHub URL
+  // validation as the plain-text token channel or drop to a link-less chip.
+  const githubUrl = clipboardString(rawCommit, "githubUrl").trim();
   return normalizeCommitMention({
     sha,
     shortSha: clipboardString(rawCommit, "shortSha", sha.slice(0, 7)),
@@ -998,7 +1007,7 @@ function normalizeClipboardCommit(
     stat: clipboardString(rawCommit, "stat"),
     remoteName: clipboardString(rawCommit, "remoteName"),
     remoteUrl: clipboardString(rawCommit, "remoteUrl"),
-    githubUrl: clipboardString(rawCommit, "githubUrl") || undefined,
+    githubUrl: extractGitHubCommitSha(githubUrl) ? githubUrl : undefined,
   });
 }
 
@@ -1008,6 +1017,9 @@ function normalizeClipboardGitFile(
   const path = clipboardString(rawFile, "path").trim().replace(/\\/g, "/");
   const commitSha = clipboardString(rawFile, "commitSha").trim();
   if (!createFileMentionReference(path, "file") || !commitSha) return null;
+  // Same trust boundary as normalizeClipboardCommit: only a real GitHub blob
+  // URL may reach the chip's open action.
+  const githubUrl = clipboardString(rawFile, "githubUrl").trim();
   return normalizeGitFileMention({
     path,
     oldPath: clipboardString(rawFile, "oldPath") || undefined,
@@ -1017,7 +1029,7 @@ function normalizeClipboardGitFile(
     refName: clipboardString(rawFile, "refName"),
     remoteName: clipboardString(rawFile, "remoteName"),
     remoteUrl: clipboardString(rawFile, "remoteUrl"),
-    githubUrl: clipboardString(rawFile, "githubUrl") || undefined,
+    githubUrl: extractGitHubFileReference(githubUrl) ? githubUrl : undefined,
   });
 }
 
@@ -1106,6 +1118,24 @@ export function parseComposerClipboardPayload(
   } catch {
     return null;
   }
+}
+
+// Restored segments must obey the same large-paste threshold as direct input:
+// text over the limit collapses into a chip, and carried-over largePaste
+// segments are rebuilt with fresh ids so they cannot collide in the map.
+export function rebuildClipboardSegmentsForPaste(
+  segments: MentionComposerDraftSegment[],
+  createLargePaste: (text: string) => MentionComposerLargePaste,
+): MentionComposerDraftSegment[] {
+  return segments.map((segment) => {
+    if (segment.type === "largePaste") {
+      return { type: "largePaste" as const, paste: createLargePaste(segment.paste.text) };
+    }
+    if (segment.type === "text" && isLargePasteText(segment.text)) {
+      return { type: "largePaste" as const, paste: createLargePaste(segment.text) };
+    }
+    return segment;
+  });
 }
 
 export function parseSerializedComposerText(
@@ -3899,7 +3929,16 @@ export const MentionComposer = memo(
         event.preventDefault();
         writeComposerClipboardSnapshot(event.clipboardData, snapshot);
         resetPromptHistoryRecall();
-        if (!deleteComposerSelection(editor, largePastesRef.current)) return;
+        // execCommand routes the removal through the browser editing pipeline
+        // so Ctrl+Z still restores the cut content — native cut was undoable
+        // before this interception. Its synchronous input event runs
+        // handleInput, which prunes detached large-paste map entries.
+        if (
+          !document.execCommand("delete") &&
+          !deleteComposerSelection(editor, largePastesRef.current)
+        ) {
+          return;
+        }
         closeMentionSession();
         refreshEmptyState();
         refreshMention();
@@ -3923,10 +3962,9 @@ export const MentionComposer = memo(
         const clipboardSegments = readComposerClipboardSegments(e.clipboardData, enabledSkills);
         if (clipboardSegments) {
           e.preventDefault();
-          const restoredSegments = clipboardSegments.map((segment) =>
-            segment.type === "largePaste"
-              ? { type: "largePaste" as const, paste: createLargePaste(segment.paste.text) }
-              : segment,
+          const restoredSegments = rebuildClipboardSegmentsForPaste(
+            clipboardSegments,
+            createLargePaste,
           );
           const editor = editorRef.current;
           if (editor) {

--- a/crates/agent-gui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-gui/src/components/chat/MentionComposer.tsx
@@ -33,6 +33,7 @@ import {
   formatFileMentionToken,
   formatMarkdownReferenceDestination,
 } from "../../lib/chat/messages/mentionReferences";
+import { tokenizeUserMessage } from "../../lib/chat/messages/userMessageContent";
 import { createUuid } from "../../lib/shared/id";
 import { cn } from "../../lib/shared/utils";
 import { readClipboardText } from "../../lib/system/clipboardText";
@@ -175,6 +176,12 @@ export type MentionComposerDraft = {
   isEmpty: boolean;
 };
 
+type ComposerClipboardSnapshot = {
+  text: string;
+  html: string;
+  payload: string;
+};
+
 export interface MentionComposerProps {
   /** Called when user presses Enter (without Shift). */
   onSend: () => void;
@@ -236,6 +243,9 @@ const CODE_MENTION_PATH_ATTR = "data-code-mention-path";
 const CODE_MENTION_START_ATTR = "data-code-mention-start";
 const CODE_MENTION_END_ATTR = "data-code-mention-end";
 const LARGE_PASTE_TAG_ATTR = "data-large-paste-id";
+export const COMPOSER_CLIPBOARD_MIME = "application/x-liveagent-composer-draft+json";
+const COMPOSER_CLIPBOARD_HTML_ATTR = "data-liveagent-composer-clipboard";
+const COMPOSER_CLIPBOARD_VERSION = 1;
 const LARGE_PASTE_CHAR_THRESHOLD = 8_000;
 const LARGE_PASTE_LINE_THRESHOLD = 200;
 const LARGE_PASTE_PREVIEW_CHARS = 160;
@@ -451,7 +461,11 @@ function serializeChildren(
   parent: Node,
   largePastes: Map<string, MentionComposerLargePaste>,
 ): string {
-  return serializeChildrenToSegments(parent, largePastes)
+  return serializeDraftSegments(serializeChildrenToSegments(parent, largePastes));
+}
+
+function serializeDraftSegments(segments: MentionComposerDraftSegment[]) {
+  return segments
     .map((segment) => {
       if (segment.type === "fileMention") return formatFileMentionToken(segment.reference);
       if (segment.type === "largePaste") return segment.paste.text;
@@ -488,23 +502,37 @@ function editorSelectionRange(root: HTMLElement) {
   return editorRangeIsInsideRoot(root, range) ? range : null;
 }
 
-function resolveComposerSelectionText(
+export function serializeComposerClipboardPayload(segments: MentionComposerDraftSegment[]) {
+  return JSON.stringify({ version: COMPOSER_CLIPBOARD_VERSION, segments });
+}
+
+function resolveComposerSelection(
   root: HTMLElement | null,
   largePastes: Map<string, MentionComposerLargePaste>,
-) {
-  if (!root) return "";
+): ComposerClipboardSnapshot | null {
+  if (!root) return null;
 
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
-    return "";
+    return null;
   }
 
   const range = selection.getRangeAt(0);
   if (!editorRangeIsInsideRoot(root, range)) {
-    return "";
+    return null;
   }
 
-  return normalizeSerializedText(serializeChildren(range.cloneContents(), largePastes));
+  const fragment = range.cloneContents();
+  const segments = serializeChildrenToSegments(fragment, largePastes);
+  const payload = serializeComposerClipboardPayload(segments);
+  const htmlWrapper = document.createElement("div");
+  htmlWrapper.setAttribute(COMPOSER_CLIPBOARD_HTML_ATTR, payload);
+  htmlWrapper.appendChild(fragment);
+  return {
+    text: normalizeSerializedText(serializeDraftSegments(segments)),
+    html: htmlWrapper.outerHTML,
+    payload,
+  };
 }
 
 function selectionContainsPoint(
@@ -587,6 +615,19 @@ function selectComposerContents(root: HTMLElement) {
   selection?.addRange(range);
 }
 
+function pruneLargePastesInRange(
+  range: Range,
+  largePastes: Map<string, MentionComposerLargePaste>,
+) {
+  range
+    .cloneContents()
+    .querySelectorAll<HTMLElement>(`[${LARGE_PASTE_TAG_ATTR}]`)
+    .forEach((chip) => {
+      const largePasteId = chip.getAttribute(LARGE_PASTE_TAG_ATTR);
+      if (largePasteId) largePastes.delete(largePasteId);
+    });
+}
+
 function deleteComposerSelection(
   root: HTMLElement,
   largePastes: Map<string, MentionComposerLargePaste>,
@@ -597,16 +638,7 @@ function deleteComposerSelection(
   const range = selection.getRangeAt(0);
   if (!editorRangeIsInsideRoot(root, range)) return false;
 
-  range
-    .cloneContents()
-    .querySelectorAll<HTMLElement>(`[${LARGE_PASTE_TAG_ATTR}]`)
-    .forEach((chip) => {
-      const largePasteId = chip.getAttribute(LARGE_PASTE_TAG_ATTR);
-      if (largePasteId) {
-        largePastes.delete(largePasteId);
-      }
-    });
-
+  pruneLargePastesInRange(range, largePastes);
   range.deleteContents();
   selection.removeAllRanges();
   selection.addRange(range);
@@ -907,6 +939,259 @@ function codeMentionFromElement(el: HTMLElement): CodeMentionReference | null {
     startLine: Number(el.getAttribute(CODE_MENTION_START_ATTR) ?? "1"),
     endLine: Number(el.getAttribute(CODE_MENTION_END_ATTR) ?? "1"),
   });
+}
+
+function clipboardRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function clipboardString(record: Record<string, unknown>, key: string, fallback = "") {
+  const value = record[key];
+  return typeof value === "string" ? value : fallback;
+}
+
+function clipboardNumber(record: Record<string, unknown>, key: string) {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function normalizeClipboardSkill(
+  rawSkill: Record<string, unknown>,
+  enabledSkills: readonly MentionComposerSkill[],
+): MentionComposerDraftSegment | null {
+  const name = clipboardString(rawSkill, "name").trim();
+  const skillFile = clipboardString(rawSkill, "skillFile").trim().replace(/\\/g, "/");
+  const baseDir = clipboardString(rawSkill, "baseDir").trim().replace(/\\/g, "/");
+  if (!name || !skillFile || !baseDir) return null;
+
+  const enabledSkill = enabledSkills.find(
+    (candidate) =>
+      candidate.name === name &&
+      candidate.skillFile.trim().replace(/\\/g, "/") === skillFile &&
+      candidate.baseDir.trim().replace(/\\/g, "/") === baseDir,
+  );
+  if (!enabledSkill) {
+    return { type: "text", text: `/${name}` };
+  }
+  return { type: "skillMention", skill: enabledSkill };
+}
+
+function normalizeClipboardCommit(
+  rawCommit: Record<string, unknown>,
+): MentionComposerCommitMention | null {
+  const sha = clipboardString(rawCommit, "sha").trim();
+  if (!/^[0-9a-f]{7,64}$/i.test(sha)) return null;
+  return normalizeCommitMention({
+    sha,
+    shortSha: clipboardString(rawCommit, "shortSha", sha.slice(0, 7)),
+    subject: clipboardString(rawCommit, "subject"),
+    body: clipboardString(rawCommit, "body"),
+    authorName: clipboardString(rawCommit, "authorName"),
+    authorEmail: clipboardString(rawCommit, "authorEmail"),
+    authorDate: clipboardString(rawCommit, "authorDate"),
+    fileCount: clipboardNumber(rawCommit, "fileCount"),
+    filesChanged: clipboardNumber(rawCommit, "filesChanged"),
+    insertions: clipboardNumber(rawCommit, "insertions"),
+    deletions: clipboardNumber(rawCommit, "deletions"),
+    stat: clipboardString(rawCommit, "stat"),
+    remoteName: clipboardString(rawCommit, "remoteName"),
+    remoteUrl: clipboardString(rawCommit, "remoteUrl"),
+    githubUrl: clipboardString(rawCommit, "githubUrl") || undefined,
+  });
+}
+
+function normalizeClipboardGitFile(
+  rawFile: Record<string, unknown>,
+): MentionComposerGitFileMention | null {
+  const path = clipboardString(rawFile, "path").trim().replace(/\\/g, "/");
+  const commitSha = clipboardString(rawFile, "commitSha").trim();
+  if (!createFileMentionReference(path, "file") || !commitSha) return null;
+  return normalizeGitFileMention({
+    path,
+    oldPath: clipboardString(rawFile, "oldPath") || undefined,
+    status: clipboardString(rawFile, "status"),
+    commitSha,
+    shortSha: clipboardString(rawFile, "shortSha", commitSha.slice(0, 7)),
+    refName: clipboardString(rawFile, "refName"),
+    remoteName: clipboardString(rawFile, "remoteName"),
+    remoteUrl: clipboardString(rawFile, "remoteUrl"),
+    githubUrl: clipboardString(rawFile, "githubUrl") || undefined,
+  });
+}
+
+function normalizeComposerClipboardSegment(
+  rawSegment: unknown,
+  enabledSkills: readonly MentionComposerSkill[],
+): MentionComposerDraftSegment | null {
+  const segment = clipboardRecord(rawSegment);
+  if (!segment) return null;
+  const type = clipboardString(segment, "type");
+
+  if (type === "text") {
+    return { type, text: normalizeLogicalLineEndings(clipboardString(segment, "text")) };
+  }
+  if (type === "fileMention") {
+    const rawReference = clipboardRecord(segment.reference);
+    if (!rawReference) return null;
+    const kind = clipboardString(rawReference, "kind") === "dir" ? "dir" : "file";
+    const reference = createFileMentionReference(clipboardString(rawReference, "path"), kind);
+    return reference ? { type, reference } : null;
+  }
+  if (type === "largePaste") {
+    const rawPaste = clipboardRecord(segment.paste);
+    if (!rawPaste) return null;
+    const id = clipboardString(rawPaste, "id").trim();
+    const label = clipboardString(rawPaste, "label").trim();
+    const text = normalizeLogicalLineEndings(clipboardString(rawPaste, "text"));
+    if (!id || !label || !text) return null;
+    return {
+      type,
+      paste: {
+        id,
+        label,
+        text,
+        charCount: text.length,
+        lineCount: countLargePasteLines(text),
+        preview: normalizeLargePastePreview(text),
+      },
+    };
+  }
+  if (type === "skillMention") {
+    const rawSkill = clipboardRecord(segment.skill);
+    return rawSkill ? normalizeClipboardSkill(rawSkill, enabledSkills) : null;
+  }
+  if (type === "commitMention") {
+    const rawCommit = clipboardRecord(segment.commit);
+    const commit = rawCommit ? normalizeClipboardCommit(rawCommit) : null;
+    return commit ? { type, commit } : null;
+  }
+  if (type === "gitFileMention") {
+    const rawFile = clipboardRecord(segment.file);
+    const file = rawFile ? normalizeClipboardGitFile(rawFile) : null;
+    return file ? { type, file } : null;
+  }
+  if (type === "codeMention") {
+    const rawReference = clipboardRecord(segment.reference);
+    if (!rawReference) return null;
+    const reference = createCodeMentionReference({
+      path: clipboardString(rawReference, "path"),
+      startLine: clipboardNumber(rawReference, "startLine"),
+      endLine: clipboardNumber(rawReference, "endLine"),
+    });
+    return reference ? { type, reference } : null;
+  }
+  return null;
+}
+
+export function parseComposerClipboardPayload(
+  rawPayload: string,
+  enabledSkills: readonly MentionComposerSkill[] = [],
+): MentionComposerDraftSegment[] | null {
+  if (!rawPayload) return null;
+  try {
+    const payload = clipboardRecord(JSON.parse(rawPayload));
+    if (!payload || payload.version !== COMPOSER_CLIPBOARD_VERSION) return null;
+    if (!Array.isArray(payload.segments) || payload.segments.length > 10_000) return null;
+    const segments: MentionComposerDraftSegment[] = [];
+    for (const rawSegment of payload.segments) {
+      const segment = normalizeComposerClipboardSegment(rawSegment, enabledSkills);
+      if (!segment) return null;
+      if (segment.type !== "text" || segment.text) {
+        segments.push(segment);
+      }
+    }
+    return segments.length > 0 ? segments : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseSerializedComposerText(
+  value: string,
+  enabledSkills: readonly MentionComposerSkill[] = [],
+): MentionComposerDraftSegment[] | null {
+  const segments: MentionComposerDraftSegment[] = [];
+  let matched = false;
+  for (const segment of tokenizeUserMessage(normalizeLogicalLineEndings(value), [])) {
+    if (segment.type === "text") {
+      pushTextSegment(segments, segment.value);
+    } else if (segment.type === "mention") {
+      segments.push({ type: "fileMention", reference: segment.reference });
+      matched = true;
+    } else if (segment.type === "skill") {
+      const enabledSkill = enabledSkills.find((skill) => skill.name === segment.name);
+      if (enabledSkill) {
+        segments.push({ type: "skillMention", skill: enabledSkill });
+        matched = true;
+      } else {
+        pushTextSegment(segments, `/${segment.name}`);
+      }
+    } else if (segment.type === "commit") {
+      segments.push({
+        type: "commitMention",
+        commit: normalizeCommitMention({
+          body: "",
+          authorName: "",
+          authorEmail: "",
+          authorDate: "",
+          fileCount: 0,
+          filesChanged: 0,
+          insertions: 0,
+          deletions: 0,
+          stat: "",
+          remoteName: "",
+          remoteUrl: "",
+          ...segment.commit,
+        }),
+      });
+      matched = true;
+    } else if (segment.type === "gitFile") {
+      segments.push({
+        type: "gitFileMention",
+        file: normalizeGitFileMention({
+          status: "",
+          remoteName: "",
+          remoteUrl: "",
+          ...segment.file,
+        }),
+      });
+      matched = true;
+    } else if (segment.type === "codeRef") {
+      segments.push({ type: "codeMention", reference: segment.reference });
+      matched = true;
+    }
+  }
+  return matched ? segments : null;
+}
+
+function readComposerClipboardSegments(
+  data: DataTransfer,
+  enabledSkills: readonly MentionComposerSkill[],
+) {
+  const privatePayload = data.getData(COMPOSER_CLIPBOARD_MIME);
+  const privateSegments = parseComposerClipboardPayload(privatePayload, enabledSkills);
+  if (privateSegments) return privateSegments;
+
+  const html = data.getData("text/html");
+  if (!html) return null;
+  const wrapper = new DOMParser()
+    .parseFromString(html, "text/html")
+    .querySelector<HTMLElement>(`[${COMPOSER_CLIPBOARD_HTML_ATTR}]`);
+  return parseComposerClipboardPayload(
+    wrapper?.getAttribute(COMPOSER_CLIPBOARD_HTML_ATTR) ?? "",
+    enabledSkills,
+  );
+}
+
+function writeComposerClipboardSnapshot(data: DataTransfer, snapshot: ComposerClipboardSnapshot) {
+  data.clearData();
+  data.setData("text/plain", snapshot.text);
+  data.setData("text/html", snapshot.html);
+  try {
+    data.setData(COMPOSER_CLIPBOARD_MIME, snapshot.payload);
+  } catch {}
 }
 
 function createMentionIcon(svgMarkup: string) {
@@ -1386,6 +1671,89 @@ function createLargePasteChip(paste: MentionComposerLargePaste) {
     ),
   );
   return chip;
+}
+
+function createComposerSegmentNode(
+  segment: MentionComposerDraftSegment,
+  largePastes: Map<string, MentionComposerLargePaste>,
+): Node | null {
+  if (segment.type === "text") {
+    return segment.text ? document.createTextNode(normalizeLogicalLineEndings(segment.text)) : null;
+  }
+  if (segment.type === "fileMention") {
+    return createFileMentionChip(segment.reference.path, segment.reference.kind);
+  }
+  if (segment.type === "largePaste") {
+    largePastes.set(segment.paste.id, segment.paste);
+    return createLargePasteChip(segment.paste);
+  }
+  if (segment.type === "skillMention") {
+    return createSkillMentionChip(segment.skill);
+  }
+  if (segment.type === "commitMention") {
+    return createCommitMentionChip(segment.commit);
+  }
+  if (segment.type === "gitFileMention") {
+    return createGitFileMentionChip(segment.file);
+  }
+  return createCodeMentionChip(segment.reference);
+}
+
+function insertComposerSegmentsAtSelection(
+  root: HTMLElement,
+  segments: MentionComposerDraftSegment[],
+  largePastes: Map<string, MentionComposerLargePaste>,
+) {
+  const nodes = segments
+    .map((segment) => createComposerSegmentNode(segment, largePastes))
+    .filter((node): node is Node => node !== null);
+  if (nodes.length === 0) return false;
+
+  const selection = window.getSelection();
+  let range = editorSelectionRange(root);
+  if (!range) {
+    range = document.createRange();
+    range.selectNodeContents(root);
+    range.collapse(false);
+  }
+
+  // A caret parked inside a non-editable chip (WebKit drops clicks there)
+  // must hop after the chip instead of letting the boundary extension below
+  // swallow the chip into the replaced range.
+  if (range.collapsed) {
+    const chip = closestComposerChipFromNode(root, range.startContainer);
+    if (chip) {
+      range.setStartAfter(chip);
+      range.collapse(true);
+    }
+  } else {
+    const startChip = closestComposerChipFromNode(root, range.startContainer);
+    if (startChip) range.setStartBefore(startChip);
+    const endChip = closestComposerChipFromNode(root, range.endContainer);
+    if (endChip) range.setEndAfter(endChip);
+    pruneLargePastesInRange(range, largePastes);
+    range.deleteContents();
+  }
+
+  const fragment = document.createDocumentFragment();
+  for (const node of nodes) fragment.appendChild(node);
+  const lastNode = nodes[nodes.length - 1];
+  range.insertNode(fragment);
+
+  if (lastNode.nodeType === Node.TEXT_NODE) {
+    placeCaretInTextNode(lastNode as Text, (lastNode.textContent ?? "").length);
+  } else if (isComposerChipElement(lastNode)) {
+    const anchor = ensureCaretAnchorAfterChip(lastNode);
+    if (anchor) placeCaretInTextNode(anchor.textNode, anchor.offset);
+  } else if (selection) {
+    const caret = document.createRange();
+    caret.setStartAfter(lastNode);
+    caret.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(caret);
+  }
+  ensureTrailingCaretAnchor(root);
+  return true;
 }
 
 function insertNodeAtCursor(root: HTMLElement, node: HTMLElement) {
@@ -3031,6 +3399,20 @@ export const MentionComposer = memo(
         return;
       }
 
+      // Same token-restore fallback as handlePaste: the native clipboard
+      // channel is text-only, so serialized tags must be rebuilt here too.
+      const serializedSegments = parseSerializedComposerText(text, enabledSkills);
+      if (
+        serializedSegments &&
+        insertComposerSegmentsAtSelection(el, serializedSegments, largePastesRef.current)
+      ) {
+        closeMentionSession();
+        refreshEmptyState();
+        refreshMention();
+        closeComposerContextMenu();
+        return;
+      }
+
       document.execCommand("insertText", false, text);
       closeMentionSession();
       refreshEmptyState();
@@ -3040,6 +3422,7 @@ export const MentionComposer = memo(
       closeComposerContextMenu,
       closeMentionSession,
       disabled,
+      enabledSkills,
       insertLargePaste,
       refreshEmptyState,
       refreshMention,
@@ -3073,7 +3456,7 @@ export const MentionComposer = memo(
         let rangeForMenu: Range | null = null;
 
         if (selectionContainsPoint(el, selection, event.clientX, event.clientY)) {
-          selectedText = resolveComposerSelectionText(el, largePastesRef.current);
+          selectedText = resolveComposerSelection(el, largePastesRef.current)?.text ?? "";
           rangeForMenu = editorSelectionRange(el)?.cloneRange() ?? null;
         } else {
           el.focus({ preventScroll: true });
@@ -3497,6 +3880,33 @@ export const MentionComposer = memo(
       ],
     );
 
+    const handleCopy = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
+      const snapshot = resolveComposerSelection(editorRef.current, largePastesRef.current);
+      if (!snapshot) return;
+      event.preventDefault();
+      writeComposerClipboardSnapshot(event.clipboardData, snapshot);
+    }, []);
+
+    const handleCut = useCallback(
+      (event: ClipboardEvent<HTMLDivElement>) => {
+        if (disabled || typewriterRef.current) {
+          event.preventDefault();
+          return;
+        }
+        const editor = editorRef.current;
+        const snapshot = resolveComposerSelection(editor, largePastesRef.current);
+        if (!editor || !snapshot) return;
+        event.preventDefault();
+        writeComposerClipboardSnapshot(event.clipboardData, snapshot);
+        resetPromptHistoryRecall();
+        if (!deleteComposerSelection(editor, largePastesRef.current)) return;
+        closeMentionSession();
+        refreshEmptyState();
+        refreshMention();
+      },
+      [closeMentionSession, disabled, refreshEmptyState, refreshMention, resetPromptHistoryRecall],
+    );
+
     const handlePaste = useCallback(
       (e: ClipboardEvent<HTMLDivElement>) => {
         if (disabled) {
@@ -3510,6 +3920,23 @@ export const MentionComposer = memo(
         // The large-paste chip path mutates the DOM without an input event,
         // so the recall session must reset here as well.
         resetPromptHistoryRecall();
+        const clipboardSegments = readComposerClipboardSegments(e.clipboardData, enabledSkills);
+        if (clipboardSegments) {
+          e.preventDefault();
+          const restoredSegments = clipboardSegments.map((segment) =>
+            segment.type === "largePaste"
+              ? { type: "largePaste" as const, paste: createLargePaste(segment.paste.text) }
+              : segment,
+          );
+          const editor = editorRef.current;
+          if (editor) {
+            insertComposerSegmentsAtSelection(editor, restoredSegments, largePastesRef.current);
+          }
+          closeMentionSession();
+          refreshEmptyState();
+          refreshMention();
+          return;
+        }
         const clipboardFiles = extractClipboardFiles(e.clipboardData);
         if (clipboardFiles.length > 0) {
           e.preventDefault();
@@ -3522,12 +3949,27 @@ export const MentionComposer = memo(
           insertLargePaste(text);
           return;
         }
+        const serializedSegments = parseSerializedComposerText(text, enabledSkills);
+        const editor = editorRef.current;
+        if (
+          serializedSegments &&
+          editor &&
+          insertComposerSegmentsAtSelection(editor, serializedSegments, largePastesRef.current)
+        ) {
+          closeMentionSession();
+          refreshEmptyState();
+          refreshMention();
+          return;
+        }
         insertPlainTextWithUndo(text);
         refreshEmptyState();
         refreshMention();
       },
       [
         disabled,
+        closeMentionSession,
+        createLargePaste,
+        enabledSkills,
         insertLargePaste,
         onPasteFiles,
         refreshEmptyState,
@@ -3705,6 +4147,8 @@ export const MentionComposer = memo(
           onMouseLeave={scheduleCommitTooltipClose}
           onMouseMove={handleMouseMove}
           onMouseUp={handleMouseUp}
+          onCopy={handleCopy}
+          onCut={handleCut}
           onPaste={handlePaste}
           onContextMenu={handleContextMenu}
           onCompositionStart={handleCompositionStart}

--- a/crates/agent-gui/src/lib/chat/messages/userMessageContent.tsx
+++ b/crates/agent-gui/src/lib/chat/messages/userMessageContent.tsx
@@ -141,10 +141,17 @@ function normalizeReferencePath(value: string) {
   return normalizeMentionPath(value);
 }
 
-function extractGitHubCommitSha(value: string) {
+function isGitHubHttpUrl(url: URL) {
+  return (
+    (url.protocol === "https:" || url.protocol === "http:") &&
+    ["github.com", "www.github.com"].includes(url.hostname.toLowerCase())
+  );
+}
+
+export function extractGitHubCommitSha(value: string) {
   try {
     const url = new URL(value);
-    if (!["github.com", "www.github.com"].includes(url.hostname.toLowerCase())) return "";
+    if (!isGitHubHttpUrl(url)) return "";
     const parts = url.pathname.split("/").filter(Boolean);
     const commitIndex = parts.findIndex((part) => part.toLowerCase() === "commit");
     const sha = commitIndex >= 0 ? (parts[commitIndex + 1] ?? "") : "";
@@ -178,10 +185,10 @@ export function buildGitHubCommitUrl(remoteUrl: string, sha: string) {
   }
 }
 
-function extractGitHubFileReference(value: string) {
+export function extractGitHubFileReference(value: string) {
   try {
     const url = new URL(value);
-    if (!["github.com", "www.github.com"].includes(url.hostname.toLowerCase())) return null;
+    if (!isGitHubHttpUrl(url)) return null;
     const parts = url.pathname.split("/").filter(Boolean);
     const blobIndex = parts.findIndex((part) => part.toLowerCase() === "blob");
     const ref = blobIndex >= 0 ? (parts[blobIndex + 1] ?? "") : "";

--- a/crates/agent-gui/src/pages/chat/composer/composerDraftText.ts
+++ b/crates/agent-gui/src/pages/chat/composer/composerDraftText.ts
@@ -64,7 +64,7 @@ export function buildTextFromComposerDraft(
           return formatFileMentionToken(segment.reference);
         }
         if (segment.type === "skillMention") {
-          return `$${segment.skill.name}`;
+          return `/${segment.skill.name}`;
         }
         if (segment.type === "commitMention") {
           return formatComposerCommitMention(segment.commit);

--- a/crates/agent-gui/src/pages/chat/queue/chatTurnQueue.ts
+++ b/crates/agent-gui/src/pages/chat/queue/chatTurnQueue.ts
@@ -87,7 +87,7 @@ export function buildQueuedChatTurnPreview(draft: MentionComposerDraft) {
       case "largePaste":
         return segment.paste.label;
       case "skillMention":
-        return `$${segment.skill.name}`;
+        return `/${segment.skill.name}`;
       case "commitMention":
         return segment.commit.subject || segment.commit.shortSha || segment.commit.sha;
       case "gitFileMention":

--- a/crates/agent-gui/test/browser/paste-newline-pipeline.html
+++ b/crates/agent-gui/test/browser/paste-newline-pipeline.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="editor" class="mention-composer whitespace-pre-wrap" contenteditable="true"></div>
+    <div id="tag-composer"></div>
     <div id="bubble" class="chat-user-bubble w-fit px-4 py-2.5 font-chat text-[14.5px] leading-relaxed"></div>
     <script type="module">
       import React from "react";
@@ -17,7 +18,11 @@
         insertPlainTextWithUndo,
         normalizeLogicalLineEndings,
       } from "/src/lib/chat/composerText.ts";
-      import { serializeChildrenToSegments } from "/src/components/chat/MentionComposer.tsx";
+      import {
+        COMPOSER_CLIPBOARD_MIME,
+        MentionComposer,
+        serializeChildrenToSegments,
+      } from "/src/components/chat/MentionComposer.tsx";
       import { buildTextFromComposerDraft } from "/src/pages/chat/composer/composerDraftText.ts";
       import {
         createUserMessageWithUploads,
@@ -26,8 +31,26 @@
       import { UserMessageContent } from "/src/lib/chat/messages/userMessageContent.tsx";
 
       const editor = document.querySelector("#editor");
+      const tagComposerHost = document.querySelector("#tag-composer");
       const bubble = document.querySelector("#bubble");
+      const tagComposerRef = React.createRef();
+      const tagComposerRoot = createRoot(tagComposerHost);
       const bubbleRoot = createRoot(bubble);
+      const reviewerSkill = {
+        name: "reviewer",
+        description: "Review changed code",
+        skillFile: "reviewer/SKILL.md",
+        baseDir: "reviewer",
+      };
+
+      tagComposerRoot.render(
+        React.createElement(MentionComposer, {
+          ref: tagComposerRef,
+          onSend() {},
+          workdir: "",
+          enabledSkills: [reviewerSkill],
+        }),
+      );
 
       editor.addEventListener("paste", (event) => {
         event.preventDefault();
@@ -127,6 +150,139 @@
           whiteSpace: getComputedStyle(bubble).whiteSpace,
         };
       };
+      window.runTagClipboardRoundTrip = () => {
+        const segments = [
+          { type: "text", text: "Inspect " },
+          { type: "fileMention", reference: { path: "src/App.tsx", kind: "file" } },
+          { type: "fileMention", reference: { path: "docs/guides", kind: "dir" } },
+          { type: "skillMention", skill: reviewerSkill },
+          {
+            type: "commitMention",
+            commit: {
+              sha: "abcdef1234567890",
+              shortSha: "abcdef1",
+              subject: "Preserve tags",
+              body: "Full commit body",
+              authorName: "Author",
+              authorEmail: "author@example.com",
+              authorDate: "2026-08-08T00:00:00Z",
+              fileCount: 2,
+              filesChanged: 2,
+              insertions: 12,
+              deletions: 3,
+              stat: "2 files changed",
+              remoteName: "origin",
+              remoteUrl: "https://github.com/example/repo.git",
+              githubUrl: "https://github.com/example/repo/commit/abcdef1234567890",
+            },
+          },
+          {
+            type: "gitFileMention",
+            file: {
+              path: "src/App.tsx",
+              status: "M",
+              commitSha: "abcdef1234567890",
+              shortSha: "abcdef1",
+              refName: "main",
+              remoteName: "origin",
+              remoteUrl: "https://github.com/example/repo.git",
+              githubUrl:
+                "https://github.com/example/repo/blob/abcdef1234567890/src/App.tsx",
+            },
+          },
+          {
+            type: "codeMention",
+            reference: { path: "src/App.tsx", startLine: 4, endLine: 9 },
+          },
+          {
+            type: "largePaste",
+            paste: {
+              id: "browser-large-paste",
+              label: "Pasted text 1",
+              text: "large\nbody",
+              charCount: 10,
+              lineCount: 2,
+              preview: "large body",
+            },
+          },
+        ];
+        tagComposerRef.current.setDraft({
+          segments,
+          text: "",
+          textWithoutLargePastes: "",
+          largePastes: [],
+          skillMentions: [],
+          commitMentions: [],
+          gitFileMentions: [],
+          codeMentions: [],
+          isEmpty: false,
+        });
+
+        const tagEditor = tagComposerHost.querySelector(".mention-composer");
+        const selection = getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(tagEditor);
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        const transfer = new DataTransfer();
+        const copyEvent = new ClipboardEvent("copy", {
+          clipboardData: transfer,
+          bubbles: true,
+          cancelable: true,
+        });
+        tagEditor.dispatchEvent(copyEvent);
+
+        tagComposerRef.current.setText("");
+        tagEditor.focus();
+        const pasteRange = document.createRange();
+        pasteRange.selectNodeContents(tagEditor);
+        pasteRange.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(pasteRange);
+        const pasteEvent = new ClipboardEvent("paste", {
+          clipboardData: transfer,
+          bubbles: true,
+          cancelable: true,
+        });
+        tagEditor.dispatchEvent(pasteEvent);
+        const restoredDraft = tagComposerRef.current.getDraft();
+
+        const plainTransfer = new DataTransfer();
+        plainTransfer.setData("text/plain", transfer.getData("text/plain"));
+        tagComposerRef.current.setText("");
+        tagEditor.focus();
+        const plainRange = document.createRange();
+        plainRange.selectNodeContents(tagEditor);
+        plainRange.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(plainRange);
+        tagEditor.dispatchEvent(
+          new ClipboardEvent("paste", {
+            clipboardData: plainTransfer,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+        const plainRestoredDraft = tagComposerRef.current.getDraft();
+
+        return {
+          copyPrevented: copyEvent.defaultPrevented,
+          pastePrevented: pasteEvent.defaultPrevented,
+          plainText: transfer.getData("text/plain"),
+          hasHtmlPayload: transfer
+            .getData("text/html")
+            .includes("data-liveagent-composer-clipboard"),
+          hasPrivatePayload: transfer.getData(COMPOSER_CLIPBOARD_MIME).length > 0,
+          restoredTypes: restoredDraft.segments
+            .filter((segment) => segment.type !== "text")
+            .map((segment) => segment.type),
+          plainRestoredTypes: plainRestoredDraft.segments
+            .filter((segment) => segment.type !== "text")
+            .map((segment) => segment.type),
+        };
+      };
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
       window.pipelineReady = true;
     </script>
   </body>

--- a/crates/agent-gui/test/browser/verify-paste-newline-pipeline.playwright.js
+++ b/crates/agent-gui/test/browser/verify-paste-newline-pipeline.playwright.js
@@ -104,6 +104,44 @@ async (page) => {
       );
     }
 
+    const tagClipboard = await page.evaluate(() => window.runTagClipboardRoundTrip());
+    expectEqual(tagClipboard.copyPrevented, true, `${targetName}/tag copy handled`);
+    expectEqual(tagClipboard.pastePrevented, true, `${targetName}/tag paste handled`);
+    expectEqual(tagClipboard.hasHtmlPayload, true, `${targetName}/tag HTML payload`);
+    expectEqual(tagClipboard.hasPrivatePayload, true, `${targetName}/tag private payload`);
+    expectEqual(
+      JSON.stringify(tagClipboard.restoredTypes),
+      JSON.stringify([
+        "fileMention",
+        "fileMention",
+        "skillMention",
+        "commitMention",
+        "gitFileMention",
+        "codeMention",
+        "largePaste",
+      ]),
+      `${targetName}/structured tag round trip`,
+    );
+    expectEqual(
+      JSON.stringify(tagClipboard.plainRestoredTypes),
+      JSON.stringify([
+        "fileMention",
+        "fileMention",
+        "skillMention",
+        "commitMention",
+        "gitFileMention",
+        "codeMention",
+      ]),
+      `${targetName}/user bubble token fallback`,
+    );
+    if (!tagClipboard.plainText.includes("/reviewer")) {
+      throw new Error(`${targetName}/tag plain text: missing slash skill token`);
+    }
+    if (!tagClipboard.plainText.includes("[guides](docs/guides/)")) {
+      throw new Error(`${targetName}/tag plain text: missing directory token`);
+    }
+    targetEvidence.push({ caseName: "structured tag clipboard", ...tagClipboard });
+
     const replayText = "reload\n\nreconnect";
     const beforeReload = await page.evaluate((text) => window.runPastePipeline(text), replayText);
     await page.reload();

--- a/crates/agent-gui/test/chat/chat-turn-queue.test.mjs
+++ b/crates/agent-gui/test/chat/chat-turn-queue.test.mjs
@@ -137,7 +137,7 @@ test("queued chat turn preview keeps structured draft hints compact", () => {
     },
   ]);
 
-  assert.equal(queue.buildQueuedChatTurnPreview(richDraft), "hello pasted.txt$reviewer");
+  assert.equal(queue.buildQueuedChatTurnPreview(richDraft), "hello pasted.txt/reviewer");
   assert.equal(queue.queuedChatTurnHasContent(richDraft, []), true);
   assert.equal(queue.queuedChatTurnHasContent(draft(""), [{ fileName: "a.txt" }]), true);
 });

--- a/crates/agent-gui/test/chat/paste-newline-pipeline.test.mjs
+++ b/crates/agent-gui/test/chat/paste-newline-pipeline.test.mjs
@@ -149,3 +149,148 @@ test("composer serialization preserves newlines around mention chips", () => {
     ],
   );
 });
+
+const reviewerSkill = {
+  name: "reviewer",
+  description: "Review changed code",
+  skillFile: "reviewer/SKILL.md",
+  baseDir: "reviewer",
+};
+
+function structuredClipboardSegments() {
+  return [
+    { type: "text", text: "Inspect " },
+    {
+      type: "fileMention",
+      reference: { path: "src/App.tsx", kind: "file" },
+    },
+    {
+      type: "fileMention",
+      reference: { path: "docs/guides", kind: "dir" },
+    },
+    { type: "skillMention", skill: reviewerSkill },
+    {
+      type: "commitMention",
+      commit: {
+        sha: "abcdef1234567890",
+        shortSha: "abcdef1",
+        subject: "Preserve tags",
+        body: "Full commit body",
+        authorName: "Author",
+        authorEmail: "author@example.com",
+        authorDate: "2026-08-08T00:00:00Z",
+        fileCount: 2,
+        filesChanged: 2,
+        insertions: 12,
+        deletions: 3,
+        stat: "2 files changed",
+        remoteName: "origin",
+        remoteUrl: "https://github.com/example/repo.git",
+        githubUrl: "https://github.com/example/repo/commit/abcdef1234567890",
+      },
+    },
+    {
+      type: "gitFileMention",
+      file: {
+        path: "src/App.tsx",
+        oldPath: "src/OldApp.tsx",
+        status: "M",
+        commitSha: "abcdef1234567890",
+        shortSha: "abcdef1",
+        refName: "main",
+        remoteName: "origin",
+        remoteUrl: "https://github.com/example/repo.git",
+        githubUrl:
+          "https://github.com/example/repo/blob/abcdef1234567890/src/App.tsx",
+      },
+    },
+    {
+      type: "codeMention",
+      reference: { path: "src/App.tsx", startLine: 4, endLine: 9 },
+    },
+    {
+      type: "largePaste",
+      paste: {
+        id: "large-paste-copy",
+        label: "Pasted text 1",
+        text: "large\nclipboard\nbody",
+        charCount: 999,
+        lineCount: 999,
+        preview: "stale preview",
+      },
+    },
+  ];
+}
+
+test("composer clipboard payload round trips every structured tag", () => {
+  const payload = composer.serializeComposerClipboardPayload(structuredClipboardSegments());
+  const restored = composer.parseComposerClipboardPayload(payload, [reviewerSkill]);
+
+  assert.deepEqual(
+    restored.map((segment) => segment.type),
+    [
+      "text",
+      "fileMention",
+      "fileMention",
+      "skillMention",
+      "commitMention",
+      "gitFileMention",
+      "codeMention",
+      "largePaste",
+    ],
+  );
+  assert.equal(restored[1].reference.path, "src/App.tsx");
+  assert.equal(restored[2].reference.kind, "dir");
+  assert.deepEqual(restored[3].skill, reviewerSkill);
+  assert.equal(restored[4].commit.body, "Full commit body");
+  assert.equal(restored[5].file.oldPath, "src/OldApp.tsx");
+  assert.deepEqual(restored[6].reference, {
+    path: "src/App.tsx",
+    startLine: 4,
+    endLine: 9,
+  });
+  assert.equal(restored[7].paste.charCount, "large\nclipboard\nbody".length);
+  assert.equal(restored[7].paste.lineCount, 3);
+});
+
+test("clipboard skill metadata cannot escape the currently enabled skill", () => {
+  const payload = composer.serializeComposerClipboardPayload([
+    {
+      type: "skillMention",
+      skill: { ...reviewerSkill, baseDir: "another-skill" },
+    },
+  ]);
+  assert.deepEqual(composer.parseComposerClipboardPayload(payload, [reviewerSkill]), [
+    { type: "text", text: "/reviewer" },
+  ]);
+});
+
+test("serialized user bubble tokens restore composer tags as a plain-text fallback", () => {
+  const text = [
+    "Inspect",
+    "[App.tsx](src/App.tsx)",
+    "[guides](docs/guides/)",
+    "/reviewer",
+    "[commit abcdef1: Preserve tags](https://github.com/example/repo/commit/abcdef1234567890)",
+    "[git file main: src/App.tsx](https://github.com/example/repo/blob/abcdef1234567890/src/App.tsx)",
+    "[App.tsx:4-9](src/App.tsx#L4-L9)",
+  ].join(" ");
+  const restored = composer.parseSerializedComposerText(text, [reviewerSkill]);
+  assert.deepEqual(
+    restored.filter((segment) => segment.type !== "text").map((segment) => segment.type),
+    [
+      "fileMention",
+      "fileMention",
+      "skillMention",
+      "commitMention",
+      "gitFileMention",
+      "codeMention",
+    ],
+  );
+  assert.equal(composer.parseSerializedComposerText("[OpenAI](https://openai.com)", []), null);
+});
+
+test("outbound skill tokens use the same slash contract as composer and user bubbles", () => {
+  const draft = draftFromSegments([{ type: "skillMention", skill: reviewerSkill }]);
+  assert.equal(draftText.buildTextFromComposerDraft(draft), "/reviewer");
+});

--- a/crates/agent-gui/test/chat/paste-newline-pipeline.test.mjs
+++ b/crates/agent-gui/test/chat/paste-newline-pipeline.test.mjs
@@ -243,7 +243,15 @@ test("composer clipboard payload round trips every structured tag", () => {
   assert.equal(restored[2].reference.kind, "dir");
   assert.deepEqual(restored[3].skill, reviewerSkill);
   assert.equal(restored[4].commit.body, "Full commit body");
+  assert.equal(
+    restored[4].commit.githubUrl,
+    "https://github.com/example/repo/commit/abcdef1234567890",
+  );
   assert.equal(restored[5].file.oldPath, "src/OldApp.tsx");
+  assert.equal(
+    restored[5].file.githubUrl,
+    "https://github.com/example/repo/blob/abcdef1234567890/src/App.tsx",
+  );
   assert.deepEqual(restored[6].reference, {
     path: "src/App.tsx",
     startLine: 4,
@@ -263,6 +271,75 @@ test("clipboard skill metadata cannot escape the currently enabled skill", () =>
   assert.deepEqual(composer.parseComposerClipboardPayload(payload, [reviewerSkill]), [
     { type: "text", text: "/reviewer" },
   ]);
+});
+
+test("clipboard github URLs that fail the plain-text channel validation are dropped", () => {
+  const segments = structuredClipboardSegments();
+  const commit = segments.find((segment) => segment.type === "commitMention").commit;
+  const file = segments.find((segment) => segment.type === "gitFileMention").file;
+  const hostileUrls = [
+    "javascript:alert(1)",
+    "liveagent://internal/action",
+    "ftp://github.com/example/repo/commit/abcdef1234567890",
+    "https://evil.example/example/repo/commit/abcdef1234567890",
+    "https://github.com.evil.example/example/repo/commit/abcdef1234567890",
+    "https://github.com/example/repo",
+  ];
+  for (const githubUrl of hostileUrls) {
+    const payload = composer.serializeComposerClipboardPayload([
+      { type: "commitMention", commit: { ...commit, githubUrl } },
+      { type: "gitFileMention", file: { ...file, githubUrl } },
+    ]);
+    const restored = composer.parseComposerClipboardPayload(payload, []);
+    assert.deepEqual(
+      restored.map((segment) => segment.type),
+      ["commitMention", "gitFileMention"],
+      githubUrl,
+    );
+    assert.equal(restored[0].commit.githubUrl, undefined, githubUrl);
+    assert.equal(restored[1].file.githubUrl, undefined, githubUrl);
+  }
+});
+
+test("oversized text segments restored from the clipboard collapse into large-paste chips", () => {
+  let counter = 0;
+  const createLargePaste = (text) => ({
+    id: `fresh-${++counter}`,
+    label: `Pasted text ${counter}`,
+    text,
+    charCount: text.length,
+    lineCount: text.split("\n").length,
+    preview: text.slice(0, 160),
+  });
+  const overCharLimit = "x".repeat(8_000);
+  const overLineLimit = "line\n".repeat(200);
+  const rebuilt = composer.rebuildClipboardSegmentsForPaste(
+    [
+      { type: "text", text: "small" },
+      { type: "text", text: overCharLimit },
+      { type: "text", text: overLineLimit },
+      {
+        type: "largePaste",
+        paste: {
+          id: "stale-id",
+          label: "Pasted text 9",
+          text: "chunk",
+          charCount: 5,
+          lineCount: 1,
+          preview: "chunk",
+        },
+      },
+    ],
+    createLargePaste,
+  );
+  assert.deepEqual(
+    rebuilt.map((segment) => segment.type),
+    ["text", "largePaste", "largePaste", "largePaste"],
+  );
+  assert.equal(rebuilt[1].paste.text, overCharLimit);
+  assert.equal(rebuilt[2].paste.text, overLineLimit);
+  assert.equal(rebuilt[3].paste.text, "chunk");
+  assert.notEqual(rebuilt[3].paste.id, "stale-id");
 });
 
 test("serialized user bubble tokens restore composer tags as a plain-text fallback", () => {


### PR DESCRIPTION
Closes #397

## 问题

输入框中的 tag(文件/文件夹 mention、skill、commit、git 文件、代码引用、大段粘贴 chip)在 Ctrl+A 复制后再粘贴会退化为纯文本——contentEditable 原生复制只带 DOM 外观,chip 的结构化元数据不在剪贴板任何格式中。

## 方案:三层剪贴板通道

两端 MentionComposer 拦截 copy/cut/paste,写入/回读三种格式,按序回退:

1. **私有 MIME** `application/x-liveagent-composer-draft+json`——版本化的 draft segments 载荷;
2. **text/html 回退**——同一载荷藏在 `data-liveagent-composer-clipboard` 属性中(HTML 本体只是载体,不回读 DOM),兼容剥离自定义 MIME 的 webview,支持 GUI↔WebUI 跨端往返;
3. **text/plain 回退**——`parseSerializedComposerText` 用与用户气泡同源的 `tokenizeUserMessage` 从序列化 token 恢复 tag(仅当至少命中一个结构化 token 才接管,不误吞普通 markdown 粘贴),覆盖 GUI 原生剪贴板通道(纯文本)和从消息气泡复制的场景。

## 安全与正确性

- **skill 白名单**:恢复 skillMention 必须与 enabledSkills 精确匹配(name+skillFile+baseDir),否则降级为 `/name` 纯文本——剪贴板元数据无法注入技能(有测试锁定);
- **largePaste 重建**:粘贴时经 `createLargePaste` 生成新 id/label,避免 map 冲突;
- **chip 内光标防吞**:collapsed 光标落在非可编辑 chip 内(WebKit 怪癖)时外跳到 chip 之后,不再被边界扩展吞掉整颗 chip;
- **GUI 右键菜单粘贴**与键盘粘贴共用同一条 token 恢复管线(原先直接 `execCommand insertText` 必丢 tag);
- **skill token 出站统一 `/name`**(chatDraft / composerDraftText / chatTurnQueue),对齐 slash 触发契约;WebUI 目录 mention label 与 `fileMentionDisplayName` 对齐(无尾斜杠),目录 tag 在用户气泡中可正常 tokenize。

## 测试

- 两端镜像 node 测试:载荷全类型往返、skill 白名单防逃逸、纯文本 token 回退、`/` 契约(GUI 14 通过 / WebUI 13 通过,全套 558+537 通过)
- 浏览器端到端(`verify-paste-newline-pipeline.playwright.js`,两端 vite + Chromium):结构化 tag 复制往返恢复全部 7 种类型、纯文本回退恢复 6 种(largePaste 按设计降级)、原有 18 个换行用例与跨端回放全绿
- `tsc --noEmit` 两端零错误;biome 警告与 base 持平;`scripts/check-mirror.mjs` 通过

## Screenshots / preview
<img width="932" height="178" alt="image" src="https://github.com/user-attachments/assets/2410f9ca-08e5-454d-a91b-f9c869ee6143" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)