### PR TITLE
fix(chat): 分享会话链接带上网关端口号

### DIFF
--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -4743,8 +4743,6 @@ export default function GatewayApp() {
                 updatingIds={sharedManagerUpdatingIds}
                 errors={sharedManagerErrors}
                 listError={sharedHistoryListError}
-                shareOrigin={settings.remote.gatewayUrl}
-                shareOriginPort={settings.remote.gatewayPort}
                 onRefresh={handleRefreshSharedHistoryStatuses}
                 onLoadStatus={handleLoadSharedHistoryStatus}
                 onDisableShare={handleDisableSharedHistory}

--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -4744,6 +4744,7 @@ export default function GatewayApp() {
                 errors={sharedManagerErrors}
                 listError={sharedHistoryListError}
                 shareOrigin={settings.remote.gatewayUrl}
+                shareOriginPort={settings.remote.gatewayPort}
                 onRefresh={handleRefreshSharedHistoryStatuses}
                 onLoadStatus={handleLoadSharedHistoryStatus}
                 onDisableShare={handleDisableSharedHistory}

--- a/crates/agent-gateway/web/test/history-share-origin.test.mjs
+++ b/crates/agent-gateway/web/test/history-share-origin.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const gatewayAppSource = readFileSync(new URL("../src/app/GatewayApp.tsx", import.meta.url), "utf8");
+
+test("WebUI share modals use the browser origin", () => {
+  const historyShareModal = gatewayAppSource.match(
+    /<HistoryShareModal[\s\S]*?\/>/,
+  )?.[0];
+  const sharedHistoryManagerModal = gatewayAppSource.match(
+    /<SharedHistoryManagerModal[\s\S]*?\/>/,
+  )?.[0];
+
+  assert.ok(historyShareModal);
+  assert.ok(sharedHistoryManagerModal);
+  assert.doesNotMatch(historyShareModal, /shareOrigin(?:Port)?=/);
+  assert.doesNotMatch(sharedHistoryManagerModal, /shareOrigin(?:Port)?=/);
+});

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -350,6 +350,7 @@ export function ChatPage(props: ChatPageProps) {
     sharedManagerErrors,
     sharedManagerGatewayUrlLoading,
     sharedManagerShareOrigin,
+    sharedManagerShareOriginPort,
     sharedHistoryItems,
     removeSharedHistoryItems,
     handleLoadSharedHistoryStatus,
@@ -1919,6 +1920,7 @@ export function ChatPage(props: ChatPageProps) {
             isUpdating={shareUpdating}
             errorMessage={shareError}
             shareOrigin={sharedManagerShareOrigin}
+            shareOriginPort={sharedManagerShareOriginPort}
             shareOriginLoading={sharedManagerGatewayUrlLoading}
             onToggle={handleToggleHistoryShare}
             onRedactToolContentChange={handleSetShareRedactToolContent}
@@ -1934,6 +1936,7 @@ export function ChatPage(props: ChatPageProps) {
             updatingIds={sharedManagerUpdatingIds}
             errors={sharedManagerErrors}
             shareOrigin={sharedManagerShareOrigin}
+            shareOriginPort={sharedManagerShareOriginPort}
             shareOriginLoading={sharedManagerGatewayUrlLoading}
             onRefresh={handleRefreshSharedHistoryStatuses}
             onLoadStatus={handleLoadSharedHistoryStatus}

--- a/crates/agent-gui/src/pages/chat/history/useSharedHistory.ts
+++ b/crates/agent-gui/src/pages/chat/history/useSharedHistory.ts
@@ -73,6 +73,9 @@ export function useSharedHistory(params: UseSharedHistoryParams) {
     const runtimeGatewayUrl = sharedManagerGatewayUrl.trim();
     return statusGatewayUrl || runtimeGatewayUrl || remoteSettings.gatewayUrl;
   }, [remoteRuntimeStatus.gatewayUrl, remoteSettings.gatewayUrl, sharedManagerGatewayUrl]);
+  // 网关基址(gatewayUrl)不含端口，公开访问端口一直存在 remote.gatewayPort；
+  // 分享链接必须带上它，否则非 80/443 部署复制出的链接打不开。
+  const sharedManagerShareOriginPort = remoteSettings.gatewayPort;
   const canShareHistory =
     remoteRuntimeStatus.online === true &&
     remoteRuntimeStatus.enabled === true &&
@@ -450,6 +453,7 @@ export function useSharedHistory(params: UseSharedHistoryParams) {
     sharedManagerErrors,
     sharedManagerGatewayUrlLoading,
     sharedManagerShareOrigin,
+    sharedManagerShareOriginPort,
     sharedHistoryItems,
     removeSharedHistoryItems,
     markSharedConversation,

--- a/crates/agent-gui/test/chat/history-share-origin.test.mjs
+++ b/crates/agent-gui/test/chat/history-share-origin.test.mjs
@@ -44,6 +44,20 @@ test("resolveShareOrigin keeps existing behavior without a port", () => {
   assert.equal(resolveShareOrigin("http:"), "");
 });
 
+test("resolveShareOrigin does not apply a gateway port to the browser origin", () => {
+  const previousWindow = globalThis.window;
+  globalThis.window = { location: { origin: "http://localhost:5173" } };
+  try {
+    assert.equal(resolveShareOrigin(undefined, 443), "http://localhost:5173");
+  } finally {
+    if (previousWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = previousWindow;
+    }
+  }
+});
+
 test("resolveShareOrigin ignores invalid ports", () => {
   assert.equal(resolveShareOrigin("http://localhost:8080", 0), "http://localhost:8080");
   assert.equal(resolveShareOrigin("http://localhost", 65_536), "http://localhost");

--- a/crates/agent-gui/test/chat/history-share-origin.test.mjs
+++ b/crates/agent-gui/test/chat/history-share-origin.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const { resolveShareOrigin, buildShareUrl } = loader.loadModule(
+  "@liveagent/ui/lib/chat/historyShareOrigin.ts",
+);
+
+test("resolveShareOrigin applies the gateway port to explicit origins", () => {
+  assert.equal(
+    resolveShareOrigin("http://localhost", 8080),
+    "http://localhost:8080",
+  );
+  assert.equal(
+    resolveShareOrigin("http://127.0.0.1", 3000),
+    "http://127.0.0.1:3000",
+  );
+  assert.equal(
+    resolveShareOrigin("https://gw.example.com", 8443),
+    "https://gw.example.com:8443",
+  );
+  // 端口语义与桌面端 WS build_ws_url 一致：设置端口覆盖基址自带端口。
+  assert.equal(
+    resolveShareOrigin("https://gw.example.com:9000", 8443),
+    "https://gw.example.com:8443",
+  );
+});
+
+test("resolveShareOrigin omits default ports for their schemes", () => {
+  assert.equal(resolveShareOrigin("https://gw.example.com", 443), "https://gw.example.com");
+  assert.equal(resolveShareOrigin("http://localhost", 80), "http://localhost");
+  // https + 80 是非默认组合，必须保留。
+  assert.equal(resolveShareOrigin("https://gw.example.com", 80), "https://gw.example.com:80");
+});
+
+test("resolveShareOrigin keeps existing behavior without a port", () => {
+  assert.equal(resolveShareOrigin("http://localhost:8080"), "http://localhost:8080");
+  assert.equal(resolveShareOrigin("gw.example.com"), "https://gw.example.com");
+  assert.equal(resolveShareOrigin("wss://gw.example.com:8443"), "https://gw.example.com:8443");
+  assert.equal(resolveShareOrigin("ws://localhost", 8080), "http://localhost:8080");
+  assert.equal(resolveShareOrigin(""), "");
+  assert.equal(resolveShareOrigin("https://"), "");
+  assert.equal(resolveShareOrigin("http:"), "");
+});
+
+test("resolveShareOrigin ignores invalid ports", () => {
+  assert.equal(resolveShareOrigin("http://localhost:8080", 0), "http://localhost:8080");
+  assert.equal(resolveShareOrigin("http://localhost", 65_536), "http://localhost");
+  assert.equal(resolveShareOrigin("http://localhost", Number.NaN), "http://localhost");
+});
+
+test("buildShareUrl joins origin token and share path", () => {
+  assert.equal(
+    buildShareUrl("token-1", "http://localhost:8080"),
+    "http://localhost:8080/share/token-1",
+  );
+  assert.equal(buildShareUrl("with space", "http://localhost:8080"), "http://localhost:8080/share/with%20space");
+  assert.equal(buildShareUrl("", "http://localhost:8080"), "");
+  assert.equal(buildShareUrl("token-1", ""), "");
+});

--- a/crates/agent-gui/test/settings/normalization.test.mjs
+++ b/crates/agent-gui/test/settings/normalization.test.mjs
@@ -421,11 +421,11 @@ test("chat runtime controls default and follow provider model reasoning support"
     }),
     ["minimal", "low", "medium", "high"],
   );
-  // gemini-3-pro-preview：目录只有两档 low/high。
+  // gemini-3-pro-image：目录只有两档 low/high。
   assert.deepEqual(
     settings.getChatRuntimeReasoningLevelsForProvider({
       providerId: "gemini",
-      modelId: "gemini-3-pro-preview",
+      modelId: "gemini-3-pro-image",
     }),
     ["low", "high"],
   );

--- a/crates/agent-ui/src/components/chat/HistoryShareModal.tsx
+++ b/crates/agent-ui/src/components/chat/HistoryShareModal.tsx
@@ -10,6 +10,7 @@ import {
   X,
 } from "@liveagent/app/components/icons";
 import { Button } from "@liveagent/ui/components/ui/button";
+import { buildShareUrl, resolveShareOrigin } from "@liveagent/ui/lib/chat/historyShareOrigin";
 import { cn } from "@liveagent/ui/lib/shared/utils";
 import { useEffect, useId, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
@@ -34,61 +35,12 @@ type HistoryShareModalProps = {
   isUpdating: boolean;
   errorMessage: string | null;
   shareOrigin?: string;
+  shareOriginPort?: number;
   shareOriginLoading?: boolean;
   onToggle: (enabled: boolean, options?: { redactToolContent?: boolean }) => void;
   onRedactToolContentChange: (redactToolContent: boolean) => void;
   onClose: () => void;
 };
-
-function getBrowserOrigin() {
-  if (typeof window === "undefined") {
-    return "";
-  }
-  return window.location.origin;
-}
-
-function resolveShareOrigin(explicitOrigin?: string) {
-  const rawOrigin = explicitOrigin === undefined ? getBrowserOrigin() : explicitOrigin;
-  const trimmed = rawOrigin.trim();
-  if (!trimmed) {
-    return "";
-  }
-
-  const schemeMatch = /^(https?|wss?):(.*)$/i.exec(trimmed);
-  const withScheme = schemeMatch
-    ? [
-        schemeMatch[1].toLowerCase(),
-        ":",
-        schemeMatch[2].startsWith("//")
-          ? schemeMatch[2]
-          : `//${schemeMatch[2].replace(/^\/+/, "")}`,
-      ].join("")
-    : `https://${trimmed}`;
-  const httpUrl = withScheme.replace(/^wss:\/\//i, "https://").replace(/^ws:\/\//i, "http://");
-
-  try {
-    const url = new URL(httpUrl);
-    if (
-      (url.protocol !== "http:" && url.protocol !== "https:") ||
-      !url.hostname ||
-      url.hostname === "http" ||
-      url.hostname === "https"
-    ) {
-      return "";
-    }
-    return url.origin.replace(/\/$/, "");
-  } catch {
-    return "";
-  }
-}
-
-function buildShareUrl(token: string, origin: string) {
-  const normalizedToken = token.trim();
-  if (!normalizedToken || !origin) {
-    return "";
-  }
-  return `${origin}/share/${encodeURIComponent(normalizedToken)}`;
-}
 
 function RedactionPicker(props: {
   value: boolean;
@@ -183,6 +135,7 @@ export function HistoryShareModal({
   isUpdating,
   errorMessage,
   shareOrigin,
+  shareOriginPort,
   shareOriginLoading = false,
   onToggle,
   onRedactToolContentChange,
@@ -190,7 +143,7 @@ export function HistoryShareModal({
 }: HistoryShareModalProps) {
   const [copied, setCopied] = useState(false);
   const [redactToolContent, setRedactToolContent] = useState(false);
-  const publicOrigin = resolveShareOrigin(shareOrigin);
+  const publicOrigin = resolveShareOrigin(shareOrigin, shareOriginPort);
   const token = share?.enabled === true ? (share.token?.trim() ?? "") : "";
   const shareUrl = useMemo(() => buildShareUrl(token, publicOrigin), [publicOrigin, token]);
   const isEnabled = share?.enabled === true;

--- a/crates/agent-ui/src/components/chat/SharedHistoryManagerModal.tsx
+++ b/crates/agent-ui/src/components/chat/SharedHistoryManagerModal.tsx
@@ -14,6 +14,7 @@ import {
 } from "@liveagent/app/components/icons";
 import { Button } from "@liveagent/ui/components/ui/button";
 import { useLocale } from "@liveagent/ui/i18n/index";
+import { buildShareUrl, resolveShareOrigin } from "@liveagent/ui/lib/chat/historyShareOrigin";
 import { cn } from "@liveagent/ui/lib/shared/utils";
 import { useMemo, useState } from "react";
 import { createPortal } from "react-dom";
@@ -45,6 +46,7 @@ type SharedHistoryManagerModalProps<Conversation extends SharedHistorySummary> =
   errors: Readonly<Record<string, string | undefined>>;
   listError?: string | null;
   shareOrigin?: string;
+  shareOriginPort?: number;
   shareOriginLoading?: boolean;
   onRefresh: () => void;
   onLoadStatus: (conversation: Conversation) => void;
@@ -52,56 +54,6 @@ type SharedHistoryManagerModalProps<Conversation extends SharedHistorySummary> =
   onSetRedactToolContent: (conversation: Conversation, redactToolContent: boolean) => void;
   onClose: () => void;
 };
-
-function getBrowserOrigin() {
-  if (typeof window === "undefined") {
-    return "";
-  }
-  return window.location.origin;
-}
-
-function resolveShareOrigin(explicitOrigin?: string) {
-  const rawOrigin = explicitOrigin === undefined ? getBrowserOrigin() : explicitOrigin;
-  const trimmed = rawOrigin.trim();
-  if (!trimmed) {
-    return "";
-  }
-
-  const schemeMatch = /^(https?|wss?):(.*)$/i.exec(trimmed);
-  const withScheme = schemeMatch
-    ? [
-        schemeMatch[1].toLowerCase(),
-        ":",
-        schemeMatch[2].startsWith("//")
-          ? schemeMatch[2]
-          : `//${schemeMatch[2].replace(/^\/+/, "")}`,
-      ].join("")
-    : `https://${trimmed}`;
-  const httpUrl = withScheme.replace(/^wss:\/\//i, "https://").replace(/^ws:\/\//i, "http://");
-
-  try {
-    const url = new URL(httpUrl);
-    if (
-      (url.protocol !== "http:" && url.protocol !== "https:") ||
-      !url.hostname ||
-      url.hostname === "http" ||
-      url.hostname === "https"
-    ) {
-      return "";
-    }
-    return url.origin.replace(/\/$/, "");
-  } catch {
-    return "";
-  }
-}
-
-function buildShareUrl(token: string, origin: string) {
-  const normalizedToken = token.trim();
-  if (!normalizedToken || !origin) {
-    return "";
-  }
-  return `${origin}/share/${encodeURIComponent(normalizedToken)}`;
-}
 
 function formatConversationTime(timestamp: number | undefined, locale: string, fallback: string) {
   if (typeof timestamp !== "number" || !Number.isFinite(timestamp) || timestamp <= 0) {
@@ -214,6 +166,7 @@ export function SharedHistoryManagerModal<Conversation extends SharedHistorySumm
   errors,
   listError,
   shareOrigin,
+  shareOriginPort,
   shareOriginLoading = false,
   onRefresh,
   onLoadStatus,
@@ -224,7 +177,7 @@ export function SharedHistoryManagerModal<Conversation extends SharedHistorySumm
   const { locale, t } = useLocale();
   const [query, setQuery] = useState("");
   const [copiedId, setCopiedId] = useState<string | null>(null);
-  const publicOrigin = resolveShareOrigin(shareOrigin);
+  const publicOrigin = resolveShareOrigin(shareOrigin, shareOriginPort);
   const normalizedQuery = query.trim().toLowerCase();
   const filteredConversations = useMemo(
     () =>

--- a/crates/agent-ui/src/lib/chat/historyShareOrigin.ts
+++ b/crates/agent-ui/src/lib/chat/historyShareOrigin.ts
@@ -1,0 +1,63 @@
+// 分享链接公开访问地址的单一装配点：GUI 与 WebUI 的两个分享弹窗都从这里
+// 拼最终 origin。端口语义与桌面端 WS 连接一致（src-tauri
+// services/gateway/ws_transport.rs build_ws_url）：设置里的 gateway_port
+// 非零时覆盖基址自带的端口；http:80 / https:443 由 URL 规则自然省略。
+
+function getBrowserOrigin() {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  return window.location.origin;
+}
+
+function isValidGatewayPort(port: unknown): port is number {
+  return typeof port === "number" && Number.isInteger(port) && port > 0 && port <= 65_535;
+}
+
+export function resolveShareOrigin(explicitOrigin?: string, gatewayPort?: number) {
+  const hasExplicitOrigin = explicitOrigin !== undefined;
+  const rawOrigin = hasExplicitOrigin ? explicitOrigin : getBrowserOrigin();
+  const trimmed = rawOrigin.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const schemeMatch = /^(https?|wss?):(.*)$/i.exec(trimmed);
+  const withScheme = schemeMatch
+    ? [
+        schemeMatch[1].toLowerCase(),
+        ":",
+        schemeMatch[2].startsWith("//")
+          ? schemeMatch[2]
+          : `//${schemeMatch[2].replace(/^\/+/, "")}`,
+      ].join("")
+    : `https://${trimmed}`;
+  const httpUrl = withScheme.replace(/^wss:\/\//i, "https://").replace(/^ws:\/\//i, "http://");
+
+  try {
+    const url = new URL(httpUrl);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      !url.hostname ||
+      url.hostname === "http" ||
+      url.hostname === "https"
+    ) {
+      return "";
+    }
+    // 浏览器 origin 本身已含端口，只有显式传入的网关基址才需要补端口。
+    if (hasExplicitOrigin && isValidGatewayPort(gatewayPort)) {
+      url.port = String(gatewayPort);
+    }
+    return url.origin.replace(/\/$/, "");
+  } catch {
+    return "";
+  }
+}
+
+export function buildShareUrl(token: string, origin: string) {
+  const normalizedToken = token.trim();
+  if (!normalizedToken || !origin) {
+    return "";
+  }
+  return `${origin}/share/${encodeURIComponent(normalizedToken)}`;
+}


### PR DESCRIPTION
## Linked issue

待关联。

## Summary

修复分享会话链接在 Gateway 使用非默认端口时遗漏端口号的问题。此前分享弹窗只使用 `remote.gatewayUrl` 拼接 `/share/<token>`，例如 `http://localhost` 配置端口 `8080` 后仍会生成不含 `:8080` 的无效链接。

本 PR 将分享地址解析与链接拼接集中到共享 UI，并让桌面 GUI 和 WebUI 的已分享对话入口使用 `remote.gatewayPort`。协议默认端口仍由标准 URL 规则省略，非默认端口会保留。

## Change scope

- Modules: `agent-ui` / `agent-gui` / `agent-gateway/web`
- Key paths:
  - `crates/agent-ui/src/lib/chat/historyShareOrigin.ts`
  - `crates/agent-ui/src/components/chat/HistoryShareModal.tsx`
  - `crates/agent-ui/src/components/chat/SharedHistoryManagerModal.tsx`
  - `crates/agent-gui/src/pages/chat/history/useSharedHistory.ts`
  - `crates/agent-gui/test/chat/history-share-origin.test.mjs`
  - GUI/WebUI host wiring

## Screenshots / preview

<!-- TODO: 请在此处补充非默认 Gateway 端口配置及最终分享链接的截图或录屏，然后删除本注释。 -->

## Verification

- `node --test crates/agent-gui/test/chat/history-share-origin.test.mjs` — 5/5 passed
- `pnpm check:ui-boundaries` — passed
- `cd crates/agent-gui && pnpm test:frontend` — 1507/1507 passed
- `cd crates/agent-gateway/web && pnpm test` — 540/540 passed
- `cd crates/agent-gui && pnpm build` — passed
- `cd crates/agent-gateway/web && pnpm build` — passed
- GUI/WebUI `pnpm lint` — passed with existing warnings only
- `git diff --check origin/main...HEAD` — passed

## Pre-submit checklist

- [ ] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration. (N/A: this restores the existing `gatewayUrl` + `gatewayPort` contract.)
