### PR TITLE
fix(scripts): 修复 UI 边界检查在 Windows 上的路径分隔符误报

### DIFF
--- a/scripts/check-ui-boundaries.mjs
+++ b/scripts/check-ui-boundaries.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { join, relative, resolve } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 import { findRetiredSharedDeclarations } from "./ui-boundary-declarations.mjs";
 
 const repoRoot = resolve(import.meta.dirname, "..");
+const toPosixPath = (path) => path.split(sep).join("/");
 
 function listSourceFiles(root, directory = root) {
   const files = [];
@@ -197,10 +198,10 @@ for (const sharedFile of listSourceFiles(sharedRoot)) {
   for (const appRoot of appRoots) {
     const appFile = join(appRoot, sharedRelativePath);
     if (!existsSync(appFile)) continue;
-    if (sharedFacades.has(relative(repoRoot, appFile))) continue;
+    if (sharedFacades.has(toPosixPath(relative(repoRoot, appFile)))) continue;
     failures += 1;
     console.error(
-      `${relative(repoRoot, appRoot)}/${sharedRelativePath}: 共享源码不能在应用目录保留同路径副本`,
+      `${toPosixPath(relative(repoRoot, appFile))}: 共享源码不能在应用目录保留同路径副本`,
     );
   }
 }


### PR DESCRIPTION
Closes #456

## 问题

在 Windows 上对干净的 `main` 执行 `pnpm check:ui-boundaries` 会失败，报告三处并不存在的违规——而这三个文件正是 `sharedFacades` 已显式声明豁免的兼容入口。Windows 贡献者因此无法在本地跑通该门禁。

## 根因

`sharedFacades` 的 key 是正斜杠字面量：

```
crates/agent-gui/src/lib/settings/index.ts
crates/agent-gateway/web/src/lib/settings/index.ts
crates/agent-gateway/web/src/lib/chat/uiMessages.ts
```

而 `relative(repoRoot, appFile)` 在 Windows 上返回 `crates\agent-gui\src\lib\settings\index.ts`。`Map.has()` 做精确字符串比较，因此每条豁免声明在 Windows 上都失配，全部落入违规分支。

CI 运行在 Linux 上，`relative()` 返回正斜杠、匹配成功，所以该问题不会在 CI 中暴露。同一 commit `14844e1a` 上，上游 CI 为 success 而 Windows 本地该门禁失败。

## 改动

- 查表前用 `toPosixPath()` 统一分隔符
- 报错信息改为直接由 `appFile` 计算相对路径，消除混合分隔符输出

`sep` 在 POSIX 上即 `/`，`toPosixPath` 为空操作，**Linux 与 macOS 行为不变**。已用 `path.posix` 逐组比对，报错信息新旧写法在 POSIX 上输出逐字符一致。

## 验证（Windows 11 / Node 24.14.0 / pnpm 10.32.1）

修复前：

```
$ pnpm check:ui-boundaries
crates\agent-gateway\web\src/lib\chat\uiMessages.ts: 共享源码不能在应用目录保留同路径副本
crates\agent-gui\src/lib\settings\index.ts: 共享源码不能在应用目录保留同路径副本
crates\agent-gateway\web\src/lib\settings\index.ts: 共享源码不能在应用目录保留同路径副本
 ELIFECYCLE  Command failed with exit code 1.
```

修复后：

```
$ pnpm check:ui-boundaries
UI boundary check passed.
```

负向验证——手动在应用目录造一份真实的同路径副本，确认门禁没有被改废，且路径输出已是干净的正斜杠：

```
$ cp crates/agent-ui/src/lib/shared/id.ts crates/agent-gui/src/lib/shared/id.ts
$ pnpm check:ui-boundaries
crates/agent-gui/src/lib/shared/id.ts: 共享源码不能在应用目录保留同路径副本
```

`git diff --check` 通过。

## 未包含的改动

- 另外三处 `relative()`（`:111`、`:190`、`:283`）在 Windows 上同样输出反斜杠，但仅影响显示、不影响判定，为保持改动聚焦未一并处理。如果希望统一，我可以补上。
- 该脚本为顶层副作用式执行（import 即运行检查），不重构就无法单测，因此本次未加测试。如果希望覆盖，可以把路径归一化抽到 `ui-boundary-declarations.mjs` 并在既有测试文件中补用例。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
