### PR TITLE
feat(providers): Codex 缓存提示协议可选，Responses 对齐 CLI

### DIFF
--- a/crates/agent-gateway/test/webui/web-settings.test.mjs
+++ b/crates/agent-gateway/test/webui/web-settings.test.mjs
@@ -1580,6 +1580,40 @@ test("web provider normalization keeps native web search toggle", () => {
   assert.equal(disabled.nativeWebSearchEnabled, false);
 });
 
+test("web provider normalization preserves codex cache hint policy", () => {
+  const defaults = settings.normalizeCustomProvider({ id: "codex-default", type: "codex" });
+  assert.equal(defaults.promptCacheHintMode, "auto");
+  assert.equal(defaults.promptCachingEnabled, true);
+
+  const legacyDisabled = settings.normalizeCustomProvider({
+    id: "codex-legacy-disabled",
+    type: "codex",
+    promptCachingEnabled: false,
+  });
+  assert.equal(legacyDisabled.promptCacheHintMode, "none");
+  assert.equal(legacyDisabled.promptCachingEnabled, false);
+
+  const overridden = settings.normalizeCustomProvider({
+    id: "codex-overridden",
+    type: "codex",
+    promptCacheHintMode: "openrouter-session",
+    models: [
+      { id: "openai-model", promptCacheHintMode: "openai-key" },
+      { id: "invalid-model", promptCacheHintMode: "invalid" },
+    ],
+  });
+  assert.equal(overridden.promptCacheHintMode, "openrouter-session");
+  assert.equal(overridden.models[0].promptCacheHintMode, "openai-key");
+  assert.equal(overridden.models[1].promptCacheHintMode, undefined);
+
+  const invalid = settings.normalizeCustomProvider({
+    id: "codex-invalid",
+    type: "codex",
+    promptCacheHintMode: "invalid",
+  });
+  assert.equal(invalid.promptCacheHintMode, "auto");
+});
+
 test("web right dock normalize keeps unknown session ids and unresolved active tab", () => {
   const project = settings.normalizeRightDockProjectState({
     activeTabId: "sess-active",

--- a/crates/agent-gateway/web/src/i18n/config.ts
+++ b/crates/agent-gateway/web/src/i18n/config.ts
@@ -1443,7 +1443,15 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.promptCaching": "Prompt 缓存",
     "settings.promptCachingDescClaude":
       "在请求上标注 ephemeral 缓存断点，长会话可显著降低输入费用。",
-    "settings.promptCachingDescCodex": "为请求携带稳定的 prompt_cache_key，提升前缀缓存命中率。",
+    "settings.promptCachingDescCodex":
+      "自动选择兼容的缓存提示；未知端点默认只使用服务端自动前缀缓存。",
+    "settings.promptCacheHintMode": "缓存提示协议",
+    "settings.promptCacheHintMode.auto": "自动（推荐）",
+    "settings.promptCacheHintMode.openaiKey": "OpenAI 缓存键",
+    "settings.promptCacheHintMode.openrouterSession": "OpenRouter 会话粘性",
+    "settings.promptCacheHintMode.none": "不发送缓存提示",
+    "settings.promptCacheHintMode.inherit": "继承供应商设置",
+    "settings.promptCacheHintModelOverride": "缓存提示协议",
     "settings.promptCacheRetention": "缓存保留",
     "settings.promptCacheRetentionShort": "5 分钟（默认）",
     "settings.promptCacheRetentionLong": "1 小时（仅官方 API）",
@@ -3732,7 +3740,14 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.promptCachingDescClaude":
       "Mark ephemeral cache breakpoints on requests; long sessions get much cheaper input.",
     "settings.promptCachingDescCodex":
-      "Send a stable prompt_cache_key so prefix-cache hits survive across turns.",
+      "Select a compatible cache hint automatically; unknown endpoints use server-side prefix caching only.",
+    "settings.promptCacheHintMode": "Cache hint protocol",
+    "settings.promptCacheHintMode.auto": "Automatic (recommended)",
+    "settings.promptCacheHintMode.openaiKey": "OpenAI cache key",
+    "settings.promptCacheHintMode.openrouterSession": "OpenRouter session affinity",
+    "settings.promptCacheHintMode.none": "Send no cache hint",
+    "settings.promptCacheHintMode.inherit": "Inherit provider setting",
+    "settings.promptCacheHintModelOverride": "Cache hint protocol",
     "settings.promptCacheRetention": "Cache retention",
     "settings.promptCacheRetentionShort": "5 minutes (default)",
     "settings.promptCacheRetentionLong": "1 hour (official API only)",

--- a/crates/agent-gateway/web/src/lib/gatewayTypes.ts
+++ b/crates/agent-gateway/web/src/lib/gatewayTypes.ts
@@ -1,6 +1,7 @@
 import type {
   ChatRuntimeControls,
   CodexRequestFormat,
+  PromptCacheHintMode,
   ProviderId,
   ProviderModelConfig,
   ReasoningLevel,
@@ -43,6 +44,7 @@ export type GatewayProviderSummary = {
   requestFormat?: CodexRequestFormat;
   reasoning: ReasoningLevel;
   promptCachingEnabled: boolean;
+  promptCacheHintMode?: PromptCacheHintMode;
   nativeWebSearchEnabled: boolean;
 };
 

--- a/crates/agent-gateway/web/src/lib/settings/index.ts
+++ b/crates/agent-gateway/web/src/lib/settings/index.ts
@@ -301,12 +301,16 @@ export type SelectedModel = {
   model: string;
 };
 
+export type PromptCacheHintMode = "auto" | "openai-key" | "openrouter-session" | "none";
+
 export type ProviderModelConfig = {
   id: string;
   /** /models 元数据；缺失时保持旧设置格式兼容。 */
   ownedBy?: string;
   contextWindow: number;
   maxOutputToken: number;
+  /** OpenAI 兼容端点的缓存提示协议；缺失时继承供应商设置。 */
+  promptCacheHintMode?: PromptCacheHintMode;
 };
 
 export type ChatRuntimeControls = {
@@ -445,6 +449,8 @@ export type CustomProvider = {
   requestFormat?: CodexRequestFormat;
   reasoning: ReasoningLevel;
   promptCachingEnabled: boolean;
+  /** OpenAI 兼容端点的缓存提示协议；旧配置由 promptCachingEnabled 迁移。 */
+  promptCacheHintMode?: PromptCacheHintMode;
   /** 仅 Anthropic：ephemeral 缓存保留档位；long 在官方 API 上映射为 1h TTL。 */
   promptCacheRetention?: "short" | "long";
   nativeWebSearchEnabled: boolean;
@@ -495,6 +501,13 @@ export const CODEX_REQUEST_FORMAT_LABELS: Record<CodexRequestFormat, string> = {
   "openai-responses": "Responses API",
 };
 
+export const PROMPT_CACHE_HINT_MODES = [
+  "auto",
+  "openai-key",
+  "openrouter-session",
+  "none",
+] as const satisfies readonly PromptCacheHintMode[];
+
 const CODEX_RESPONSES_SUFFIX = "/responses";
 const CODEX_RESPONSE_SUFFIX = "/response";
 const CODEX_CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
@@ -523,6 +536,10 @@ function normalizeCodexRequestFormat(input: unknown): CodexRequestFormat | undef
     default:
       return undefined;
   }
+}
+
+function normalizePromptCacheHintMode(input: unknown): PromptCacheHintMode | undefined {
+  return PROMPT_CACHE_HINT_MODES.find((mode) => mode === input);
 }
 
 function normalizeCodexRouting(
@@ -582,6 +599,7 @@ export function getBuiltinCustomProviders(): CustomProvider[] {
       requestFormat: "openai-responses",
       reasoning: "off",
       promptCachingEnabled: true,
+      promptCacheHintMode: "auto",
       nativeWebSearchEnabled: true,
       useSystemProxy: false,
       usageQuery: getDefaultUsageQueryConfig(),
@@ -1388,11 +1406,14 @@ export function normalizeProviderModelConfig(
   // 跨供应商回查上线前落库的别家模型吃过本供应商兜底值，同样读侧修复，
   // 不需要用户删除重加（识别与替换规则见 repairStaleCrossProviderLimits）。
   const limits = repairStaleCrossProviderLimits(providerId, id, normalizeModelLimits(storedLimits));
+  const promptCacheHintMode =
+    providerId === "codex" ? normalizePromptCacheHintMode(obj.promptCacheHintMode) : undefined;
   return {
     id,
     ...(ownedBy ? { ownedBy } : {}),
     contextWindow: limits.contextWindow,
     maxOutputToken: limits.maxOutputToken,
+    ...(promptCacheHintMode ? { promptCacheHintMode } : {}),
   };
 }
 export function normalizeProviderModelConfigs(
@@ -1581,6 +1602,11 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
   const validModelIds = new Set(models.map((model) => model.id));
   const apiKey = normalizeApiKey(typeof obj.apiKey === "string" ? obj.apiKey : "");
   const id = typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : createUuid();
+  const promptCacheHintMode =
+    type === "codex"
+      ? (normalizePromptCacheHintMode(obj.promptCacheHintMode) ??
+        (obj.promptCachingEnabled === false ? "none" : "auto"))
+      : undefined;
 
   return {
     id,
@@ -1599,10 +1625,15 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
     ),
     requestFormat: type === "xai" ? "openai-responses" : codexRouting?.requestFormat,
     reasoning: normalizeReasoningLevel(obj.reasoning),
-    // Anthropic/OpenAI 默认开启提示词缓存（OpenAI 侧体现为稳定的
-    // prompt_cache_key 路由提示）；Gemini / xAI 不使用 OpenAI 风格 prompt cache。
+    // Anthropic 默认开启显式缓存；Codex 的布尔值仅保留旧设置兼容，实际 wire
+    // 行为由 promptCacheHintMode 决定。Gemini / xAI 不使用这里的缓存控制。
     promptCachingEnabled:
-      type === "gemini" || type === "xai" ? false : obj.promptCachingEnabled !== false,
+      type === "codex"
+        ? promptCacheHintMode !== "none"
+        : type === "gemini" || type === "xai"
+          ? false
+          : obj.promptCachingEnabled !== false,
+    ...(promptCacheHintMode ? { promptCacheHintMode } : {}),
     ...(type === "claude_code" && obj.promptCacheRetention === "long"
       ? { promptCacheRetention: "long" as const }
       : {}),

--- a/crates/agent-gui/src-tauri/src/services/gateway_bridge.rs
+++ b/crates/agent-gui/src-tauri/src/services/gateway_bridge.rs
@@ -1400,6 +1400,7 @@ fn sanitize_provider_summary(provider: &Value) -> Result<Value, String> {
         "requestFormat",
         "reasoning",
         "promptCachingEnabled",
+        "promptCacheHintMode",
         "nativeWebSearchEnabled",
     ] {
         if let Some(value) = source.get(key) {
@@ -1475,12 +1476,14 @@ mod tests {
                 "apiKey": "secret-key",
                 "models": [],
                 "activeModels": [],
+                "promptCacheHintMode": "openrouter-session",
                 "nativeWebSearchEnabled": false
             }
         ])))
         .expect("sanitize provider summaries");
 
         assert_eq!(result[0]["id"], "provider-a");
+        assert_eq!(result[0]["promptCacheHintMode"], "openrouter-session");
         assert_eq!(result[0]["nativeWebSearchEnabled"], false);
         assert_eq!(result[0]["apiKey"], Value::Null);
         assert_eq!(result[0]["baseUrl"], Value::Null);

--- a/crates/agent-gui/src-tauri/src/services/proxy.rs
+++ b/crates/agent-gui/src-tauri/src/services/proxy.rs
@@ -733,6 +733,22 @@ mod tests {
     }
 
     #[test]
+    fn forwards_openrouter_session_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("x-session-id"),
+            HeaderValue::from_static("session-123"),
+        );
+
+        let upstream_headers =
+            build_upstream_request_headers(&headers).expect("build upstream headers");
+        assert_eq!(
+            upstream_headers.get("x-session-id"),
+            Some(&HeaderValue::from_static("session-123"))
+        );
+    }
+
+    #[test]
     fn validates_image_proxy_urls() {
         assert!(validate_image_proxy_url("https://example.com/photo.png").is_ok());
         assert!(validate_image_proxy_url("http://example.com/photo.png").is_ok());

--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -1508,7 +1508,15 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.promptCaching": "Prompt 缓存",
     "settings.promptCachingDescClaude":
       "在请求上标注 ephemeral 缓存断点，长会话可显著降低输入费用。",
-    "settings.promptCachingDescCodex": "为请求携带稳定的 prompt_cache_key，提升前缀缓存命中率。",
+    "settings.promptCachingDescCodex":
+      "自动选择兼容的缓存提示；未知端点默认只使用服务端自动前缀缓存。",
+    "settings.promptCacheHintMode": "缓存提示协议",
+    "settings.promptCacheHintMode.auto": "自动（推荐）",
+    "settings.promptCacheHintMode.openaiKey": "OpenAI 缓存键",
+    "settings.promptCacheHintMode.openrouterSession": "OpenRouter 会话粘性",
+    "settings.promptCacheHintMode.none": "不发送缓存提示",
+    "settings.promptCacheHintMode.inherit": "继承供应商设置",
+    "settings.promptCacheHintModelOverride": "缓存提示协议",
     "settings.promptCacheRetention": "缓存保留",
     "settings.promptCacheRetentionShort": "5 分钟（默认）",
     "settings.promptCacheRetentionLong": "1 小时（仅官方 API）",
@@ -3866,7 +3874,14 @@ export const translations: Record<Locale, Record<string, string>> = {
     "settings.promptCachingDescClaude":
       "Mark ephemeral cache breakpoints on requests; long sessions get much cheaper input.",
     "settings.promptCachingDescCodex":
-      "Send a stable prompt_cache_key so prefix-cache hits survive across turns.",
+      "Select a compatible cache hint automatically; unknown endpoints use server-side prefix caching only.",
+    "settings.promptCacheHintMode": "Cache hint protocol",
+    "settings.promptCacheHintMode.auto": "Automatic (recommended)",
+    "settings.promptCacheHintMode.openaiKey": "OpenAI cache key",
+    "settings.promptCacheHintMode.openrouterSession": "OpenRouter session affinity",
+    "settings.promptCacheHintMode.none": "Send no cache hint",
+    "settings.promptCacheHintMode.inherit": "Inherit provider setting",
+    "settings.promptCacheHintModelOverride": "Cache hint protocol",
     "settings.promptCacheRetention": "Cache retention",
     "settings.promptCacheRetentionShort": "5 minutes (default)",
     "settings.promptCacheRetentionLong": "1 hour (official API only)",

--- a/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
+++ b/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
@@ -1481,6 +1481,8 @@ export async function runAssistantWithTools(params: {
           model: targetModel,
           workdir: params.workdir,
           nativeWebSearch: params.nativeWebSearch,
+          promptCacheHintMode:
+            target.runtime.modelConfig?.promptCacheHintMode ?? target.runtime.promptCacheHintMode,
           debugLogger: params.debugLogger,
           extra: {
             round,

--- a/crates/agent-gui/src/lib/providers/llm.ts
+++ b/crates/agent-gui/src/lib/providers/llm.ts
@@ -1,5 +1,6 @@
 export { providerSupportsNativeWebSearch } from "./nativeWebSearch";
 export { attachAnthropicAutomaticCaching } from "./runtime/anthropicCache";
+export { resolvePromptCacheHintMode } from "./runtime/codexPromptCache";
 export { attachCodexResponsesStorage } from "./runtime/codexStorage";
 export { normalizeErrorMessage } from "./runtime/errors";
 export {

--- a/crates/agent-gui/src/lib/providers/runtime/codexPromptCache.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/codexPromptCache.ts
@@ -1,4 +1,4 @@
-import type { PromptCacheHintMode, ProviderId } from "../../settings";
+import type { CodexRequestFormat, PromptCacheHintMode, ProviderId } from "../../settings";
 import { isRecord, normalizeSessionId } from "./common";
 import type { StreamOptionsEx } from "./types";
 
@@ -35,8 +35,10 @@ function parseHostname(baseUrl: string): string | undefined {
 export function resolvePromptCacheHintMode(
   configuredMode: PromptCacheHintMode | undefined,
   baseUrl: string,
+  modelApi?: CodexRequestFormat,
 ): Exclude<PromptCacheHintMode, "auto"> {
   if (configuredMode && configuredMode !== "auto") return configuredMode;
+  if (modelApi === "openai-responses") return "openai-key";
   const hostname = parseHostname(baseUrl);
   if (hostname === "api.openai.com" || hostname?.endsWith(".api.openai.com")) {
     return "openai-key";
@@ -65,13 +67,14 @@ export function attachCodexPromptCacheHint(
   providerId: ProviderId,
   baseUrl: string,
   configuredMode: PromptCacheHintMode | undefined,
+  modelApi: CodexRequestFormat | undefined,
   options: StreamOptionsEx,
 ): StreamOptionsEx {
   if (providerId !== "codex") return options;
   const mode =
     options.cacheRetention === "none"
       ? "none"
-      : resolvePromptCacheHintMode(configuredMode, baseUrl);
+      : resolvePromptCacheHintMode(configuredMode, baseUrl, modelApi);
   const sessionId = normalizeSessionId(options.sessionId);
 
   const previousOnPayload = options.onPayload;

--- a/crates/agent-gui/src/lib/providers/runtime/codexPromptCache.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/codexPromptCache.ts
@@ -1,9 +1,10 @@
-import type { ProviderId } from "../../settings";
+import type { PromptCacheHintMode, ProviderId } from "../../settings";
 import { isRecord, normalizeSessionId } from "./common";
 import type { StreamOptionsEx } from "./types";
 
 // OpenAI 对 prompt_cache_key 的长度上限（与 pi-ai 的 clamp 规则一致）。
 const OPENAI_PROMPT_CACHE_KEY_MAX_CHARS = 64;
+const OPENROUTER_SESSION_ID_MAX_CHARS = 256;
 
 function clampPromptCacheKey(value: string): string {
   return value.length > OPENAI_PROMPT_CACHE_KEY_MAX_CHARS
@@ -11,26 +12,79 @@ function clampPromptCacheKey(value: string): string {
     : value;
 }
 
-/**
- * 为 Codex 请求兜底注入稳定的 prompt_cache_key（按会话 id 路由缓存）。
- * pi-ai 仅在 openai-responses、或 openai-completions 命中官方 host 时下发该
- * 字段；经中转（自定义 base URL）的 completions 请求拿不到稳定 key，长
- * agent 循环的前缀缓存命中率随之丢失。该中间件在 pi-ai 未设置时补齐，
- * 已有值时不覆盖；缓存开关关闭（retention=none）或无会话 id 时不注入。
- */
-export function attachCodexPromptCacheKey(
+function clampOpenRouterSessionId(value: string): string {
+  return value.length > OPENROUTER_SESSION_ID_MAX_CHARS
+    ? value.slice(0, OPENROUTER_SESSION_ID_MAX_CHARS)
+    : value;
+}
+
+const OPENAI_PROMPT_CACHE_PAYLOAD_KEYS = [
+  "prompt_cache_key",
+  "prompt_cache_retention",
+  "prompt_cache_options",
+] as const;
+
+function parseHostname(baseUrl: string): string | undefined {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolvePromptCacheHintMode(
+  configuredMode: PromptCacheHintMode | undefined,
+  baseUrl: string,
+): Exclude<PromptCacheHintMode, "auto"> {
+  if (configuredMode && configuredMode !== "auto") return configuredMode;
+  const hostname = parseHostname(baseUrl);
+  if (hostname === "api.openai.com" || hostname?.endsWith(".api.openai.com")) {
+    return "openai-key";
+  }
+  if (hostname === "openrouter.ai" || hostname?.endsWith(".openrouter.ai")) {
+    return "openrouter-session";
+  }
+  return "none";
+}
+
+function stripOpenAIPromptCacheFields(payload: Record<string, unknown>) {
+  // pi-ai 的 completions buildParams 恒显式写 prompt_cache_key: undefined；
+  // 按值判断，undefined 序列化时本就会被丢弃，不值得为它每请求拷贝 payload。
+  if (!OPENAI_PROMPT_CACHE_PAYLOAD_KEYS.some((key) => payload[key] !== undefined)) return payload;
+  const nextPayload = { ...payload };
+  for (const key of OPENAI_PROMPT_CACHE_PAYLOAD_KEYS) delete nextPayload[key];
+  return nextPayload;
+}
+
+function hasHeader(headers: StreamOptionsEx["headers"], name: string): boolean {
+  const expected = name.toLowerCase();
+  return Object.keys(headers ?? {}).some((key) => key.toLowerCase() === expected);
+}
+
+export function attachCodexPromptCacheHint(
   providerId: ProviderId,
+  baseUrl: string,
+  configuredMode: PromptCacheHintMode | undefined,
   options: StreamOptionsEx,
 ): StreamOptionsEx {
-  // xai 不使用 OpenAI prompt_cache_key 路由；仅 Codex 需要。
   if (providerId !== "codex") return options;
-  if (options.cacheRetention === "none") return options;
+  const mode =
+    options.cacheRetention === "none"
+      ? "none"
+      : resolvePromptCacheHintMode(configuredMode, baseUrl);
   const sessionId = normalizeSessionId(options.sessionId);
-  if (!sessionId) return options;
 
   const previousOnPayload = options.onPayload;
   return {
     ...options,
+    // mode=none 时把 retention 一并压成 none：让 pi-ai 从源头不生成任何缓存
+    // 提示（responses 链路会按 retention 注入 prompt_cache_key），而不是依赖
+    // 事后剥离已知字段兜底。
+    cacheRetention: mode === "none" ? "none" : options.cacheRetention,
+    headers:
+      mode === "openrouter-session" && sessionId && !hasHeader(options.headers, "x-session-id")
+        ? { ...options.headers, "x-session-id": clampOpenRouterSessionId(sessionId) }
+        : options.headers,
     onPayload: async (payload, model) => {
       let nextPayload = payload;
       if (previousOnPayload) {
@@ -40,9 +94,12 @@ export function attachCodexPromptCacheKey(
         }
       }
 
+      if (!isRecord(nextPayload)) return nextPayload;
+
       if (
+        mode === "openai-key" &&
+        sessionId &&
         (model.api === "openai-responses" || model.api === "openai-completions") &&
-        isRecord(nextPayload) &&
         typeof nextPayload.prompt_cache_key !== "string"
       ) {
         return {
@@ -51,7 +108,7 @@ export function attachCodexPromptCacheKey(
         };
       }
 
-      return nextPayload;
+      return mode === "openai-key" ? nextPayload : stripOpenAIPromptCacheFields(nextPayload);
     },
   };
 }

--- a/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
@@ -99,6 +99,7 @@ const finalizePayloadMiddlewares = composePayloadMiddlewares([
       params.providerId,
       params.baseUrl,
       params.promptCacheHintMode,
+      params.model?.api,
       options,
     ),
   (options, params) =>

--- a/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
@@ -1,6 +1,6 @@
 import type { Context, Model } from "@earendil-works/pi-ai";
 import type { StreamDebugLogger } from "../../debug/agentDebug";
-import type { ProviderId } from "../../settings";
+import type { PromptCacheHintMode, ProviderId } from "../../settings";
 import { attachDeepSeekProviderPayloadAdapter } from "../deepSeekProviderAdapter";
 import {
   attachAnthropicMessagesNativeAttachments,
@@ -10,7 +10,7 @@ import {
 } from "../nativeResponsesAttachments";
 import { attachAnthropicAutomaticCaching } from "./anthropicCache";
 import { attachAnthropicLongContextBeta } from "./anthropicLongContext";
-import { attachCodexPromptCacheKey } from "./codexPromptCache";
+import { attachCodexPromptCacheHint } from "./codexPromptCache";
 import { attachCodexResponsesStorage } from "./codexStorage";
 import { attachGeminiThoughtSignatureGuard } from "./geminiToolPayload";
 import { attachProviderNativeWebSearch } from "./nativeSearchPayload";
@@ -31,6 +31,7 @@ export type FinalizeProviderStreamOptionsParams = {
   model?: Model<any>;
   workdir?: string;
   nativeWebSearch?: boolean;
+  promptCacheHintMode?: PromptCacheHintMode;
   debugLogger?: StreamDebugLogger;
   extra?: {
     phase?: string;
@@ -93,7 +94,13 @@ const finalizePayloadMiddlewares = composePayloadMiddlewares([
       context: params.context,
     }),
   (options, params) => attachCodexResponsesStorage(params.providerId, options),
-  (options, params) => attachCodexPromptCacheKey(params.providerId, options),
+  (options, params) =>
+    attachCodexPromptCacheHint(
+      params.providerId,
+      params.baseUrl,
+      params.promptCacheHintMode,
+      options,
+    ),
   (options, params) =>
     attachOpenAICompletionsFinishReasonCompatibility(options, {
       providerId: params.providerId,

--- a/crates/agent-gui/src/lib/providers/runtime/providerRuntimeConfig.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/providerRuntimeConfig.ts
@@ -34,6 +34,7 @@ export function createProviderRuntimeConfig(
         : "off"
       : undefined,
     promptCachingEnabled: provider.promptCachingEnabled,
+    promptCacheHintMode: provider.promptCacheHintMode,
     promptCacheRetention: provider.promptCacheRetention,
     nativeWebSearchEnabled: controls.nativeWebSearchEnabled,
     useSystemProxy: provider.useSystemProxy,

--- a/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
@@ -106,9 +106,10 @@ export function resolveProviderCacheRetention(
   requestOverride?: CacheRetention,
   providerPreference?: CacheRetention,
 ): CacheRetention | undefined {
-  // OpenAI 侧的"缓存"体现为稳定的 prompt_cache_key 路由提示；开关关闭时
-  // 显式返回 none，阻止 pi-ai 按 sessionId 默认下发。
+  // Codex 的 wire 策略由 promptCacheHintMode 处理；这里保留 short 让供应商级
+  // none 仍可被单模型覆盖。请求级 none 则始终优先，供标题/压缩等辅助请求禁用。
   if (providerId !== "claude_code" && providerId !== "codex") return undefined;
+  if (providerId === "codex") return requestOverride ?? "short";
   if (promptCachingEnabled === false) return "none";
   // 请求级 override 优先（压缩/标题等辅助请求强制 none）。
   if (requestOverride) return requestOverride;

--- a/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
@@ -121,6 +121,8 @@ function buildTextOnlyStreamOptions(params: {
     model: params.model,
     workdir: params.workdir,
     nativeWebSearch: params.nativeWebSearch,
+    promptCacheHintMode:
+      params.runtime.modelConfig?.promptCacheHintMode ?? params.runtime.promptCacheHintMode,
     debugLogger: params.debugLogger,
     extra: { sessionId },
   });

--- a/crates/agent-gui/src/lib/providers/runtime/types.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/types.ts
@@ -2,6 +2,7 @@ import type { SimpleStreamOptions } from "@earendil-works/pi-ai";
 import type {
   CodexRequestFormat,
   CustomProvider,
+  PromptCacheHintMode,
   ProviderId,
   ProviderModelConfig,
   ReasoningLevel,
@@ -36,6 +37,7 @@ export type ProviderRuntimeConfig = {
   requestFormat?: CodexRequestFormat;
   reasoning?: ReasoningLevel;
   promptCachingEnabled?: boolean;
+  promptCacheHintMode?: PromptCacheHintMode;
   promptCacheRetention?: "short" | "long";
   nativeWebSearchEnabled?: boolean;
   useSystemProxy?: boolean;

--- a/crates/agent-gui/src/lib/settings/index.ts
+++ b/crates/agent-gui/src/lib/settings/index.ts
@@ -313,12 +313,16 @@ export type SelectedModel = {
   model: string;
 };
 
+export type PromptCacheHintMode = "auto" | "openai-key" | "openrouter-session" | "none";
+
 export type ProviderModelConfig = {
   id: string;
   /** /models 元数据；缺失时保持旧设置格式兼容。 */
   ownedBy?: string;
   contextWindow: number;
   maxOutputToken: number;
+  /** OpenAI 兼容端点的缓存提示协议；缺失时继承供应商设置。 */
+  promptCacheHintMode?: PromptCacheHintMode;
 };
 
 export type ChatRuntimeControls = {
@@ -457,6 +461,8 @@ export type CustomProvider = {
   requestFormat?: CodexRequestFormat;
   reasoning: ReasoningLevel;
   promptCachingEnabled: boolean;
+  /** OpenAI 兼容端点的缓存提示协议；旧配置由 promptCachingEnabled 迁移。 */
+  promptCacheHintMode?: PromptCacheHintMode;
   /** 仅 Anthropic：ephemeral 缓存保留档位；long 在官方 API 上映射为 1h TTL。 */
   promptCacheRetention?: "short" | "long";
   nativeWebSearchEnabled: boolean;
@@ -515,6 +521,13 @@ export const CODEX_REQUEST_FORMAT_LABELS: Record<CodexRequestFormat, string> = {
   "openai-responses": "Responses API",
 };
 
+export const PROMPT_CACHE_HINT_MODES = [
+  "auto",
+  "openai-key",
+  "openrouter-session",
+  "none",
+] as const satisfies readonly PromptCacheHintMode[];
+
 const CODEX_RESPONSES_SUFFIX = "/responses";
 const CODEX_RESPONSE_SUFFIX = "/response";
 const CODEX_CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
@@ -543,6 +556,10 @@ function normalizeCodexRequestFormat(input: unknown): CodexRequestFormat | undef
     default:
       return undefined;
   }
+}
+
+function normalizePromptCacheHintMode(input: unknown): PromptCacheHintMode | undefined {
+  return PROMPT_CACHE_HINT_MODES.find((mode) => mode === input);
 }
 
 function normalizeCodexRouting(
@@ -602,6 +619,7 @@ export function getBuiltinCustomProviders(): CustomProvider[] {
       requestFormat: "openai-responses",
       reasoning: "off",
       promptCachingEnabled: true,
+      promptCacheHintMode: "auto",
       nativeWebSearchEnabled: true,
       useSystemProxy: false,
       usageQuery: getDefaultUsageQueryConfig(),
@@ -1386,11 +1404,14 @@ export function normalizeProviderModelConfig(
   // 跨供应商回查上线前落库的别家模型吃过本供应商兜底值，同样读侧修复，
   // 不需要用户删除重加（识别与替换规则见 repairStaleCrossProviderLimits）。
   const limits = repairStaleCrossProviderLimits(providerId, id, normalizeModelLimits(storedLimits));
+  const promptCacheHintMode =
+    providerId === "codex" ? normalizePromptCacheHintMode(obj.promptCacheHintMode) : undefined;
   return {
     id,
     ...(ownedBy ? { ownedBy } : {}),
     contextWindow: limits.contextWindow,
     maxOutputToken: limits.maxOutputToken,
+    ...(promptCacheHintMode ? { promptCacheHintMode } : {}),
   };
 }
 export function normalizeProviderModelConfigs(
@@ -1583,6 +1604,11 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
   const validModelIds = new Set(models.map((model) => model.id));
   const apiKey = normalizeApiKey(typeof obj.apiKey === "string" ? obj.apiKey : "");
   const id = typeof obj.id === "string" && obj.id.trim() ? obj.id.trim() : createUuid();
+  const promptCacheHintMode =
+    type === "codex"
+      ? (normalizePromptCacheHintMode(obj.promptCacheHintMode) ??
+        (obj.promptCachingEnabled === false ? "none" : "auto"))
+      : undefined;
 
   return {
     id,
@@ -1601,10 +1627,15 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
     ),
     requestFormat: type === "xai" ? "openai-responses" : codexRouting?.requestFormat,
     reasoning: normalizeReasoningLevel(obj.reasoning),
-    // Anthropic/OpenAI 默认开启提示词缓存（OpenAI 侧体现为稳定的
-    // prompt_cache_key 路由提示）；Gemini / xAI 不使用 OpenAI 风格 prompt cache。
+    // Anthropic 默认开启显式缓存；Codex 的布尔值仅保留旧设置兼容，实际 wire
+    // 行为由 promptCacheHintMode 决定。Gemini / xAI 不使用这里的缓存控制。
     promptCachingEnabled:
-      type === "gemini" || type === "xai" ? false : obj.promptCachingEnabled !== false,
+      type === "codex"
+        ? promptCacheHintMode !== "none"
+        : type === "gemini" || type === "xai"
+          ? false
+          : obj.promptCachingEnabled !== false,
+    ...(promptCacheHintMode ? { promptCacheHintMode } : {}),
     ...(type === "claude_code" && obj.promptCacheRetention === "long"
       ? { promptCacheRetention: "long" as const }
       : {}),

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -533,6 +533,58 @@ test("Codex Chat Completions streams forward reasoning effort", async () => {
   assert.equal(captured.options.toolChoice, "auto");
 });
 
+test("third-party Codex Responses auto sends the session prompt cache key on the wire", async () => {
+  const realOpenAIResponses = await import(
+    new URL(
+      "../../node_modules/@earendil-works/pi-ai/dist/api/openai-responses.js",
+      import.meta.url,
+    ).href
+  );
+  const localLoader = createTsModuleLoader({
+    mocks: {
+      "@earendil-works/pi-ai/api/openai-responses": {
+        stream: realOpenAIResponses.stream,
+      },
+    },
+  });
+  const localProviders = localLoader.loadModule("src/lib/providers/llm.ts");
+  const baseUrl = "https://relay.example.test/v1";
+  const model = localProviders.createModelFromConfig(
+    "codex",
+    "gpt-5",
+    baseUrl,
+    "openai-responses",
+  );
+  let capturedPayload;
+  const options = localProviders.finalizeProviderStreamOptions({
+    providerId: "codex",
+    baseUrl,
+    model,
+    promptCacheHintMode: "auto",
+    options: {
+      apiKey: "sk-test",
+      sessionId: "conversation-1234",
+      cacheRetention: "short",
+    },
+    debugLogger: {
+      logRequest(entry) {
+        capturedPayload = entry.payload;
+        throw new Error("__capture_stop__");
+      },
+    },
+  });
+
+  const stream = localProviders.streamSimpleByApi(
+    model,
+    { messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+    options,
+  );
+  await stream.result();
+
+  assert.ok(capturedPayload);
+  assert.equal(capturedPayload.prompt_cache_key, "conversation-1234");
+});
+
 test("DeepSeek OpenAI payload adapter maps reasoning=max to reasoning_effort=max (regression)", async () => {
   let captured;
   const localLoader = createTsModuleLoader({
@@ -1412,13 +1464,24 @@ test("resolveProviderCacheRetention maps provider settings and per-request overr
   assert.equal(resolve("gemini", true), undefined);
 });
 
-test("codex automatic cache hint resolution is conservative for compatible endpoints", () => {
+test("codex automatic cache hint resolution follows request format before endpoint hints", () => {
   const resolve = providers.resolvePromptCacheHintMode;
-  assert.equal(resolve("auto", "https://api.openai.com/v1"), "openai-key");
-  assert.equal(resolve(undefined, "https://openrouter.ai/api/v1"), "openrouter-session");
-  assert.equal(resolve("auto", "https://relay.example/v1"), "none");
-  assert.equal(resolve("auto", "not-a-url"), "none");
-  assert.equal(resolve("openai-key", "https://relay.example/v1"), "openai-key");
+  assert.equal(resolve("auto", "https://api.openai.com/v1", "openai-completions"), "openai-key");
+  assert.equal(
+    resolve(undefined, "https://openrouter.ai/api/v1", "openai-completions"),
+    "openrouter-session",
+  );
+  assert.equal(resolve("auto", "https://relay.example/v1", "openai-completions"), "none");
+  assert.equal(resolve("auto", "https://relay.example/v1", "openai-responses"), "openai-key");
+  assert.equal(
+    resolve("auto", "https://openrouter.ai/api/v1", "openai-responses"),
+    "openai-key",
+  );
+  assert.equal(resolve("auto", "not-a-url", "openai-completions"), "none");
+  assert.equal(
+    resolve("openrouter-session", "https://relay.example/v1", "openai-responses"),
+    "openrouter-session",
+  );
 });
 
 test("codex automatic cache hints follow the endpoint capability matrix", async () => {
@@ -1427,6 +1490,7 @@ test("codex automatic cache hints follow the endpoint capability matrix", async 
       providerId: "codex",
       baseUrl: "https://api.openai.com/v1",
       promptCacheHintMode: "auto",
+      model: { api, provider: "openai", id: "gpt-5" },
       options: { sessionId: "conv-1234", cacheRetention: "short" },
     });
     const payload = await official.onPayload(
@@ -1443,10 +1507,33 @@ test("codex automatic cache hints follow the endpoint capability matrix", async 
     "https://api.groq.com/openai/v1",
     "https://api.moonshot.cn/v1",
   ]) {
+    const responses = providers.finalizeProviderStreamOptions({
+      providerId: "codex",
+      baseUrl,
+      promptCacheHintMode: "auto",
+      model: { api: "openai-responses", provider: "openai", id: "compatible-model" },
+      options: { sessionId: "conv-1234", cacheRetention: "short" },
+    });
+    const payload = await responses.onPayload(
+      { input: "hello" },
+      { api: "openai-responses", provider: "openai", id: "compatible-model" },
+    );
+    assert.equal(responses.cacheRetention, "short", baseUrl);
+    assert.equal(payload.prompt_cache_key, "conv-1234", baseUrl);
+  }
+
+  for (const baseUrl of [
+    "https://relay.example/v1",
+    "https://integrate.api.nvidia.com/v1",
+    "https://api.deepseek.com/v1",
+    "https://api.groq.com/openai/v1",
+    "https://api.moonshot.cn/v1",
+  ]) {
     const compatible = providers.finalizeProviderStreamOptions({
       providerId: "codex",
       baseUrl,
       promptCacheHintMode: "auto",
+      model: { api: "openai-completions", provider: "openai", id: "compatible-model" },
       options: {
         sessionId: "conv-1234",
         onPayload: async (payload) => ({
@@ -1470,6 +1557,7 @@ test("codex automatic cache hints follow the endpoint capability matrix", async 
     providerId: "codex",
     baseUrl: "https://openrouter.ai/api/v1",
     promptCacheHintMode: "auto",
+    model: { api: "openai-completions", provider: "openai", id: "openrouter-model" },
     options: { sessionId: "conv-1234" },
   });
   const openRouterPayload = await openRouter.onPayload(
@@ -1508,11 +1596,19 @@ test("codex explicit cache hints respect overrides, user values, and limits", as
   );
   assert.equal(presetPayload.prompt_cache_key, "explicit-key");
 
-  for (const promptCacheHintMode of ["openai-key", "none"]) {
+  for (const { promptCacheHintMode, model } of [
+    { promptCacheHintMode: "openai-key" },
+    { promptCacheHintMode: "none" },
+    {
+      promptCacheHintMode: "auto",
+      model: { api: "openai-responses", provider: "openai", id: "gpt-5" },
+    },
+  ]) {
     const disabled = providers.finalizeProviderStreamOptions({
       providerId: "codex",
       baseUrl: "https://api.openai.com/v1",
       promptCacheHintMode,
+      model,
       options: { sessionId: "conv-1234", cacheRetention: "none" },
     });
     const payload = await disabled.onPayload(

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -83,6 +83,7 @@ test("llm facade preserves provider runtime exports", () => {
     "parseModelValue",
     "providerSupportsNativeWebSearch",
     "resolveProviderCacheRetention",
+    "resolvePromptCacheHintMode",
     "streamAssistantMessage",
     "streamSimpleByApi",
     "toModelValue",
@@ -1404,70 +1405,158 @@ test("resolveProviderCacheRetention maps provider settings and per-request overr
   // 请求级 override（压缩/标题等辅助请求）永远优先于供应商偏好。
   assert.equal(resolve("claude_code", true, "none", "long"), "none");
   assert.equal(resolve("codex", undefined), "short");
-  assert.equal(resolve("codex", false), "none");
+  assert.equal(resolve("codex", false), "short");
   assert.equal(resolve("codex", true, "none"), "none");
   // long 档位仅对 Anthropic 生效。
   assert.equal(resolve("codex", true, undefined, "long"), "short");
   assert.equal(resolve("gemini", true), undefined);
 });
 
-test("codex payloads get a stable prompt_cache_key on relay hosts", async () => {
-  const options = providers.finalizeProviderStreamOptions({
-    providerId: "codex",
-    baseUrl: "https://relay.example/v1",
-    options: { sessionId: "conv-1234", cacheRetention: "short" },
-  });
-
-  const completionsPayload = await options.onPayload(
-    { messages: [] },
-    { api: "openai-completions", provider: "openai", id: "relay-model" },
-  );
-  assert.equal(completionsPayload.prompt_cache_key, "conv-1234");
-
-  const responsesPayload = await options.onPayload(
-    { input: "hello" },
-    { api: "openai-responses", provider: "openai", id: "relay-model" },
-  );
-  assert.equal(responsesPayload.prompt_cache_key, "conv-1234");
+test("codex automatic cache hint resolution is conservative for compatible endpoints", () => {
+  const resolve = providers.resolvePromptCacheHintMode;
+  assert.equal(resolve("auto", "https://api.openai.com/v1"), "openai-key");
+  assert.equal(resolve(undefined, "https://openrouter.ai/api/v1"), "openrouter-session");
+  assert.equal(resolve("auto", "https://relay.example/v1"), "none");
+  assert.equal(resolve("auto", "not-a-url"), "none");
+  assert.equal(resolve("openai-key", "https://relay.example/v1"), "openai-key");
 });
 
-test("codex prompt_cache_key injection respects retention, existing keys, and length", async () => {
-  const disabled = providers.finalizeProviderStreamOptions({
+test("codex automatic cache hints follow the endpoint capability matrix", async () => {
+  for (const api of ["openai-completions", "openai-responses"]) {
+    const official = providers.finalizeProviderStreamOptions({
+      providerId: "codex",
+      baseUrl: "https://api.openai.com/v1",
+      promptCacheHintMode: "auto",
+      options: { sessionId: "conv-1234", cacheRetention: "short" },
+    });
+    const payload = await official.onPayload(
+      api === "openai-completions" ? { messages: [] } : { input: "hello" },
+      { api, provider: "openai", id: "gpt-5" },
+    );
+    assert.equal(payload.prompt_cache_key, "conv-1234");
+  }
+
+  for (const baseUrl of [
+    "https://relay.example/v1",
+    "https://integrate.api.nvidia.com/v1",
+    "https://api.deepseek.com/v1",
+    "https://api.groq.com/openai/v1",
+    "https://api.moonshot.cn/v1",
+  ]) {
+    const compatible = providers.finalizeProviderStreamOptions({
+      providerId: "codex",
+      baseUrl,
+      promptCacheHintMode: "auto",
+      options: {
+        sessionId: "conv-1234",
+        onPayload: async (payload) => ({
+          ...payload,
+          prompt_cache_key: "library-key",
+          prompt_cache_retention: "24h",
+          prompt_cache_options: { enabled: true },
+        }),
+      },
+    });
+    const payload = await compatible.onPayload(
+      { messages: [] },
+      { api: "openai-completions", provider: "openai", id: "compatible-model" },
+    );
+    assert.equal(Object.hasOwn(payload, "prompt_cache_key"), false, baseUrl);
+    assert.equal(Object.hasOwn(payload, "prompt_cache_retention"), false, baseUrl);
+    assert.equal(Object.hasOwn(payload, "prompt_cache_options"), false, baseUrl);
+  }
+
+  const openRouter = providers.finalizeProviderStreamOptions({
+    providerId: "codex",
+    baseUrl: "https://openrouter.ai/api/v1",
+    promptCacheHintMode: "auto",
+    options: { sessionId: "conv-1234" },
+  });
+  const openRouterPayload = await openRouter.onPayload(
+    { messages: [], prompt_cache_key: "library-key" },
+    { api: "openai-completions", provider: "openai", id: "openrouter-model" },
+  );
+  assert.equal(openRouter.headers["x-session-id"], "conv-1234");
+  assert.equal(Object.hasOwn(openRouterPayload, "prompt_cache_key"), false);
+});
+
+test("codex explicit cache hints respect overrides, user values, and limits", async () => {
+  const explicitOpenAI = providers.finalizeProviderStreamOptions({
     providerId: "codex",
     baseUrl: "https://relay.example/v1",
-    options: { sessionId: "conv-1234", cacheRetention: "none" },
+    promptCacheHintMode: "openai-key",
+    options: { sessionId: "k".repeat(80), cacheRetention: "short" },
   });
-  const disabledPayload = await disabled.onPayload(
+  const clampedPayload = await explicitOpenAI.onPayload(
     { messages: [] },
     { api: "openai-completions", provider: "openai", id: "relay-model" },
   );
-  assert.equal(disabledPayload.prompt_cache_key, undefined);
+  assert.equal(clampedPayload.prompt_cache_key, "k".repeat(64));
 
   const preset = providers.finalizeProviderStreamOptions({
     providerId: "codex",
-    baseUrl: "https://relay.example/v1",
+    baseUrl: "https://api.openai.com/v1",
+    promptCacheHintMode: "auto",
     options: {
       sessionId: "conv-1234",
-      cacheRetention: "short",
       onPayload: async (payload) => ({ ...payload, prompt_cache_key: "explicit-key" }),
     },
   });
   const presetPayload = await preset.onPayload(
     { messages: [] },
-    { api: "openai-completions", provider: "openai", id: "relay-model" },
+    { api: "openai-completions", provider: "openai", id: "gpt-5" },
   );
   assert.equal(presetPayload.prompt_cache_key, "explicit-key");
 
-  const clamped = providers.finalizeProviderStreamOptions({
+  for (const promptCacheHintMode of ["openai-key", "none"]) {
+    const disabled = providers.finalizeProviderStreamOptions({
+      providerId: "codex",
+      baseUrl: "https://api.openai.com/v1",
+      promptCacheHintMode,
+      options: { sessionId: "conv-1234", cacheRetention: "none" },
+    });
+    const payload = await disabled.onPayload(
+      { messages: [], prompt_cache_key: "library-key" },
+      { api: "openai-completions", provider: "openai", id: "gpt-5" },
+    );
+    assert.equal(Object.hasOwn(payload, "prompt_cache_key"), false);
+  }
+
+  // mode=none 必须把 retention 一并压成 none：pi-ai 会按 retention 生成缓存
+  // 提示（如 OpenRouter anthropic/* 的 cache_control 断点），剥 payload 拦不住。
+  const explicitNone = providers.finalizeProviderStreamOptions({
+    providerId: "codex",
+    baseUrl: "https://openrouter.ai/api/v1",
+    promptCacheHintMode: "none",
+    options: { sessionId: "conv-1234", cacheRetention: "short" },
+  });
+  assert.equal(explicitNone.cacheRetention, "none");
+  assert.equal(explicitNone.headers?.["x-session-id"], undefined);
+
+  // pi-ai 恒显式写 prompt_cache_key: undefined；值为 undefined 时无须拷贝剥离。
+  const undefinedKeyPayload = { messages: [], prompt_cache_key: undefined };
+  const passthrough = await explicitNone.onPayload(undefinedKeyPayload, {
+    api: "openai-completions",
+    provider: "openai",
+    id: "openrouter-model",
+  });
+  assert.equal(passthrough, undefinedKeyPayload);
+
+  const explicitOpenRouter = providers.finalizeProviderStreamOptions({
     providerId: "codex",
     baseUrl: "https://relay.example/v1",
-    options: { sessionId: "k".repeat(80), cacheRetention: "short" },
+    promptCacheHintMode: "openrouter-session",
+    options: { sessionId: "s".repeat(300) },
   });
-  const clampedPayload = await clamped.onPayload(
-    { messages: [] },
-    { api: "openai-completions", provider: "openai", id: "relay-model" },
-  );
-  assert.equal(clampedPayload.prompt_cache_key, "k".repeat(64));
+  assert.equal(explicitOpenRouter.headers["x-session-id"], "s".repeat(256));
+
+  const customHeader = providers.finalizeProviderStreamOptions({
+    providerId: "codex",
+    baseUrl: "https://openrouter.ai/api/v1",
+    promptCacheHintMode: "auto",
+    options: { headers: { "X-Session-ID": "user-session" }, sessionId: "conv-1234" },
+  });
+  assert.deepEqual(customHeader.headers, { "X-Session-ID": "user-session" });
 });
 
 test("runtime models always carry zero pricing (billing removed)", () => {

--- a/crates/agent-gui/test/settings/normalization.test.mjs
+++ b/crates/agent-gui/test/settings/normalization.test.mjs
@@ -56,8 +56,9 @@ test("codex provider normalization strips route suffixes and keeps only configur
   assert.equal(provider.baseUrl, "https://api.openai.com/v1");
   assert.equal(provider.apiKey, "key");
   assert.equal(provider.requestFormat, "openai-responses");
-  // OpenAI 缓存（稳定 prompt_cache_key）默认开启，可显式关闭。
+  // Codex 默认自动选择端点支持的缓存提示协议。
   assert.equal(provider.promptCachingEnabled, true);
+  assert.equal(provider.promptCacheHintMode, "auto");
   assert.equal(provider.nativeWebSearchEnabled, false);
   assert.deepEqual(provider.activeModels, ["gpt-5"]);
   assert.deepEqual(
@@ -96,7 +97,51 @@ test("codex provider normalization can disable prompt caching explicitly", () =>
     promptCachingEnabled: false,
   });
   assert.equal(provider.promptCachingEnabled, false);
+  assert.equal(provider.promptCacheHintMode, "none");
   assert.equal(provider.promptCacheRetention, undefined);
+});
+
+test("codex cache hint modes normalize provider and model overrides", () => {
+  const explicit = settings.normalizeCustomProvider({
+    id: "codex-explicit",
+    type: "codex",
+    promptCachingEnabled: false,
+    promptCacheHintMode: "openrouter-session",
+    models: [
+      { id: "openai-model", promptCacheHintMode: "openai-key" },
+      { id: "invalid-model", promptCacheHintMode: "invalid" },
+    ],
+  });
+  assert.equal(explicit.promptCacheHintMode, "openrouter-session");
+  assert.equal(explicit.promptCachingEnabled, true);
+  assert.equal(explicit.models[0].promptCacheHintMode, "openai-key");
+  assert.equal(explicit.models[1].promptCacheHintMode, undefined);
+
+  const disabled = settings.normalizeCustomProvider({
+    id: "codex-none",
+    type: "codex",
+    promptCacheHintMode: "none",
+  });
+  assert.equal(disabled.promptCacheHintMode, "none");
+  assert.equal(disabled.promptCachingEnabled, false);
+
+  const invalid = settings.normalizeCustomProvider({
+    id: "codex-invalid",
+    type: "codex",
+    promptCacheHintMode: "invalid",
+  });
+  assert.equal(invalid.promptCacheHintMode, "auto");
+
+  const nonCodex = settings.normalizeProviderModelConfig(
+    { id: "claude-model", promptCacheHintMode: "openai-key" },
+    "claude_code",
+  );
+  assert.equal(nonCodex.promptCacheHintMode, undefined);
+
+  const builtinCodex = settings
+    .getBuiltinCustomProviders()
+    .find((provider) => provider.type === "codex");
+  assert.equal(builtinCodex.promptCacheHintMode, "auto");
 });
 
 test("claude provider normalization keeps the long cache retention preference", () => {

--- a/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
@@ -43,6 +43,8 @@ import {
   type CustomProvider,
   getDefaultUsageQueryConfig,
   MODEL_FAILOVER_QUEUE_LIMIT,
+  PROMPT_CACHE_HINT_MODES,
+  type PromptCacheHintMode,
   type ProviderFailoverSettings,
   type ProviderId,
   type ProviderModelConfig,
@@ -234,6 +236,13 @@ const PROVIDER_LABELS: Record<ProviderId, string> = {
   xai: "Grok",
 };
 
+const PROMPT_CACHE_HINT_LABEL_KEYS: Record<PromptCacheHintMode, string> = {
+  auto: "settings.promptCacheHintMode.auto",
+  "openai-key": "settings.promptCacheHintMode.openaiKey",
+  "openrouter-session": "settings.promptCacheHintMode.openrouterSession",
+  none: "settings.promptCacheHintMode.none",
+};
+
 function getProviderLabel(type: ProviderId) {
   return PROVIDER_LABELS[type];
 }
@@ -371,6 +380,10 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
   const [useSystemProxy, setUseSystemProxy] = useState(initialData?.useSystemProxy ?? false);
   const [promptCachingEnabled, setPromptCachingEnabled] = useState(
     initialData?.promptCachingEnabled ?? (providerType !== "gemini" && providerType !== "xai"),
+  );
+  const [promptCacheHintMode, setPromptCacheHintMode] = useState<PromptCacheHintMode>(
+    initialData?.promptCacheHintMode ??
+      (initialData?.promptCachingEnabled === false ? "none" : "auto"),
   );
   const [promptCacheRetention, setPromptCacheRetention] = useState<"short" | "long">(
     initialData?.promptCacheRetention === "long" ? "long" : "short",
@@ -871,7 +884,12 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
           ? "high"
           : (initialData?.reasoning ?? "off"),
       promptCachingEnabled:
-        providerType === "gemini" || providerType === "xai" ? false : promptCachingEnabled,
+        providerType === "codex"
+          ? promptCacheHintMode !== "none"
+          : providerType === "gemini" || providerType === "xai"
+            ? false
+            : promptCachingEnabled,
+      promptCacheHintMode: providerType === "codex" ? promptCacheHintMode : undefined,
       promptCacheRetention:
         providerType === "claude_code" && promptCachingEnabled && promptCacheRetention === "long"
           ? "long"
@@ -1524,6 +1542,53 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                                       }}
                                     />
                                   </div>
+                                  {providerType === "codex" ? (
+                                    <div className="col-span-2 space-y-1.5 max-[720px]:col-span-1">
+                                      <Label>{t("settings.promptCacheHintModelOverride")}</Label>
+                                      <Select
+                                        value={editingModel.model.promptCacheHintMode ?? "inherit"}
+                                        onValueChange={(value) =>
+                                          setEditingModel((prev) =>
+                                            prev
+                                              ? {
+                                                  ...prev,
+                                                  model: {
+                                                    ...prev.model,
+                                                    promptCacheHintMode:
+                                                      value === "inherit"
+                                                        ? undefined
+                                                        : (value as PromptCacheHintMode),
+                                                  },
+                                                }
+                                              : prev,
+                                          )
+                                        }
+                                      >
+                                        <SelectTrigger>
+                                          {/* value≠label：闭合态必须显式渲染本地化标签。 */}
+                                          <SelectValue>
+                                            {t(
+                                              editingModel.model.promptCacheHintMode
+                                                ? PROMPT_CACHE_HINT_LABEL_KEYS[
+                                                    editingModel.model.promptCacheHintMode
+                                                  ]
+                                                : "settings.promptCacheHintMode.inherit",
+                                            )}
+                                          </SelectValue>
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                          <SelectItem value="inherit">
+                                            {t("settings.promptCacheHintMode.inherit")}
+                                          </SelectItem>
+                                          {PROMPT_CACHE_HINT_MODES.map((mode) => (
+                                            <SelectItem key={mode} value={mode}>
+                                              {t(PROMPT_CACHE_HINT_LABEL_KEYS[mode])}
+                                            </SelectItem>
+                                          ))}
+                                        </SelectContent>
+                                      </Select>
+                                    </div>
+                                  ) : null}
                                 </div>
 
                                 {!canSaveEditingModel ? (
@@ -1591,14 +1656,18 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                   <div
                     className={cn(
                       "mt-3 rounded-xl border bg-card px-4 py-3 transition-colors",
-                      promptCachingEnabled && "border-primary/35 bg-primary/[0.04]",
+                      (providerType === "codex"
+                        ? promptCacheHintMode !== "none"
+                        : promptCachingEnabled) && "border-primary/35 bg-primary/[0.04]",
                     )}
                   >
                     <div className="flex items-center gap-3">
                       <span
                         className={cn(
                           "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors",
-                          promptCachingEnabled && "bg-primary/15 text-primary",
+                          (providerType === "codex"
+                            ? promptCacheHintMode !== "none"
+                            : promptCachingEnabled) && "bg-primary/15 text-primary",
                         )}
                       >
                         <Zap className="h-4 w-4" />
@@ -1611,12 +1680,38 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                             : t("settings.promptCachingDescCodex")}
                         </div>
                       </div>
-                      <DialogSwitch
-                        checked={promptCachingEnabled}
-                        onCheckedChange={setPromptCachingEnabled}
-                        ariaLabel={t("settings.promptCaching")}
-                      />
+                      {providerType === "claude_code" ? (
+                        <DialogSwitch
+                          checked={promptCachingEnabled}
+                          onCheckedChange={setPromptCachingEnabled}
+                          ariaLabel={t("settings.promptCaching")}
+                        />
+                      ) : null}
                     </div>
+                    {providerType === "codex" ? (
+                      <div className="mt-3 border-t pt-3">
+                        <Select
+                          value={promptCacheHintMode}
+                          onValueChange={(value) =>
+                            setPromptCacheHintMode(value as PromptCacheHintMode)
+                          }
+                        >
+                          <SelectTrigger aria-label={t("settings.promptCacheHintMode")}>
+                            {/* value≠label：闭合态必须显式渲染本地化标签。 */}
+                            <SelectValue>
+                              {t(PROMPT_CACHE_HINT_LABEL_KEYS[promptCacheHintMode])}
+                            </SelectValue>
+                          </SelectTrigger>
+                          <SelectContent>
+                            {PROMPT_CACHE_HINT_MODES.map((mode) => (
+                              <SelectItem key={mode} value={mode}>
+                                {t(PROMPT_CACHE_HINT_LABEL_KEYS[mode])}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    ) : null}
                     {providerType === "claude_code" && promptCachingEnabled ? (
                       <div className="mt-3 flex flex-wrap items-center gap-2 border-t pt-3">
                         <span className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Linked issue

Closes #435

## Summary

Codex（OpenAI 兼容）供应商此前只用一个布尔开关控制 Prompt 缓存，无法区分 Responses API、Chat Completions，以及不同端点支持的缓存提示协议。本 PR 将它拆成四选一的 `promptCacheHintMode`，并让 `auto` 同时依据**请求格式**与**端点能力**决定 wire 行为。

| 模式 | wire 行为 |
| --- | --- |
| `auto`（默认，推荐） | **Responses API**：所有 Codex 端点都发送会话级 `prompt_cache_key`，与 Codex CLI 对齐；**Chat Completions**：`api.openai.com` 发送 `prompt_cache_key`，`openrouter.ai` 发送 `x-session-id`，其他端点不发送缓存提示 |
| `openai-key` | 发送 `prompt_cache_key`（按会话 id，64 字符上限） |
| `openrouter-session` | 发送 `x-session-id` 请求头（256 字符上限） |
| `none` | 不发送任何缓存提示 |

设计要点：

1. **Responses API 与 Codex CLI 对齐**。Codex CLI 的 Responses 请求使用稳定的会话 ID 作为 `prompt_cache_key`，不按 Base URL 主机名关闭该字段；LiveAgent 的 `auto` 现在采用相同行为，第三方 Responses 端点也会收到该键。
2. **Chat Completions 保持保守兼容**。严格校验未知参数的中转站 / NVIDIA NIM / DeepSeek / Groq / Moonshot 等端点在 `auto` 下不会收到 `prompt_cache_key`，避免 #307 的 400；OpenRouter 改用 `x-session-id` 会话粘性头。
3. **显式设置仍具有最高优先级**。用户可以用 `openai-key` / `openrouter-session` 覆盖自动判定，或用 `none` 完全禁用。标题、压缩等请求级 `cacheRetention: none` 仍会压过 `auto`，不会发送缓存字段。
4. **模型级覆盖**。`ProviderModelConfig.promptCacheHintMode` 可选，缺省继承供应商设置，适合同一供应商下混用不同协议或能力的模型。
5. **旧配置无损迁移**。`promptCachingEnabled: false` → `none`，未设置 → `auto`。布尔字段仅用于读取旧设置；非 Codex 供应商不受影响，Anthropic 的 ephemeral 缓存断点与 retention 档位保持原行为。
6. **`none` 从源头禁用缓存提示**。该模式会把 `cacheRetention` 一并压成 `none`，阻止 pi-ai 在 Responses 或兼容链路生成缓存字段；最终 payload 中间件还会剥离既有的 `prompt_cache_key`、`prompt_cache_retention` 与 `prompt_cache_options`。

## Change scope

- Modules: `agent-gui`（前端 + src-tauri）/ `agent-ui`（共享设置 UI）/ `agent-gateway/web`（WebUI 镜像）
- Key paths:

| 路径 | 变更 |
| --- | --- |
| `crates/agent-gui/src/lib/providers/runtime/codexPromptCache.ts` | 核心：`auto` 先按 Responses/Completions 分流，再按端点选择注入或剥离策略 |
| `crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts` | 将当前模型 API 格式传给缓存提示中间件 |
| `crates/agent-gui/src/lib/providers/runtime/requestOptions.ts` | Codex 的 retention 解析交给 hint mode，请求级禁用仍优先 |
| `crates/agent-gui/src/lib/providers/runtime/types.ts` / `providerRuntimeConfig.ts` / `textOnlyRuntime.ts` | mode 参数贯通到聊天与 text-only 请求链路 |
| `crates/agent-gui/src/lib/chat/runner/agentRunner.ts` | 模型级覆盖优先于供应商级 |
| `crates/agent-gui/src/lib/settings/index.ts` + `crates/agent-gateway/web/src/lib/settings/index.ts` | 类型、常量、归一化与旧配置迁移（两端镜像） |
| `crates/agent-ui/src/pages/settings/ProvidersSection.tsx` | 供应商级 + 模型级缓存提示协议下拉 |
| `crates/agent-gui/src-tauri/src/services/gateway_bridge.rs` | provider summary 白名单放行新字段 |
| `crates/agent-gui/src-tauri/src/services/proxy.rs` | `x-session-id` 转发回归测试 |
| 两端 `i18n/config.ts` | 中英文案 |

## Screenshots / preview

**UI 变更**：Codex 供应商弹窗的 Prompt 缓存卡片，开关替换为“缓存提示协议”下拉（4 项）；模型编辑区新增“缓存提示协议”下拉（5 项，含“继承供应商设置”）。Anthropic 供应商仍保持开关 + 保留档位。

> 截图待补：下方 wire 行为与自动化测试可以先用于行为审核；合入前仍需补真实 before/after 截图或录屏以满足 UI 治理要求。

**wire 行为**：

```jsonc
// auto + Responses API：无论是否为第三方域名，都与 Codex CLI 一样发送会话级 key
POST https://relay.example/v1/responses
{
  "model": "gpt-5",
  "input": [...],
  "prompt_cache_key": "conv-1234"
}

// auto + OpenAI Chat Completions：发送 prompt_cache_key
POST https://api.openai.com/v1/chat/completions
{
  "messages": [...],
  "prompt_cache_key": "conv-1234"
}

// auto + 第三方 Chat Completions：严格兼容端点不发送 OpenAI 私有缓存字段
POST https://relay.example/v1/chat/completions
{
  "messages": [...]
}

// auto + OpenRouter Chat Completions：改用会话粘性头
POST https://openrouter.ai/api/v1/chat/completions
x-session-id: conv-1234
{
  "messages": [...]
}
```

边界行为也有测试覆盖：pi-ai 已写入的字符串 `prompt_cache_key` 不被覆盖；用户自带的 `X-Session-ID` 不被顶掉；会话 ID 按 64 / 256 字符分别截断；显式模式覆盖 `auto`；请求级 `cacheRetention: none` 在 Responses 下仍禁止发送；`prompt_cache_key: undefined` 不触发无意义 payload 拷贝。

## Verification

```text
pnpm test:gui                                      # 1552 passed / 0 failed
pnpm test:webui                                    #  555 passed / 0 failed
pnpm check:ui-boundaries                           # passed
pnpm exec tsc --noEmit                             # agent-gui passed
pnpm exec tsc --noEmit                             # agent-gateway/web passed
node --test test/providers/request-options.test.mjs # 49 passed / 0 failed
biome check changed files                          # 0 errors; 1 pre-existing noExplicitAny warning
git diff --check                                   # passed
```

新增/更新的测试：

- `test/providers/request-options.test.mjs`：请求格式优先级、第三方 Responses 的 `prompt_cache_key` 矩阵、第三方 Completions 字段剥离、OpenRouter 头注入、显式覆盖、长度上限、请求级禁用。
- 同一测试文件通过真实 `pi-ai` Responses `stream()` 截获最终 wire payload，确认第三方 Base URL 在 `auto` 下实际发送稳定的会话 key，而不仅是中间件结构断言。
- `test/settings/normalization.test.mjs` + `crates/agent-gateway/test/webui/web-settings.test.mjs`：双端归一化、旧配置迁移、非法值回落、模型级覆盖、非 Codex 供应商隔离。
- `services/proxy.rs`：`x-session-id` 转发。

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the PR source branch; no concurrent head update was overwritten.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Runtime behavior and bilingual setting copy are updated consistently.
- [ ] Add real before/after screenshots or a recording before merge.
