### PR TITLE
feat(chat): 用量环触屏二段点按 + tooltip 两行排版与进出场动画

### DIFF
--- a/crates/agent-gateway/web/src/styles.css
+++ b/crates/agent-gateway/web/src/styles.css
@@ -4922,8 +4922,36 @@ html[data-liveagent-webui="gateway"]
   transform: translateY(calc(var(--confirm-popover-slide-y) / 2)) scale(0.98);
 }
 
+/* Label tooltip (context usage ring's usage readout): mirror of the GUI's
+ * fade + grow enter/exit, keyed off Base UI's data-starting-style /
+ * data-ending-style. */
+.label-tooltip-popup {
+  --label-tooltip-slide-y: -4px;
+  transform-origin: var(--transform-origin);
+  transition:
+    opacity 0.15s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.label-tooltip-popup[data-side="top"] {
+  --label-tooltip-slide-y: 4px;
+}
+
+.label-tooltip-popup[data-starting-style],
+.label-tooltip-popup[data-ending-style] {
+  opacity: 0;
+  transform: translateY(var(--label-tooltip-slide-y)) scale(0.96);
+}
+
+.label-tooltip-popup[data-ending-style] {
+  transition-duration: 0.1s;
+  transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+  transform: translateY(calc(var(--label-tooltip-slide-y) / 2)) scale(0.98);
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .confirm-action-popover-popup {
+  .confirm-action-popover-popup,
+  .label-tooltip-popup {
     transition: none;
   }
 }

--- a/crates/agent-gui/src/index.css
+++ b/crates/agent-gui/src/index.css
@@ -1401,6 +1401,34 @@
     transform: translateY(calc(var(--confirm-popover-slide-y) / 2)) scale(0.98);
   }
 
+  /* Label tooltip (composer runtime controls, context usage ring): fade +
+   * grow out of the anchor. Base UI keeps the popup mounted until the exit
+   * transition ends, so enter/exit key off data-starting-style /
+   * data-ending-style. */
+  .label-tooltip-popup {
+    --label-tooltip-slide-y: -4px;
+    transform-origin: var(--transform-origin);
+    transition:
+      opacity 0.15s cubic-bezier(0.16, 1, 0.3, 1),
+      transform 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .label-tooltip-popup[data-side="top"] {
+    --label-tooltip-slide-y: 4px;
+  }
+
+  .label-tooltip-popup[data-starting-style],
+  .label-tooltip-popup[data-ending-style] {
+    opacity: 0;
+    transform: translateY(var(--label-tooltip-slide-y)) scale(0.96);
+  }
+
+  .label-tooltip-popup[data-ending-style] {
+    transition-duration: 0.1s;
+    transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+    transform: translateY(calc(var(--label-tooltip-slide-y) / 2)) scale(0.98);
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .settings-section-enter,
     .settings-section-title-enter,
@@ -1424,6 +1452,11 @@
     }
 
     .confirm-action-popover-popup {
+      animation: none !important;
+      transition: none !important;
+    }
+
+    .label-tooltip-popup {
       animation: none !important;
       transition: none !important;
     }

--- a/crates/agent-ui/src/components/chat/ContextUsageRing.tsx
+++ b/crates/agent-ui/src/components/chat/ContextUsageRing.tsx
@@ -1,6 +1,7 @@
 import { Meter } from "@base-ui/react";
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { cn } from "@liveagent/ui/lib/shared/utils";
+import { useMemo, useState } from "react";
 import {
   canManualCompact,
   contextUsageLevel,
@@ -31,6 +32,10 @@ function getTokenFormatter(locale: string): Intl.NumberFormat {
  * 上下文用量环：composer 内展示当前会话上下文占用百分比，占用 ≥ 50%（黄档）
  * 起可点击弹出确认后触发手动压缩。阈值与 WebUI 补算口径见 lib/chat/contextUsage.ts。
  * 语义用 Meter（静态量度）而非 Progress（任务进度）。
+ *
+ * 触屏（无 hover）环境没有悬停，tooltip 与压缩确认改为点按分段：首次点按只弹
+ * 用量 tooltip，≥50% 时第二次点按收起 tooltip 再弹压缩确认——两个弹层同侧
+ * 定位，必须互斥展示。桌面端保持悬停出 tooltip、点击出确认的原行为。
  */
 export function ContextUsageRing(props: {
   totalTokens?: number;
@@ -41,6 +46,15 @@ export function ContextUsageRing(props: {
 }) {
   const { totalTokens, contextWindow, disabled, onConfirm, className } = props;
   const { t, locale } = useLocale();
+  const isCoarsePointer = useMemo(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(hover: none), (pointer: coarse)").matches,
+    [],
+  );
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   if (typeof contextWindow !== "number" || !Number.isFinite(contextWindow) || contextWindow <= 0) {
     return null;
   }
@@ -51,10 +65,40 @@ export function ContextUsageRing(props: {
   const displayedPercentage = Math.min(999, Math.round(ratio * 100));
   const clampedPercentage = Math.min(100, ratio * 100);
   const formatTokens = getTokenFormatter(locale);
-  const usageLabel = `${displayedPercentage}% · ${t("chat.usageTotal")} ${formatTokens.format(
+  const usageLine = `${displayedPercentage}% · ${t("chat.usageTotal")} ${formatTokens.format(
     Math.max(0, Math.floor(totalTokens ?? 0)),
-  )} · ${t("chat.contextWindow")} ${formatTokens.format(contextWindow)}`;
+  )}`;
+  const windowLine = `${t("chat.contextWindow")} ${formatTokens.format(contextWindow)}`;
+  // a11y 量度/无障碍标签仍是单行字符串；tooltip 视觉上分两行（百分比+总计 /
+  // 上下文窗口），窄屏不再挤成一长条折行。
+  const usageLabel = `${usageLine} · ${windowLine}`;
+  const usageTooltip = (
+    <span className="flex flex-col gap-0.5">
+      <span>{usageLine}</span>
+      <span className="text-muted-foreground">{windowLine}</span>
+    </span>
+  );
   const compactAvailable = canManualCompact(ratio) && !disabled && Boolean(onConfirm);
+
+  const handleTooltipOpenChange = (nextOpen: boolean) => {
+    // 确认弹层展示期间抑制 tooltip 的打开请求（悬停/点按），保证不重叠。
+    if (nextOpen && confirmOpen) return;
+    setTooltipOpen(nextOpen);
+  };
+
+  const handleConfirmOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setConfirmOpen(false);
+      return;
+    }
+    // 触屏端首次点按只弹用量 tooltip；tooltip 已可见的第二次点按才进入确认。
+    if (isCoarsePointer && !tooltipOpen) {
+      setTooltipOpen(true);
+      return;
+    }
+    setTooltipOpen(false);
+    setConfirmOpen(true);
+  };
 
   const ring = (
     <Meter.Root
@@ -91,24 +135,50 @@ export function ContextUsageRing(props: {
     </Meter.Root>
   );
 
+  // 触屏端一律禁用 closeOnClick：trigger 按压关闭发生在 pointerdown，早于
+  // click 阶段的开合裁决——保留会让第二次点按先关掉 tooltip，裁决误判为
+  // "首次点按"而永远进不了确认弹层（span 分支同理会点按即关又即开）。
   if (!compactAvailable) {
     return (
-      <LabelTooltip label={usageLabel}>
-        <span className={cn("inline-flex h-8 w-8 shrink-0 cursor-default opacity-90", className)}>
-          {ring}
-        </span>
+      <LabelTooltip
+        label={usageTooltip}
+        open={tooltipOpen}
+        onOpenChange={handleTooltipOpenChange}
+        closeOnClick={!isCoarsePointer}
+      >
+        {isCoarsePointer ? (
+          <button
+            type="button"
+            aria-label={usageLabel}
+            onClick={() => handleTooltipOpenChange(!tooltipOpen)}
+            className={cn("inline-flex h-8 w-8 shrink-0 opacity-90 outline-hidden", className)}
+          >
+            {ring}
+          </button>
+        ) : (
+          <span className={cn("inline-flex h-8 w-8 shrink-0 cursor-default opacity-90", className)}>
+            {ring}
+          </span>
+        )}
       </LabelTooltip>
     );
   }
 
   return (
-    <LabelTooltip label={usageLabel}>
+    <LabelTooltip
+      label={usageTooltip}
+      open={tooltipOpen}
+      onOpenChange={handleTooltipOpenChange}
+      closeOnClick={!isCoarsePointer}
+    >
       <ConfirmActionPopover
         title={t("chat.manualCompactTitle")}
         description={t("chat.manualCompactDescription")}
         confirmLabel={t("chat.manualCompactConfirm")}
         tone="default"
         side="top"
+        open={confirmOpen}
+        onOpenChange={handleConfirmOpenChange}
         onConfirm={() => void onConfirm?.()}
       >
         {(open) => (

--- a/crates/agent-ui/src/components/ui/confirm-action-popover.tsx
+++ b/crates/agent-ui/src/components/ui/confirm-action-popover.tsx
@@ -17,6 +17,10 @@ export function ConfirmActionPopover(props: {
   // Visual intent: "destructive" (default) for irreversible actions,
   // "default" for non-destructive confirmations (e.g. branching).
   tone?: "destructive" | "default";
+  // Controlled mode (both or neither): callers that gate opening on extra
+  // state (e.g. the usage ring's two-tap touch flow) own the open state.
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
   children: (open: () => void) => ReactNode;
 }) {
   const {
@@ -27,12 +31,17 @@ export function ConfirmActionPopover(props: {
     align = "end",
     side = "bottom",
     tone = "destructive",
+    open,
+    onOpenChange,
     children,
   } = props;
   const { t } = useLocale();
 
   return (
-    <Popover.Root>
+    <Popover.Root
+      open={open}
+      onOpenChange={onOpenChange ? (nextOpen) => onOpenChange(nextOpen) : undefined}
+    >
       {/* Pass no-op — Popover.Trigger merges its own click handler via render prop */}
       <Popover.Trigger render={children(() => {}) as React.ReactElement} />
       <Popover.Portal>

--- a/crates/agent-ui/src/components/ui/label-tooltip.tsx
+++ b/crates/agent-ui/src/components/ui/label-tooltip.tsx
@@ -4,13 +4,26 @@ import type { ReactNode } from "react";
 /**
  * 纯文本标签气泡（Base UI）：composer 运行时控件与上下文用量环共用同一视觉。
  * z-index 必须挂在 Positioner 上（Popup 上无效，见弹层拓扑约定）。
+ * 默认非受控（悬停展示）；触屏点按驱动的调用方（上下文用量环）传入
+ * open/onOpenChange 受控，并禁用 closeOnClick——trigger 按压关闭发生在
+ * pointerdown，早于调用方 click 阶段的开合裁决，保留会让二段点按判据失效。
  */
-export function LabelTooltip(props: { label: string; children: ReactNode }) {
+export function LabelTooltip(props: {
+  label: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  closeOnClick?: boolean;
+  children: ReactNode;
+}) {
+  const { onOpenChange } = props;
   return (
-    <Tooltip.Root>
+    <Tooltip.Root
+      open={props.open}
+      onOpenChange={onOpenChange ? (open) => onOpenChange(open) : undefined}
+    >
       <Tooltip.Trigger
         delay={0}
-        closeOnClick
+        closeOnClick={props.closeOnClick ?? true}
         render={<span className="inline-flex shrink-0">{props.children}</span>}
       />
       <Tooltip.Portal>
@@ -21,7 +34,7 @@ export function LabelTooltip(props: { label: string; children: ReactNode }) {
           collisionPadding={8}
           className="z-[9999]"
         >
-          <Tooltip.Popup className="max-w-64 rounded-xl border border-border/60 bg-popover px-3 py-2 text-xs font-medium leading-4 text-popover-foreground shadow-lg outline-hidden data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95">
+          <Tooltip.Popup className="label-tooltip-popup max-w-64 rounded-xl border border-border/60 bg-popover px-3 py-2 text-xs font-medium leading-4 text-popover-foreground shadow-lg outline-hidden">
             {props.label}
           </Tooltip.Popup>
         </Tooltip.Positioner>


### PR DESCRIPTION
## 概要

上下文用量环（GUI 与 WebUI 共享组件）的两批交互优化：

### 触屏二段点按（移动端）
- `(hover: none), (pointer: coarse)` 命中时：首次点按只弹用量 tooltip；占用 ≥50%（有压缩入口）时第二次点按收起 tooltip 再弹压缩确认——两个弹层同侧定位，全程互斥展示不重叠。
- 桌面端保持原行为：悬停出 tooltip、点击出确认；确认弹层展示期间抑制 tooltip 打开请求。
- 关键时序：触屏必须 `closeOnClick={false}`。Base UI trigger 的按压关闭发生在 pointerdown，早于 click 阶段的开合裁决，保留会让第二次点按先关掉 tooltip、裁决误判为"首次点按"而永远进不了确认弹层。
- <50% 分支触屏渲染真按钮（键盘可达），细指针保持原静态 span。

### tooltip 排版与动画
- 内容拆两行：`百分比 · 总计 tokens` / `上下文窗口 xxx`（第二行 muted 弱化）；`aria-valuetext`/`aria-label` 仍是单行字符串，a11y 口径不变。
- 进出场动画走 `label-tooltip-popup` 专属类，按弹层动画拓扑在 GUI `index.css` 与 WebUI `styles.css` 各登记一份（这两个文件有意不镜像）：`data-starting-style`/`data-ending-style` + transition，淡入 + 锚点侧滑入 + 缩放生长，入场 150ms/退场 100ms，`data-side="top"` 方向翻转，含 `prefers-reduced-motion` 关停。
- 删除 Popup 上的 `animate-in`/`zoom-in-95` 等死类（`tailwindcss-animate` 未安装，原本零动画）。

### API 变更（向后兼容）
- `LabelTooltip`：新增可选 `open`/`onOpenChange`/`closeOnClick`，`label` 由 `string` 放宽为 `ReactNode`；不传时保持原非受控行为。
- `ConfirmActionPopover`：新增可选 `open`/`onOpenChange`；其他调用方（删除确认等）不受影响。

## 验证
- 两端 `tsc` 通过
- biome 无告警
- GUI chat 测试 615 通过；WebUI 测试 554 通过
- `check-ui-boundaries.mjs` 通过