### PR TITLE
fix(test): 修复 save_system_persists_project_setting_rows 与 workspace resource settings 不一致

### DIFF
--- a/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
@@ -1121,7 +1121,7 @@ mod tests {
         };
         let loaded = load_system(&conn).expect("load system");
 
-        assert_eq!(row_count, 9);
+        assert_eq!(row_count, 10);
         assert_eq!(
             keys,
             vec![
@@ -1134,6 +1134,7 @@ mod tests {
                 SYSTEM_TOOL_POLICIES_KEY.to_string(),
                 SYSTEM_WORKDIR_KEY.to_string(),
                 SYSTEM_WORKSPACE_PROJECTS_KEY.to_string(),
+                SYSTEM_WORKSPACE_RESOURCE_SETTINGS_KEY.to_string(),
             ]
         );
         assert_eq!(


### PR DESCRIPTION
### 问题

`save_system_persists_project_setting_rows` 测试在运行时必然失败。

PR #317（feat(workspace): configure Skills and MCP per workspace）为 `save_system` 新增了 `SYSTEM_WORKSPACE_RESOURCE_SETTINGS_KEY` 的无条件写入（写入行数 9 → 10），但该测试的期望值未同步更新：

- `assert_eq!(row_count, 9)` 仍期望 9 行（实际 10 行）
- keys 列表缺少 `SYSTEM_WORKSPACE_RESOURCE_SETTINGS_KEY`

测试中 `row_count` 断言在最前面，一旦执行会立即 panic。

### 为什么 CI 一直没发现

该测试是 settings 模块的普通 `#[test]`，没有 `#[ignore]` 或条件跳过。但 Tauri Rust Check 只运行四个过滤子集（`chat_history` / `ssh_local_forward` / `shell_runner` / `integration_commands::mcp`），加上 `cargo check --tests`（仅编译不运行），settings 模块的测试从未被 CI 执行。

该问题是由 fork 侧的全量 `cargo test --lib` 运行暴露的。

### 修复

- `row_count` 期望 9 → 10
- keys 列表在 `SYSTEM_WORKSPACE_PROJECTS_KEY` 后追加 `SYSTEM_WORKSPACE_RESOURCE_SETTINGS_KEY`（保持 ASC 排序）

### 验证

修复后的测试在 fork 的全量 `cargo test --lib` 中通过。

> 备注：建议后续考虑将 settings 模块纳入 CI 测试范围（例如改为运行全部 `--lib` 测试），避免此类回归再次隐藏。