### PR TITLE
fix(ui): 工作区 Markdown 预览支持选中复制文本

### DIFF
--- a/crates/agent-ui/src/components/workspace-editor/WorkspaceMarkdownPreview.tsx
+++ b/crates/agent-ui/src/components/workspace-editor/WorkspaceMarkdownPreview.tsx
@@ -281,8 +281,9 @@ export const WorkspaceMarkdownPreview = memo(function WorkspaceMarkdownPreview(
     () => ({ workdir, markdownPath, onOpenWorkspacePath }),
     [markdownPath, onOpenWorkspacePath, workdir],
   );
+  // select-text 覆盖宿主全局的 user-select: none，允许在预览中选中复制文本。
   return (
-    <div data-workspace-markdown-preview="">
+    <div data-workspace-markdown-preview="" className="select-text">
       <WorkspaceMarkdownPreviewContext.Provider value={contextValue}>
         <Markdown
           content={content}


### PR DESCRIPTION
## Linked issue

Closes #430

## Summary

工作区文件预览中打开 `.md` 文档时，渲染出的文本无法选中，导致无法复制内容。

根因:桌面端与 WebUI 的全局样式在 `html/body/#root` 上设置了 `user-select: none`(`crates/agent-gui/src/index.css:339`、`crates/agent-gateway/web/src/index.css:340`),项目惯例是在可复制区域局部放开(`ChatTranscript`、`BackgroundTasksPanel`、Git Review diff 均已加 `select-text`),但 `WorkspaceMarkdownPreview` 漏掉了这一步,全局规则一路继承到预览文本。

修复:在 `WorkspaceMarkdownPreview` 组件根节点加 `select-text`。组件位于共享包 `agent-ui`,桌面端与 WebUI 一并修复。按 issue 讨论范围,本次仅处理 Markdown 预览,overlay 中 document/spreadsheet 分支暂不涉及。

## Change scope

- Modules: agent-ui(GUI/WebUI 共享组件)
- Key paths: `crates/agent-ui/src/components/workspace-editor/WorkspaceMarkdownPreview.tsx`(仅 1 个文件,+2/-1)

## Screenshots / preview

(稍后补充修复前后对比截图,补充后转 Ready for review)

## Verification

- `pnpm lint:ui` 对改动文件的 `biome check` 通过(仓库现存的其他文件 lint 报错与本 PR 无关,main 上同样存在)
- `pnpm build:gui` 类型检查与构建通过
- 本地 `make build` 打包 macOS 应用,实机验证结果与截图一并补充
- 纯样式类改动,无行为逻辑变化,未新增测试

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.
