### PR TITLE
fix(webui): 修复桌面设置同步页 Logo 显示

### DIFF
--- a/crates/agent-gateway/web/src/pages/SettingsSyncLoading.tsx
+++ b/crates/agent-gateway/web/src/pages/SettingsSyncLoading.tsx
@@ -13,7 +13,7 @@ export function SettingsSyncLoading({ locale }: SettingsSyncLoadingProps) {
       <div className="sync-loading-stage">
         <div className="sync-loading-icon">
           <img
-            src="/favicon.svg"
+            src="/icon-simple.png"
             alt=""
             width={60}
             height={60}

--- a/crates/agent-gateway/web/src/styles.css
+++ b/crates/agent-gateway/web/src/styles.css
@@ -2049,7 +2049,6 @@ html[data-liveagent-webui="gateway"] .settings-tools-view-enter {
   display: block;
   width: 60px;
   height: 60px;
-  border-radius: 16px;
   filter: drop-shadow(0 6px 14px hsl(206 45% 28% / 0.18));
   user-select: none;
 }


### PR DESCRIPTION
## Linked issue

Closes #413

## Summary

- 修复“正在同步桌面端设置”加载页错误复用 `favicon.svg`，导致深色界面中显示缩小白底方块的问题。
- 改用已有透明品牌资源 `icon-simple.png`，并移除仅适用于方形 favicon 的圆角裁切。
- 保留原有 60×60 尺寸、呼吸动画和投影效果，不改变设置同步逻辑。

## Change scope

- Modules: `agent-gateway/web`
- Key paths:
  - `crates/agent-gateway/web/src/pages/SettingsSyncLoading.tsx`
  - `crates/agent-gateway/web/src/styles.css`

## Screenshots / preview

<table>
  <tr>
    <th>修复前：白底 favicon</th>
    <th>修复后：透明品牌 Logo</th>
  </tr>
  <tr>
    <td align="center"><img src="https://raw.githubusercontent.com/Stack-Cairn/LiveAgent/f373aa8a017444559f6b28e892096e71d5ecb3fa/crates/agent-gateway/web/public/favicon.svg" width="96" alt="修复前白底 favicon"></td>
    <td align="center"><img src="https://raw.githubusercontent.com/Stack-Cairn/LiveAgent/f373aa8a017444559f6b28e892096e71d5ecb3fa/crates/agent-gateway/web/public/icon-simple.png" width="96" alt="修复后透明品牌 Logo"></td>
  </tr>
</table>

预览展示同步加载页切换前后的实际品牌资源；页面中的图标容器仍为 60×60。

## Verification

- `pnpm --filter @liveagent/gateway-webui test`：548 项测试全部通过。
- `pnpm --filter @liveagent/gateway-webui lint`：退出码 0，仅报告仓库已有的非阻塞告警。
- `pnpm --filter @liveagent/gateway-webui build`：TypeScript 与 Vite 生产构建通过。
- `git diff --check`：通过。
- 构建产物中的 `dist/icon-simple.png` 与源资源 SHA-256 一致。
- 未新增测试：本次仅替换既有静态资源引用并移除对应裁切样式，现有测试、Lint 和生产构建已覆盖集成有效性。

## Pre-submit checklist

- [x] 已关联 Issue #413，合并后自动关闭。
- [x] 已同步目标分支，且与 `main` 无冲突。
- [x] 改动范围集中，不包含无关修改。
- [x] 未包含密钥、令牌或个人数据。
- [x] 无需更新文档：不改变功能、配置、部署或用户操作流程。
