### PR TITLE
fix(git): 新建 Worktree 与路径选择弹窗改用 Base UI Dialog，修复 WebUI 层级压盖

### DIFF
--- a/crates/agent-gateway/web/src/components/RemotePathPickerModal.tsx
+++ b/crates/agent-gateway/web/src/components/RemotePathPickerModal.tsx
@@ -1,3 +1,4 @@
+import { Dialog } from "@base-ui/react/dialog";
 import { invoke } from "@liveagent/app/shims/tauriCore";
 import {
   AlertTriangle,
@@ -12,7 +13,6 @@ import {
 import { Button } from "@liveagent/ui/components/ui/button";
 import { Input } from "@liveagent/ui/components/ui/input";
 import { useLocale } from "@liveagent/ui/i18n/index";
-import { useModalMotion } from "@liveagent/ui/lib/shared/modalMotion";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   IndividualTreeViewState,
@@ -21,7 +21,6 @@ import type {
   TreeViewState,
 } from "react-complex-tree";
 import { ControlledTreeEnvironment, Tree } from "react-complex-tree";
-import { createPortal } from "react-dom";
 import type { RemoteFsRoot } from "./remotePathPickerPaths";
 import {
   basenameFromPath,
@@ -147,7 +146,10 @@ export function RemotePathPickerModal(props: RemotePathPickerModalProps) {
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [createFolderError, setCreateFolderError] = useState<string | null>(null);
   const didExpandInitialPathRef = useRef(false);
-  const { modalState, requestClose } = useModalMotion(onClose);
+  // Base UI 控制 open：先置 false 播放退场过渡，onOpenChangeComplete 再通知
+  // 调用方卸载（onSelect 已先行 resolve，onClose 的 resolve(null) 为 no-op）。
+  const [open, setOpen] = useState(true);
+  const requestClose = useCallback(() => setOpen(false), []);
 
   const modalTitle =
     title ?? (mode === "file" ? t("settings.filePickerTitle") : t("settings.workdirPickerTitle"));
@@ -282,16 +284,6 @@ export function RemotePathPickerModal(props: RemotePathPickerModalProps) {
       cancelled = true;
     };
   }, []);
-
-  useEffect(() => {
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key !== "Escape") return;
-      event.preventDefault();
-      requestClose();
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [requestClose]);
 
   useEffect(() => {
     if (loadingRoots || didExpandInitialPathRef.current) return;
@@ -520,187 +512,202 @@ export function RemotePathPickerModal(props: RemotePathPickerModalProps) {
     }
   }
 
-  const overlay = (
-    <div
-      className="settings-modal-overlay fixed inset-0 z-50 flex items-center justify-center p-4"
-      data-state={modalState}
+  // 挂 z-[120]：需要压过新建 worktree 弹窗（z-[110]）等上层来源；作为嵌套
+  // Base UI Dialog 打开时 DOM 顺序也保证在后。settings-modal-* 类只复用其
+  // 响应式布局规则，动画由 modal-dialog-* 的 Base UI 过渡属性驱动。
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={setOpen}
+      onOpenChangeComplete={(nextOpen) => {
+        if (!nextOpen) onClose();
+      }}
     >
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={requestClose} />
-
-      <div className="settings-modal-panel relative z-10 flex max-h-[92vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-border/60 bg-background shadow-2xl">
-        <div className="settings-modal-header flex items-center gap-3 border-b border-border/40 px-6 py-4">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
-            {mode === "file" ? <File className="h-5 w-5" /> : <FolderOpen className="h-5 w-5" />}
-          </div>
-          <div className="min-w-0 flex-1">
-            <h2 className="text-base font-semibold">{modalTitle}</h2>
-            <p className="mt-0.5 text-xs text-muted-foreground">{modalDescription}</p>
-          </div>
-          <button
-            type="button"
-            onClick={requestClose}
-            title={t("settings.cancel")}
-            aria-label={t("settings.cancel")}
-            className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-
-        <div className="settings-modal-subheader border-b border-border/30 px-6 py-4">
-          <div className="settings-field-row flex items-center gap-3">
-            <div className="w-24 shrink-0 text-xs font-medium text-muted-foreground">
-              {mode === "file" ? t("settings.pathPickerPathLabel") : t("settings.workdir")}
-            </div>
-            <Input value={headerPath} readOnly className="font-mono text-[13px]" />
-          </div>
-        </div>
-
-        <div className="settings-modal-body flex min-h-0 flex-1 flex-col gap-3 px-6 py-4">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <div className="flex items-center gap-1.5">
-              <Home className="h-3.5 w-3.5" />
-              <span>~</span>
-            </div>
-            <span className="text-muted-foreground/40">·</span>
-            <div className="flex items-center gap-1.5">
-              <HardDrive className="h-3.5 w-3.5" />
-              <span>Root</span>
-            </div>
-          </div>
-
-          {mode === "directory" ? (
-            <div className="rounded-xl border border-border/60 bg-background/70 p-2">
-              <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2">
-                <Input
-                  value={newFolderName}
-                  onChange={(event) => {
-                    setNewFolderName(event.currentTarget.value);
-                    if (createFolderError) {
-                      setCreateFolderError(null);
-                    }
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key !== "Enter") return;
-                    event.preventDefault();
-                    void createFolderInActivePath();
-                  }}
-                  placeholder={
-                    activePath
-                      ? t("settings.newFolderNamePlaceholder")
-                      : t("settings.newFolderSelectParentFirst")
-                  }
-                  disabled={!activePath || creatingFolder}
-                  className="h-9"
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-9 gap-2"
-                  onClick={() => void createFolderInActivePath()}
-                  disabled={!canCreateFolder}
-                >
-                  {creatingFolder ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : (
-                    <Plus className="h-3.5 w-3.5" />
-                  )}
-                  {t("settings.createFolder")}
-                </Button>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="modal-dialog-backdrop fixed inset-0 z-[120] bg-black/60 backdrop-blur-sm" />
+        <Dialog.Viewport className="settings-modal-overlay modal-dialog-viewport fixed inset-0 z-[120] flex items-center justify-center p-4">
+          <Dialog.Popup className="settings-modal-panel modal-dialog-popup relative flex max-h-[92vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-border/60 bg-background shadow-2xl outline-none">
+            <div className="settings-modal-header flex items-center gap-3 border-b border-border/40 px-6 py-4">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                {mode === "file" ? (
+                  <File className="h-5 w-5" />
+                ) : (
+                  <FolderOpen className="h-5 w-5" />
+                )}
               </div>
-              {createFolderError ? (
-                <div className="mt-2 flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                  <span className="min-w-0 flex-1">{createFolderError}</span>
+              <div className="min-w-0 flex-1">
+                <Dialog.Title className="text-base font-semibold">{modalTitle}</Dialog.Title>
+                <Dialog.Description className="mt-0.5 text-xs text-muted-foreground">
+                  {modalDescription}
+                </Dialog.Description>
+              </div>
+              <button
+                type="button"
+                onClick={requestClose}
+                title={t("settings.cancel")}
+                aria-label={t("settings.cancel")}
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="settings-modal-subheader border-b border-border/30 px-6 py-4">
+              <div className="settings-field-row flex items-center gap-3">
+                <div className="w-24 shrink-0 text-xs font-medium text-muted-foreground">
+                  {mode === "file" ? t("settings.pathPickerPathLabel") : t("settings.workdir")}
+                </div>
+                <Input value={headerPath} readOnly className="font-mono text-[13px]" />
+              </div>
+            </div>
+
+            <div className="settings-modal-body flex min-h-0 flex-1 flex-col gap-3 px-6 py-4">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <div className="flex items-center gap-1.5">
+                  <Home className="h-3.5 w-3.5" />
+                  <span>~</span>
+                </div>
+                <span className="text-muted-foreground/40">·</span>
+                <div className="flex items-center gap-1.5">
+                  <HardDrive className="h-3.5 w-3.5" />
+                  <span>Root</span>
+                </div>
+              </div>
+
+              {mode === "directory" ? (
+                <div className="rounded-xl border border-border/60 bg-background/70 p-2">
+                  <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2">
+                    <Input
+                      value={newFolderName}
+                      onChange={(event) => {
+                        setNewFolderName(event.currentTarget.value);
+                        if (createFolderError) {
+                          setCreateFolderError(null);
+                        }
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter") return;
+                        event.preventDefault();
+                        void createFolderInActivePath();
+                      }}
+                      placeholder={
+                        activePath
+                          ? t("settings.newFolderNamePlaceholder")
+                          : t("settings.newFolderSelectParentFirst")
+                      }
+                      disabled={!activePath || creatingFolder}
+                      className="h-9"
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-9 gap-2"
+                      onClick={() => void createFolderInActivePath()}
+                      disabled={!canCreateFolder}
+                    >
+                      {creatingFolder ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Plus className="h-3.5 w-3.5" />
+                      )}
+                      {t("settings.createFolder")}
+                    </Button>
+                  </div>
+                  {createFolderError ? (
+                    <div className="mt-2 flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                      <span className="min-w-0 flex-1">{createFolderError}</span>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+
+              <div className="workdir-picker-tree min-h-0 flex-1 overflow-auto rounded-xl border border-border/60 bg-muted/20 p-2">
+                <ControlledTreeEnvironment
+                  items={items}
+                  getItemTitle={(item) => item.data.label}
+                  viewState={viewState}
+                  onExpandItem={(item, treeId) => {
+                    const index = typeof item.index === "string" ? item.index : "";
+                    if (!index || index === ROOT_ID) return;
+                    updateTreeViewState(treeId, (treePrev) => ({
+                      ...treePrev,
+                      expandedItems: treePrev.expandedItems?.includes(index)
+                        ? treePrev.expandedItems
+                        : [...(treePrev.expandedItems ?? []), index],
+                    }));
+                    void loadChildren(index);
+                  }}
+                  onCollapseItem={(item, treeId) => {
+                    const index = typeof item.index === "string" ? item.index : "";
+                    if (!index || index === ROOT_ID) return;
+                    updateTreeViewState(treeId, (treePrev) => ({
+                      ...treePrev,
+                      expandedItems: (treePrev.expandedItems ?? []).filter(
+                        (entry) => entry !== index,
+                      ),
+                    }));
+                  }}
+                  onSelectItems={(selectedItems, treeId) => {
+                    updateTreeViewState(treeId, (treePrev) => ({
+                      ...treePrev,
+                      selectedItems,
+                    }));
+                  }}
+                  onFocusItem={(item, treeId) => {
+                    updateTreeViewState(treeId, (treePrev) => ({
+                      ...treePrev,
+                      focusedItem: item.index,
+                    }));
+                  }}
+                >
+                  <Tree treeId={TREE_ID} rootItem={ROOT_ID} treeLabel="Remote paths" />
+                </ControlledTreeEnvironment>
+              </div>
+
+              {statusLine ? (
+                <div
+                  className={`flex items-start gap-2 rounded-lg border px-3 py-2.5 text-xs ${
+                    statusLine.kind === "error"
+                      ? "border-destructive/30 bg-destructive/5 text-destructive"
+                      : statusLine.kind === "warn"
+                        ? "border-amber-500/30 bg-amber-500/5 text-amber-700 dark:text-amber-300"
+                        : "border-border/60 bg-background/70 text-muted-foreground"
+                  }`}
+                >
+                  {statusLine.kind === "loading" ? (
+                    <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin" />
+                  ) : statusLine.kind === "error" ? (
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  ) : (
+                    <FolderOpen className="mt-0.5 h-4 w-4 shrink-0" />
+                  )}
+                  <span className="min-w-0 flex-1">{statusLine.text}</span>
                 </div>
               ) : null}
             </div>
-          ) : null}
 
-          <div className="workdir-picker-tree min-h-0 flex-1 overflow-auto rounded-xl border border-border/60 bg-muted/20 p-2">
-            <ControlledTreeEnvironment
-              items={items}
-              getItemTitle={(item) => item.data.label}
-              viewState={viewState}
-              onExpandItem={(item, treeId) => {
-                const index = typeof item.index === "string" ? item.index : "";
-                if (!index || index === ROOT_ID) return;
-                updateTreeViewState(treeId, (treePrev) => ({
-                  ...treePrev,
-                  expandedItems: treePrev.expandedItems?.includes(index)
-                    ? treePrev.expandedItems
-                    : [...(treePrev.expandedItems ?? []), index],
-                }));
-                void loadChildren(index);
-              }}
-              onCollapseItem={(item, treeId) => {
-                const index = typeof item.index === "string" ? item.index : "";
-                if (!index || index === ROOT_ID) return;
-                updateTreeViewState(treeId, (treePrev) => ({
-                  ...treePrev,
-                  expandedItems: (treePrev.expandedItems ?? []).filter((entry) => entry !== index),
-                }));
-              }}
-              onSelectItems={(selectedItems, treeId) => {
-                updateTreeViewState(treeId, (treePrev) => ({
-                  ...treePrev,
-                  selectedItems,
-                }));
-              }}
-              onFocusItem={(item, treeId) => {
-                updateTreeViewState(treeId, (treePrev) => ({
-                  ...treePrev,
-                  focusedItem: item.index,
-                }));
-              }}
-            >
-              <Tree treeId={TREE_ID} rootItem={ROOT_ID} treeLabel="Remote paths" />
-            </ControlledTreeEnvironment>
-          </div>
-
-          {statusLine ? (
-            <div
-              className={`flex items-start gap-2 rounded-lg border px-3 py-2.5 text-xs ${
-                statusLine.kind === "error"
-                  ? "border-destructive/30 bg-destructive/5 text-destructive"
-                  : statusLine.kind === "warn"
-                    ? "border-amber-500/30 bg-amber-500/5 text-amber-700 dark:text-amber-300"
-                    : "border-border/60 bg-background/70 text-muted-foreground"
-              }`}
-            >
-              {statusLine.kind === "loading" ? (
-                <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin" />
-              ) : statusLine.kind === "error" ? (
-                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-              ) : (
-                <FolderOpen className="mt-0.5 h-4 w-4 shrink-0" />
-              )}
-              <span className="min-w-0 flex-1">{statusLine.text}</span>
+            <div className="settings-modal-footer flex items-center justify-end gap-2 border-t border-border/40 px-6 py-4">
+              <Button variant="outline" onClick={requestClose}>
+                {t("settings.cancel")}
+              </Button>
+              <Button
+                disabled={!canConfirm}
+                onClick={() => {
+                  if (!canConfirm || !selectedPath) return;
+                  onSelect(selectedPath);
+                  requestClose();
+                }}
+              >
+                {t("settings.select")}
+              </Button>
             </div>
-          ) : null}
-        </div>
-
-        <div className="settings-modal-footer flex items-center justify-end gap-2 border-t border-border/40 px-6 py-4">
-          <Button variant="outline" onClick={requestClose}>
-            {t("settings.cancel")}
-          </Button>
-          <Button
-            disabled={!canConfirm}
-            onClick={() => {
-              if (!canConfirm || !selectedPath) return;
-              onSelect(selectedPath);
-              requestClose();
-            }}
-          >
-            {t("settings.select")}
-          </Button>
-        </div>
-      </div>
-    </div>
+          </Dialog.Popup>
+        </Dialog.Viewport>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
-
-  return createPortal(overlay, document.body);
 }
 
 type PickPathOptions = {

--- a/crates/agent-ui/src/components/git/GitBranchSelector.tsx
+++ b/crates/agent-ui/src/components/git/GitBranchSelector.tsx
@@ -1,3 +1,4 @@
+import { Dialog } from "@base-ui/react/dialog";
 import { useDirectoryPicker } from "@liveagent/adapters/directoryPicker";
 import {
   Check,
@@ -325,12 +326,9 @@ function WorktreeCreateModal(props: {
   } = props;
   const { t } = useLocale();
   const { pickDirectory, directoryPickerElement } = useDirectoryPicker();
-  const titleId = useId();
   const branchInputId = useId();
   const directoryInputId = useId();
   const parentInputId = useId();
-
-  if (!open) return directoryPickerElement;
 
   async function chooseParentDirectory() {
     try {
@@ -342,25 +340,28 @@ function WorktreeCreateModal(props: {
     }
   }
 
+  // directoryPickerElement 渲染在 Root 内、Portal 外：WebUI 的远程路径选择器
+  // 由此成为嵌套 Base UI Dialog，天然叠在本弹窗之上（GUI 为原生目录选择器，元素为 null）。
   return (
-    <>
-      {createPortal(
-        <div
-          className="fixed inset-0 z-[110] flex items-center justify-center p-4"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby={titleId}
-        >
-          <div
-            className="absolute inset-0 bg-black/55 backdrop-blur-sm"
-            onClick={loading ? undefined : onClose}
-          />
-          <form
-            className="relative z-10 w-full max-w-md overflow-hidden rounded-2xl border border-border/70 bg-background shadow-2xl"
-            onSubmit={(event) => {
-              event.preventDefault();
-              onSubmit();
-            }}
+    <Dialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && !loading) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Backdrop className="modal-dialog-backdrop fixed inset-0 z-[110] bg-black/55 backdrop-blur-sm" />
+        <Dialog.Viewport className="fixed inset-0 z-[110] flex items-center justify-center p-4">
+          <Dialog.Popup
+            className="modal-dialog-popup relative w-full max-w-md overflow-hidden rounded-2xl border border-border/70 bg-background shadow-2xl outline-none"
+            render={
+              <form
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  onSubmit();
+                }}
+              />
+            }
           >
             <div className="flex items-start justify-between gap-4 border-b border-border/60 px-5 py-4">
               <div className="flex min-w-0 items-start gap-3">
@@ -368,12 +369,15 @@ function WorktreeCreateModal(props: {
                   <FolderTree className="h-5 w-5" />
                 </div>
                 <div className="min-w-0">
-                  <div id={titleId} className="text-sm font-semibold text-foreground">
+                  <Dialog.Title className="text-sm font-semibold text-foreground" render={<div />}>
                     {t("git.branchSelector.createWorktreeTitle")}
-                  </div>
-                  <div className="mt-1 text-xs leading-5 text-muted-foreground">
+                  </Dialog.Title>
+                  <Dialog.Description
+                    className="mt-1 text-xs leading-5 text-muted-foreground"
+                    render={<div />}
+                  >
                     {t("git.branchSelector.worktreeDescription")}
-                  </div>
+                  </Dialog.Description>
                 </div>
               </div>
               <Button
@@ -525,12 +529,11 @@ function WorktreeCreateModal(props: {
                 {t("git.branchSelector.createWorktree")}
               </Button>
             </div>
-          </form>
-        </div>,
-        document.body,
-      )}
+          </Dialog.Popup>
+        </Dialog.Viewport>
+      </Dialog.Portal>
       {directoryPickerElement}
-    </>
+    </Dialog.Root>
   );
 }
 

--- a/crates/agent-ui/src/styles/common.css
+++ b/crates/agent-ui/src/styles/common.css
@@ -1606,6 +1606,51 @@ body > div:not(#root) [data-streamdown="mermaid"]:has([style*="cursor:grabbing"]
     transform: translateY(12px) scale(0.985);
   }
 
+  /* Base UI Dialog 通用进出场（WorktreeCreateModal、RemotePathPickerModal 等）。
+     与 settings-modal-* 的 useModalMotion/data-state 机制不同，Base UI 弹层由
+     data-starting-style / data-ending-style 驱动，退场过渡结束后才卸载。 */
+  .modal-dialog-backdrop {
+    opacity: 1;
+    transition: opacity 180ms ease;
+  }
+
+  .modal-dialog-backdrop[data-starting-style],
+  .modal-dialog-backdrop[data-ending-style] {
+    opacity: 0;
+  }
+
+  .modal-dialog-popup {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    transition:
+      opacity 180ms ease,
+      transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .modal-dialog-popup[data-starting-style],
+  .modal-dialog-popup[data-ending-style] {
+    opacity: 0;
+    transform: translateY(12px) scale(0.985);
+  }
+
+  /* settings-modal-* 基线为 opacity:0 且靠 data-state 显形；Base UI 驱动的
+     同款外观（复用其响应式布局规则）必须中和该基线，否则弹层恒隐藏。 */
+  .settings-modal-overlay.modal-dialog-viewport {
+    opacity: 1;
+    transition: none;
+  }
+
+  .settings-modal-panel.modal-dialog-popup {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  .settings-modal-panel.modal-dialog-popup[data-starting-style],
+  .settings-modal-panel.modal-dialog-popup[data-ending-style] {
+    opacity: 0;
+    transform: translateY(12px) scale(0.985);
+  }
+
   .settings-tools-view-enter {
     animation: settingsToolsViewIn 0.22s cubic-bezier(0.16, 1, 0.3, 1);
     will-change: transform, opacity;
@@ -1874,7 +1919,9 @@ body > div:not(#root) [data-streamdown="mermaid"]:has([style*="cursor:grabbing"]
     .settings-modal-overlay,
     .settings-modal-panel,
     .ssh-forward-dialog-backdrop,
-    .ssh-forward-dialog-popup {
+    .ssh-forward-dialog-popup,
+    .modal-dialog-backdrop,
+    .modal-dialog-popup {
       transition-duration: 1ms;
     }
 


### PR DESCRIPTION
Closes #449

## 问题

WebUI 端新建 Worktree 弹窗中点击「保存位置」选择后，远程路径选择模态框显示在弹窗**下方**：两者都是手写 `createPortal`，但 Worktree 弹窗为 `z-[110]`、路径选择器仅 `z-50`。

## 改动

**WorktreeCreateModal（crates/agent-ui/src/components/git/GitBranchSelector.tsx，两端共享）**
- 手写 portal + 遮罩 div 改为 Base UI `Dialog.Root/Portal/Backdrop/Viewport/Popup`（对齐 SshPortForwardDialog / confirm-dialog 既有模式），表单经 `Popup render={<form/>}` 承载，标题/描述换 `Dialog.Title/Description`
- `directoryPickerElement` 渲染进 `Dialog.Root` 内：WebUI 路径选择器由此成为 Base UI 嵌套 Dialog，焦点陷阱、Escape 只关最上层、遮罩点击只关自己均为原生行为；`loading` 期间禁止关闭的语义保留在 `onOpenChange` 守卫
- 层级维持 `z-[110]`（仍低于共享 ConfirmDialog 的 `z-[120]`）

**RemotePathPickerModal（crates/agent-gateway/web，WebUI 专属）**
- 同样改为 Base UI Dialog，提升到 `z-[120]` 压过 Worktree 弹窗；嵌套打开时 DOM 顺序也保证在后
- 移除 `useModalMotion` 与手动 window Escape 监听；退场动画改为内部 `open` 状态 + `onOpenChangeComplete`，过渡播完再通知调用方卸载，promise 语义（选中 resolve 路径 / 关闭 resolve null）不变
- `settings-modal-*` 类名全部保留，WebUI 移动端响应式布局规则继续生效；设置页工作目录/文件选择等其它入口行为不变

**common.css（crates/agent-ui）**
- 新增通用 `.modal-dialog-backdrop` / `.modal-dialog-popup` 进出场过渡类（`data-starting-style`/`data-ending-style` 驱动，180ms，登记进 reduced-motion）
- 中和 `settings-modal-overlay/panel` 的 `opacity:0` 基线（原靠 useModalMotion 的 `data-state` 显形），避免 Base UI 弹层复用布局类时恒隐藏

GUI 端不受影响：目录选择走原生 `system_pick_folder`，`directoryPickerElement` 为 null；分支起点 Select 弹层为 `z-[9999]` 不受弹窗层级影响。

## Screenshots / preview
<img width="1032" height="1126" alt="31ac170360b8d006e537352e6bf0fdad" src="https://github.com/user-attachments/assets/9b4d844f-689b-491d-94ec-c11484287488" />


## 验证

- GUI / WebUI `tsc --noEmit` 通过
- agent-ui、gateway-webui（嵌套 biome 配置）、gui lint 通过；`check:ui-boundaries` 通过
- `pnpm test:webui`、`pnpm test:gui` 全部通过