### PR TITLE
refactor(ui): 适配 context-usage-ring WIP 中未落地的共享化修复批次

### DIFF
--- a/crates/agent-gateway/test/webui/web-settings.test.mjs
+++ b/crates/agent-gateway/test/webui/web-settings.test.mjs
@@ -598,6 +598,57 @@ test("Anthropic settings keep 1M context parity for adaptive and explicit relay 
     ).contextWindow,
     200_000,
   );
+  assert.equal(
+    settings.findProviderModelConfig(
+      {
+        models: [
+          {
+            id: "custom-context-model[1m]",
+            contextWindow: 2_000_000,
+            maxOutputToken: 64_000,
+          },
+        ],
+        type: "claude_code",
+      },
+      "custom-context-model[1m]",
+    ).contextWindow,
+    2_000_000,
+  );
+});
+
+test("desktop model context-window edits replace stale WebUI provider values", () => {
+  const current = settings.normalizeSettings({
+    customProviders: [
+      {
+        id: "context-provider",
+        name: "Context Provider",
+        type: "codex",
+        models: [
+          {
+            id: "context-model",
+            contextWindow: 128_000,
+            maxOutputToken: 16_000,
+          },
+        ],
+        activeModels: ["context-model"],
+      },
+    ],
+  });
+  const desktop = settings.normalizeSettings({
+    ...current,
+    customProviders: current.customProviders.map((provider) => ({
+      ...provider,
+      models: provider.models.map((model) => ({ ...model, contextWindow: 512_000 })),
+    })),
+  });
+  const synced = settingsSync.applyGatewaySettingsSyncPayload(
+    current,
+    settingsSync.buildGatewaySettingsSyncPayload(desktop),
+  );
+  const provider = synced.customProviders.find((item) => item.id === "context-provider");
+
+  assert.ok(provider);
+  assert.equal(settings.findProviderModelConfig(provider, "context-model").contextWindow, 512_000);
 });
 
 test("loadWebSettings forces current gateway URL/token over stale persisted remote settings", () => {

--- a/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
+++ b/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
@@ -1,20 +1,19 @@
 import {
   AssistantAvatar,
   AssistantBubble,
-  AssistantStatus,
-  CompactingText,
-  RetryDetailsBlock,
-  VibingText,
+  LiveAssistantStatus,
 } from "@liveagent/ui/components/chat/AssistantBubble";
 import { ChatEmptyState } from "@liveagent/ui/components/chat/ChatEmptyState";
+import { ContextCheckpointCard } from "@liveagent/ui/components/chat/ContextCheckpointCard";
 import { getUploadedFileTypeIcon } from "@liveagent/ui/components/chat/fileTypeIcons";
 import { ImagePreview, type ImagePreviewSlide } from "@liveagent/ui/components/chat/ImagePreview";
+import { RetryDetailsBlock } from "@liveagent/ui/components/chat/RetryDetailsBlock";
 import {
   TranscriptAssistantMessageActions,
   TranscriptUserMessageActions,
 } from "@liveagent/ui/components/chat/TranscriptMessageActions";
-import { Markdown } from "@liveagent/ui/components/Markdown";
 import { useLocale } from "@liveagent/ui/i18n/LocaleContext";
+import { normalizeLiveToolStatus, VIBING_STATUS } from "@liveagent/ui/lib/chat/assistantStatus";
 import type { ChatFileLink } from "@liveagent/ui/lib/chat/chatFileLinks";
 import {
   getUploadedImagePreviewCacheKey,
@@ -48,7 +47,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { normalizeLiveToolStatus, VIBING_STATUS } from "@/lib/chat/chatPageHelpers";
 import type { HistoryMessageRef } from "@/lib/chat/conversationState";
 import { getRoundText } from "@/lib/chat/uiMessages";
 import {
@@ -66,7 +64,7 @@ import { DEFAULT_CHAT_TRANSCRIPT_WIDTH } from "@/lib/settings";
 import { extractLiveRange } from "@/lib/transcript-virtual/liveRangeExtractor";
 import type { RetryAttemptRecord, TranscriptRow } from "../lib/chat/transcript/types";
 import type { SectionId } from "../pages/settings/types";
-import { CheckCircle2, ChevronDown, Loader2, X } from "./icons";
+import { Loader2, X } from "./icons";
 
 type GatewayTranscriptProps = {
   conversationId?: string;
@@ -102,7 +100,6 @@ type GatewayTranscriptProps = {
   hasMoreHistory?: boolean;
   isLoadingMoreHistory?: boolean;
   onLoadEarlierHistory?: () => void;
-  isAgentMode?: boolean;
   showUsage?: boolean;
   usageContextWindow?: number;
   workspaceRoot?: string;
@@ -161,13 +158,7 @@ function LiveStatusFooter(props: { status: string; isCompaction?: boolean }) {
   const { status, isCompaction = false } = props;
   return (
     <div className="gateway-live-status-footer ml-9 min-w-0 overflow-hidden pt-1">
-      {isCompaction ? (
-        <CompactingText className="w-full" />
-      ) : status === VIBING_STATUS ? (
-        <VibingText className="w-full" />
-      ) : (
-        <AssistantStatus className="w-full">{status}</AssistantStatus>
-      )}
+      <LiveAssistantStatus status={status} isCompaction={isCompaction} className="w-full" />
     </div>
   );
 }
@@ -200,62 +191,17 @@ function CheckpointCard(props: {
   readOnly?: boolean;
 }) {
   const { item, readOnly = false } = props;
-  const { t } = useLocale();
-  const [expanded, setExpanded] = useState(false);
-  const isExpanded = expanded;
-  const messageCountLabel =
-    item.coveredMessageCount > 0
-      ? t("chat.contextCheckpoint.messageCount").replace(
-          "{count}",
-          String(item.coveredMessageCount),
-        )
-      : t("chat.contextCheckpoint.compressed");
-  const headerContent = (
-    <>
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-black/[0.04] dark:bg-white/[0.08]">
-        <CheckCircle2 size={16} strokeWidth={1.8} className="text-muted-foreground" />
-      </div>
-
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="text-[calc(13px*var(--zone-font-scale,1))] font-medium text-foreground/90">
-            {t("chat.contextCheckpoint.title")}
-          </span>
-          <span className="inline-flex items-center rounded-md bg-black/[0.05] px-1.5 py-[1px] text-[calc(11px*var(--zone-font-scale,1))] font-normal tabular-nums text-muted-foreground dark:bg-white/[0.08]">
-            {messageCountLabel}
-          </span>
-        </div>
-        <div className="mt-[2px] text-[calc(11px*var(--zone-font-scale,1))] text-muted-foreground/70">
-          {item.generatedBy.providerId} · {item.generatedBy.model}
-        </div>
-      </div>
-
-      <ChevronDown
-        className={`h-3.5 w-3.5 shrink-0 text-muted-foreground/50 transition-transform duration-200 ${isExpanded ? "rotate-0" : "-rotate-90"}`}
-      />
-    </>
-  );
 
   return (
     <div className="checkpoint-row flex w-full max-w-full items-start gap-3">
       <div className="checkpoint-row-spacer mt-0.5 h-6 w-6 shrink-0" aria-hidden="true" />
       <div className="checkpoint-row-body min-w-0 flex-1">
-        <div className="checkpoint-card w-full overflow-hidden rounded-[14px] border border-black/[0.06] bg-white/[0.85] shadow-[0_1px_3px_rgba(0,0,0,0.04),0_4px_12px_rgba(0,0,0,0.03)] dark:border-white/[0.1] dark:bg-white/[0.06] dark:shadow-[0_1px_3px_rgba(0,0,0,0.2),0_4px_12px_rgba(0,0,0,0.15)]">
-          <button
-            type="button"
-            aria-expanded={isExpanded}
-            onClick={() => setExpanded((prev) => !prev)}
-            className="flex w-full items-center gap-3 px-3.5 py-3 text-left transition-colors duration-150 hover:bg-black/[0.02] dark:hover:bg-white/[0.03]"
-          >
-            {headerContent}
-          </button>
-
-          {isExpanded ? (
-            <div className="checkpoint-expand border-t border-black/[0.05] px-3.5 py-3 dark:border-white/[0.06]">
-              <Markdown content={item.content} className="font-chat text-sm" readOnly={readOnly} />
-            </div>
-          ) : null}
-        </div>
+        <ContextCheckpointCard
+          content={item.content}
+          coveredMessageCount={item.coveredMessageCount}
+          generatedBy={item.generatedBy}
+          readOnly={readOnly}
+        />
       </div>
     </div>
   );
@@ -1063,7 +1009,6 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
   isLoadingMoreHistory?: boolean;
   onLoadEarlierHistory?: () => void;
   isStreaming: boolean;
-  isAgentMode: boolean;
   showUsage: boolean;
   usageContextWindow?: number;
   workspaceRoot?: string;
@@ -1098,7 +1043,6 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
     isLoadingMoreHistory,
     onLoadEarlierHistory,
     isStreaming,
-    isAgentMode,
     showUsage,
     usageContextWindow,
     workspaceRoot,
@@ -1501,37 +1445,12 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
               <div className="flex w-full max-w-full items-start gap-3">
                 <AssistantAvatar />
                 <div className="min-w-0 flex-1 space-y-2 pt-1">
-                  {displayedToolStatusIsCompaction ? (
-                    <div className="flex items-center py-1">
-                      <CompactingText />
-                    </div>
-                  ) : isAgentMode ? (
-                    displayedToolStatus === VIBING_STATUS ? (
-                      <div className="flex items-center py-1">
-                        <VibingText />
-                      </div>
-                    ) : displayedToolStatus ? (
-                      <div className="py-1">
-                        <AssistantStatus>{displayedToolStatus}</AssistantStatus>
-                      </div>
-                    ) : (
-                      <div className="py-1">
-                        <VibingText />
-                      </div>
-                    )
-                  ) : displayedToolStatus === VIBING_STATUS ? (
-                    <div className="flex items-center py-1">
-                      <VibingText />
-                    </div>
-                  ) : displayedToolStatus ? (
-                    <div className="py-1">
-                      <AssistantStatus>{displayedToolStatus}</AssistantStatus>
-                    </div>
-                  ) : (
-                    <div className="py-1">
-                      <VibingText />
-                    </div>
-                  )}
+                  <div className="flex items-center py-1">
+                    <LiveAssistantStatus
+                      status={displayedToolStatus}
+                      isCompaction={displayedToolStatusIsCompaction}
+                    />
+                  </div>
                   {retryAttempts && retryAttempts.length > 0 ? (
                     <RetryDetailsBlock attempts={retryAttempts} />
                   ) : null}
@@ -1682,7 +1601,6 @@ export function GatewayTranscript({
   hasMoreHistory = false,
   isLoadingMoreHistory = false,
   onLoadEarlierHistory,
-  isAgentMode = true,
   showUsage = false,
   usageContextWindow,
   workspaceRoot,
@@ -1763,7 +1681,6 @@ export function GatewayTranscript({
           isLoadingMoreHistory={isLoadingMoreHistory}
           onLoadEarlierHistory={onLoadEarlierHistory}
           isStreaming={isStreaming}
-          isAgentMode={isAgentMode}
           showUsage={showUsage}
           usageContextWindow={usageContextWindow}
           workspaceRoot={workspaceRoot}

--- a/crates/agent-gateway/web/src/lib/chat/assistantBubbleAdapter.ts
+++ b/crates/agent-gateway/web/src/lib/chat/assistantBubbleAdapter.ts
@@ -16,11 +16,9 @@ export type {
   SkillsManagerResultDetails,
   WriteResultDetails,
 } from "../tools/builtinTypes";
-export { normalizeLiveToolStatus, VIBING_STATUS } from "./chatPageHelpers";
 export { deriveFileChangeStats } from "./fileChangeStats";
 export type { HostedSearchBlock } from "./hostedSearch";
 export { deriveFileToolPreview, FILE_TOOL_TEXT_FIELDS } from "./toolPreview";
-export type { RetryAttemptRecord } from "./transcript/types";
 export {
   previewText,
   safeStringify,

--- a/crates/agent-gateway/web/src/lib/chat/chatPageHelpers.ts
+++ b/crates/agent-gateway/web/src/lib/chat/chatPageHelpers.ts
@@ -1,10 +1,6 @@
 import { type ModelOption, toModelValue } from "../providers/llm";
 import type { AppSettings } from "../settings";
 
-const MODEL_GENERATING_STATUS_PATTERN = /^第\s*\d+\s*轮：模型生成中\.\.\.$/;
-
-export const VIBING_STATUS = "Vibing...";
-
 export type ModelOptionGroup = {
   id: string;
   name: string;
@@ -102,11 +98,6 @@ export function buildModelOptions(
   const [selectedOption] = options.splice(selectedIndex, 1);
   options.unshift(selectedOption);
   return options;
-}
-
-export function normalizeLiveToolStatus(status: string | null) {
-  if (status && MODEL_GENERATING_STATUS_PATTERN.test(status)) return VIBING_STATUS;
-  return status;
 }
 
 export function isAbortLikeError(error: unknown) {

--- a/crates/agent-gateway/web/src/lib/chat/transcript/types.ts
+++ b/crates/agent-gateway/web/src/lib/chat/transcript/types.ts
@@ -1,3 +1,4 @@
+import type { RetryAttemptRecord } from "@liveagent/ui/lib/chat/retryAttempts";
 import type { HistoryMessageRef } from "@/lib/chat/conversationState";
 import type { StreamRunActivity } from "@/lib/chat/stream/streamTypes";
 import type { PendingUploadedFile } from "@/lib/chat/uploadedFiles";
@@ -8,11 +9,8 @@ export type UserChatEntry = Extract<ChatEntry, { kind: "user" }>;
 // One failed-and-retried network attempt of the live run's model request,
 // mirrored from the desktop's stream-retry layer over the tool_status event.
 // attempt/maxAttempts are retry ordinals (1..5 of 5), not total attempts.
-export type RetryAttemptRecord = {
-  attempt: number;
-  maxAttempts: number;
-  errorMessage: string;
-};
+// 类型真源在共享包 lib/chat/retryAttempts；此处 re-export 供既有导入路径。
+export type { RetryAttemptRecord } from "@liveagent/ui/lib/chat/retryAttempts";
 
 // A turn is one prompt/response exchange of the live stream: the user bubble
 // (a single slot — a second user_message for the same run can only upsert it,

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -1,5 +1,13 @@
 import {
-  findCatalogModel,
+  ANTHROPIC_LONG_CONTEXT_WINDOW,
+  ANTHROPIC_STANDARD_CONTEXT_WINDOW,
+  hasAnthropicLongContextSuffix,
+  isAnthropicAdaptiveModelId,
+  resolveAnthropicContextWindow,
+  resolveAnthropicKnownModelLimits,
+  shouldSendAnthropicLongContextHeader,
+} from "@liveagent/ui/lib/models/anthropicContext";
+import {
   getProviderFallbackLimits,
   normalizeModelLimits,
   repairStaleCrossProviderLimits,
@@ -8,7 +16,6 @@ import {
 } from "@liveagent/ui/lib/models/modelCatalog";
 import {
   clampThinkingLevelToList,
-  isAnthropicAdaptiveModelId,
   resolveModelThinking,
   type ThinkingLevel,
 } from "@liveagent/ui/lib/models/modelThinking";
@@ -1268,29 +1275,6 @@ export function normalizeRemoteSettings(input: unknown): RemoteSettings {
   };
 }
 
-// 旧世代默认按 200K 处理；显式 [1m] 变体表示中转端能力，adaptive 世代
-// （isAnthropicAdaptiveModelId，来自镜像模块 lib/models/modelThinking）则是
-// 1M GA 世代。与桌面端 anthropicModels.ts 的有效窗口规则手动保持同步。
-const ANTHROPIC_STANDARD_CONTEXT_WINDOW = 200_000;
-const ANTHROPIC_LONG_CONTEXT_WINDOW = 1_000_000;
-
-function shouldSendAnthropicLongContextHeader(baseUrl: string | undefined): boolean {
-  if (!baseUrl?.trim()) return false;
-  try {
-    const host = new URL(baseUrl).hostname.toLowerCase();
-    return !(
-      host === "api.anthropic.com" ||
-      host.includes("aiplatform.googleapis.com") ||
-      host.includes("vertexai.googleapis.com") ||
-      host.endsWith(".deepseek.com") ||
-      host === "deepseek.com" ||
-      host.endsWith(".amazonaws.com")
-    );
-  } catch {
-    return false;
-  }
-}
-
 function getKnownModelLimits(
   providerId: ProviderId,
   modelId: string | undefined,
@@ -1298,19 +1282,8 @@ function getKnownModelLimits(
 ): Pick<ProviderModelConfig, "contextWindow" | "maxOutputToken"> | undefined {
   const trimmedId = modelId?.trim();
   if (!trimmedId) return undefined;
-  // Anthropic 的有效窗口叠加 1M beta/adaptive 世代策略（与桌面端
-  // anthropicModels.ts 手动同步）；其余供应商直接读生成目录（数据已在
-  // 生成期过统一语义规则）。
   if (providerId === "claude_code") {
-    const known = findCatalogModel("claude_code", trimmedId);
-    if (!known) return undefined;
-    const contextWindow = isAnthropicAdaptiveModelId(trimmedId)
-      ? known.contextWindow
-      : /\[1m\]$/i.test(trimmedId) &&
-          (baseUrl === undefined || shouldSendAnthropicLongContextHeader(baseUrl))
-        ? Math.max(known.contextWindow, ANTHROPIC_LONG_CONTEXT_WINDOW)
-        : Math.min(known.contextWindow, ANTHROPIC_STANDARD_CONTEXT_WINDOW);
-    return { contextWindow, maxOutputToken: known.maxOutputToken };
+    return resolveAnthropicKnownModelLimits(trimmedId, baseUrl);
   }
   return resolveModelLimits(providerId, trimmedId);
 }
@@ -1346,11 +1319,13 @@ export function getProviderModelDefaults(
   if (
     providerId === "claude_code" &&
     modelId &&
-    (/\[1m\]$/i.test(modelId.trim()) || isAnthropicAdaptiveModelId(modelId))
+    (hasAnthropicLongContextSuffix(modelId) || isAnthropicAdaptiveModelId(modelId))
   ) {
     return {
       contextWindow:
-        /\[1m\]$/i.test(modelId.trim()) && baseUrl && !shouldSendAnthropicLongContextHeader(baseUrl)
+        hasAnthropicLongContextSuffix(modelId) &&
+        baseUrl &&
+        !shouldSendAnthropicLongContextHeader(baseUrl)
           ? ANTHROPIC_STANDARD_CONTEXT_WINDOW
           : ANTHROPIC_LONG_CONTEXT_WINDOW,
       maxOutputToken: getProviderFallbackLimits(providerId).maxOutputToken,
@@ -1454,26 +1429,13 @@ export function findProviderModelConfig(
     };
   }
   if (provider.type !== "claude_code") return matched;
-  const defaults = getProviderModelDefaults(provider.type, normalizedId, provider.baseUrl);
-  const known = findCatalogModel("claude_code", normalizedId);
-  const isAdaptive = isAnthropicAdaptiveModelId(normalizedId);
-  const hasLongContextSuffix = /\[1m\]$/i.test(normalizedId);
-  const contextWindow = isAdaptive
-    ? Math.max(matched.contextWindow, defaults.contextWindow)
-    : hasLongContextSuffix
-      ? shouldSendAnthropicLongContextHeader(provider.baseUrl)
-        ? Math.max(matched.contextWindow, defaults.contextWindow)
-        : defaults.contextWindow
-      : known &&
-          !shouldSendAnthropicLongContextHeader(provider.baseUrl) &&
-          known.contextWindow > ANTHROPIC_STANDARD_CONTEXT_WINDOW
-        ? defaults.contextWindow
-        : matched.contextWindow === ANTHROPIC_STANDARD_CONTEXT_WINDOW
-          ? defaults.contextWindow
-          : matched.contextWindow;
   return {
     ...matched,
-    contextWindow,
+    contextWindow: resolveAnthropicContextWindow(
+      normalizedId,
+      matched.contextWindow,
+      provider.baseUrl,
+    ),
   };
 }
 

--- a/crates/agent-gateway/web/src/pages/SharedHistoryPage.tsx
+++ b/crates/agent-gateway/web/src/pages/SharedHistoryPage.tsx
@@ -115,7 +115,6 @@ export function SharedHistoryPage({ token }: SharedHistoryPageProps) {
                   rows={transcriptRows}
                   readOnly
                   redactToolContent={state.detail.redact_tool_content === true}
-                  isAgentMode
                 />
               </ScrollArea>
             )}

--- a/crates/agent-gateway/web/test/live-status-layout.test.mjs
+++ b/crates/agent-gateway/web/test/live-status-layout.test.mjs
@@ -6,6 +6,10 @@ const transcriptSource = fs.readFileSync(
   new URL("../src/components/GatewayTranscript.tsx", import.meta.url),
   "utf8",
 );
+const sharedAssistantStatusSource = fs.readFileSync(
+  new URL("../../../agent-ui/src/components/chat/AssistantStatus.tsx", import.meta.url),
+  "utf8",
+);
 
 test("the streaming assistant always owns one stable live-status footer", () => {
   assert.doesNotMatch(transcriptSource, /function shouldShowLiveStatusForRounds/);
@@ -15,8 +19,11 @@ test("the streaming assistant always owns one stable live-status footer", () => 
   );
   assert.match(transcriptSource, /data-row-key=\{row\.key\}/);
   assert.match(transcriptSource, /gateway-live-status-footer ml-9 min-w-0 overflow-hidden pt-1/);
-  assert.match(transcriptSource, /<VibingText className="w-full"/);
-  assert.match(transcriptSource, /<AssistantStatus className="w-full"/);
+  assert.match(transcriptSource, /<LiveAssistantStatus status=\{status\}/);
+  assert.match(sharedAssistantStatusSource, /export function LiveAssistantStatus/);
+  assert.match(sharedAssistantStatusSource, /if \(isCompaction\) return <CompactingText/);
+  assert.match(sharedAssistantStatusSource, /return <VibingText/);
+  assert.match(sharedAssistantStatusSource, /return <AssistantStatus/);
 });
 
 test("compaction does not add a second pending bubble after assistant output", () => {

--- a/crates/agent-gui/src/lib/chat/assistantBubbleAdapter.ts
+++ b/crates/agent-gui/src/lib/chat/assistantBubbleAdapter.ts
@@ -1,5 +1,4 @@
 export type { ImageContent, ToolResultMessage } from "@earendil-works/pi-ai";
-export type { RetryAttemptRecord } from "../providers/runtime/streamRetry";
 export type {
   DeleteResultDetails,
   DisplayImageItemDetails,
@@ -33,4 +32,3 @@ export {
   toolResultMessageToText,
   type UiRound,
 } from "./messages/uiMessages";
-export { normalizeLiveToolStatus, VIBING_STATUS } from "./page/chatPageHelpers";

--- a/crates/agent-gui/src/lib/chat/page/chatPageHelpers.ts
+++ b/crates/agent-gui/src/lib/chat/page/chatPageHelpers.ts
@@ -14,9 +14,6 @@ const TITLE_MAX_CHARS = 80;
 // Global on purpose: only ever used with String#match below, never with #test
 // (a sticky lastIndex would make alternating calls disagree).
 const CJK_CHAR_PATTERN = /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff]/g;
-const MODEL_GENERATING_STATUS_PATTERN = /^第\s*\d+\s*轮：模型生成中\.\.\.$/;
-
-export const VIBING_STATUS = "Vibing...";
 
 // Must match BRANCH_DEFAULT_TITLE in src-tauri/src/commands/history/chat_history/branch.rs.
 export const BRANCH_CONVERSATION_DEFAULT_TITLE = "新分支";
@@ -188,11 +185,6 @@ export function buildFallbackConversationTitle(content: string) {
   if (!singleLine) return "新对话";
   if (singleLine.length <= FALLBACK_TITLE_MAX_CHARS) return singleLine;
   return `${singleLine.slice(0, FALLBACK_TITLE_MAX_CHARS).trimEnd()}...`;
-}
-
-export function normalizeLiveToolStatus(status: string | null) {
-  if (status && MODEL_GENERATING_STATUS_PATTERN.test(status)) return VIBING_STATUS;
-  return status;
 }
 
 export function getFirstUserMessageText(context: Context) {

--- a/crates/agent-gui/src/lib/providers/anthropicModels.ts
+++ b/crates/agent-gui/src/lib/providers/anthropicModels.ts
@@ -1,14 +1,20 @@
 import type { Model } from "@earendil-works/pi-ai";
 import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import {
-  findCatalogModel,
-  normalizeModelIdCandidates,
-} from "@liveagent/ui/lib/models/modelCatalog";
-import {
-  anthropicModelSupportsXHigh,
-  isAnthropicAdaptiveModelId,
-} from "@liveagent/ui/lib/models/modelThinking";
+  hasAnthropicLongContextSuffix,
+  shouldSendAnthropicLongContextHeader,
+} from "@liveagent/ui/lib/models/anthropicContext";
+import { normalizeModelIdCandidates } from "@liveagent/ui/lib/models/modelCatalog";
+import { anthropicModelSupportsXHigh } from "@liveagent/ui/lib/models/modelThinking";
 
+export {
+  ANTHROPIC_LONG_CONTEXT_WINDOW,
+  ANTHROPIC_STANDARD_CONTEXT_WINDOW,
+  hasAnthropicLongContextSuffix,
+  resolveAnthropicContextWindow,
+  resolveAnthropicKnownModelLimits,
+  shouldSendAnthropicLongContextHeader,
+} from "@liveagent/ui/lib/models/anthropicContext";
 // ---------------------------------------------------------------------------
 // Anthropic 1M 长上下文窗口策略（请求行为，单一真源）
 // ---------------------------------------------------------------------------
@@ -21,9 +27,7 @@ import {
 // 本文件对 pi-ai 目录的回查（findBuiltinAnthropicModel）只服务 compat 等请求
 // 路径元数据。
 export { normalizeModelIdCandidates as normalizeAnthropicModelIdCandidates } from "@liveagent/ui/lib/models/modelCatalog";
-
-export const ANTHROPIC_STANDARD_CONTEXT_WINDOW = 200_000;
-export const ANTHROPIC_LONG_CONTEXT_WINDOW = 1_000_000;
+export { isAnthropicAdaptiveModelId } from "@liveagent/ui/lib/models/modelThinking";
 
 // 中转/网关常给官方 Anthropic 模型 id 加装饰，逐字匹配会漏检 pi-ai 目录；
 // 漏检后模型丢失 compat.forceAdaptiveThinking 等请求路径元数据，思考档位失效。
@@ -45,42 +49,9 @@ export function getAnthropicCompat(
   return model.compat;
 }
 
-export function hasAnthropicLongContextSuffix(modelId: string): boolean {
-  return /\[1m\]$/i.test(modelId.trim());
-}
-
 // 世代启发式的唯一实现在镜像模块 lib/models/modelThinking（web 端同源）；
 // 此处 re-export 供限额/1M 路径的既有消费者使用。
-export { anthropicModelSupportsXHigh, isAnthropicAdaptiveModelId };
-
-function getAnthropicEndpointHost(baseUrl: string | undefined): string | undefined {
-  if (!baseUrl?.trim()) return undefined;
-  try {
-    return new URL(baseUrl).hostname.toLowerCase();
-  } catch {
-    return undefined;
-  }
-}
-
-export function shouldSendAnthropicLongContextHeader(baseUrl: string | undefined): boolean {
-  const host = getAnthropicEndpointHost(baseUrl);
-  if (!host) return false;
-
-  // These endpoints either have 1M GA semantics already or require a
-  // provider-specific body/auth contract instead of an HTTP beta header.
-  if (
-    host === "api.anthropic.com" ||
-    host.includes("aiplatform.googleapis.com") ||
-    host.includes("vertexai.googleapis.com") ||
-    host.endsWith(".deepseek.com") ||
-    host === "deepseek.com" ||
-    host.endsWith(".amazonaws.com")
-  ) {
-    return false;
-  }
-
-  return true;
-}
+export { anthropicModelSupportsXHigh };
 
 export function resolveAnthropicWireModelId(modelId: string, baseUrl: string | undefined): string {
   if (hasAnthropicLongContextSuffix(modelId) && !shouldSendAnthropicLongContextHeader(baseUrl)) {
@@ -89,63 +60,5 @@ export function resolveAnthropicWireModelId(modelId: string, baseUrl: string | u
   return modelId;
 }
 
-function effectiveAnthropicContextWindow(
-  knownContextWindow: number,
-  modelId: string,
-  baseUrl?: string,
-): number {
-  if (isAnthropicAdaptiveModelId(modelId)) return knownContextWindow;
-  if (
-    hasAnthropicLongContextSuffix(modelId) &&
-    (baseUrl === undefined || shouldSendAnthropicLongContextHeader(baseUrl))
-  ) {
-    return ANTHROPIC_LONG_CONTEXT_WINDOW;
-  }
-  return Math.min(knownContextWindow, ANTHROPIC_STANDARD_CONTEXT_WINDOW);
-}
-
-export function resolveAnthropicContextWindow(
-  modelId: string,
-  configuredContextWindow: number,
-  baseUrl?: string,
-): number {
-  const known = findCatalogModel("claude_code", modelId);
-  if (isAnthropicAdaptiveModelId(modelId)) {
-    return Math.max(configuredContextWindow, known?.contextWindow ?? ANTHROPIC_LONG_CONTEXT_WINDOW);
-  }
-  if (hasAnthropicLongContextSuffix(modelId)) {
-    if (baseUrl === undefined || shouldSendAnthropicLongContextHeader(baseUrl)) {
-      return Math.max(configuredContextWindow, ANTHROPIC_LONG_CONTEXT_WINDOW);
-    }
-    return known
-      ? effectiveAnthropicContextWindow(known.contextWindow, modelId, baseUrl)
-      : Math.min(configuredContextWindow, ANTHROPIC_STANDARD_CONTEXT_WINDOW);
-  }
-  if (
-    known &&
-    baseUrl !== undefined &&
-    shouldSendAnthropicLongContextHeader(baseUrl) &&
-    configuredContextWindow > ANTHROPIC_STANDARD_CONTEXT_WINDOW
-  ) {
-    return configuredContextWindow;
-  }
-  return known
-    ? effectiveAnthropicContextWindow(known.contextWindow, modelId, baseUrl)
-    : configuredContextWindow;
-}
-
 // adaptive 世代即 1M GA 世代；旧世代目录里的 1M 是退役前的历史数值，按 200K
 // 报有效窗口。
-export function resolveAnthropicKnownModelLimits(
-  modelId: string | undefined,
-  baseUrl?: string,
-): { contextWindow: number; maxOutputToken: number } | undefined {
-  const trimmedId = modelId?.trim();
-  if (!trimmedId) return undefined;
-  const known = findCatalogModel("claude_code", trimmedId);
-  if (!known) return undefined;
-  return {
-    contextWindow: resolveAnthropicContextWindow(trimmedId, known.contextWindow, baseUrl),
-    maxOutputToken: known.maxOutputToken,
-  };
-}

--- a/crates/agent-gui/src/lib/providers/runtime/streamRetry.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/streamRetry.ts
@@ -5,14 +5,10 @@ import {
   isRetryableAssistantError,
 } from "@earendil-works/pi-ai";
 
+export type { RetryAttemptRecord } from "@liveagent/ui/lib/chat/retryAttempts";
+
 /** 6 total attempts = 5 retries after the initial try — matches codex's stream_max_retries=5. */
 export const DEFAULT_STREAM_RETRY_MAX_ATTEMPTS = 6;
-
-export type RetryAttemptRecord = {
-  attempt: number;
-  maxAttempts: number;
-  errorMessage: string;
-};
 
 const STREAM_RETRY_BASE_DELAY_MS = 200;
 const STREAM_RETRY_BACKOFF_FACTOR = 2;

--- a/crates/agent-gui/src/pages/chat/components/AssistantBubble.tsx
+++ b/crates/agent-gui/src/pages/chat/components/AssistantBubble.tsx
@@ -1,18 +1,11 @@
 import { AssistantAvatar } from "@liveagent/ui/components/chat/AssistantAvatar";
-import {
-  AssistantStatus,
-  CompactingText,
-  VibingText,
-} from "@liveagent/ui/components/chat/AssistantStatus";
-import {
-  RetryDetailsBlock,
-  RoundBlockContent,
-} from "@liveagent/ui/components/chat/assistant-bubble/RoundContent";
+import { LiveAssistantStatus } from "@liveagent/ui/components/chat/AssistantStatus";
+import { RoundBlockContent } from "@liveagent/ui/components/chat/assistant-bubble/RoundContent";
+import { RetryDetailsBlock } from "@liveagent/ui/components/chat/RetryDetailsBlock";
 import { UsagePanel } from "@liveagent/ui/components/chat/UsagePanel";
 import type { ChatFileLink } from "@liveagent/ui/lib/chat/chatFileLinks";
-import { memo, type ReactNode } from "react";
+import { memo } from "react";
 import type { RetryAttemptRecord } from "../../../lib/chat/conversation/liveTranscriptStore";
-import { VIBING_STATUS } from "../../../lib/chat/page/chatPageHelpers";
 import type { AssistantUnitRow } from "../transcript/rowModel";
 
 export { AssistantAvatar } from "@liveagent/ui/components/chat/AssistantAvatar";
@@ -42,17 +35,14 @@ export const AssistantBubbleUnit = memo(function AssistantBubbleUnit(props: {
   const { unit } = row;
   if (unit.kind === "footer") return null;
 
-  const isVibingStatus = toolStatus === VIBING_STATUS;
-  let status: ReactNode = null;
-  if (unit.kind === "status") {
-    status = isCompactionRunning ? (
-      <CompactingText className="w-full" />
-    ) : isVibingStatus || !toolStatus ? (
-      <VibingText className="w-full" />
-    ) : (
-      <AssistantStatus className="w-full">{toolStatus}</AssistantStatus>
-    );
-  }
+  const status =
+    unit.kind === "status" ? (
+      <LiveAssistantStatus
+        status={toolStatus}
+        isCompaction={isCompactionRunning}
+        className="w-full"
+      />
+    ) : null;
 
   return (
     <div className="flex w-full max-w-full items-start gap-3">

--- a/crates/agent-gui/src/pages/chat/transcript/TranscriptList.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/TranscriptList.tsx
@@ -1,5 +1,5 @@
-import { Markdown } from "@liveagent/ui/components/Markdown";
-import { useLocale } from "@liveagent/ui/i18n/index";
+import { ContextCheckpointCard } from "@liveagent/ui/components/chat/ContextCheckpointCard";
+import { normalizeLiveToolStatus } from "@liveagent/ui/lib/chat/assistantStatus";
 import type { ChatFileLink } from "@liveagent/ui/lib/chat/chatFileLinks";
 import type { GitClient } from "@liveagent/ui/lib/git/types";
 import { createEntranceRegistry } from "@liveagent/ui/lib/transcript-virtual/entranceOnce";
@@ -21,7 +21,6 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { CheckCircle2, ChevronDown } from "../../../components/icons";
 import type {
   HistoryMessageRef,
   RenderSummaryCard,
@@ -34,7 +33,6 @@ import {
   type CommitDetailsLoader,
   type CommitDisplayReference,
 } from "../../../lib/chat/messages/userMessageContent";
-import { normalizeLiveToolStatus } from "../../../lib/chat/page/chatPageHelpers";
 import { AssistantActivityRow } from "./AssistantActivityRow";
 import { AssistantRenderUnit } from "./AssistantRenderUnit";
 import { extractRenderUnitRange } from "./renderUnitRangeExtractor";
@@ -55,46 +53,15 @@ const transcriptMeasurementsLru = createTranscriptMeasurementsLru();
 
 const SummaryCard = memo(function SummaryCard(props: { item: RenderSummaryCard }) {
   const { item } = props;
-  const { t } = useLocale();
-  const [expanded, setExpanded] = useState(false);
 
   return (
     <div className="flex justify-center px-2">
-      <div className="checkpoint-card w-full max-w-3xl overflow-hidden rounded-[14px] border border-black/[0.06] bg-white/[0.85] shadow-[0_1px_3px_rgba(0,0,0,0.04),0_4px_12px_rgba(0,0,0,0.03)] dark:border-white/[0.1] dark:bg-white/[0.06] dark:shadow-[0_1px_3px_rgba(0,0,0,0.2),0_4px_12px_rgba(0,0,0,0.15)]">
-        <button
-          type="button"
-          onClick={() => setExpanded((prev) => !prev)}
-          className="flex w-full items-center gap-3 px-3.5 py-3 text-left transition-colors duration-150 hover:bg-black/[0.02] dark:hover:bg-white/[0.03]"
-        >
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-black/[0.04] dark:bg-white/[0.08]">
-            <CheckCircle2 size={16} strokeWidth={1.8} className="text-muted-foreground" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="text-[calc(13px*var(--zone-font-scale,1))] font-medium text-foreground/90">
-                {t("chat.contextCheckpoint.title")}
-              </span>
-              <span className="inline-flex items-center rounded-md bg-black/[0.05] px-1.5 py-[1px] text-[calc(11px*var(--zone-font-scale,1))] font-normal tabular-nums text-muted-foreground dark:bg-white/[0.08]">
-                {t("chat.contextCheckpoint.messageCount").replace(
-                  "{count}",
-                  String(item.coveredMessageCount),
-                )}
-              </span>
-            </div>
-            <div className="mt-[2px] text-[calc(11px*var(--zone-font-scale,1))] text-muted-foreground/70">
-              {item.generatedBy.providerId} · {item.generatedBy.model}
-            </div>
-          </div>
-          <ChevronDown
-            className={`h-3.5 w-3.5 shrink-0 text-muted-foreground/50 transition-transform duration-200 ${expanded ? "rotate-0" : "-rotate-90"}`}
-          />
-        </button>
-        {expanded ? (
-          <div className="checkpoint-expand border-t border-black/[0.05] px-3.5 py-3 dark:border-white/[0.06]">
-            <Markdown content={item.content} className="font-chat text-sm" />
-          </div>
-        ) : null}
-      </div>
+      <ContextCheckpointCard
+        content={item.content}
+        coveredMessageCount={item.coveredMessageCount}
+        generatedBy={item.generatedBy}
+        className="max-w-3xl"
+      />
     </div>
   );
 });

--- a/crates/agent-gui/test/chat/live-status-width.test.mjs
+++ b/crates/agent-gui/test/chat/live-status-width.test.mjs
@@ -10,12 +10,17 @@ const bubbleSource = fs.readFileSync(
   new URL("../../src/pages/chat/components/AssistantBubble.tsx", import.meta.url),
   "utf8",
 );
+const sharedStatusSource = fs.readFileSync(
+  new URL("../../../agent-ui/src/components/chat/AssistantStatus.tsx", import.meta.url),
+  "utf8",
+);
 
 test("desktop live status cannot widen the transcript", () => {
   assert.match(activitySource, /min-w-0 w-full max-w-full/);
   assert.match(bubbleSource, /min-w-0 max-w-full overflow-hidden py-1\.5/);
-  assert.match(bubbleSource, /<VibingText className="w-full"/);
-  assert.match(bubbleSource, /<AssistantStatus className="w-full"/);
+  assert.match(bubbleSource, /<LiveAssistantStatus[\s\S]*?className="w-full"/);
+  assert.match(sharedStatusSource, /return <VibingText className=\{className\}/);
+  assert.match(sharedStatusSource, /return <AssistantStatus className=\{className\}/);
 });
 
 test("desktop retry details render only in the stable live-status unit", () => {
@@ -24,4 +29,8 @@ test("desktop retry details render only in the stable live-status unit", () => {
     /retryAttempts=\{\s*unit\.mutable && unit\.unit\.kind === "status"\s*\? retryAttempts\s*: undefined\s*\}/,
   );
   assert.doesNotMatch(activitySource, /retryAttempts=\{unit\.mutable \? retryAttempts/);
+  assert.match(
+    bubbleSource,
+    /@liveagent\/ui\/components\/chat\/RetryDetailsBlock/,
+  );
 });

--- a/crates/agent-gui/test/chat/messages.test.mjs
+++ b/crates/agent-gui/test/chat/messages.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 
 const loader = createTsModuleLoader();
+const assistantStatus = loader.loadModule("@liveagent/ui/lib/chat/assistantStatus.ts");
 const uploadedFiles = loader.loadModule("src/lib/chat/messages/uploadedFiles.ts");
 const conversationState = loader.loadModule("src/lib/chat/conversation/conversationState.ts");
 const uiMessages = loader.loadModule("src/lib/chat/messages/uiMessages.ts");
@@ -2328,8 +2329,11 @@ test("chat page helpers keep model options stable and normalize status/title edg
   assert.match(chatHelpers.buildConversationTitlePrompt("hello", "zh-CN"), /简体中文标题/);
   assert.match(chatHelpers.buildConversationTitlePrompt("hello", "en-US"), /within 10 words/i);
   assert.equal(chatHelpers.buildFallbackConversationTitle("x".repeat(60)), `${"x".repeat(48)}...`);
-  assert.equal(chatHelpers.normalizeLiveToolStatus("第 2 轮：模型生成中..."), chatHelpers.VIBING_STATUS);
-  assert.equal(chatHelpers.normalizeLiveToolStatus("Running"), "Running");
+  assert.equal(
+    assistantStatus.normalizeLiveToolStatus("第 2 轮：模型生成中..."),
+    assistantStatus.VIBING_STATUS,
+  );
+  assert.equal(assistantStatus.normalizeLiveToolStatus("Running"), "Running");
   assert.equal(chatHelpers.isAbortLikeError(new Error("AbortError: aborted")), true);
   assert.equal(chatHelpers.isAbortLikeError("network failed"), false);
 });

--- a/crates/agent-ui/README.md
+++ b/crates/agent-ui/README.md
@@ -39,7 +39,7 @@ GUI 与 WebUI 应用只负责：
 - GUI：全局快捷键、关于页、桌面标题栏、原生剪贴板；
 - WebUI：设备管理、浏览器文件能力、网关连接状态。
 
-供应商设置、聊天侧栏、聊天顶部栏、空会话页、工具参数、待办列表、助手状态、用量、联网搜索组和 Diff 视图等公共 UI 同样只在 `agent-ui` 保留一份；GUI 的 CC Switch/Cherry Studio 导入由
+供应商设置、聊天侧栏、聊天顶部栏、空会话页、工具参数、待办列表、助手状态、上下文检查点、重试详情、上下文用量、联网搜索组和 Diff 视图等公共 UI 同样只在 `agent-ui` 保留一份；GUI 的 CC Switch/Cherry Studio 导入由
 `src/agent-ui-adapters/providerSettings.tsx` 注入，WebUI 使用同名空适配器。聊天侧栏的桌面标题栏、
 应用更新按钮和系统文件管理器入口由 GUI 的 `src/agent-ui-adapters/sidebarChrome.tsx` 注入。
 助手头像资源由两端的 `src/agent-ui-adapters/assistantAvatar.ts` 提供，共享组件不感知 Tauri 资源路径或 Web 公共目录。

--- a/crates/agent-ui/src/components/chat/AssistantBubble.tsx
+++ b/crates/agent-ui/src/components/chat/AssistantBubble.tsx
@@ -10,9 +10,10 @@ export { AssistantAvatar } from "./AssistantAvatar";
 export {
   AssistantStatus,
   CompactingText,
+  LiveAssistantStatus,
   VibingText,
 } from "./AssistantStatus";
-export { RetryDetailsBlock } from "./assistant-bubble/RoundContent";
+export { RetryDetailsBlock } from "./RetryDetailsBlock";
 
 const EMPTY_RUNNING_TOOL_CALL_IDS: string[] = [];
 

--- a/crates/agent-ui/src/components/chat/AssistantStatus.tsx
+++ b/crates/agent-ui/src/components/chat/AssistantStatus.tsx
@@ -2,9 +2,10 @@ import { assistantStatusSpinnerClassName } from "@liveagent/adapters/assistantSt
 import { Loader2 } from "@liveagent/app/components/icons";
 import type { ReactNode } from "react";
 import { useLocale } from "../../i18n/index";
+import { normalizeLiveToolStatus, VIBING_STATUS } from "../../lib/chat/assistantStatus";
 import { cn } from "../../lib/shared/utils";
 
-export const VIBING_STATUS = "Vibing...";
+export { VIBING_STATUS } from "../../lib/chat/assistantStatus";
 
 export function VibingText({ className }: { className?: string }) {
   return <AssistantStatus className={className}>{VIBING_STATUS}</AssistantStatus>;
@@ -13,6 +14,20 @@ export function VibingText({ className }: { className?: string }) {
 export function CompactingText({ className }: { className?: string }) {
   const { t } = useLocale();
   return <AssistantStatus className={className}>{t("chat.compactingContext")}</AssistantStatus>;
+}
+
+export function LiveAssistantStatus(props: {
+  status: string | null;
+  isCompaction?: boolean;
+  className?: string;
+}) {
+  const { status, isCompaction = false, className } = props;
+  const normalizedStatus = normalizeLiveToolStatus(status);
+  if (isCompaction) return <CompactingText className={className} />;
+  if (!normalizedStatus || normalizedStatus === VIBING_STATUS) {
+    return <VibingText className={className} />;
+  }
+  return <AssistantStatus className={className}>{normalizedStatus}</AssistantStatus>;
 }
 
 export function AssistantStatus({

--- a/crates/agent-ui/src/components/chat/ContextCheckpointCard.tsx
+++ b/crates/agent-ui/src/components/chat/ContextCheckpointCard.tsx
@@ -1,0 +1,62 @@
+import { Markdown } from "@liveagent/ui/components/Markdown";
+import { useState } from "react";
+import { useLocale } from "../../i18n/index";
+import { cn } from "../../lib/shared/utils";
+import { CheckCircle2, ChevronDown } from "../IconSet";
+
+export function ContextCheckpointCard(props: {
+  content: string;
+  coveredMessageCount: number;
+  generatedBy: { providerId: string; model: string };
+  readOnly?: boolean;
+  className?: string;
+}) {
+  const { content, coveredMessageCount, generatedBy, readOnly = false, className } = props;
+  const { t } = useLocale();
+  const [expanded, setExpanded] = useState(false);
+  const messageCountLabel =
+    coveredMessageCount > 0
+      ? t("chat.contextCheckpoint.messageCount").replace("{count}", String(coveredMessageCount))
+      : t("chat.contextCheckpoint.compressed");
+
+  return (
+    <div
+      className={cn(
+        "checkpoint-card w-full overflow-hidden rounded-[14px] border border-black/[0.06] bg-white/[0.85] shadow-[0_1px_3px_rgba(0,0,0,0.04),0_4px_12px_rgba(0,0,0,0.03)] dark:border-white/[0.1] dark:bg-white/[0.06] dark:shadow-[0_1px_3px_rgba(0,0,0,0.2),0_4px_12px_rgba(0,0,0,0.15)]",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((previous) => !previous)}
+        className="flex w-full items-center gap-3 px-3.5 py-3 text-left transition-colors duration-150 hover:bg-black/[0.02] dark:hover:bg-white/[0.03]"
+      >
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-black/[0.04] dark:bg-white/[0.08]">
+          <CheckCircle2 size={16} strokeWidth={1.8} className="text-muted-foreground" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-[calc(13px*var(--zone-font-scale,1))] font-medium text-foreground/90">
+              {t("chat.contextCheckpoint.title")}
+            </span>
+            <span className="inline-flex items-center rounded-md bg-black/[0.05] px-1.5 py-[1px] text-[calc(11px*var(--zone-font-scale,1))] font-normal tabular-nums text-muted-foreground dark:bg-white/[0.08]">
+              {messageCountLabel}
+            </span>
+          </div>
+          <div className="mt-[2px] text-[calc(11px*var(--zone-font-scale,1))] text-muted-foreground/70">
+            {generatedBy.providerId} · {generatedBy.model}
+          </div>
+        </div>
+        <ChevronDown
+          className={`h-3.5 w-3.5 shrink-0 text-muted-foreground/50 transition-transform duration-200 ${expanded ? "rotate-0" : "-rotate-90"}`}
+        />
+      </button>
+      {expanded ? (
+        <div className="checkpoint-expand border-t border-black/[0.05] px-3.5 py-3 dark:border-white/[0.06]">
+          <Markdown content={content} className="font-chat text-sm" readOnly={readOnly} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/crates/agent-ui/src/components/chat/ContextUsageRing.tsx
+++ b/crates/agent-ui/src/components/chat/ContextUsageRing.tsx
@@ -29,7 +29,7 @@ function getTokenFormatter(locale: string): Intl.NumberFormat {
 
 /**
  * 上下文用量环：composer 内展示当前会话上下文占用百分比，占用 ≥ 50%（黄档）
- * 起可点击弹出确认后触发手动压缩。数据口径见 lib/chat/contextUsage.ts。
+ * 起可点击弹出确认后触发手动压缩。阈值与 WebUI 补算口径见 lib/chat/contextUsage.ts。
  * 语义用 Meter（静态量度）而非 Progress（任务进度）。
  */
 export function ContextUsageRing(props: {

--- a/crates/agent-ui/src/components/chat/RetryDetailsBlock.tsx
+++ b/crates/agent-ui/src/components/chat/RetryDetailsBlock.tsx
@@ -1,0 +1,57 @@
+import { memo, useState } from "react";
+import { useLocale } from "../../i18n/index";
+import type { RetryAttemptRecord } from "../../lib/chat/retryAttempts";
+import { ChevronRight, RefreshCw } from "../IconSet";
+import { LazyCollapse } from "./LazyCollapse";
+
+// Expandable per-attempt stream-retry history for the live run.
+export const RetryDetailsBlock = memo(function RetryDetailsBlock({
+  attempts,
+}: {
+  attempts: readonly RetryAttemptRecord[];
+}) {
+  const { t } = useLocale();
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (attempts.length === 0) return null;
+
+  return (
+    <div className="group/retry w-full">
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="retry-details-toggle flex w-full cursor-pointer select-none items-center gap-2 py-1.5 text-left text-[calc(13px*var(--zone-font-scale,1))] font-normal text-muted-foreground/80 hover:text-foreground"
+      >
+        <RefreshCw className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+        <span>{t("chat.retryDetailsToggle").replace("{count}", String(attempts.length))}</span>
+        <ChevronRight
+          className={`ml-auto h-3.5 w-3.5 text-muted-foreground/60 transition-transform duration-200 ease-out ${isOpen ? "rotate-90" : ""}`}
+        />
+      </button>
+      <LazyCollapse open={isOpen}>
+        {() => (
+          <div className="space-y-1 pb-1 pt-1.5">
+            {/* Index-keyed: attempt ordinals can repeat within one list (text
+                mode's tool-recovery loop restarts each wrapper's counter at 1)
+                and the list is append-only, so the index is the stable key. */}
+            {attempts.map((entry, index) => (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: retry attempts are append-only and their reported ordinals can repeat.
+                key={`${index}-${entry.attempt}-${entry.maxAttempts}`}
+                className="rounded-md border border-border/60 bg-muted/30 px-2.5 py-1.5 text-[calc(12px*var(--zone-font-scale,1))] text-muted-foreground"
+              >
+                <div className="font-medium text-foreground/80">
+                  {t("chat.retryAttemptLabel")
+                    .replace("{attempt}", String(entry.attempt))
+                    .replace("{maxAttempts}", String(entry.maxAttempts))}
+                </div>
+                <div className="whitespace-pre-wrap break-words">{entry.errorMessage}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </LazyCollapse>
+    </div>
+  );
+});

--- a/crates/agent-ui/src/components/chat/WorkspaceResourceSettingsDrawer.tsx
+++ b/crates/agent-ui/src/components/chat/WorkspaceResourceSettingsDrawer.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useMemo, useState } from "react";
-import { createPortal } from "react-dom";
 import { Blend, Cable, Search, X } from "@liveagent/app/components/icons";
 import {
   type AppSettings,
@@ -9,12 +7,14 @@ import {
 } from "@liveagent/app/lib/settings";
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { cn } from "@liveagent/ui/lib/shared/utils";
-import { isAlwaysEnabledSkillName, type SkillSummary } from "@liveagent/ui/lib/skills/index";
 import {
   CLAWHUB_CATEGORY_SLUGS,
   type ClawHubCategorySlug,
   classifyClawHubSkill,
 } from "@liveagent/ui/lib/skills/clawHubCategories";
+import { isAlwaysEnabledSkillName, type SkillSummary } from "@liveagent/ui/lib/skills/index";
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { ResourceActivationSwitch } from "../resources/ResourceActivationSwitch";
 import { Button } from "../ui/button";
 

--- a/crates/agent-ui/src/components/chat/assistant-bubble/RoundContent.tsx
+++ b/crates/agent-ui/src/components/chat/assistant-bubble/RoundContent.tsx
@@ -1,24 +1,17 @@
-import {
-  normalizeLiveToolStatus,
-  type RetryAttemptRecord,
-  type UiRound,
-  VIBING_STATUS,
-} from "@liveagent/app/lib/chat/assistantBubbleAdapter";
-import type { ChatFileLink } from "@liveagent/ui/lib/chat/chatFileLinks";
+import type { UiRound } from "@liveagent/app/lib/chat/assistantBubbleAdapter";
 import {
   AssistantStatus,
   CompactingText,
   VibingText,
 } from "@liveagent/ui/components/chat/AssistantStatus";
 import { HostedSearchGroupView } from "@liveagent/ui/components/chat/HostedSearchGroupView";
-import { LazyCollapse } from "@liveagent/ui/components/chat/LazyCollapse";
 import { ThinkingActivity } from "@liveagent/ui/components/chat/ThinkingActivity";
 import { UsagePanel } from "@liveagent/ui/components/chat/UsagePanel";
 import { Markdown } from "@liveagent/ui/components/Markdown";
-import { useLocale } from "@liveagent/ui/i18n/index";
+import { normalizeLiveToolStatus, VIBING_STATUS } from "@liveagent/ui/lib/chat/assistantStatus";
+import type { ChatFileLink } from "@liveagent/ui/lib/chat/chatFileLinks";
 import { isTaskToolBlock } from "@liveagent/ui/lib/chat/taskProgress";
-import { memo, type ReactNode, useMemo, useState } from "react";
-import { ChevronRight, RefreshCw } from "../../IconSet";
+import { memo, type ReactNode, useMemo } from "react";
 import {
   type GroupedRoundBlock,
   groupRoundBlocks,
@@ -29,58 +22,6 @@ import { getNativeDisplayImagePayload, NativeDisplayImageBlock } from "./ToolIma
 import { ToolTraceGroup } from "./ToolTraceGroup";
 
 const EMPTY_RUNNING_TOOL_CALL_IDS: string[] = [];
-
-// Expandable per-attempt stream-retry history for the live run.
-export const RetryDetailsBlock = memo(function RetryDetailsBlock({
-  attempts,
-}: {
-  attempts: readonly RetryAttemptRecord[];
-}) {
-  const { t } = useLocale();
-  const [isOpen, setIsOpen] = useState(false);
-
-  if (attempts.length === 0) return null;
-
-  return (
-    <div className="group/retry w-full">
-      <button
-        type="button"
-        aria-expanded={isOpen}
-        onClick={() => setIsOpen((prev) => !prev)}
-        className="retry-details-toggle flex w-full cursor-pointer select-none items-center gap-2 py-1.5 text-left text-[calc(13px*var(--zone-font-scale,1))] font-normal text-muted-foreground/80 hover:text-foreground"
-      >
-        <RefreshCw className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
-        <span>{t("chat.retryDetailsToggle").replace("{count}", String(attempts.length))}</span>
-        <ChevronRight
-          className={`ml-auto h-3.5 w-3.5 text-muted-foreground/60 transition-transform duration-200 ease-out ${isOpen ? "rotate-90" : ""}`}
-        />
-      </button>
-      <LazyCollapse open={isOpen}>
-        {() => (
-          <div className="space-y-1 pb-1 pt-1.5">
-            {/* Index-keyed: attempt ordinals can repeat within one list (text
-                mode's tool-recovery loop restarts each wrapper's counter at 1)
-                and the list is append-only, so the index is the stable key. */}
-            {attempts.map((entry, index) => (
-              <div
-                // biome-ignore lint/suspicious/noArrayIndexKey: retry attempts are append-only and their reported ordinals can repeat.
-                key={`${index}-${entry.attempt}-${entry.maxAttempts}`}
-                className="rounded-md border border-border/60 bg-muted/30 px-2.5 py-1.5 text-[calc(12px*var(--zone-font-scale,1))] text-muted-foreground"
-              >
-                <div className="font-medium text-foreground/80">
-                  {t("chat.retryAttemptLabel")
-                    .replace("{attempt}", String(entry.attempt))
-                    .replace("{maxAttempts}", String(entry.maxAttempts))}
-                </div>
-                <div className="whitespace-pre-wrap break-words">{entry.errorMessage}</div>
-              </div>
-            ))}
-          </div>
-        )}
-      </LazyCollapse>
-    </div>
-  );
-});
 
 export const RoundBlockContent = memo(function RoundBlockContent(props: {
   block: GroupedRoundBlock;

--- a/crates/agent-ui/src/components/resources/ResourceActivationSwitch.tsx
+++ b/crates/agent-ui/src/components/resources/ResourceActivationSwitch.tsx
@@ -1,5 +1,5 @@
-import type { MouseEvent } from "react";
 import { cn } from "@liveagent/ui/lib/shared/utils";
+import type { MouseEvent } from "react";
 
 export function ResourceActivationSwitch(props: {
   checked: boolean;

--- a/crates/agent-ui/src/lib/chat/assistantStatus.ts
+++ b/crates/agent-ui/src/lib/chat/assistantStatus.ts
@@ -1,0 +1,8 @@
+const MODEL_GENERATING_STATUS_PATTERN = /^第\s*\d+\s*轮：模型生成中\.\.\.$/;
+
+export const VIBING_STATUS = "Vibing...";
+
+export function normalizeLiveToolStatus(status: string | null) {
+  if (status && MODEL_GENERATING_STATUS_PATTERN.test(status)) return VIBING_STATUS;
+  return status;
+}

--- a/crates/agent-ui/src/lib/chat/retryAttempts.ts
+++ b/crates/agent-ui/src/lib/chat/retryAttempts.ts
@@ -1,0 +1,5 @@
+export type RetryAttemptRecord = {
+  attempt: number;
+  maxAttempts: number;
+  errorMessage: string;
+};

--- a/crates/agent-ui/src/lib/models/anthropicContext.ts
+++ b/crates/agent-ui/src/lib/models/anthropicContext.ts
@@ -1,0 +1,92 @@
+import { findCatalogModel } from "./modelCatalog";
+import { isAnthropicAdaptiveModelId } from "./modelThinking";
+
+export { isAnthropicAdaptiveModelId };
+
+export const ANTHROPIC_STANDARD_CONTEXT_WINDOW = 200_000;
+export const ANTHROPIC_LONG_CONTEXT_WINDOW = 1_000_000;
+
+export function hasAnthropicLongContextSuffix(modelId: string): boolean {
+  return /\[1m\]$/i.test(modelId.trim());
+}
+
+function getAnthropicEndpointHost(baseUrl: string | undefined): string | undefined {
+  if (!baseUrl?.trim()) return undefined;
+  try {
+    return new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+export function shouldSendAnthropicLongContextHeader(baseUrl: string | undefined): boolean {
+  const host = getAnthropicEndpointHost(baseUrl);
+  if (!host) return false;
+  return !(
+    host === "api.anthropic.com" ||
+    host.includes("aiplatform.googleapis.com") ||
+    host.includes("vertexai.googleapis.com") ||
+    host.endsWith(".deepseek.com") ||
+    host === "deepseek.com" ||
+    host.endsWith(".amazonaws.com")
+  );
+}
+
+function effectiveAnthropicContextWindow(
+  knownContextWindow: number,
+  modelId: string,
+  baseUrl?: string,
+): number {
+  if (isAnthropicAdaptiveModelId(modelId)) return knownContextWindow;
+  if (
+    hasAnthropicLongContextSuffix(modelId) &&
+    (baseUrl === undefined || shouldSendAnthropicLongContextHeader(baseUrl))
+  ) {
+    return ANTHROPIC_LONG_CONTEXT_WINDOW;
+  }
+  return Math.min(knownContextWindow, ANTHROPIC_STANDARD_CONTEXT_WINDOW);
+}
+
+export function resolveAnthropicContextWindow(
+  modelId: string,
+  configuredContextWindow: number,
+  baseUrl?: string,
+): number {
+  const known = findCatalogModel("claude_code", modelId);
+  if (isAnthropicAdaptiveModelId(modelId)) {
+    return Math.max(configuredContextWindow, known?.contextWindow ?? ANTHROPIC_LONG_CONTEXT_WINDOW);
+  }
+  if (hasAnthropicLongContextSuffix(modelId)) {
+    if (baseUrl === undefined || shouldSendAnthropicLongContextHeader(baseUrl)) {
+      return Math.max(configuredContextWindow, ANTHROPIC_LONG_CONTEXT_WINDOW);
+    }
+    return known
+      ? effectiveAnthropicContextWindow(known.contextWindow, modelId, baseUrl)
+      : Math.min(configuredContextWindow, ANTHROPIC_STANDARD_CONTEXT_WINDOW);
+  }
+  if (
+    known &&
+    baseUrl !== undefined &&
+    shouldSendAnthropicLongContextHeader(baseUrl) &&
+    configuredContextWindow > ANTHROPIC_STANDARD_CONTEXT_WINDOW
+  ) {
+    return configuredContextWindow;
+  }
+  return known
+    ? effectiveAnthropicContextWindow(known.contextWindow, modelId, baseUrl)
+    : configuredContextWindow;
+}
+
+export function resolveAnthropicKnownModelLimits(
+  modelId: string | undefined,
+  baseUrl?: string,
+): { contextWindow: number; maxOutputToken: number } | undefined {
+  const trimmedId = modelId?.trim();
+  if (!trimmedId) return undefined;
+  const known = findCatalogModel("claude_code", trimmedId);
+  if (!known) return undefined;
+  return {
+    contextWindow: resolveAnthropicContextWindow(trimmedId, known.contextWindow, baseUrl),
+    maxOutputToken: known.maxOutputToken,
+  };
+}

--- a/scripts/check-ui-boundaries.mjs
+++ b/scripts/check-ui-boundaries.mjs
@@ -41,6 +41,15 @@ const checks = [
       },
       {
         pattern:
+          /(?:function|const)\s+(?:ContextCheckpointCard|RetryDetailsBlock)\b|checkpoint-card|retry-details-toggle/,
+        reason: "上下文检查点与重试详情必须使用 @liveagent/ui 共享组件",
+      },
+      {
+        pattern: /(?:function\s+normalizeLiveToolStatus|const\s+VIBING_STATUS\s*=|function\s+buildContextUsageScanItems)\b/,
+        reason: "聊天实时状态与上下文用量投影必须使用 @liveagent/ui 共享逻辑",
+      },
+      {
+        pattern:
           /(?:from\s+|import\s*\(\s*|import\s+)["']@liveagent\/ui\/(?:components\/chat\/ChatHeader|pages\/(?:skills-hub\/SkillsHubPage|mcp-hub\/McpHubPage))["']/,
         reason: "公共页面与聊天顶部栏必须由共享 ApplicationView 统一组装",
       },
@@ -67,6 +76,15 @@ const checks = [
       {
         pattern: /chat-(?:user-bubble|assistant)-action/,
         reason: "消息操作栏必须使用 @liveagent/ui/components/chat/TranscriptMessageActions",
+      },
+      {
+        pattern:
+          /(?:function|const)\s+(?:ContextCheckpointCard|RetryDetailsBlock)\b|checkpoint-card|retry-details-toggle/,
+        reason: "上下文检查点与重试详情必须使用 @liveagent/ui 共享组件",
+      },
+      {
+        pattern: /(?:function\s+normalizeLiveToolStatus|const\s+VIBING_STATUS\s*=|function\s+buildContextUsageScanItems)\b/,
+        reason: "聊天实时状态与上下文用量投影必须使用 @liveagent/ui 共享逻辑",
       },
       {
         pattern:


### PR DESCRIPTION
## 背景

feat/context-usage-ring 分支上有 71 个未提交的 WIP 改动（63 个修改 + 8 个新文件）。逐文件与 main 比对后分类：

- **10 个已落地**：内容与 main 逐字节一致（经 #426 评审修复合入）。
- **37 个核心逻辑文件已被 main 超越**：压缩控制器/TokenLedger/手动压缩装配/compact_now 中继/WebUI pending 等，main 上是评审修复后的新契约（探针过才 accepted、印章只记 usage、按会话 pending Map、多会话侧栏转圈等），WIP 是旧迭代，**不回灌**（其中 WIP tokenLedger 甚至含已被评审否决的估算盖章行为）。
- **其余为未落地的有效批次**：本 PR 适配的内容。

## 变更一：Anthropic 上下文窗口裁决收敛（修用量环两端不一致）

WebUI settings 的 `findProviderModelConfig` 还是旧的手动同步内联逻辑，缺 `baseUrl === undefined` 放行分支——`[1m]` 模型未配 baseUrl 时用目录默认窗口覆盖用户配置值（GUI 正常、WebUI 显示模型默认窗口）。

- 窗口策略抽到共享真源 `agent-ui/lib/models/anthropicContext.ts`，桌面端 `anthropicModels.ts` re-export，WebUI settings 直接消费。
- 回归测试：`[1m]` 自定义 2M 窗口保留；桌面改窗口值同步后 WebUI 立即生效。

## 变更二：聊天状态/重试详情/检查点卡共享化

- 新共享模块：`lib/chat/assistantStatus.ts`、`lib/chat/retryAttempts.ts`、`components/chat/RetryDetailsBlock.tsx`（自 RoundContent 抽出）、`components/chat/ContextCheckpointCard.tsx`、`LiveAssistantStatus` 组件。
- 两端重复副本删除：chatPageHelpers 的 normalizeLiveToolStatus/VIBING_STATUS ×2、streamRetry 与 transcript/types 的 RetryAttemptRecord ×2、检查点卡片标记 ×2、Compacting/Vibing 三元树 ×2（含 GatewayTranscript 一处 isAgentMode 两侧完全相同的死分支，连同贯穿的死 prop 一并移除）。
- `check-ui-boundaries.mjs` 新增门禁规则，防止镜像漂移复发（正是本次窗口 bug 的病根类别）。
- 顺带补齐 GUI 检查点卡的 aria-expanded 与 0 条消息"已压缩"回退文案（对齐 WebUI 既有行为）。

## 验证

- GUI 前端 1549 项、WebUI 554 项测试全过（含更新后的 live-status 源码断言与新增回归）
- 两端 `tsc --noEmit` 干净；`check-ui-boundaries.mjs` 通过；biome 无新增告警