### PR TITLE
fix(chat): restore transcript scrolling and thinking collapse

### DIFF
--- a/crates/agent-gateway/web/src/pages/chat/assistant-bubble/RoundContent.tsx
+++ b/crates/agent-gateway/web/src/pages/chat/assistant-bubble/RoundContent.tsx
@@ -57,6 +57,7 @@ export const RetryDetailsBlock = memo(function RetryDetailsBlock({
                 and the list is append-only, so the index is the stable key. */}
             {attempts.map((entry, index) => (
               <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: retry attempts are append-only and their reported ordinals can repeat.
                 key={`${index}-${entry.attempt}-${entry.maxAttempts}`}
                 className="rounded-md border border-border/60 bg-muted/30 px-2.5 py-1.5 text-[calc(12px*var(--zone-font-scale,1))] text-muted-foreground"
               >
@@ -193,6 +194,7 @@ export const RoundContent = memo(function RoundContent(props: {
             <ThinkingActivity
               key={block.key}
               text={block.text}
+              open={autoOpenThinking && block.key === latestThinkingKey}
               isRunning={autoOpenThinking && block.key === latestThinkingKey}
               renderMode={renderMode ?? (isStreaming ? "streaming" : "static")}
               workdir={workdir}

--- a/crates/agent-gateway/web/test/thinking-overlay-model.test.mjs
+++ b/crates/agent-gateway/web/test/thinking-overlay-model.test.mjs
@@ -12,6 +12,10 @@ const componentSource = fs.readFileSync(
   new URL("../../../agent-ui/src/components/chat/ThinkingActivity.tsx", import.meta.url),
   "utf8",
 );
+const roundContentSource = fs.readFileSync(
+  new URL("../src/pages/chat/assistant-bubble/RoundContent.tsx", import.meta.url),
+  "utf8",
+);
 
 test("thinking overlay placement is upward and narrow-safe", () => {
   const above = resolveThinkingOverlayPlacement(
@@ -36,9 +40,19 @@ test("keeps a renderable overlay inside an extremely narrow viewport", () => {
   assert.ok(placement.left + placement.width <= 8);
 });
 
-test("thinking details use a portal overlay instead of inline collapse", () => {
-  assert.match(componentSource, /createPortal/);
-  assert.match(componentSource, /role="dialog"/);
-  assert.match(componentSource, /className="fixed/);
-  assert.doesNotMatch(componentSource, /LazyCollapse/);
+test("thinking details use inline collapse instead of a portal overlay", () => {
+  assert.match(componentSource, /open\?: boolean;/);
+  assert.match(componentSource, /<LazyCollapse open=\{isOpen\}>/);
+  assert.match(componentSource, /userInteractedRef/);
+  assert.doesNotMatch(componentSource, /createPortal/);
+  assert.doesNotMatch(componentSource, /role="dialog"/);
+  assert.doesNotMatch(componentSource, /thinkingOverlayModel/);
+});
+
+test("WebUI transcript forwards live thinking auto-open into the shared collapse", () => {
+  assert.match(roundContentSource, /const autoOpenThinking = isLive \? Boolean\(isActive && thinkingOpen\) : false;/);
+  assert.match(
+    roundContentSource,
+    /open=\{autoOpenThinking && block\.key === latestThinkingKey\}/,
+  );
 });

--- a/crates/agent-gui/src/pages/chat/components/assistant-bubble/RoundContent.tsx
+++ b/crates/agent-gui/src/pages/chat/components/assistant-bubble/RoundContent.tsx
@@ -89,6 +89,7 @@ export const RoundBlockContent = memo(function RoundBlockContent(props: {
     content = (
       <ThinkingActivity
         text={block.text}
+        open={isRunning}
         isRunning={isRunning}
         renderMode={renderMode}
         workdir={workdir}

--- a/crates/agent-gui/test/chat/chat-transcript-scroller.test.mjs
+++ b/crates/agent-gui/test/chat/chat-transcript-scroller.test.mjs
@@ -6,6 +6,10 @@ const source = fs.readFileSync(
   new URL("../../src/pages/chat/transcript/ChatTranscript.tsx", import.meta.url),
   "utf8",
 );
+const applicationViewSource = fs.readFileSync(
+  new URL("../../../agent-ui/src/application/ApplicationView.tsx", import.meta.url),
+  "utf8",
+);
 
 test("chat transcript uses one native viewport for scrolling and follow listeners", () => {
   assert.doesNotMatch(source, /components\/ui\/scroll-area/);
@@ -23,4 +27,11 @@ test("earlier-history rejection is handled before pagination cleanup", () => {
     /onLoadEarlierHistory\(\)\s*\.catch\(\(\) => undefined\)\s*\.finally\(/,
   );
   assert.doesNotMatch(source, /onLoadEarlierHistory\(\)\.finally\(/);
+});
+
+test("application chat wrapper preserves the transcript flex height chain", () => {
+  assert.match(
+    applicationViewSource,
+    /className=\{cn\(\s*"relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",\s*containerProps\?\.className,\s*\)\}/s,
+  );
 });

--- a/crates/agent-gui/test/chat/thinking-overlay-model.test.mjs
+++ b/crates/agent-gui/test/chat/thinking-overlay-model.test.mjs
@@ -10,6 +10,10 @@ const componentSource = fs.readFileSync(
   new URL("../../../agent-ui/src/components/chat/ThinkingActivity.tsx", import.meta.url),
   "utf8",
 );
+const roundContentSource = fs.readFileSync(
+  new URL("../../src/pages/chat/components/assistant-bubble/RoundContent.tsx", import.meta.url),
+  "utf8",
+);
 
 test("places thinking details above without consuming transcript height", () => {
   const placement = resolveThinkingOverlayPlacement(
@@ -41,10 +45,16 @@ test("keeps a renderable overlay inside an extremely narrow viewport", () => {
   assert.ok(placement.left + placement.width <= 8);
 });
 
-test("thinking details use a portal overlay instead of inline collapse", () => {
-  assert.match(componentSource, /createPortal/);
-  assert.match(componentSource, /role="dialog"/);
-  assert.match(componentSource, /className="fixed/);
-  assert.match(componentSource, /event\.key !== "Escape"/);
-  assert.doesNotMatch(componentSource, /LazyCollapse/);
+test("thinking details use inline collapse instead of a portal overlay", () => {
+  assert.match(componentSource, /open\?: boolean;/);
+  assert.match(componentSource, /<LazyCollapse open=\{isOpen\}>/);
+  assert.match(componentSource, /userInteractedRef/);
+  assert.doesNotMatch(componentSource, /createPortal/);
+  assert.doesNotMatch(componentSource, /role="dialog"/);
+  assert.doesNotMatch(componentSource, /thinkingOverlayModel/);
+});
+
+test("GUI transcript forwards live thinking auto-open into the shared collapse", () => {
+  assert.match(roundContentSource, /const isRunning = isLive && thinkingOpen && isLatestThinking;/);
+  assert.match(roundContentSource, /open=\{isRunning\}/);
 });

--- a/crates/agent-ui/src/application/ApplicationView.tsx
+++ b/crates/agent-ui/src/application/ApplicationView.tsx
@@ -80,7 +80,13 @@ export function ApplicationView(props: ApplicationViewProps) {
       ...headerProps
     } = chat;
     content = (
-      <div {...containerProps} className={containerProps?.className}>
+      <div
+        {...containerProps}
+        className={cn(
+          "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
+          containerProps?.className,
+        )}
+      >
         <div className={headerClassName}>
           <ChatHeader {...headerProps} settings={settings} />
           {headerOverlay}

--- a/crates/agent-ui/src/components/chat/ThinkingActivity.tsx
+++ b/crates/agent-ui/src/components/chat/ThinkingActivity.tsx
@@ -1,109 +1,46 @@
 import { ChevronRight, Lightbulb } from "@liveagent/app/components/icons";
 import type { ChatFileLink } from "@liveagent/app/lib/chat/chatFileLinks";
 import { useLocale } from "@liveagent/ui/i18n/index";
-import { useCallback, useId, useLayoutEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import {
-  resolveThinkingOverlayPlacement,
-  type ThinkingOverlayPlacement,
-} from "../../lib/chat/thinkingOverlayModel";
+import { useEffect, useRef, useState } from "react";
 import { Markdown } from "../Markdown";
+import { AssistantStatus } from "./AssistantStatus";
+import { LazyCollapse } from "./LazyCollapse";
 
 export function ThinkingActivity(props: {
   text: string;
+  open?: boolean;
   isRunning?: boolean;
   renderMode: "streaming" | "static";
   workdir?: string;
   onOpenFileLink?: (link: ChatFileLink) => void;
 }) {
-  const { text, isRunning = false, renderMode, workdir, onOpenFileLink } = props;
+  const { text, open, isRunning = false, renderMode, workdir, onOpenFileLink } = props;
   const { t } = useLocale();
-  const [open, setOpen] = useState(false);
-  const [placement, setPlacement] = useState<ThinkingOverlayPlacement | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const panelRef = useRef<HTMLDivElement | null>(null);
-  const panelId = useId();
+  const [isOpen, setIsOpen] = useState(typeof open === "boolean" ? open : false);
+  const userInteractedRef = useRef(false);
   const hasText = /\S/.test(text);
 
-  const updatePlacement = useCallback(() => {
-    const trigger = triggerRef.current;
-    if (!trigger) return;
-    setPlacement(
-      resolveThinkingOverlayPlacement(trigger.getBoundingClientRect(), {
-        width: window.innerWidth,
-        height: window.innerHeight,
-      }),
-    );
-  }, []);
-
-  const close = useCallback((restoreFocus = false) => {
-    setOpen(false);
-    setPlacement(null);
-    if (restoreFocus) {
-      requestAnimationFrame(() => triggerRef.current?.focus({ preventScroll: true }));
+  useEffect(() => {
+    if (!userInteractedRef.current && typeof open === "boolean") {
+      setIsOpen(open);
     }
-  }, []);
-
-  useLayoutEffect(() => {
-    if (!open) return;
-    updatePlacement();
-    const focusFrame = requestAnimationFrame(() =>
-      panelRef.current?.focus({ preventScroll: true }),
-    );
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target;
-      if (!(target instanceof Node)) return;
-      if (triggerRef.current?.contains(target) || panelRef.current?.contains(target)) return;
-      close();
-    };
-    const handleFocusIn = (event: FocusEvent) => {
-      const target = event.target;
-      if (!(target instanceof Node)) return;
-      if (triggerRef.current?.contains(target) || panelRef.current?.contains(target)) return;
-      close();
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      event.preventDefault();
-      event.stopPropagation();
-      close(true);
-    };
-    window.addEventListener("pointerdown", handlePointerDown, true);
-    window.addEventListener("focusin", handleFocusIn, true);
-    window.addEventListener("keydown", handleKeyDown, true);
-    window.addEventListener("resize", updatePlacement);
-    window.addEventListener("scroll", updatePlacement, true);
-    return () => {
-      cancelAnimationFrame(focusFrame);
-      window.removeEventListener("pointerdown", handlePointerDown, true);
-      window.removeEventListener("focusin", handleFocusIn, true);
-      window.removeEventListener("keydown", handleKeyDown, true);
-      window.removeEventListener("resize", updatePlacement);
-      window.removeEventListener("scroll", updatePlacement, true);
-    };
-  }, [close, open, updatePlacement]);
+  }, [open]);
 
   if (!hasText) return null;
 
   return (
     <div className="group/think w-full">
       <button
-        ref={triggerRef}
         type="button"
-        aria-controls={open ? panelId : undefined}
-        aria-expanded={open}
-        aria-haspopup="dialog"
+        aria-expanded={isOpen}
         onClick={() => {
-          if (open) close();
-          else setOpen(true);
+          userInteractedRef.current = true;
+          setIsOpen((previous) => !previous);
         }}
         className="thinking-block-toggle flex w-full cursor-pointer select-none items-center gap-2 py-1.5 text-left text-[calc(13px*var(--zone-font-scale,1))] font-normal text-muted-foreground/80 hover:text-foreground"
       >
         {isRunning ? (
-          <span className="flex items-center gap-2">
-            <span className="h-3.5 w-3.5 shrink-0 animate-spin rounded-full border-2 border-current border-r-transparent motion-reduce:animate-none" />
-            {t("chat.thinking")}
-          </span>
+          <AssistantStatus className="min-h-0">{t("chat.thinking")}</AssistantStatus>
         ) : (
           <>
             <Lightbulb className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
@@ -111,39 +48,23 @@ export function ThinkingActivity(props: {
           </>
         )}
         <ChevronRight
-          className={`ml-auto h-3.5 w-3.5 text-muted-foreground/60 transition-transform duration-200 ease-out motion-reduce:transition-none ${open ? "rotate-90" : ""}`}
+          className={`ml-auto h-3.5 w-3.5 text-muted-foreground/60 transition-transform duration-200 ease-out motion-reduce:transition-none ${isOpen ? "rotate-90" : ""}`}
         />
       </button>
-      {open && placement
-        ? createPortal(
-            <div
-              ref={panelRef}
-              id={panelId}
-              role="dialog"
-              aria-label={t("chat.thinkingProcess")}
-              tabIndex={-1}
-              data-scroll-follow-ignore-keys
-              className="fixed z-[120] overflow-y-auto overscroll-contain rounded-xl border border-border/80 bg-background/95 p-4 shadow-2xl outline-none backdrop-blur-md"
-              style={{
-                left: placement.left,
-                width: placement.width,
-                maxHeight: placement.maxHeight,
-                top: placement.top,
-                bottom: placement.bottom,
-              }}
-            >
-              <Markdown
-                content={text}
-                className="thinking-markdown space-y-1.5"
-                renderMode={renderMode}
-                showCaret={false}
-                workdir={workdir}
-                onOpenFileLink={onOpenFileLink}
-              />
-            </div>,
-            document.body,
-          )
-        : null}
+      <LazyCollapse open={isOpen}>
+        {() => (
+          <div className="pb-1 pt-1.5">
+            <Markdown
+              content={text}
+              className="thinking-markdown space-y-1.5"
+              renderMode={renderMode}
+              showCaret={false}
+              workdir={workdir}
+              onOpenFileLink={onOpenFileLink}
+            />
+          </div>
+        )}
+      </LazyCollapse>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- restore the shared chat wrapper flex height chain so long GUI transcripts remain scrollable
- render thinking details inline with the existing lazy collapse instead of a portal bubble
- preserve live auto-open behavior while respecting manual expand/collapse choices across GUI and WebUI
- add regression coverage for transcript layout and thinking rendering contracts

## Testing

- `node --test test/chat/chat-transcript-scroller.test.mjs test/chat/thinking-overlay-model.test.mjs` (agent-gui)
- `node --test test/thinking-overlay-model.test.mjs` (gateway web)
- targeted Biome checks for all changed TypeScript files
- `pnpm check:ui-boundaries`
- `pnpm build:gui`
- `pnpm build:webui`

## Screenshots / preview
<img width="1050" height="468" alt="image" src="https://github.com/user-attachments/assets/74564a2e-4a52-4121-bffd-23cab832880a" />

Fixes #405