### PR TITLE
fix(sftp): WebUI 端补回 SFTP 双栏底部横向滚动条

### DIFF
--- a/crates/agent-gateway/web/src/styles.css
+++ b/crates/agent-gateway/web/src/styles.css
@@ -223,6 +223,18 @@ html[data-liveagent-webui="gateway"] *::-webkit-scrollbar-corner {
   background: transparent;
 }
 
+/* SFTP 双栏 <860px 时靠这条横向滚动条露出被裁切的右栏，但全局
+   scrollbar-width: thin 会让 Chromium 121+/Safari 18.2+ 忽略上面的
+   *::-webkit-scrollbar 自绘样式，macOS 上退化成"滚动中才短暂浮现"的悬浮
+   滚动条——静止时底部看不到任何滚动条。恢复 auto 让自绘样式重新生效，
+   与 GUI 端的常驻滚动条对齐。必须排在全局 *:hover / *:focus-within 的
+   scrollbar-color 规则之后：两者同优先级，靠源码顺序覆盖，否则悬停一瞬间
+   scrollbar-color 变回非 auto，滚动条会当场消失。 */
+html[data-liveagent-webui="gateway"] .sftp-panes-scroll {
+  scrollbar-width: auto;
+  scrollbar-color: auto;
+}
+
 html[data-liveagent-webui="gateway"] .project-tools-panel-tabs {
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/crates/agent-ui/src/components/workspace-editor/WorkspaceSftpPanel.tsx
+++ b/crates/agent-ui/src/components/workspace-editor/WorkspaceSftpPanel.tsx
@@ -1450,7 +1450,7 @@ export function WorkspaceSftpPanel(props: WorkspaceSftpPanelProps) {
       ) : null}
       <div
         className={cn(
-          "flex min-h-0 flex-1 overflow-y-hidden",
+          "sftp-panes-scroll flex min-h-0 flex-1 overflow-y-hidden",
           isMobileLayout ? "overflow-x-hidden" : "overflow-x-auto",
         )}
       >


### PR DESCRIPTION
Closes #446

## 问题

WebUI 端 SSH 隧道 → SFTP tab，面板宽度小于 860px（双栏 `min-w-[860px]`）时右侧「远端设备」栏被裁切，但底部**没有横向滚动条**——被裁切的内容既看不到也没有滚动入口。GUI 端同一共享组件表现正常。

## 根因

SFTP 面板是 agent-ui 共享代码，两端同一份；差异在 WebUI 的全局滚动条样式：

- gateway styles.css 对 `html[data-liveagent-webui="gateway"] *` 全局设了 `scrollbar-width: thin` + `scrollbar-color`；
- Chromium 121+ / Safari 18.2+ 一旦见到非 auto 的这两个属性，就**整体忽略 `::-webkit-scrollbar` 自绘样式**，退回平台原生细滚动条；
- macOS 原生滚动条是滚动中才浮现的悬浮式，静止时不画 → 横向滚动条隐形；
- GUI（WKWebView）不加载 gateway styles.css，走共享 base.css 的 `::-webkit-scrollbar` 常驻 6px 样式，因此一直正常。

## 改动

1. `WorkspaceSftpPanel.tsx`：给横向滚动容器加稳定类名 `sftp-panes-scroll`（与既有 `sftp-path-scroll` 命名对齐）。
2. `styles.css`（WebUI 专属）：对该容器恢复 `scrollbar-width: auto; scrollbar-color: auto`，让 WebUI 自己的 10px pill 形 `::-webkit-scrollbar` 样式重新生效，滚动条常驻，与 GUI 表现对齐。

注意点（已写进 CSS 注释）：豁免规则必须排在全局 `*:hover / *:focus-within` 的 scrollbar-color 规则**之后**——两者同优先级 (0,2,1) 靠源码顺序决胜，放前面会出现「悬停瞬间滚动条消失」。

## 影响面

- 移动端布局（≤820px）该容器为 `overflow-x-hidden`，无滚动条，不受影响
- GUI 端零改动（改动的 CSS 仅 WebUI 加载；tsx 仅新增类名）
- Firefox 无 `::-webkit-scrollbar`，回退到原生 auto 滚动条，行为不劣化

## 验证

- gateway web `tsc --noEmit` 通过
- Biome 检查两个文件警告数与改动前一致（均为存量），无新增