### PR TITLE
fix(updater): 避免任务运行时直接重启应用

### DIFF
--- a/crates/agent-gui/src/App.tsx
+++ b/crates/agent-gui/src/App.tsx
@@ -1,5 +1,6 @@
 import type { Context } from "@earendil-works/pi-ai";
 import { AppErrorBoundary } from "@liveagent/ui/components/AppErrorBoundary";
+import { useConfirmDialog } from "@liveagent/ui/components/ui/confirm-dialog";
 import { LocaleContext, t as translate } from "@liveagent/ui/i18n/index";
 import { initAutomation } from "@liveagent/ui/lib/automation/index";
 import {
@@ -49,6 +50,13 @@ function asErrorMessage(error: unknown, fallback: string) {
   if (error instanceof Error && error.message.trim()) return error.message.trim();
   const text = String(error ?? "").trim();
   return text || fallback;
+}
+
+function interpolateMessage(template: string, values: Record<string, string>) {
+  return Object.entries(values).reduce(
+    (text, [key, value]) => text.replaceAll(`{${key}}`, value),
+    template,
+  );
 }
 
 const GATEWAY_SETTINGS_SYNC_EVENT = "gateway:settings-sync";
@@ -176,6 +184,8 @@ export default function App() {
   });
   const [context, setContext] = useState<Context>(() => getDefaultContext());
   const [overlay, setOverlay] = useState<"closed" | "entering" | "open" | "leaving">("closed");
+  const runningConversationCountRef = useRef(0);
+  const { confirm: requestRestartConfirm, dialog: restartConfirmDialog } = useConfirmDialog();
 
   const saveSequenceRef = useRef(0);
   const saveChainRef = useRef<Promise<unknown>>(Promise.resolve());
@@ -519,10 +529,33 @@ export default function App() {
     [settings.locale],
   );
 
+  const beforeAppRestart = useCallback(async () => {
+    const count = runningConversationCountRef.current;
+    if (count === 0) return true;
+
+    return requestRestartConfirm({
+      title: translate("appUpdate.runningTasksTitle", settings.locale),
+      description: interpolateMessage(
+        translate("appUpdate.runningTasksDescription", settings.locale),
+        { count: String(count) },
+      ),
+      cancelLabel: translate("appUpdate.restartLater", settings.locale),
+      confirmLabel: translate("appUpdate.restartAnyway", settings.locale),
+      closeLabel: translate("appUpdate.restartLater", settings.locale),
+      tone: "warning",
+      preferCancel: true,
+    });
+  }, [requestRestartConfirm, settings.locale]);
+
+  const handleRunningConversationCountChange = useCallback((count: number) => {
+    runningConversationCountRef.current = count;
+  }, []);
+
   const appUpdate = useAppUpdateController({
     enabled: settingsReady,
     includePrereleases: settings.updates.includePrereleases,
     messages: appUpdateMessages,
+    beforeRestart: beforeAppRestart,
   });
   // 托盘「检查更新」动作：controller 在监听 effect 之后创建，经 ref 回填。
   runUpdateCheckRef.current = () => {
@@ -601,6 +634,7 @@ export default function App() {
             onOpenSettings={openSettings}
             onToggleTheme={toggleTheme}
             appUpdate={appUpdate}
+            onRunningConversationCountChange={handleRunningConversationCountChange}
           />
         </AppErrorBoundary>
         {visible && (
@@ -636,6 +670,7 @@ export default function App() {
             {translate("app.windowPinned", settings.locale)}
           </button>
         )}
+        {restartConfirmDialog}
       </AppChrome>
     </LocaleContext.Provider>
   );

--- a/crates/agent-gui/src/components/AppUpdateButton.tsx
+++ b/crates/agent-gui/src/components/AppUpdateButton.tsx
@@ -2,7 +2,7 @@ import { Button } from "@liveagent/ui/components/ui/button";
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { cn } from "@liveagent/ui/lib/shared/utils";
 import { type AppUpdateController, getAppUpdateDisplayVersion } from "../lib/appUpdates";
-import { Download, Loader2 } from "./icons";
+import { Download, Loader2, RefreshCw } from "./icons";
 
 type AppUpdateButtonProps = {
   appUpdate: AppUpdateController;
@@ -31,12 +31,16 @@ export function AppUpdateButton({
 
   const version = getAppUpdateDisplayVersion(appUpdate.result);
   const busy = appUpdate.installing || appUpdate.restarting;
+  const installed = appUpdate.installed;
+  const actionLabel = installed ? t("appUpdate.restart") : t("appUpdate.update");
   const title =
     appUpdate.status === "error" && appUpdate.message
       ? interpolate(t("appUpdate.failedRetry"), { message: appUpdate.message })
-      : version
-        ? interpolate(t("appUpdate.updateTo"), { version })
-        : t("appUpdate.update");
+      : installed
+        ? t("appUpdate.restartToComplete")
+        : version
+          ? interpolate(t("appUpdate.updateTo"), { version })
+          : t("appUpdate.update");
 
   return (
     <Button
@@ -52,11 +56,24 @@ export function AppUpdateButton({
       disabled={busy}
       title={title}
       aria-label={title}
-      onClick={() => void appUpdate.installAndRestart().catch(() => undefined)}
+      onClick={() =>
+        void (installed ? appUpdate.restart() : appUpdate.installAndRestart()).catch(
+          () => undefined,
+        )
+      }
     >
       {busy ? (
         <Loader2
           className={cn(iconOnly ? "h-3 w-3" : "h-[13px] w-[13px]", iconClassName, "animate-spin")}
+        />
+      ) : installed ? (
+        <RefreshCw
+          className={cn(
+            iconOnly
+              ? "h-3 w-3 transition-opacity duration-150 group-hover/update:opacity-0"
+              : "h-[13px] w-[13px]",
+            iconClassName,
+          )}
         />
       ) : (
         <Download
@@ -71,11 +88,11 @@ export function AppUpdateButton({
       {iconOnly ? (
         busy ? null : (
           <span className="pointer-events-none absolute whitespace-nowrap opacity-0 transition-opacity duration-150 group-hover/update:opacity-100">
-            {t("appUpdate.update")}
+            {actionLabel}
           </span>
         )
       ) : (
-        t("appUpdate.update")
+        actionLabel
       )}
     </Button>
   );

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -45,6 +45,13 @@ export const translations: Record<Locale, Record<string, string>> = {
     "appUpdate.update": "更新",
     "appUpdate.updateTo": "更新到 v{version}",
     "appUpdate.failedRetry": "更新失败：{message}。点击重试。",
+    "appUpdate.restart": "重启",
+    "appUpdate.restartToComplete": "更新已安装，重启以完成更新",
+    "appUpdate.runningTasksTitle": "有任务正在运行",
+    "appUpdate.runningTasksDescription":
+      "当前有 {count} 个会话仍在执行。重启会终止回复和工具调用，未完成的进度可能丢失。",
+    "appUpdate.restartLater": "稍后重启",
+    "appUpdate.restartAnyway": "仍然重启",
 
     /* ── Chat Page ── */
     "chat.newConversation": "新对话",
@@ -2331,6 +2338,13 @@ export const translations: Record<Locale, Record<string, string>> = {
     "appUpdate.update": "Update",
     "appUpdate.updateTo": "Update to v{version}",
     "appUpdate.failedRetry": "Update failed: {message}. Click to retry.",
+    "appUpdate.restart": "Restart",
+    "appUpdate.restartToComplete": "Update installed. Restart to finish updating.",
+    "appUpdate.runningTasksTitle": "Tasks are still running",
+    "appUpdate.runningTasksDescription":
+      "{count} conversations are still running. Restarting will stop replies and tool calls, and unfinished progress may be lost.",
+    "appUpdate.restartLater": "Restart later",
+    "appUpdate.restartAnyway": "Restart anyway",
 
     /* ── Chat Page ── */
     "chat.newConversation": "New Conversation",

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -1187,6 +1187,8 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.aboutCurrentVersion": "当前版本",
     "settings.aboutOpenRelease": "发布页",
     "settings.aboutCheckUpdate": "检查更新",
+    "settings.aboutRestartBeforeCheck": "请先重启应用",
+    "settings.aboutRestartBeforeCheckDesc": "更新已安装，请重启应用后再检查。",
     "settings.aboutInstallUpdate": "安装更新",
     "settings.aboutRestartApp": "重启应用",
     "settings.aboutChecking": "正在检查更新",
@@ -3535,6 +3537,9 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.aboutCurrentVersion": "Current Version",
     "settings.aboutOpenRelease": "Release",
     "settings.aboutCheckUpdate": "Check",
+    "settings.aboutRestartBeforeCheck": "Restart the app first",
+    "settings.aboutRestartBeforeCheckDesc":
+      "The update is installed. Restart the app before checking again.",
     "settings.aboutInstallUpdate": "Install Update",
     "settings.aboutRestartApp": "Restart App",
     "settings.aboutChecking": "Checking for updates",

--- a/crates/agent-gui/src/lib/appUpdates.ts
+++ b/crates/agent-gui/src/lib/appUpdates.ts
@@ -169,8 +169,12 @@ export function useAppUpdateController({
       return undefined;
     }
 
-    const requestId = ++checkSeqRef.current;
     const current = stateRef.current;
+    if (current.status === "installed") {
+      return current.result;
+    }
+
+    const requestId = ++checkSeqRef.current;
     setUpdateState({
       status: "checking",
       result: getAppUpdateStateResult(current),

--- a/crates/agent-gui/src/lib/appUpdates.ts
+++ b/crates/agent-gui/src/lib/appUpdates.ts
@@ -43,6 +43,8 @@ export type AppUpdateMessages = {
   restartFailed: string;
 };
 
+export type BeforeAppRestart = () => boolean | Promise<boolean>;
+
 export type AppUpdateController = {
   state: AppUpdateState;
   status: AppUpdateStatus;
@@ -65,6 +67,7 @@ type UseAppUpdateControllerOptions = {
   enabled: boolean;
   includePrereleases: boolean;
   messages?: Partial<AppUpdateMessages>;
+  beforeRestart?: BeforeAppRestart;
 };
 
 const DEFAULT_MESSAGES: AppUpdateMessages = {
@@ -109,8 +112,23 @@ export function canInstallAppUpdate(state: AppUpdateState) {
 export function shouldShowAppUpdateButton(state: AppUpdateState) {
   const result = getAppUpdateStateResult(state);
   return Boolean(
-    result?.available || state.status === "installing" || state.status === "restarting",
+    result?.available ||
+      state.status === "installing" ||
+      state.status === "installed" ||
+      state.status === "restarting",
   );
+}
+
+export async function requestAppRestart(options: {
+  beforeRestart?: BeforeAppRestart;
+  restart: () => Promise<unknown>;
+}) {
+  if (options.beforeRestart && !(await options.beforeRestart())) {
+    return false;
+  }
+
+  await options.restart();
+  return true;
 }
 
 export function shouldRunAutomaticAppUpdateCheck(state: AppUpdateState) {
@@ -126,10 +144,12 @@ export function useAppUpdateController({
   enabled,
   includePrereleases,
   messages,
+  beforeRestart,
 }: UseAppUpdateControllerOptions): AppUpdateController {
   const [state, setState] = useState<AppUpdateState>({ status: "idle" });
   const stateRef = useRef<AppUpdateState>(state);
   const checkSeqRef = useRef(0);
+  const restartRequestRef = useRef<Promise<void> | null>(null);
   const messagesRef = useRef<AppUpdateMessages>(DEFAULT_MESSAGES);
 
   useEffect(() => {
@@ -183,7 +203,6 @@ export function useAppUpdateController({
       setUpdateState({ status: "idle" });
       return undefined;
     }
-
     const checkForUpdates = () => {
       if (!shouldRunAutomaticAppUpdateCheck(stateRef.current)) {
         return;
@@ -222,25 +241,47 @@ export function useAppUpdateController({
     }
   }, [includePrereleases, setUpdateState]);
 
-  const restart = useCallback(async () => {
-    const current = stateRef.current;
-    const result = getAppUpdateStateResult(current);
-    if (!result || current.status === "restarting") {
-      return;
+  const restart = useCallback(() => {
+    if (restartRequestRef.current) {
+      return restartRequestRef.current;
     }
 
-    setUpdateState({ status: "restarting", result });
-    try {
-      await invoke("app_restart");
-    } catch (error) {
-      setUpdateState({
-        status: "error",
-        result,
-        message: asErrorMessage(error, messagesRef.current.restartFailed),
+    const request = (async () => {
+      const current = stateRef.current;
+      const result = getAppUpdateStateResult(current);
+      if (!result || current.status === "restarting") {
+        return;
+      }
+
+      await requestAppRestart({
+        beforeRestart,
+        restart: async () => {
+          setUpdateState({ status: "restarting", result });
+          try {
+            await invoke("app_restart");
+          } catch (error) {
+            setUpdateState({
+              status: "error",
+              result,
+              message: asErrorMessage(error, messagesRef.current.restartFailed),
+            });
+            throw error;
+          }
+        },
       });
-      throw error;
-    }
-  }, [setUpdateState]);
+    })();
+
+    restartRequestRef.current = request;
+    void request.then(
+      () => {
+        if (restartRequestRef.current === request) restartRequestRef.current = null;
+      },
+      () => {
+        if (restartRequestRef.current === request) restartRequestRef.current = null;
+      },
+    );
+    return request;
+  }, [beforeRestart, setUpdateState]);
 
   const installAndRestart = useCallback(async () => {
     const result = await installOnly();
@@ -248,19 +289,9 @@ export function useAppUpdateController({
       return undefined;
     }
 
-    setUpdateState({ status: "restarting", result });
-    try {
-      await invoke("app_restart");
-      return result;
-    } catch (error) {
-      setUpdateState({
-        status: "error",
-        result,
-        message: asErrorMessage(error, messagesRef.current.restartFailed),
-      });
-      throw error;
-    }
-  }, [installOnly, setUpdateState]);
+    await restart();
+    return result;
+  }, [installOnly, restart]);
 
   const result = getAppUpdateStateResult(state);
   const message = state.status === "error" ? state.message : undefined;

--- a/crates/agent-gui/src/lib/appUpdates.ts
+++ b/crates/agent-gui/src/lib/appUpdates.ts
@@ -43,6 +43,11 @@ export type AppUpdateMessages = {
   restartFailed: string;
 };
 
+export type AppUpdateNotice = {
+  id: number;
+  kind: "restart-required";
+};
+
 export type BeforeAppRestart = () => boolean | Promise<boolean>;
 
 export type AppUpdateController = {
@@ -57,6 +62,7 @@ export type AppUpdateController = {
   busy: boolean;
   canInstall: boolean;
   showUpdateButton: boolean;
+  notice?: AppUpdateNotice;
   runCheck: () => Promise<AppUpdateCheckResult | undefined>;
   installOnly: () => Promise<AppUpdateCheckResult | undefined>;
   installAndRestart: () => Promise<AppUpdateCheckResult | undefined>;
@@ -119,6 +125,10 @@ export function shouldShowAppUpdateButton(state: AppUpdateState) {
   );
 }
 
+export function shouldShowRestartRequiredNotice(state: AppUpdateState, notice?: AppUpdateNotice) {
+  return state.status === "installed" && notice?.kind === "restart-required";
+}
+
 export async function requestAppRestart(options: {
   beforeRestart?: BeforeAppRestart;
   restart: () => Promise<unknown>;
@@ -147,6 +157,7 @@ export function useAppUpdateController({
   beforeRestart,
 }: UseAppUpdateControllerOptions): AppUpdateController {
   const [state, setState] = useState<AppUpdateState>({ status: "idle" });
+  const [notice, setNotice] = useState<AppUpdateNotice>();
   const stateRef = useRef<AppUpdateState>(state);
   const checkSeqRef = useRef(0);
   const restartRequestRef = useRef<Promise<void> | null>(null);
@@ -161,6 +172,9 @@ export function useAppUpdateController({
 
   const setUpdateState = useCallback((next: AppUpdateState) => {
     stateRef.current = next;
+    if (next.status !== "installed") {
+      setNotice(undefined);
+    }
     setState(next);
   }, []);
 
@@ -171,7 +185,14 @@ export function useAppUpdateController({
 
     const current = stateRef.current;
     if (current.status === "installed") {
+      setNotice((previous) => ({
+        id: (previous?.id ?? 0) + 1,
+        kind: "restart-required",
+      }));
       return current.result;
+    }
+    if (isAppUpdateBusy(current)) {
+      return getAppUpdateStateResult(current);
     }
 
     const requestId = ++checkSeqRef.current;
@@ -203,6 +224,12 @@ export function useAppUpdateController({
   }, [enabled, includePrereleases, setUpdateState]);
 
   useEffect(() => {
+    if (!notice) return undefined;
+    const timeoutId = window.setTimeout(() => setNotice(undefined), 4000);
+    return () => window.clearTimeout(timeoutId);
+  }, [notice]);
+
+  useEffect(() => {
     if (!enabled) {
       setUpdateState({ status: "idle" });
       return undefined;
@@ -224,7 +251,7 @@ export function useAppUpdateController({
   const installOnly = useCallback(async () => {
     const current = stateRef.current;
     const result = getAppUpdateStateResult(current);
-    if (!result?.configured || !result.available || current.status === "installing") {
+    if (!canInstallAppUpdate(current) || !result) {
       return undefined;
     }
 
@@ -320,6 +347,7 @@ export function useAppUpdateController({
       busy,
       canInstall,
       showUpdateButton,
+      notice,
       runCheck,
       installOnly,
       installAndRestart,
@@ -336,6 +364,7 @@ export function useAppUpdateController({
       busy,
       canInstall,
       showUpdateButton,
+      notice,
       runCheck,
       installOnly,
       installAndRestart,

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -183,6 +183,7 @@ type ChatPageProps = {
   onOpenSettings: (section?: SectionId, providerId?: string) => void;
   onToggleTheme: () => void;
   appUpdate?: AppUpdateController;
+  onRunningConversationCountChange?: (count: number) => void;
 };
 
 function CurrentTaskProgress(props: {
@@ -218,6 +219,7 @@ export function ChatPage(props: ChatPageProps) {
     onOpenSettings,
     onToggleTheme,
     appUpdate,
+    onRunningConversationCountChange,
   } = props;
   // Monaco reads NLS globals while the lazy editor module imports monaco-editor.
   setPreferredMonacoNlsLocale(settings.locale);
@@ -1668,6 +1670,15 @@ export function ChatPage(props: ChatPageProps) {
   const sidebarRunningConversationIds = useSidebarSelector(
     sidebarStore,
     selectRunningConversationIds,
+  );
+  useEffect(() => {
+    onRunningConversationCountChange?.(sidebarRunningConversationIds.size);
+  }, [onRunningConversationCountChange, sidebarRunningConversationIds.size]);
+  useEffect(
+    () => () => {
+      onRunningConversationCountChange?.(0);
+    },
+    [onRunningConversationCountChange],
   );
   const appActionParamsRef = useRef({
     handleSelectConversation,

--- a/crates/agent-gui/src/pages/settings/AboutSection.tsx
+++ b/crates/agent-gui/src/pages/settings/AboutSection.tsx
@@ -14,7 +14,11 @@ import {
   Shield,
   Sparkles,
 } from "../../components/icons";
-import type { AppUpdateCheckResult, AppUpdateController } from "../../lib/appUpdates";
+import {
+  type AppUpdateCheckResult,
+  type AppUpdateController,
+  shouldShowRestartRequiredNotice,
+} from "../../lib/appUpdates";
 import { updateUpdateSettings } from "../../lib/settings";
 import { formatReleaseDate } from "./aboutDate";
 import type { SettingsSectionProps } from "./types";
@@ -86,9 +90,11 @@ export function AboutSection(props: AboutSectionProps) {
   const installing = checkState.status === "installing";
   const installed = checkState.status === "installed";
   const restarting = checkState.status === "restarting";
+  const restartRequiredNotice = shouldShowRestartRequiredNotice(checkState, appUpdate.notice);
   const canInstall = appUpdate.canInstall;
-  const statusTitle =
-    checkState.status === "error"
+  const statusTitle = restartRequiredNotice
+    ? t("settings.aboutRestartBeforeCheck")
+    : checkState.status === "error"
       ? t("settings.aboutUpdateError")
       : checking
         ? t("settings.aboutChecking")
@@ -105,8 +111,9 @@ export function AboutSection(props: AboutSectionProps) {
                   : latestResult?.configured
                     ? t("settings.aboutUpToDate")
                     : t("settings.aboutUpdaterNotConfigured");
-  const statusDescription =
-    checkState.status === "error"
+  const statusDescription = restartRequiredNotice
+    ? t("settings.aboutRestartBeforeCheckDesc")
+    : checkState.status === "error"
       ? appUpdate.message || t("settings.aboutUpdateError")
       : checking
         ? t("settings.aboutCheckingDesc")
@@ -188,7 +195,7 @@ export function AboutSection(props: AboutSectionProps) {
           <div className="rounded-xl border border-border/60 bg-background/70 p-4">
             <div className="flex items-start gap-3">
               <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
-                {checkState.status === "error" ? (
+                {checkState.status === "error" || restartRequiredNotice ? (
                   <AlertTriangle className="h-4 w-4 text-amber-500" />
                 ) : restarting ? (
                   <Loader2 className="h-4 w-4 animate-spin text-primary" />
@@ -200,7 +207,7 @@ export function AboutSection(props: AboutSectionProps) {
                   <CheckCircle2 className="h-4 w-4 text-emerald-500" />
                 )}
               </div>
-              <div className="min-w-0 flex-1">
+              <div className="min-w-0 flex-1" role="status" aria-live="polite" aria-atomic="true">
                 <div className="text-sm font-semibold">{statusTitle}</div>
                 <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
                   {statusDescription}

--- a/crates/agent-gui/test/settings/app-updates.test.mjs
+++ b/crates/agent-gui/test/settings/app-updates.test.mjs
@@ -17,6 +17,73 @@ const {
   shouldShowAppUpdateButton,
 } = loader.loadModule("src/lib/appUpdates.ts");
 
+function createAppUpdateControllerHarness() {
+  const states = [];
+  const refs = [];
+  let stateIndex = 0;
+  let refIndex = 0;
+  const invokeCalls = [];
+  const checkResult = {
+    configured: true,
+    available: true,
+    currentVersion: "1.3.0",
+    version: "1.3.1",
+    channel: "stable",
+    repository: "Stack-Cairn/LiveAgent",
+  };
+  const installedResult = { ...checkResult, available: false };
+  const react = {
+    useState(initialValue) {
+      const index = stateIndex++;
+      if (!(index in states)) {
+        states[index] = typeof initialValue === "function" ? initialValue() : initialValue;
+      }
+      return [
+        states[index],
+        (next) => {
+          states[index] = typeof next === "function" ? next(states[index]) : next;
+        },
+      ];
+    },
+    useRef(initialValue) {
+      const index = refIndex++;
+      refs[index] ??= { current: initialValue };
+      return refs[index];
+    },
+    useCallback(callback) {
+      return callback;
+    },
+    useEffect() {},
+    useMemo(factory) {
+      return factory();
+    },
+  };
+  const controllerLoader = createTsModuleLoader({
+    mocks: {
+      react,
+      "@tauri-apps/api/core": {
+        async invoke(command) {
+          invokeCalls.push(command);
+          if (command === "app_update_check") return checkResult;
+          if (command === "app_update_install") return installedResult;
+          throw new Error(`Unexpected invoke: ${command}`);
+        },
+      },
+    },
+  });
+  const { useAppUpdateController } = controllerLoader.loadModule("src/lib/appUpdates.ts");
+
+  return {
+    invokeCalls,
+    installedResult,
+    render() {
+      stateIndex = 0;
+      refIndex = 0;
+      return useAppUpdateController({ enabled: true, includePrereleases: false });
+    },
+  };
+}
+
 test("checks for application updates every 20 minutes", () => {
   assert.equal(APP_UPDATE_CHECK_INTERVAL_MS, 20 * 60 * 1000);
 });
@@ -41,6 +108,25 @@ test("the update button remains available after an update is installed", () => {
     false,
   );
   assert.equal(shouldShowAppUpdateButton({ status: "installed", result: {} }), true);
+});
+
+test("manual checks preserve the pending restart after an update is installed", async () => {
+  const harness = createAppUpdateControllerHarness();
+  let controller = harness.render();
+
+  await controller.runCheck();
+  controller = harness.render();
+  await controller.installOnly();
+  controller = harness.render();
+  assert.equal(controller.status, "installed");
+
+  const result = await controller.runCheck();
+  controller = harness.render();
+
+  assert.equal(result, harness.installedResult);
+  assert.equal(controller.status, "installed");
+  assert.equal(controller.result, harness.installedResult);
+  assert.deepEqual(harness.invokeCalls, ["app_update_check", "app_update_install"]);
 });
 
 test("restart is skipped when the pre-restart guard declines", async () => {

--- a/crates/agent-gui/test/settings/app-updates.test.mjs
+++ b/crates/agent-gui/test/settings/app-updates.test.mjs
@@ -15,9 +15,10 @@ const {
   requestAppRestart,
   shouldRunAutomaticAppUpdateCheck,
   shouldShowAppUpdateButton,
+  shouldShowRestartRequiredNotice,
 } = loader.loadModule("src/lib/appUpdates.ts");
 
-function createAppUpdateControllerHarness() {
+function createAppUpdateControllerHarness(options = {}) {
   const states = [];
   const refs = [];
   let stateIndex = 0;
@@ -32,6 +33,18 @@ function createAppUpdateControllerHarness() {
     repository: "Stack-Cairn/LiveAgent",
   };
   const installedResult = { ...checkResult, available: false };
+  let resolveCheck;
+  const pendingCheck = options.deferCheckAfterFirst
+    ? new Promise((resolve) => {
+        resolveCheck = () => resolve(checkResult);
+      })
+    : null;
+  let resolveInstall;
+  const pendingInstall = options.deferInstall
+    ? new Promise((resolve) => {
+        resolveInstall = () => resolve(installedResult);
+      })
+    : null;
   const react = {
     useState(initialValue) {
       const index = stateIndex++;
@@ -64,8 +77,12 @@ function createAppUpdateControllerHarness() {
       "@tauri-apps/api/core": {
         async invoke(command) {
           invokeCalls.push(command);
-          if (command === "app_update_check") return checkResult;
-          if (command === "app_update_install") return installedResult;
+          if (command === "app_update_check") {
+            const checkCount = invokeCalls.filter((call) => call === "app_update_check").length;
+            return pendingCheck && checkCount > 1 ? pendingCheck : checkResult;
+          }
+          if (command === "app_update_install") return pendingInstall || installedResult;
+          if (command === "app_restart") return undefined;
           throw new Error(`Unexpected invoke: ${command}`);
         },
       },
@@ -74,8 +91,11 @@ function createAppUpdateControllerHarness() {
   const { useAppUpdateController } = controllerLoader.loadModule("src/lib/appUpdates.ts");
 
   return {
+    checkResult,
     invokeCalls,
     installedResult,
+    resolveCheck,
+    resolveInstall,
     render() {
       stateIndex = 0;
       refIndex = 0;
@@ -86,6 +106,79 @@ function createAppUpdateControllerHarness() {
 
 test("checks for application updates every 20 minutes", () => {
   assert.equal(APP_UPDATE_CHECK_INTERVAL_MS, 20 * 60 * 1000);
+});
+
+test("tray checks cannot interrupt an update installation", async () => {
+  const harness = createAppUpdateControllerHarness({ deferInstall: true });
+  let controller = harness.render();
+
+  await controller.runCheck();
+  controller = harness.render();
+  const installPromise = controller.installOnly();
+  controller = harness.render();
+  assert.equal(controller.status, "installing");
+
+  const result = await controller.runCheck();
+  controller = harness.render();
+  assert.equal(result, harness.checkResult);
+  assert.equal(controller.status, "installing");
+  assert.deepEqual(harness.invokeCalls, ["app_update_check", "app_update_install"]);
+
+  harness.resolveInstall();
+  await installPromise;
+  controller = harness.render();
+  assert.equal(controller.status, "installed");
+  assert.equal(controller.result, harness.installedResult);
+});
+
+test("install requests cannot interrupt an update check", async () => {
+  const harness = createAppUpdateControllerHarness({ deferCheckAfterFirst: true });
+  let controller = harness.render();
+
+  await controller.runCheck();
+  controller = harness.render();
+  const checkingResult = controller.runCheck();
+  controller = harness.render();
+  assert.equal(controller.status, "checking");
+
+  const installResult = await controller.installOnly();
+  controller = harness.render();
+  assert.equal(installResult, undefined);
+  assert.equal(controller.status, "checking");
+  assert.deepEqual(harness.invokeCalls, ["app_update_check", "app_update_check"]);
+
+  harness.resolveCheck();
+  await checkingResult;
+  controller = harness.render();
+  assert.equal(controller.status, "ready");
+});
+
+test("restart-required feedback is visible only while an update is installed", () => {
+  const notice = { id: 1, kind: "restart-required" };
+  assert.equal(shouldShowRestartRequiredNotice({ status: "installed", result: {} }, notice), true);
+  assert.equal(shouldShowRestartRequiredNotice({ status: "restarting", result: {} }, notice), false);
+  assert.equal(
+    shouldShowRestartRequiredNotice({ status: "error", message: "failed" }, notice),
+    false,
+  );
+});
+
+test("restart-required feedback is cleared when the app leaves the installed state", async () => {
+  const harness = createAppUpdateControllerHarness();
+  let controller = harness.render();
+
+  await controller.runCheck();
+  controller = harness.render();
+  await controller.installOnly();
+  controller = harness.render();
+  await controller.runCheck();
+  controller = harness.render();
+  assert.equal(controller.notice?.kind, "restart-required");
+
+  await controller.restart();
+  controller = harness.render();
+  assert.equal(controller.status, "restarting");
+  assert.equal(controller.notice, undefined);
 });
 
 test("automatic checks do not interrupt active update states", () => {
@@ -126,6 +219,7 @@ test("manual checks preserve the pending restart after an update is installed", 
   assert.equal(result, harness.installedResult);
   assert.equal(controller.status, "installed");
   assert.equal(controller.result, harness.installedResult);
+  assert.deepEqual(controller.notice, { id: 1, kind: "restart-required" });
   assert.deepEqual(harness.invokeCalls, ["app_update_check", "app_update_install"]);
 });
 

--- a/crates/agent-gui/test/settings/app-updates.test.mjs
+++ b/crates/agent-gui/test/settings/app-updates.test.mjs
@@ -1,11 +1,18 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 
 const loader = createTsModuleLoader();
+const appSource = readFileSync(new URL("../../src/App.tsx", import.meta.url), "utf8");
+const confirmDialogSource = readFileSync(
+  new URL("../../../agent-ui/src/components/ui/confirm-dialog.tsx", import.meta.url),
+  "utf8",
+);
 const {
   APP_UPDATE_CHECK_INTERVAL_MS,
+  requestAppRestart,
   shouldRunAutomaticAppUpdateCheck,
   shouldShowAppUpdateButton,
 } = loader.loadModule("src/lib/appUpdates.ts");
@@ -24,7 +31,7 @@ test("automatic checks do not interrupt active update states", () => {
   }
 });
 
-test("the update button appears only after an available update is detected", () => {
+test("the update button remains available after an update is installed", () => {
   assert.equal(
     shouldShowAppUpdateButton({ status: "ready", result: { available: true } }),
     true,
@@ -32,5 +39,46 @@ test("the update button appears only after an available update is detected", () 
   assert.equal(
     shouldShowAppUpdateButton({ status: "ready", result: { available: false } }),
     false,
+  );
+  assert.equal(shouldShowAppUpdateButton({ status: "installed", result: {} }), true);
+});
+
+test("restart is skipped when the pre-restart guard declines", async () => {
+  let restartCount = 0;
+  const restarted = await requestAppRestart({
+    beforeRestart: async () => false,
+    restart: async () => {
+      restartCount += 1;
+    },
+  });
+
+  assert.equal(restarted, false);
+  assert.equal(restartCount, 0);
+});
+
+test("restart proceeds once when the guard confirms or is absent", async () => {
+  let restartCount = 0;
+  const restart = async () => {
+    restartCount += 1;
+  };
+
+  assert.equal(await requestAppRestart({ beforeRestart: () => true, restart }), true);
+  assert.equal(await requestAppRestart({ restart }), true);
+  assert.equal(restartCount, 2);
+});
+
+test("restart guard visually prioritizes the safe action", () => {
+  assert.match(appSource, /preferCancel:\s*true/);
+  assert.match(
+    confirmDialogSource,
+    /variant=\{preferCancel \? "default" : "outline"\}/,
+  );
+  assert.match(
+    confirmDialogSource,
+    /variant=\{preferCancel \? "ghost" : "destructive"\}/,
+  );
+  assert.match(
+    confirmDialogSource,
+    /text-destructive hover:bg-destructive\/10 hover:text-destructive/,
   );
 });

--- a/crates/agent-ui/src/components/ui/confirm-dialog.tsx
+++ b/crates/agent-ui/src/components/ui/confirm-dialog.tsx
@@ -15,6 +15,8 @@ export type ConfirmDialogOptions = {
   closeLabel?: string;
   tone?: ConfirmDialogTone;
   hideCancel?: boolean;
+  /** Give the safe cancel action primary emphasis and render confirmation as destructive text. */
+  preferCancel?: boolean;
 };
 
 type PendingConfirmDialog = ConfirmDialogOptions & {
@@ -51,6 +53,7 @@ function ConfirmDialog(
     closeLabel = cancelLabel,
     tone = "destructive",
     hideCancel = false,
+    preferCancel = false,
     onCancel,
     onConfirm,
   } = props;
@@ -125,7 +128,7 @@ function ConfirmDialog(
                   render={
                     <Button
                       type="button"
-                      variant="outline"
+                      variant={preferCancel ? "default" : "outline"}
                       autoFocus
                       className="w-full sm:w-auto"
                     />
@@ -136,9 +139,13 @@ function ConfirmDialog(
               )}
               <Button
                 type="button"
-                variant="destructive"
+                variant={preferCancel ? "ghost" : "destructive"}
                 onClick={onConfirm}
-                className="w-full sm:w-auto"
+                className={`w-full sm:w-auto ${
+                  preferCancel
+                    ? "text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    : ""
+                }`}
               >
                 {confirmLabel}
               </Button>
@@ -188,6 +195,7 @@ export function useConfirmDialog() {
       closeLabel={pending.closeLabel}
       tone={pending.tone}
       hideCancel={pending.hideCancel}
+      preferCancel={pending.preferCancel}
       onCancel={() => close(false)}
       onConfirm={() => close(true)}
     />


### PR DESCRIPTION
## Linked issue

Closes #260

## Summary

- 在应用重启前统计仍在执行的会话；有任务运行时先显示确认弹窗，避免更新完成后直接终止回复和工具调用。
- 用户选择“稍后重启”后保留已安装状态，并在侧边栏与“关于”页继续提供重启入口。
- controller 根部保护已安装和忙碌状态，避免手动或托盘检查与安装流程互相覆盖；重复检查时在状态卡提示先重启应用。
- 将“稍后重启”设为默认焦点和有底色的主操作，“仍然重启”降级为无框红字，降低误触风险。
- 对中英文提示、重启守卫、重复重启请求、检查/安装竞态和更新按钮状态补充回归覆盖。

## Change scope

- Modules: `agent-gui`, `agent-ui`
- Key paths:
  - `crates/agent-gui/src/App.tsx`
  - `crates/agent-gui/src/lib/appUpdates.ts`
  - `crates/agent-gui/src/components/AppUpdateButton.tsx`
  - `crates/agent-gui/src/pages/settings/AboutSection.tsx`
  - `crates/agent-ui/src/components/ui/confirm-dialog.tsx`
  - `crates/agent-gui/test/settings/app-updates.test.mjs`

## Screenshots / preview

### 有任务运行时的重启保护

![有任务运行时的重启保护弹窗](https://raw.githubusercontent.com/Skitre/LiveAgent/pr-assets/issue-260/pr-assets/issue-260/01-restart-guard.png)

### 安装完成后的侧边栏入口

| 默认图标 | 悬停文案 |
| --- | --- |
| ![更新安装完成后的重启图标](https://raw.githubusercontent.com/Skitre/LiveAgent/pr-assets/issue-260/pr-assets/issue-260/02-update-icon.png) | ![更新安装完成后的重启文案](https://raw.githubusercontent.com/Skitre/LiveAgent/pr-assets/issue-260/pr-assets/issue-260/03-restart-label.png) |

### “关于”页保留已安装状态和重启入口

![关于页的更新已安装状态](https://raw.githubusercontent.com/Skitre/LiveAgent/pr-assets/issue-260/pr-assets/issue-260/04-about-page.png)

## Verification

- `pnpm --filter liveagent exec node --test test/settings/app-updates.test.mjs` - 11 passed
- `pnpm --filter liveagent test` - 1575 passed, 0 failed
- `pnpm --filter liveagent exec tsc --noEmit`
- `pnpm --filter liveagent exec biome check src/lib/appUpdates.ts src/pages/settings/AboutSection.tsx src/i18n/config.ts test/settings/app-updates.test.mjs`
- `pnpm --filter liveagent build`
- 真实 Tauri `.app` 中验证已安装状态、侧边栏重启入口、关于页重启入口和运行任务确认弹窗

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] No documentation update is required; deployment and configuration behavior are unchanged.
