### PR TITLE
fix(chat): 输入框让出右侧控制列，滚动条不再压住用量环

### DIFF
--- a/crates/agent-gui/test/chat/context-usage.test.mjs
+++ b/crates/agent-gui/test/chat/context-usage.test.mjs
@@ -78,6 +78,14 @@ test("context usage ring stays vertically centered in the shared composer", () =
   assert.doesNotMatch(chatComposerBarSource, /className="absolute bottom-11 right-3 z-20"/);
 });
 
+test("composer editor row reserves the right control rail so the scrollbar clears the ring", () => {
+  // 让位必须做在编辑器外层容器上：padding 不移动滚动条，编辑器自带 pr-8 时
+  // 那条 6px 滚动轨会压在用量环/展开图标上（right-3 + w-8 的 44px 轨道）。
+  assert.match(chatComposerBarSource, /"relative flex flex-1 pl-4 pr-12"/);
+  assert.doesNotMatch(chatComposerBarSource, /"relative flex flex-1 px-4"/);
+  assert.doesNotMatch(chatComposerBarSource, /"px-0 py-0 pr-8"/);
+});
+
 test("contextUsageRatio guards degenerate inputs", () => {
   assert.equal(contextUsageRatio(100_000, 200_000), 0.5);
   assert.equal(contextUsageRatio(undefined, 200_000), 0);

--- a/crates/agent-ui/src/pages/chat/ChatComposerBar.tsx
+++ b/crates/agent-ui/src/pages/chat/ChatComposerBar.tsx
@@ -949,10 +949,17 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: ChatComposer
 
           {/* 常驻 flex-1：动画把卡片钳在中间高度时由本区吸收伸缩，工具栏才能
               全程贴住卡片底边。min-h-0 只在展开态加——折叠态靠自动最小高度
-              (= 编辑器钳制高) 撑起卡片的固有高度，加了会塌缩。 */}
+              (= 编辑器钳制高) 撑起卡片的固有高度，加了会塌缩。
+
+              pr-12 让出右侧控制列：展开/用量环/发送都是 right-3 + w-8，占据卡片
+              右缘 44px 宽的竖直轨道。让位必须做在本容器上，**不能只给编辑器加
+              pr-8**——padding 不改变滚动条位置（滚动条恒贴 border box 右缘），
+              只挡文字不挡滚动条，溢出时那条 6px 轨会直接压在环与展开图标上。
+              收窄编辑器 border box 才能把滚动条一并推到轨道左侧；48px = 44 轨道
+              + 4px 间隙，文本可用宽度与原先 px-4 + 编辑器 pr-8 完全一致。 */}
           <div
             className={cn(
-              "relative flex flex-1 px-4",
+              "relative flex flex-1 pl-4 pr-12",
               pendingUploadedFiles.length > 0 ? "pt-1.5" : "pt-3.5",
               isComposerExpanded && "min-h-0",
             )}
@@ -970,7 +977,9 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: ChatComposer
               workdir={workdir}
               enabledSkills={enabledSkills}
               className={cn(
-                "px-0 py-0 pr-8",
+                // 右让位由外层容器 pr-12 统一承担（见上），此处不再补 pr——
+                // 编辑器自身的右内距只会把文字推开、留下滚动条压在控制列上。
+                "px-0 py-0",
                 isComposerExpanded &&
                   (surface === "desktop" ? "h-full max-h-none" : "h-full! max-h-none!"),
               )}


### PR DESCRIPTION
## Linked issue

Closes #437

## Summary

提示词输入框里，编辑器的纵向滚动条会从上下文用量环与展开图标上穿过。

三个右侧控件（展开/还原、用量环、发送）都是 `right-3` + `h-8 w-8`，共同占据卡片右缘 44px 宽的竖直轨道；而编辑器所在行只有 `px-4`，让位靠编辑器自身的 `pr-8`。**padding 不改变滚动条位置** —— `overflow-y: auto` 元素的滚动条恒贴自身 border box 右缘，`pr-8` 只把文字推开 32px，那条全局 6px 滚动轨仍停在距卡片右缘 16–22px 处，正好落在环心与展开图标下方。

本 PR 把让位从"内边距"提升成布局让位：编辑器外层容器 `px-4` → `pl-4 pr-12`（48px = 44px 轨道 + 4px 间隙），收窄编辑器 border box，滚动条随之被推到轨道左侧；编辑器不再补 `pr`。

- **文本可用宽度不变**：改前 `W−16(pl)−16(pr)−32(编辑器 pr)`，改后 `W−16−48`，都是 `W−64`；仅溢出时同样多让出 6px 给滚动条。
- 顺带修掉两个同源表现：占位符 `::before` 的包含块是外层 wrapper 而非编辑器，此前窄屏会钻到按钮底下；输入框展开态时用量环浮在正文中央同样压字 —— 现在都落在让位区内。
- 未改全局滚动条样式：Firefox 默认较宽的滚动条也落在 48px 让位区内，不会碰到轨道，无需动两端 `index.css` 镜像。

## Change scope

- Modules: agent-ui（桌面端 GUI 与网关 WebUI 共用同一份 composer，改一处两端同时生效）
- Key paths:
  - `crates/agent-ui/src/pages/chat/ChatComposerBar.tsx` —— 编辑器行 `pl-4 pr-12`，编辑器 className 去掉 `pr-8`
  - `crates/agent-gui/test/chat/context-usage.test.mjs` —— 新增布局不变量测试

## Screenshots / preview

<img width="857" height="258" alt="41b9ecbe6003da78b61be6f8da3423c3_720" src="https://github.com/user-attachments/assets/288d798a-5ae5-4a12-9328-7d790b1bea4c" />

## Verification

- `cd crates/agent-gui && node --test test/chat/*.test.mjs` —— 616 passed / 0 failed
- `cd crates/agent-gateway/web && npm test` —— 557 passed / 0 failed
- `cd crates/agent-ui && npx biome check src/pages/chat/ChatComposerBar.tsx` —— clean
- 新增测试 `composer editor row reserves the right control rail so the scrollbar clears the ring` 锁住不变量：让位必须做在编辑器外层容器上，编辑器不得复活 `pr-8`（下次有人"顺手"把 padding 挪回去会直接红）

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.（纯布局修复，代码注释已同步说明为何让位不能做在编辑器上）
