### PR TITLE
fix(workspace): 支持打开 skills 目录下的 skill:// 文件

### DIFF
--- a/crates/agent-gateway/web/test/changed-files-card.test.mjs
+++ b/crates/agent-gateway/web/test/changed-files-card.test.mjs
@@ -55,9 +55,9 @@ function createCardModule() {
 
 function renderCard(
   { cardModule, jsxRuntime, renderToStaticMarkup },
-  { withActions = false, fileCount = 4 } = {},
+  { withActions = false, fileCount = 4, files } = {},
 ) {
-  const paths = [
+  const paths = files ?? [
     { path: "src/components/ChangedFilesCard.tsx", deleted: false },
     { path: "README.md", deleted: false },
     { path: "src\\pages\\Settings.tsx", deleted: false },
@@ -151,4 +151,40 @@ test("WebUI changed-files actions include the localized action and canonical pat
     !html.includes('aria-label="chat.changedFiles.open: tmp/removed.ts"'),
     "deleted files must not expose the open-file action",
   );
+});
+
+test("WebUI changed-files actions hide workspace-only controls for Skill paths", () => {
+  const modules = createCardModule();
+  const skillPath = "skill://demo/SKILL.md";
+  const deletedSkillPath = "skill://demo/removed.md";
+  const skillOnlyHtml = renderCard(modules, {
+    withActions: true,
+    fileCount: 2,
+    files: [
+      { path: skillPath, deleted: false },
+      { path: deletedSkillPath, deleted: true },
+    ],
+  });
+
+  assert.ok(skillOnlyHtml.includes(`aria-label="chat.changedFiles.open: ${skillPath}"`));
+  for (const path of [skillPath, deletedSkillPath]) {
+    assert.ok(!skillOnlyHtml.includes(`aria-label="chat.changedFiles.reveal: ${path}"`));
+    assert.ok(!skillOnlyHtml.includes(`aria-label="chat.changedFiles.diff: ${path}"`));
+  }
+  assert.ok(!skillOnlyHtml.includes(`aria-label="chat.changedFiles.open: ${deletedSkillPath}"`));
+  assert.ok(!skillOnlyHtml.includes(">chat.changedFiles.review</button>"));
+
+  const workspacePath = "src/app.ts";
+  const mixedHtml = renderCard(modules, {
+    withActions: true,
+    fileCount: 2,
+    files: [
+      { path: skillPath, deleted: false },
+      { path: workspacePath, deleted: false },
+    ],
+  });
+  assert.ok(mixedHtml.includes(`aria-label="chat.changedFiles.open: ${skillPath}"`));
+  assert.ok(!mixedHtml.includes(`aria-label="chat.changedFiles.diff: ${skillPath}"`));
+  assert.ok(mixedHtml.includes(`aria-label="chat.changedFiles.diff: ${workspacePath}"`));
+  assert.ok(mixedHtml.includes(">chat.changedFiles.review</button>"));
 });

--- a/crates/agent-gateway/web/test/workspace-markdown-assets.test.mjs
+++ b/crates/agent-gateway/web/test/workspace-markdown-assets.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createWebModuleLoader } from "../../test/helpers/load-web-module.mjs";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const loader = createWebModuleLoader({ rootDir });
+const markdownAssets = loader.loadModule(
+  "@liveagent/ui/components/workspace-editor/workspaceMarkdownAssets.ts",
+);
+
+test("WebUI Skill markdown keeps relative links inside the same Skill scope", () => {
+  assert.equal(
+    markdownAssets.resolveWorkspaceMarkdownPath(
+      "skill://demo/docs/readme.md",
+      "../assets/preview.png?size=2#image",
+    ),
+    "skill://demo/assets/preview.png",
+  );
+  assert.equal(
+    markdownAssets.resolveWorkspaceMarkdownPath(
+      "skill://demo/docs/nested/readme.md",
+      "../../references/guide.md",
+    ),
+    "skill://demo/references/guide.md",
+  );
+  assert.equal(
+    markdownAssets.resolveWorkspaceMarkdownPath(
+      "skill://demo/docs/readme.md",
+      "/assets/root.png",
+    ),
+    "skill://demo/assets/root.png",
+  );
+  assert.equal(
+    markdownAssets.resolveWorkspaceMarkdownPath(
+      "skill://demo/docs/readme.md",
+      "../../other-skill/SKILL.md",
+    ),
+    null,
+  );
+
+  assert.deepEqual(
+    markdownAssets.classifyWorkspaceMarkdownTarget(
+      "skill://demo/docs/readme.md",
+      "../assets/preview.png",
+    ),
+    { kind: "workspace", path: "skill://demo/assets/preview.png" },
+  );
+  assert.deepEqual(
+    markdownAssets.classifyWorkspaceMarkdownTarget(
+      "skill://demo/docs/readme.md",
+      "skill://other/SKILL.md",
+    ),
+    { kind: "unsupported" },
+  );
+});
+
+test("WebUI workspace markdown path behavior remains unchanged", () => {
+  assert.equal(
+    markdownAssets.resolveWorkspaceMarkdownPath("docs/readme.md", "../assets/preview.png"),
+    "assets/preview.png",
+  );
+});

--- a/crates/agent-gui/src-tauri/src/commands/workspace/fs.rs
+++ b/crates/agent-gui/src-tauri/src/commands/workspace/fs.rs
@@ -18,6 +18,7 @@ use zip::ZipArchive;
 
 use super::edit_match::{apply_edit_replacements, find_edit_matches};
 use crate::runtime::platform::expand_tilde_path;
+use crate::services::skills::skills_root_dir;
 
 const READ_MAX_TEXT_BYTES: usize = 200 * 1024; // 200KB
 const EDITABLE_TEXT_MAX_BYTES: usize = 3 * 1024 * 1024; // 3MB
@@ -38,6 +39,7 @@ const HARD_LIST_DIRS_MAX_RESULTS: usize = 10000;
 
 const DEFAULT_GREP_HEAD_LIMIT: usize = 200;
 const MAX_GREP_LINE_CHARS: usize = 400;
+const SKILL_PATH_SCHEME: &str = "skill://";
 
 async fn run_blocking<R: Send + 'static>(
     label: &'static str,
@@ -398,6 +400,93 @@ fn canonicalize_workdir(workdir: &str) -> Result<PathBuf, FsError> {
     }
 
     Ok(fs::canonicalize(&p)?)
+}
+
+/// A resolved fs-command target: workspace paths resolve against the
+/// canonicalized workdir, `skill://` paths against the Skills root. The
+/// logical path (and every relative path echoed in errors) keeps the caller's
+/// scheme prefix so skill:// targets round-trip through responses.
+#[derive(Debug)]
+struct ScopedFsPath {
+    root: PathBuf,
+    relative_path: PathBuf,
+    logical_path: String,
+    /// `""` for workspace scope, `SKILL_PATH_SCHEME` for Skill scope.
+    scheme: &'static str,
+}
+
+fn skill_path_remainder(input: &str) -> Option<&str> {
+    let trimmed = input.trim();
+    trimmed
+        .get(..SKILL_PATH_SCHEME.len())
+        .filter(|prefix| prefix.eq_ignore_ascii_case(SKILL_PATH_SCHEME))
+        .map(|_| &trimmed[SKILL_PATH_SCHEME.len()..])
+}
+
+fn resolve_scoped_fs_path_with(
+    workdir: &str,
+    path: &str,
+    resolve_skills_root: impl FnOnce() -> Result<PathBuf, FsError>,
+) -> Result<ScopedFsPath, FsError> {
+    let (root, relative_path, scheme) = if let Some(skill_path) = skill_path_remainder(path) {
+        // Report the caller's own skill:// form, not the bare remainder.
+        let relative_path = sanitize_rel_path(skill_path).map_err(|error| match error {
+            FsError::InvalidRelPath(_) => {
+                FsError::InvalidRelPath(format!("{SKILL_PATH_SCHEME}{skill_path}"))
+            }
+            other => other,
+        })?;
+        let root = fs::canonicalize(resolve_skills_root()?)?;
+        (root, relative_path, SKILL_PATH_SCHEME)
+    } else {
+        let root = canonicalize_workdir(workdir)?;
+        (root, sanitize_rel_path(path)?, "")
+    };
+    let logical_path = format!("{scheme}{}", logical_rel_path(&relative_path));
+    Ok(ScopedFsPath {
+        root,
+        relative_path,
+        logical_path,
+        scheme,
+    })
+}
+
+fn resolve_scoped_fs_path(workdir: &str, path: &str) -> Result<ScopedFsPath, FsError> {
+    resolve_scoped_fs_path_with(workdir, path, || skills_root_dir().map_err(FsError::Other))
+}
+
+fn scoped_relative_logical_path(path: &ScopedFsPath, relative_path: String) -> String {
+    format!("{}{relative_path}", path.scheme)
+}
+
+fn remap_scoped_path_error(path: &ScopedFsPath, error: FsError) -> FsError {
+    match error {
+        FsError::NotFound {
+            path: relative_path,
+            did_you_mean,
+        } => FsError::NotFound {
+            path: scoped_relative_logical_path(path, relative_path),
+            did_you_mean: did_you_mean
+                .into_iter()
+                .map(|candidate| scoped_relative_logical_path(path, candidate))
+                .collect(),
+        },
+        FsError::NotADirectory {
+            path: relative_path,
+            entry_kind,
+        } => FsError::NotADirectory {
+            path: scoped_relative_logical_path(path, relative_path),
+            entry_kind,
+        },
+        FsError::NotAFile {
+            path: relative_path,
+            entry_kind,
+        } => FsError::NotAFile {
+            path: scoped_relative_logical_path(path, relative_path),
+            entry_kind,
+        },
+        other => other,
+    }
 }
 
 fn normalize_rel_path_input(input: &str) -> String {
@@ -2504,15 +2593,15 @@ pub(crate) fn fs_read_workspace_image_sync(
     workdir: String,
     path: String,
 ) -> Result<ReadResponse, FsCommandError> {
-    let wd = canonicalize_workdir(&workdir)?;
-    fs_read_workspace_image_impl(&wd, &path).map_err(|e| FsCommandError::from(e).with_workdir(&wd))
+    let target = resolve_scoped_fs_path(&workdir, &path)?;
+    fs_read_workspace_image_impl(&target)
+        .map_err(|e| FsCommandError::from(e).with_workdir(&target.root))
 }
 
-fn fs_read_workspace_image_impl(wd: &Path, path: &str) -> Result<ReadResponse, FsError> {
-    let rel = sanitize_rel_path(path)?;
-    let logical_path = logical_rel_path(&rel);
-    let target = resolve_existing_file_target(wd, &rel)?;
-    read_local_preview_file(target, logical_path)
+fn fs_read_workspace_image_impl(path: &ScopedFsPath) -> Result<ReadResponse, FsError> {
+    let target = resolve_existing_file_target(&path.root, &path.relative_path)
+        .map_err(|error| remap_scoped_path_error(path, error))?;
+    read_local_preview_file(target, path.logical_path.clone())
 }
 
 #[tauri::command(rename_all = "snake_case")]
@@ -2783,14 +2872,15 @@ pub(crate) fn fs_read_editable_text_sync(
     workdir: String,
     path: String,
 ) -> Result<ReadEditableTextResponse, FsCommandError> {
-    let wd = canonicalize_workdir(&workdir)?;
-    fs_read_editable_text_impl(&wd, &path).map_err(|e| FsCommandError::from(e).with_workdir(&wd))
+    let target = resolve_scoped_fs_path(&workdir, &path)?;
+    fs_read_editable_text_impl(&target)
+        .map_err(|e| FsCommandError::from(e).with_workdir(&target.root))
 }
 
-fn fs_read_editable_text_impl(wd: &Path, path: &str) -> Result<ReadEditableTextResponse, FsError> {
-    let rel = sanitize_rel_path(path)?;
-    let logical_path = logical_rel_path(&rel);
-    let target = resolve_existing_file_target(wd, &rel)?;
+fn fs_read_editable_text_impl(path: &ScopedFsPath) -> Result<ReadEditableTextResponse, FsError> {
+    let logical_path = path.logical_path.clone();
+    let target = resolve_existing_file_target(&path.root, &path.relative_path)
+        .map_err(|error| remap_scoped_path_error(path, error))?;
     if let Some(reason) = editable_text_unsupported_reason(&target) {
         return Err(FsError::UnsupportedTarget {
             path: logical_path,
@@ -2939,29 +3029,26 @@ pub(crate) fn fs_write_text_sync(
     expected_mtime_ms: Option<u64>,
     expected_content_hash: Option<String>,
 ) -> Result<WriteTextResponse, FsCommandError> {
-    let wd = canonicalize_workdir(&workdir)?;
+    let target = resolve_scoped_fs_path(&workdir, &path)?;
     fs_write_text_impl(
-        &wd,
-        &path,
+        &target,
         content,
         mode,
         expected_mtime_ms,
         expected_content_hash,
     )
-    .map_err(|e| FsCommandError::from(e).with_workdir(&wd))
+    .map_err(|e| FsCommandError::from(e).with_workdir(&target.root))
 }
 
 fn fs_write_text_impl(
-    wd: &Path,
-    path: &str,
+    path: &ScopedFsPath,
     content: String,
     mode: String,
     expected_mtime_ms: Option<u64>,
     expected_content_hash: Option<String>,
 ) -> Result<WriteTextResponse, FsError> {
-    let rel = sanitize_rel_path(path)?;
-    let logical_path = logical_rel_path(&rel);
-    let raw_target = wd.join(&rel);
+    let logical_path = path.logical_path.clone();
+    let raw_target = path.root.join(&path.relative_path);
     let expected = parse_expected_version(expected_mtime_ms, expected_content_hash)?;
 
     if mode != "rewrite" {
@@ -2978,10 +3065,14 @@ fn fs_write_text_impl(
                     entry_kind: "dir".to_string(),
                 });
             }
-            (resolve_existing_file_target(wd, &rel)?, true)
+            (
+                resolve_existing_file_target(&path.root, &path.relative_path)
+                    .map_err(|error| remap_scoped_path_error(path, error))?,
+                true,
+            )
         }
         Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            ensure_parent_dir(wd, &raw_target)?;
+            ensure_parent_dir(&path.root, &raw_target)?;
             (raw_target.clone(), false)
         }
         Err(err) => return Err(FsError::Io(err)),
@@ -3310,19 +3401,18 @@ pub(crate) fn fs_open_workspace_path_sync(
     path: String,
     mode: Option<String>,
 ) -> Result<OpenWorkspacePathResponse, FsCommandError> {
-    let wd = canonicalize_workdir(&workdir)?;
-    fs_open_workspace_path_impl(&wd, &path, mode)
-        .map_err(|e| FsCommandError::from(e).with_workdir(&wd))
+    let target = resolve_scoped_fs_path(&workdir, &path)?;
+    fs_open_workspace_path_impl(&target, mode)
+        .map_err(|e| FsCommandError::from(e).with_workdir(&target.root))
 }
 
 fn fs_open_workspace_path_impl(
-    wd: &Path,
-    path: &str,
+    path: &ScopedFsPath,
     mode: Option<String>,
 ) -> Result<OpenWorkspacePathResponse, FsError> {
-    let rel = sanitize_rel_path(path)?;
-    let logical_path = logical_rel_path(&rel);
-    let target = resolve_target(wd, &rel)?;
+    let logical_path = path.logical_path.clone();
+    let target = resolve_target(&path.root, &path.relative_path)
+        .map_err(|error| remap_scoped_path_error(path, error))?;
     let meta = fs::metadata(&target)?;
     let kind = if meta.is_file() {
         "file"
@@ -4614,6 +4704,13 @@ mod tests {
         writer.finish().expect("finish zip").into_inner()
     }
 
+    fn resolve_test_scoped_path(workdir: &Path, skills_root: &Path, path: &str) -> ScopedFsPath {
+        resolve_scoped_fs_path_with(&workdir.display().to_string(), path, || {
+            Ok(skills_root.to_path_buf())
+        })
+        .expect("scoped path should resolve")
+    }
+
     #[test]
     fn detects_windows_reserved_path_components() {
         assert!(is_windows_reserved_path_component("CON"));
@@ -5164,6 +5261,116 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(workdir);
+    }
+
+    #[test]
+    fn skill_scoped_editor_and_preview_preserve_skill_paths() {
+        let workdir = unique_test_workdir("skill-scoped-workspace");
+        let skills_root = unique_test_workdir("skill-scoped-root");
+        fs::create_dir_all(&workdir).expect("create workdir");
+        fs::create_dir_all(skills_root.join("demo/assets")).expect("create skill directories");
+        fs::write(skills_root.join("demo/SKILL.md"), "# Demo\n").expect("write skill file");
+        let image_bytes = png_like_bytes();
+        fs::write(skills_root.join("demo/assets/preview.png"), &image_bytes)
+            .expect("write skill image");
+
+        let skill_text = resolve_test_scoped_path(&workdir, &skills_root, "skill://demo/SKILL.md");
+        let read = fs_read_editable_text_impl(&skill_text).expect("skill text should read");
+        assert_eq!(read.path, "skill://demo/SKILL.md");
+        assert_eq!(read.content, "# Demo\n");
+
+        let write = fs_write_text_impl(
+            &skill_text,
+            "# Updated\n".to_string(),
+            "rewrite".to_string(),
+            Some(read.mtime_ms),
+            Some(read.content_hash),
+        )
+        .expect("skill text should save");
+        assert_eq!(write.path, "skill://demo/SKILL.md");
+        assert_eq!(
+            fs::read_to_string(skills_root.join("demo/SKILL.md")).expect("read saved skill"),
+            "# Updated\n"
+        );
+
+        let skill_image =
+            resolve_test_scoped_path(&workdir, &skills_root, "skill://demo/assets/preview.png");
+        let preview =
+            fs_read_workspace_image_impl(&skill_image).expect("skill image should preview");
+        assert_eq!(preview.path, "skill://demo/assets/preview.png");
+        assert_eq!(preview.mime_type.as_deref(), Some("image/png"));
+        assert_eq!(
+            preview.data.as_deref(),
+            Some(BASE64_STANDARD.encode(&image_bytes).as_str())
+        );
+
+        let missing = resolve_test_scoped_path(&workdir, &skills_root, "skill://demo/missing.md");
+        let error = fs_read_editable_text_impl(&missing).expect_err("missing skill should fail");
+        match error {
+            FsError::NotFound { path, .. } => assert_eq!(path, "skill://demo/missing.md"),
+            other => panic!("unexpected error: {other}"),
+        }
+
+        let _ = fs::remove_dir_all(workdir);
+        let _ = fs::remove_dir_all(skills_root);
+    }
+
+    #[test]
+    fn skill_scoped_paths_reject_invalid_segments() {
+        let workdir = unique_test_workdir("skill-invalid-workspace");
+        let skills_root = unique_test_workdir("skill-invalid-root");
+        fs::create_dir_all(&workdir).expect("create workdir");
+        fs::create_dir_all(&skills_root).expect("create skills root");
+
+        for path in [
+            "skill://",
+            "skill://../outside.md",
+            "skill://demo/../../outside.md",
+            "skill:///absolute.md",
+            "skill://C:/drive.md",
+            "skill://demo/a:b.md",
+        ] {
+            let error = resolve_scoped_fs_path_with(&workdir.display().to_string(), path, || {
+                Ok(skills_root.clone())
+            })
+            .expect_err("invalid Skill path should fail");
+            match error {
+                // The rejected path must be echoed in the caller's own
+                // skill:// form so the message names what the user clicked.
+                FsError::InvalidRelPath(reported) => assert_eq!(reported, path),
+                other => panic!("unexpected error for {path}: {other}"),
+            }
+        }
+
+        let _ = fs::remove_dir_all(workdir);
+        let _ = fs::remove_dir_all(skills_root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_scoped_paths_reject_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let workdir = unique_test_workdir("skill-symlink-workspace");
+        let skills_root = unique_test_workdir("skill-symlink-root");
+        let outside_root = unique_test_workdir("skill-symlink-outside");
+        fs::create_dir_all(&workdir).expect("create workdir");
+        fs::create_dir_all(skills_root.join("demo")).expect("create skill directory");
+        fs::create_dir_all(&outside_root).expect("create outside directory");
+        fs::write(outside_root.join("secret.md"), "outside\n").expect("write outside file");
+        symlink(
+            outside_root.join("secret.md"),
+            skills_root.join("demo/linked.md"),
+        )
+        .expect("create escaping symlink");
+
+        let linked = resolve_test_scoped_path(&workdir, &skills_root, "skill://demo/linked.md");
+        let error = fs_read_editable_text_impl(&linked).expect_err("symlink escape should fail");
+        assert!(matches!(error, FsError::OutOfBounds(_)));
+
+        let _ = fs::remove_dir_all(workdir);
+        let _ = fs::remove_dir_all(skills_root);
+        let _ = fs::remove_dir_all(outside_root);
     }
 
     #[test]

--- a/crates/agent-gui/test/chat/changed-files-card.test.mjs
+++ b/crates/agent-gui/test/chat/changed-files-card.test.mjs
@@ -55,9 +55,9 @@ function createCardModule(rootDir) {
 
 function renderCard(
   { cardModule, jsxRuntime, renderToStaticMarkup },
-  { withActions = false, fileCount = 4 } = {},
+  { withActions = false, fileCount = 4, files } = {},
 ) {
-  const paths = [
+  const paths = files ?? [
     { path: "src/components/ChangedFilesCard.tsx", deleted: false },
     { path: "README.md", deleted: false },
     { path: "src\\pages\\Settings.tsx", deleted: false },
@@ -151,4 +151,40 @@ test("GUI changed-files actions include the localized action and canonical path"
     !html.includes('aria-label="chat.changedFiles.open: tmp/removed.ts"'),
     "deleted files must not expose the open-file action",
   );
+});
+
+test("GUI changed-files actions hide workspace-only controls for Skill paths", () => {
+  const modules = createCardModule(rootDir);
+  const skillPath = "skill://demo/SKILL.md";
+  const deletedSkillPath = "skill://demo/removed.md";
+  const skillOnlyHtml = renderCard(modules, {
+    withActions: true,
+    fileCount: 2,
+    files: [
+      { path: skillPath, deleted: false },
+      { path: deletedSkillPath, deleted: true },
+    ],
+  });
+
+  assert.ok(skillOnlyHtml.includes(`aria-label="chat.changedFiles.open: ${skillPath}"`));
+  for (const path of [skillPath, deletedSkillPath]) {
+    assert.ok(!skillOnlyHtml.includes(`aria-label="chat.changedFiles.reveal: ${path}"`));
+    assert.ok(!skillOnlyHtml.includes(`aria-label="chat.changedFiles.diff: ${path}"`));
+  }
+  assert.ok(!skillOnlyHtml.includes(`aria-label="chat.changedFiles.open: ${deletedSkillPath}"`));
+  assert.ok(!skillOnlyHtml.includes(">chat.changedFiles.review</button>"));
+
+  const workspacePath = "src/app.ts";
+  const mixedHtml = renderCard(modules, {
+    withActions: true,
+    fileCount: 2,
+    files: [
+      { path: skillPath, deleted: false },
+      { path: workspacePath, deleted: false },
+    ],
+  });
+  assert.ok(mixedHtml.includes(`aria-label="chat.changedFiles.open: ${skillPath}"`));
+  assert.ok(!mixedHtml.includes(`aria-label="chat.changedFiles.diff: ${skillPath}"`));
+  assert.ok(mixedHtml.includes(`aria-label="chat.changedFiles.diff: ${workspacePath}"`));
+  assert.ok(mixedHtml.includes(">chat.changedFiles.review</button>"));
 });

--- a/crates/agent-gui/test/chat/workspace-markdown-assets.test.mjs
+++ b/crates/agent-gui/test/chat/workspace-markdown-assets.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const rootDir = fileURLToPath(new URL("../..", import.meta.url));
+const loader = createTsModuleLoader({ rootDir });
+const markdownAssets = loader.loadModule(
+  "@liveagent/ui/components/workspace-editor/workspaceMarkdownAssets.ts",
+);
+
+test("GUI Skill markdown keeps relative links inside the same Skill scope", () => {
+  assert.equal(
+    markdownAssets.resolveWorkspaceMarkdownPath(
+      "skill://demo/docs/readme.md",
+      "../assets/preview.png?size=2#image",
+    ),
+    "skill://demo/assets/preview.png",
+  );
+  assert.equal(
+    markdownAssets.resolveWorkspaceMarkdownPath(
+      "skill://demo/docs/nested/readme.md",
+      "../../references/guide.md",
+    ),
+    "skill://demo/references/guide.md",
+  );
+  assert.equal(
+    markdownAssets.resolveWorkspaceMarkdownPath(
+      "skill://demo/docs/readme.md",
+      "/assets/root.png",
+    ),
+    "skill://demo/assets/root.png",
+  );
+  assert.equal(
+    markdownAssets.resolveWorkspaceMarkdownPath(
+      "skill://demo/docs/readme.md",
+      "../../other-skill/SKILL.md",
+    ),
+    null,
+  );
+
+  assert.deepEqual(
+    markdownAssets.classifyWorkspaceMarkdownTarget(
+      "skill://demo/docs/readme.md",
+      "../assets/preview.png",
+    ),
+    { kind: "workspace", path: "skill://demo/assets/preview.png" },
+  );
+  assert.deepEqual(
+    markdownAssets.classifyWorkspaceMarkdownTarget(
+      "skill://demo/docs/readme.md",
+      "skill://other/SKILL.md",
+    ),
+    { kind: "unsupported" },
+  );
+});
+
+test("GUI workspace markdown path behavior remains unchanged", () => {
+  assert.equal(
+    markdownAssets.resolveWorkspaceMarkdownPath("docs/readme.md", "../assets/preview.png"),
+    "assets/preview.png",
+  );
+});

--- a/crates/agent-ui/src/components/chat/ChangedFilesCard.tsx
+++ b/crates/agent-ui/src/components/chat/ChangedFilesCard.tsx
@@ -14,6 +14,7 @@ import { FileChangeBadge } from "@liveagent/ui/components/chat/FileChangeBadge";
 import { getFileTypeIcon } from "@liveagent/ui/components/chat/fileTypeIcons";
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { cn } from "@liveagent/ui/lib/shared/utils";
+import { isSkillPath } from "@liveagent/ui/lib/skills/skillPaths";
 import { createContext, memo, useContext, useMemo } from "react";
 
 export type ChangedFilesActions = {
@@ -46,7 +47,12 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
   const { t } = useLocale();
   const actions = useChangedFilesActions();
   const { dir, base } = splitPath(file.path);
+  // Skill files live outside the workspace, so the file tree and git review
+  // cannot locate them; only the editor/preview action applies.
+  const skillPath = isSkillPath(file.path);
   const canOpen = Boolean(actions?.onOpenFile) && !file.deleted;
+  const canReveal = Boolean(actions?.onRevealInFileTree) && !skillPath;
+  const canOpenDiff = Boolean(actions?.onOpenDiff) && !skillPath;
   const FileTypeIcon = getFileTypeIcon(file.path, "file");
   const openLabel = `${t("chat.changedFiles.open")}: ${file.path}`;
   const revealLabel = `${t("chat.changedFiles.reveal")}: ${file.path}`;
@@ -96,10 +102,10 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
       ) : (
         <FileChangeBadge added={file.added} removed={file.removed} />
       )}
-      {actions?.onRevealInFileTree ? (
+      {canReveal ? (
         <button
           type="button"
-          onClick={() => actions.onRevealInFileTree?.(file.path)}
+          onClick={() => actions?.onRevealInFileTree?.(file.path)}
           title={revealLabel}
           aria-label={revealLabel}
           className={ROW_ACTION_CLASS}
@@ -107,10 +113,10 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
           <FolderTree className="h-3.5 w-3.5" />
         </button>
       ) : null}
-      {actions?.onOpenDiff ? (
+      {canOpenDiff ? (
         <button
           type="button"
-          onClick={() => actions.onOpenDiff?.(file.path)}
+          onClick={() => actions?.onOpenDiff?.(file.path)}
           title={diffLabel}
           aria-label={diffLabel}
           className={ROW_ACTION_CLASS}
@@ -134,6 +140,8 @@ export const ChangedFilesCard = memo(function ChangedFilesCard({
       summary.files.length === 1 ? "chat.changedFiles.titleOne" : "chat.changedFiles.title";
     return t(key).replace("{count}", String(summary.files.length));
   }, [summary.files.length, t]);
+  const canOpenReview =
+    Boolean(actions?.onOpenDiff) && summary.files.some((file) => !isSkillPath(file.path));
 
   return (
     <div className="changed-files-card overflow-hidden rounded-xl border border-border/45 bg-background/60 backdrop-blur-sm dark:border-white/[0.07] dark:bg-white/[0.03]">
@@ -147,10 +155,10 @@ export const ChangedFilesCard = memo(function ChangedFilesCard({
           </span>
           <FileChangeBadge added={summary.totalAdded} removed={summary.totalRemoved} />
         </div>
-        {actions?.onOpenDiff ? (
+        {canOpenReview ? (
           <button
             type="button"
-            onClick={() => actions.onOpenDiff?.(null)}
+            onClick={() => actions?.onOpenDiff?.(null)}
             className="flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[calc(11px*var(--zone-font-scale,1))] font-medium leading-none text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus-visible:bg-foreground/[0.06] focus-visible:outline-none"
           >
             <GitCommitHorizontal className="h-3.5 w-3.5" />

--- a/crates/agent-ui/src/components/workspace-editor/workspaceMarkdownAssets.ts
+++ b/crates/agent-ui/src/components/workspace-editor/workspaceMarkdownAssets.ts
@@ -1,7 +1,9 @@
 // Classification and resolution of link/image targets found in a markdown
-// file rendered by the workspace file preview. `markdownPath` is the
-// workdir-relative logical path of the markdown file (forward slashes, no
-// leading slash), as returned by the fs backend.
+// file rendered by the workspace file preview. `markdownPath` is the logical
+// path returned by the fs backend: workdir-relative for workspace files, or a
+// skill:// path for installed Skill files.
+
+import { formatSkillPath, parseSkillPath } from "@liveagent/ui/lib/skills/skillPaths";
 
 export type WorkspaceMarkdownTarget =
   | { kind: "external"; url: string }
@@ -20,19 +22,23 @@ function decodePathSegment(segment: string) {
   }
 }
 
-// Resolves a relative (or workspace-root-absolute) markdown target against
-// the markdown file's directory. Returns a workdir-relative path, or null
-// when the target escapes the workspace root or resolves to nothing.
+// Resolves a relative (or scope-root-absolute) markdown target against the
+// markdown file's directory. Skill targets stay inside their originating
+// Skill directory; workspace targets stay inside the workspace root.
 export function resolveWorkspaceMarkdownPath(markdownPath: string, target: string): string | null {
   const withoutFragment = target.split("#")[0] ?? "";
   const withoutQuery = withoutFragment.split("?")[0] ?? "";
   const normalized = withoutQuery.replace(/\\/g, "/");
   if (!normalized) return null;
 
+  // A Skill's markdown resolves inside its own Skill directory, so `/foo.png`
+  // and `../foo.png` stay scoped to that Skill rather than the workspace.
+  const skillScope = parseSkillPath(markdownPath);
+  const scopeRelativePath = skillScope?.relativePath ?? markdownPath.replace(/\\/g, "/");
+
   const segments = normalized.startsWith("/")
     ? []
-    : markdownPath
-        .replace(/\\/g, "/")
+    : scopeRelativePath
         .split("/")
         .slice(0, -1)
         .filter((segment) => segment && segment !== ".");
@@ -48,7 +54,9 @@ export function resolveWorkspaceMarkdownPath(markdownPath: string, target: strin
     segments.push(segment);
   }
 
-  return segments.length ? segments.join("/") : null;
+  if (!segments.length) return null;
+  const resolvedPath = segments.join("/");
+  return skillScope ? formatSkillPath(skillScope.baseDir, resolvedPath) : resolvedPath;
 }
 
 export function classifyWorkspaceMarkdownTarget(

--- a/crates/agent-ui/src/lib/skills/skillPaths.ts
+++ b/crates/agent-ui/src/lib/skills/skillPaths.ts
@@ -1,0 +1,29 @@
+// Logical `skill://<baseDir>/<relativePath>` paths: the form file tools report
+// for files inside installed Skills, and the form the fs backend resolves
+// against the Skills root instead of the workspace root. UI surfaces that key
+// off the workspace root (file tree, git review) must exclude these paths.
+
+const SKILL_PATH_SCHEME = "skill://";
+
+const SKILL_PATH_PATTERN = /^skill:\/\/([^/]+)(?:\/(.*))?$/i;
+
+export function isSkillPath(path: string) {
+  return path.trim().toLowerCase().startsWith(SKILL_PATH_SCHEME);
+}
+
+export type SkillPathScope = {
+  /** Skills-root-relative directory that owns the file, e.g. `html-mini-game`. */
+  baseDir: string;
+  /** Path of the file inside `baseDir`; empty when the path names the Skill itself. */
+  relativePath: string;
+};
+
+export function parseSkillPath(path: string): SkillPathScope | null {
+  const match = SKILL_PATH_PATTERN.exec(path.trim().replace(/\\/g, "/"));
+  if (!match) return null;
+  return { baseDir: match[1], relativePath: match[2] ?? "" };
+}
+
+export function formatSkillPath(baseDir: string, relativePath: string) {
+  return `${SKILL_PATH_SCHEME}${baseDir}/${relativePath}`;
+}


### PR DESCRIPTION
## 问题

已编辑文件卡片里双击 skills 目录下的文件时打不开，提示：

> resolved path segment must not contain `..`, drive letters, or an absolute root path: `skill://html-mini-game-b...`

文件工具对 Skill 内文件上报的是逻辑路径 `skill://<skill-dir>/<file>`，而 fs 命令统一把 `path` 当工作区相对路径 sanitize，`skill://` 里的 `//` 被判成非法路径段，请求在解析阶段就失败了。

Closes #339

## 改动

**Rust（`commands/workspace/fs.rs`）**

新增 `ScopedFsPath`，把「解析根 + 相对路径 + 回显用逻辑路径 + scheme」收成一个值：workspace 路径按 workdir 解析，`skill://` 路径按 Skills 根解析。`fs_read_workspace_image` / `fs_read_editable_text` / `fs_write_text` / `fs_open_workspace_path` 四个命令改走它。

逻辑路径以及 `NotFound` / `NotADirectory` / `NotAFile` 错误里的相对路径都保留调用方给的 `skill://` 原形，响应可以原样回流给前端；`InvalidRelPath` 也回显 `skill://` 原形而不是裸的剩余段，报错读起来跟用户看到的路径一致。越界与 symlink 逃逸仍由原有的 `sanitize_rel_path` + `resolve_*_target` 把关，Skill 作用域同样受约束。

**共享前端（`agent-ui`）**

- 新增 `lib/skills/skillPaths.ts` 作为 scheme 的单一真源（`isSkillPath` / `parseSkillPath` / `formatSkillPath`），替掉两处各写一遍的 `"skill://"` 字面量。
- `workspaceMarkdownAssets.ts`：Skill 文档里的相对链接改在其所属 Skill 目录内解析，`/foo.png` 和 `../foo.png` 落在该 Skill 下而不是工作区根；跨 Skill 引用和越界目标一律 `unsupported`。
- `ChangedFilesCard.tsx`：Skill 路径隐藏「在文件树中显示」和 diff 入口——这两个功能都以工作区根定位，对 Skill 文件无法工作；整卡 review 按钮仅在存在非 Skill 文件时显示。

两端共用 `@liveagent/ui` alias 指向同一份 `crates/agent-ui/src`，所以共享层无需镜像。

## Screenshots / preview
<img width="608" height="507" alt="image" src="https://github.com/user-attachments/assets/1e17ee44-13ee-4e7f-ade4-c725c0b8b847" />


## 验证

- `cargo fmt --check`、`cargo clippy --all-targets`（新代码零新增告警）
- `cargo test --lib fs::` — 43 passed，含 3 个新增 skill 作用域测试（读/写/预览往返、非法段、symlink 逃逸）
- GUI 前端全量 `npm run test:frontend` — 1495 passed
- WebUI 全量 `npm test` — 548 passed
- 两端 `tsc --noEmit`、`biome check` 通过

未做人工验证：没有在真实桌面端双击复现原报错后的回归点击，判断依据是命令层单测与两端渲染测试。