### PR TITLE
🐛 fix(sidebar): 修复 Windows 下拉菜单改名无响应

### DIFF
--- a/crates/agent-gui/test/chat/sidebar-selection.test.mjs
+++ b/crates/agent-gui/test/chat/sidebar-selection.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
@@ -125,4 +126,19 @@ test("a stop request halts the batch and reports the rest as skipped", async () 
   assert.deepEqual(result.deletedIds, ["one"]);
   assert.deepEqual(result.failedIds, []);
   assert.deepEqual(result.skippedIds, ["two", "three"]);
+});
+
+test("rename menu guards the menu-close blur without changing double-click rename", () => {
+  const source = readFileSync(
+    new URL("../../../agent-ui/src/components/chat/ChatHistorySidebar.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    source,
+    /const handleStartRenamingFromMenu = useCallback\(\(\) => \{[\s\S]*?ignoreMenuCloseBlurRef\.current = true;[\s\S]*?onStartRenaming\(item\);/,
+  );
+  assert.match(source, /onDoubleClick=\{\(event\) => \{[\s\S]*?handleStartRenaming\(\);/);
+  assert.match(source, /onSelect=\{handleStartRenamingFromMenu\}/);
+  assert.equal((source.match(/if \(ignoreMenuCloseBlurRef\.current\)/g) ?? []).length, 2);
 });

--- a/crates/agent-gui/test/chat/sidebar-selection.test.mjs
+++ b/crates/agent-gui/test/chat/sidebar-selection.test.mjs
@@ -128,17 +128,24 @@ test("a stop request halts the batch and reports the rest as skipped", async () 
   assert.deepEqual(result.skippedIds, ["two", "three"]);
 });
 
-test("rename menu guards the menu-close blur without changing double-click rename", () => {
+test("menu rename suppresses the menu's return-focus without changing double-click rename", () => {
   const source = readFileSync(
     new URL("../../../agent-ui/src/components/chat/ChatHistorySidebar.tsx", import.meta.url),
     "utf8",
   );
 
-  assert.match(
-    source,
-    /const handleStartRenamingFromMenu = useCallback\(\(\) => \{[\s\S]*?ignoreMenuCloseBlurRef\.current = true;[\s\S]*?onStartRenaming\(item\);/,
+  // Both menu entries (HistoryRow + ProjectRow) arm the one-shot flag.
+  assert.equal((source.match(/suppressMenuReturnFocusRef\.current = true;/g) ?? []).length, 2);
+  assert.equal((source.match(/onSelect=\{handleStartRenamingFromMenu\}/g) ?? []).length, 2);
+  // Both dropdowns consume it declaratively via Base UI's finalFocus, keeping
+  // the default trigger return-focus for every other menu close.
+  assert.equal((source.match(/finalFocus=\{\(\) => \{/g) ?? []).length, 2);
+  assert.equal(
+    (source.match(/suppressMenuReturnFocusRef\.current = false;\s*return false;/g) ?? []).length,
+    2,
   );
+  // Double-click rename keeps the plain path, and the retired blur-swallowing
+  // guard must not come back — blur either skips once (Enter/Escape) or commits.
   assert.match(source, /onDoubleClick=\{\(event\) => \{[\s\S]*?handleStartRenaming\(\);/);
-  assert.match(source, /onSelect=\{handleStartRenamingFromMenu\}/);
-  assert.equal((source.match(/if \(ignoreMenuCloseBlurRef\.current\)/g) ?? []).length, 2);
+  assert.doesNotMatch(source, /ignoreMenuCloseBlurRef/);
 });

--- a/crates/agent-ui/src/components/chat/ChatHistorySidebar.tsx
+++ b/crates/agent-ui/src/components/chat/ChatHistorySidebar.tsx
@@ -331,11 +331,14 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
   // Enter/Escape mark the blur as handled so onBlur commits exactly once —
   // symmetric with ProjectRow's skipNextBlurCommitRef.
   const skipNextBlurCommitRef = useRef(false);
-  // The row swaps the dropdown for the rename input, so Base UI hands focus
-  // back to the now-unmounted trigger right after the menu closes. That focus
-  // handoff blurred the freshly focused input and committed the untouched
-  // title, which read as "Rename does nothing" on Windows.
-  const ignoreMenuCloseBlurRef = useRef(false);
+  // Renaming from the menu unmounts the whole dropdown in the commit that
+  // mounts the rename input, and Base UI resolves its return-focus target
+  // synchronously during that unmount — before the input's ref attaches — so
+  // the deferred focus() landed on a fallback element, blurring the input and
+  // committing the untouched title ("rename does nothing" on Windows). The
+  // menu's finalFocus callback consumes this one-shot flag to skip that
+  // return-focus entirely; the isRenaming effect owns focus placement instead.
+  const suppressMenuReturnFocusRef = useRef(false);
   const longPressTimerRef = useRef<number | null>(null);
   const longPressStartRef = useRef<{ x: number; y: number } | null>(null);
   const longPressTriggeredRef = useRef(false);
@@ -381,7 +384,7 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
     if (isInteractionDisabled) {
       return;
     }
-    ignoreMenuCloseBlurRef.current = true;
+    suppressMenuReturnFocusRef.current = true;
     onStartRenaming(item);
   }, [isInteractionDisabled, item, onStartRenaming]);
 
@@ -597,10 +600,7 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
   const shouldShowMobilePressFeedback = isMobileMenuLayout && (isLongPressActive || menuOpen);
 
   useEffect(() => {
-    if (!isRenaming) {
-      ignoreMenuCloseBlurRef.current = false;
-      return;
-    }
+    if (!isRenaming) return;
     skipNextBlurCommitRef.current = false;
     inputRef.current?.focus();
     inputRef.current?.select();
@@ -672,12 +672,6 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
             onBlur={() => {
               if (skipNextBlurCommitRef.current) {
                 skipNextBlurCommitRef.current = false;
-                return;
-              }
-              if (ignoreMenuCloseBlurRef.current) {
-                ignoreMenuCloseBlurRef.current = false;
-                inputRef.current?.focus();
-                inputRef.current?.select();
                 return;
               }
               onCommitRename();
@@ -875,6 +869,13 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
                 align="start"
                 sideOffset={8}
                 collisionPadding={12}
+                finalFocus={() => {
+                  if (suppressMenuReturnFocusRef.current) {
+                    suppressMenuReturnFocusRef.current = false;
+                    return false;
+                  }
+                  return true;
+                }}
                 className="sidebar-context-menu min-w-[10rem] rounded-xl border-border/60 bg-background/95 backdrop-blur-xl"
               >
                 {isMobileMenuLayout && !item.isPending ? (
@@ -1024,18 +1025,15 @@ const ProjectRow = memo(function ProjectRow(props: {
   const rowRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const skipNextBlurCommitRef = useRef(false);
-  // Same menu-close focus handoff as HistoryRow: the trigger unmounts when the
-  // row swaps to the rename input, so the first blur must not commit.
-  const ignoreMenuCloseBlurRef = useRef(false);
+  // Same menu-unmount return-focus hazard as HistoryRow: the menu's finalFocus
+  // callback consumes this one-shot flag so the rename input keeps focus.
+  const suppressMenuReturnFocusRef = useRef(false);
   const isDefaultProject = project.id === DEFAULT_WORKSPACE_PROJECT_ID;
   const isPinned = project.isPinned === true;
   const ProjectFolderIcon = isActive ? FolderOpen : FolderClosed;
 
   useEffect(() => {
-    if (!isRenaming) {
-      ignoreMenuCloseBlurRef.current = false;
-      return;
-    }
+    if (!isRenaming) return;
     skipNextBlurCommitRef.current = false;
     inputRef.current?.focus();
     inputRef.current?.select();
@@ -1045,7 +1043,7 @@ const ProjectRow = memo(function ProjectRow(props: {
     if (isInteractionDisabled) {
       return;
     }
-    ignoreMenuCloseBlurRef.current = true;
+    suppressMenuReturnFocusRef.current = true;
     onStartRenamingProject(project);
   }, [isInteractionDisabled, onStartRenamingProject, project]);
 
@@ -1182,12 +1180,6 @@ const ProjectRow = memo(function ProjectRow(props: {
             onBlur={() => {
               if (skipNextBlurCommitRef.current) {
                 skipNextBlurCommitRef.current = false;
-                return;
-              }
-              if (ignoreMenuCloseBlurRef.current) {
-                ignoreMenuCloseBlurRef.current = false;
-                inputRef.current?.focus();
-                inputRef.current?.select();
                 return;
               }
               onCommitProjectRename();
@@ -1391,6 +1383,13 @@ const ProjectRow = memo(function ProjectRow(props: {
                     side="right"
                     align="start"
                     sideOffset={6}
+                    finalFocus={() => {
+                      if (suppressMenuReturnFocusRef.current) {
+                        suppressMenuReturnFocusRef.current = false;
+                        return false;
+                      }
+                      return true;
+                    }}
                     className="sidebar-context-menu"
                   >
                     <DropdownMenuItem

--- a/crates/agent-ui/src/components/chat/ChatHistorySidebar.tsx
+++ b/crates/agent-ui/src/components/chat/ChatHistorySidebar.tsx
@@ -331,6 +331,11 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
   // Enter/Escape mark the blur as handled so onBlur commits exactly once —
   // symmetric with ProjectRow's skipNextBlurCommitRef.
   const skipNextBlurCommitRef = useRef(false);
+  // The row swaps the dropdown for the rename input, so Base UI hands focus
+  // back to the now-unmounted trigger right after the menu closes. That focus
+  // handoff blurred the freshly focused input and committed the untouched
+  // title, which read as "Rename does nothing" on Windows.
+  const ignoreMenuCloseBlurRef = useRef(false);
   const longPressTimerRef = useRef<number | null>(null);
   const longPressStartRef = useRef<{ x: number; y: number } | null>(null);
   const longPressTriggeredRef = useRef(false);
@@ -369,6 +374,14 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
     if (isInteractionDisabled) {
       return;
     }
+    onStartRenaming(item);
+  }, [isInteractionDisabled, item, onStartRenaming]);
+
+  const handleStartRenamingFromMenu = useCallback(() => {
+    if (isInteractionDisabled) {
+      return;
+    }
+    ignoreMenuCloseBlurRef.current = true;
     onStartRenaming(item);
   }, [isInteractionDisabled, item, onStartRenaming]);
 
@@ -584,7 +597,10 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
   const shouldShowMobilePressFeedback = isMobileMenuLayout && (isLongPressActive || menuOpen);
 
   useEffect(() => {
-    if (!isRenaming) return;
+    if (!isRenaming) {
+      ignoreMenuCloseBlurRef.current = false;
+      return;
+    }
     skipNextBlurCommitRef.current = false;
     inputRef.current?.focus();
     inputRef.current?.select();
@@ -656,6 +672,12 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
             onBlur={() => {
               if (skipNextBlurCommitRef.current) {
                 skipNextBlurCommitRef.current = false;
+                return;
+              }
+              if (ignoreMenuCloseBlurRef.current) {
+                ignoreMenuCloseBlurRef.current = false;
+                inputRef.current?.focus();
+                inputRef.current?.select();
                 return;
               }
               onCommitRename();
@@ -879,7 +901,7 @@ const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   disabled={isInteractionDisabled}
-                  onSelect={handleStartRenaming}
+                  onSelect={handleStartRenamingFromMenu}
                   className="gap-2"
                 >
                   <Edit3 className="h-3.5 w-3.5" />
@@ -1002,16 +1024,30 @@ const ProjectRow = memo(function ProjectRow(props: {
   const rowRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const skipNextBlurCommitRef = useRef(false);
+  // Same menu-close focus handoff as HistoryRow: the trigger unmounts when the
+  // row swaps to the rename input, so the first blur must not commit.
+  const ignoreMenuCloseBlurRef = useRef(false);
   const isDefaultProject = project.id === DEFAULT_WORKSPACE_PROJECT_ID;
   const isPinned = project.isPinned === true;
   const ProjectFolderIcon = isActive ? FolderOpen : FolderClosed;
 
   useEffect(() => {
-    if (!isRenaming) return;
+    if (!isRenaming) {
+      ignoreMenuCloseBlurRef.current = false;
+      return;
+    }
     skipNextBlurCommitRef.current = false;
     inputRef.current?.focus();
     inputRef.current?.select();
   }, [isRenaming]);
+
+  const handleStartRenamingFromMenu = useCallback(() => {
+    if (isInteractionDisabled) {
+      return;
+    }
+    ignoreMenuCloseBlurRef.current = true;
+    onStartRenamingProject(project);
+  }, [isInteractionDisabled, onStartRenamingProject, project]);
 
   const handleRequestRemove = useCallback(() => {
     if (isInteractionDisabled) {
@@ -1146,6 +1182,12 @@ const ProjectRow = memo(function ProjectRow(props: {
             onBlur={() => {
               if (skipNextBlurCommitRef.current) {
                 skipNextBlurCommitRef.current = false;
+                return;
+              }
+              if (ignoreMenuCloseBlurRef.current) {
+                ignoreMenuCloseBlurRef.current = false;
+                inputRef.current?.focus();
+                inputRef.current?.select();
                 return;
               }
               onCommitProjectRename();
@@ -1363,7 +1405,7 @@ const ProjectRow = memo(function ProjectRow(props: {
                       <>
                         <DropdownMenuItem
                           disabled={isInteractionDisabled}
-                          onSelect={() => onStartRenamingProject(project)}
+                          onSelect={handleStartRenamingFromMenu}
                           className="gap-2"
                         >
                           <Edit3 className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Linked issue

Closes #415

## Summary

Windows 桌面端从会话（和工作空间）的下拉菜单里点「修改标题」，输入框会瞬间闪现后立刻退回原标题，表现为「改名无响应」。

根因是焦点交接，不是菜单没触发。行在 `isRenaming` 翻转时把整个 trigger 子树换成了重命名输入框，而 Base UI 的 `FloatingFocusManager` 在菜单卸载时会在一个 microtask 里把焦点还给 trigger；此时 trigger 已随子树卸载（`domReference?.isConnected === false`），焦点落到回退元素上，把刚聚焦的输入框 blur 掉，`onBlur` 于是用未改动的原标题调用了 `onCommitRename()` 并退出编辑态。

修复把「菜单入口改名」和「双击改名」拆成两个 handler，只有菜单入口会置位 `ignoreMenuCloseBlurRef`，让输入框吞掉这一次由菜单关闭引发的 blur 并重新聚焦；双击改名和正常失焦提交的行为不变。会话行和工作空间行走同一套下拉菜单，两处都改了；移动端长按/右键复用同一菜单，一并覆盖。

## Change scope

- Modules: agent-ui（共享 UI）/ agent-gui（测试）
- Key paths:
  - `crates/agent-ui/src/components/chat/ChatHistorySidebar.tsx` — `HistoryRow` 与 `ProjectRow` 各新增 `ignoreMenuCloseBlurRef` 守卫和 `handleStartRenamingFromMenu`
  - `crates/agent-gui/test/chat/sidebar-selection.test.mjs` — 新增 1 条回归用例

## Screenshots / preview

暂缺。本次改动的验证是自动化检查（见下），未附运行时录屏——按模板规则这会使 PR 自动转为 draft，补录后再转正式。改动是纯焦点时序修复，无视觉变化，人工验证路径为三条：菜单改名、双击改名、点击输入框外提交。

## Verification

全部在本机复跑通过：

| 检查 | 结果 |
| --- | --- |
| `pnpm --dir crates/agent-gui exec tsc` | exit 0 |
| `node --test test/chat/sidebar-selection.test.mjs` | 8/8 |
| `pnpm test:gui` | 1517/1517 |
| `pnpm test:webui` | 550/550 |
| `pnpm build:gui`（tsc + vite） | ✓ |
| `pnpm build:webui` | ✓ |
| `node scripts/check-ui-boundaries.mjs` | 通过 |
| `pnpm lint:gui` | exit 0 |
| biome `ChatHistorySidebar.tsx` | exit 0 |

`pnpm lint:ui` 报 2 个 error，位于 `WorkspaceResourceSettingsDrawer.tsx` 和 `ResourceActivationSwitch.tsx`；`git diff` 确认这两个文件本次未改动，属既有问题，不在本 PR 范围内。

### 给 reviewer 的两点说明

1. **守卫标志位可能悬留。** `ignoreMenuCloseBlurRef` 只在首次 blur 或 `isRenaming` 变 false 时清除。Base UI 的 return-focus 有前置条件（回退元素需已连接且可聚焦），若该条件不满足就不会产生那次 blur，标志位会一直保持到本次改名结束，从而吞掉用户**真实的**首次外部点击（不提交、焦点被抢回并全选）。Enter/Escape 不受影响，再点一次也能提交，属可恢复降级。更稳妥的做法是改用 Base UI 声明式出口 `Menu.Popup` 的 `finalFocus`（`DropdownMenuContent` 已透传 props，传 `finalFocus={inputRef}` 可从源头消除这次交接），如 reviewer 倾向该方案我可以改。
2. **新增用例是源码正则断言，不是行为测试。** 仓库无 jsdom / testing-library，`test/settings/git-review-menu-position.test.mjs` 等约 30 处沿用同一约定，所以这是既有做法而非本 PR 引入；但它挡不住上面第 1 点的场景，也会被无害的格式改动碰红。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.（无用户可见行为/部署/配置变更，N/A）
