### PR TITLE
fix(chat): 修复重试期间点停止后转圈不停

### DIFF
--- a/crates/agent-gui/src/lib/providers/runtime/streamRetry.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/streamRetry.ts
@@ -1,4 +1,5 @@
 import {
+  type AssistantMessage,
   type AssistantMessageEvent,
   type AssistantMessageEventStream,
   createAssistantMessageEventStream,
@@ -51,6 +52,21 @@ export function computeStreamRetryBackoffMs(attempt: number): number {
   return base * (0.9 + Math.random() * 0.2);
 }
 
+/**
+ * The cancellation terminal a consumer must see when the user stops the run
+ * during a retry backoff. It reuses the failed attempt's model identity so the
+ * record keeps saying which provider/model the cancelled round belonged to.
+ */
+function buildAbortedAssistantMessage(previous: AssistantMessage | undefined): AssistantMessage {
+  return {
+    ...(previous ?? {}),
+    role: "assistant",
+    content: previous?.content ?? [],
+    stopReason: "aborted",
+    errorMessage: "Cancelled",
+  } as AssistantMessage;
+}
+
 function sleepWithAbort(ms: number, signal: AbortSignal | undefined): Promise<void> {
   if (signal?.aborted) return Promise.reject(signal.reason ?? new Error("Aborted"));
   if (ms <= 0) return Promise.resolve();
@@ -79,7 +95,9 @@ function sleepWithAbort(ms: number, signal: AbortSignal | undefined): Promise<vo
  * sees the failed attempt's events. Once committed, or once retries are
  * exhausted/disabled, events pass straight through untouched. `onRetry` /
  * `onRetryRecovered` let callers surface an ephemeral "reconnecting" status
- * in place of the frozen UI, mirroring codex's TUI behavior.
+ * in place of the frozen UI, mirroring codex's TUI behavior. A stop during the
+ * backoff ends the stream with an `aborted` terminal, never with the failed
+ * attempt's transport error.
  *
  * The pump below runs eagerly (not gated on the returned stream being
  * iterated) because pi-ai's own stream factories start their network work as
@@ -136,9 +154,22 @@ export function withStreamRetry(
             source = factory();
             continue;
           } catch {
-            // Aborted mid-backoff, or the next attempt failed to start —
-            // surface the prior attempt's real failure below instead of
-            // hanging the consumer on a retry that will never happen.
+            // Stopped mid-backoff: the terminal must say "aborted", not replay
+            // the prior attempt's transport error. Handing the consumer that
+            // error instead loses the fact that the user stopped the run — the
+            // abort branches upstream never fire, so nothing records the
+            // cancellation and the status row falls back to a spinner.
+            if (signal?.aborted) {
+              const aborted = buildAbortedAssistantMessage(
+                terminalMessage(terminal) as AssistantMessage | undefined,
+              );
+              output.push({ type: "error", reason: "aborted", error: aborted });
+              output.end(aborted);
+              return;
+            }
+            // The next attempt failed to start — surface the prior attempt's
+            // real failure below instead of hanging the consumer on a retry
+            // that will never happen.
           }
         }
       }

--- a/crates/agent-gui/src/pages/chat/components/AssistantBubble.tsx
+++ b/crates/agent-gui/src/pages/chat/components/AssistantBubble.tsx
@@ -35,8 +35,11 @@ export const AssistantBubbleUnit = memo(function AssistantBubbleUnit(props: {
   const { unit } = row;
   if (unit.kind === "footer") return null;
 
+  // 只有仍在直播的状态单元才渲染转圈状态行。落定交接阶段的同一单元
+  // (live:false) 若继续渲染，会在底部留下一个永远旋转的 spinner——运行早已
+  // 结束，用户却以为任务还在后台跑。
   const status =
-    unit.kind === "status" ? (
+    unit.kind === "status" && row.live ? (
       <LiveAssistantStatus
         status={toolStatus}
         isCompaction={isCompactionRunning}

--- a/crates/agent-gui/src/pages/chat/transcript/rowModel.ts
+++ b/crates/agent-gui/src/pages/chat/transcript/rowModel.ts
@@ -685,11 +685,13 @@ export function createTranscriptRowModel(options?: TranscriptRowModelOptions): T
         activeTurn.settlingUnits = null;
       } else {
         if (!activeTurn.settlingUnits) {
-          activeTurn.settlingUnits = activeTurn.lastLiveUnits.map((row) => ({
-            ...row,
-            live: false,
-            mutable: false,
-          }));
+          activeTurn.settlingUnits = activeTurn.lastLiveUnits
+            .filter((row) => row.unit.kind !== "status")
+            .map((row) => ({
+              ...row,
+              live: false,
+              mutable: false,
+            }));
         }
         liveUnits = activeTurn.settlingUnits;
       }

--- a/crates/agent-gui/test/chat/transcript-row-model.test.mjs
+++ b/crates/agent-gui/test/chat/transcript-row-model.test.mjs
@@ -117,8 +117,11 @@ test("persist lag: block-unit aliases still land one build later", () => {
   assert.equal(blockRows(waitingForHistory)[0].key, liveBlockKey);
   assert.equal(waitingForHistory.rows.at(-1).kind, "assistant-activity");
   assert.equal(waitingForHistory.rows.at(-1).live, false);
-  assert.equal(waitingForHistory.rows.at(-1).units.at(-1).unit.kind, "status");
-  assert.equal("active" in waitingForHistory.rows.at(-1).units.at(-1).unit, false);
+  assert.deepEqual(
+    waitingForHistory.rows.at(-1).units.map((unit) => unit.unit.kind),
+    ["block"],
+    "the settling activity must not retain an empty status row",
+  );
   const settled = model.build(
     [userItem("u1"), assistantItem("a1", [round("r1", "full reply")])],
     idleLive,

--- a/crates/agent-gui/test/providers/stream-retry.test.mjs
+++ b/crates/agent-gui/test/providers/stream-retry.test.mjs
@@ -266,8 +266,48 @@ test("withStreamRetry backoff aborted before it can fire prevents any further at
 
   const events = await collectEvents(wrapped);
   assert.equal(calls, 1);
+  assert.equal(events.length, 1);
   assert.equal(events[0].type, "error");
-  assert.match(events[0].error.errorMessage, /503/);
+  // A stop during the backoff is a cancellation, not the failed attempt's
+  // transport error: replaying the 503 here would hide the fact that the user
+  // stopped the run, so every abort branch upstream would miss it.
+  assert.equal(events[0].reason, "aborted");
+  assert.equal(events[0].error.stopReason, "aborted");
+});
+
+test("withStreamRetry resolves an aborted backoff to an aborted final message", async () => {
+  const controller = new AbortController();
+  controller.abort(new Error("cancelled"));
+  const wrapped = withStreamRetry(() => createErrorStream("502 bad gateway"), {
+    maxAttempts: 5,
+    signal: controller.signal,
+  });
+
+  await collectEvents(wrapped);
+  const final = await wrapped.result();
+  assert.equal(final.stopReason, "aborted");
+  // The model identity of the cancelled round survives, so the persisted
+  // record still says which provider/model the stopped turn belonged to.
+  assert.equal(final.model, "test-model");
+  assert.equal(final.provider, "anthropic");
+});
+
+test("withStreamRetry reports the retry that was cancelled through onRetry", async () => {
+  // The status row and the persisted stop notice both read the last retry
+  // record, so the retry that was in flight when the user stopped must have
+  // been reported before the abort lands.
+  const controller = new AbortController();
+  controller.abort(new Error("cancelled"));
+  const retryCalls = [];
+  const wrapped = withStreamRetry(() => createErrorStream("502 bad gateway"), {
+    maxAttempts: 5,
+    signal: controller.signal,
+    onRetry: (attempt, maxAttempts, errorMessage) =>
+      retryCalls.push([attempt, maxAttempts, errorMessage]),
+  });
+
+  await collectEvents(wrapped);
+  assert.deepEqual(retryCalls, [[1, 4, "502 bad gateway"]]);
 });
 
 test("withStreamRetry with disabled:true never retries", async () => {


### PR DESCRIPTION
## 问题

网络失败或 502 触发自动重试后，在退避等待期间点停止：状态行不落终态，`Vibing...` 一直转，看起来任务还在后台跑。

根因在 `withStreamRetry`：退避的 `sleepWithAbort` 被中止后，`catch` 把中止事实吞掉，转而把上一次尝试缓冲的 502 error 事件当成最终结果推给消费者。消费者拿到的终态 `reason` 是 `error` 而不是 `aborted`，`stopReason` 也不是 `aborted`，于是上游三处已有的中止分支（`runTextConversationTurn` 的 `isAbortLikeError`、`agentRunner` 的 `stopReason === "aborted"`、`withProviderFailover` 的 `reason === "aborted"` 短路）只能靠 `userStop.signal.aborted` 兜住，scope 级 abort、子代理和 failover 外层都会把这次停止当成 provider 故障处理。

第二个问题是界面兜底：`AssistantBubbleUnit` 对 `unit.kind === "status"` 无条件渲染带 `animate-spin` 的状态行，不看 `row.live`。`rowModel` 的落定交接会把含 status 单元的 `settlingUnits`（`live: false`）继续挂在底部，孪生历史项迟到或缺失时就留下一个永远旋转的 spinner。

## 改动

- `crates/agent-gui/src/lib/providers/runtime/streamRetry.ts`：退避期间被中止时推送 `{ type: "error", reason: "aborted" }` + `stopReason: "aborted"` 的终态，并沿用该轮的 provider/model 身份，不再把上一次尝试的传输错误当最终结果
- `crates/agent-gui/src/pages/chat/components/AssistantBubble.tsx`：status 单元只在 `row.live` 时渲染，落定阶段不再留下旋转 spinner
- `crates/agent-gui/test/providers/stream-retry.test.mjs`：原 `backoff aborted before it can fire` 用例断言的正是这个缺陷（`assert.match(events[0].error.errorMessage, /503/)`），改为断言 aborted 终态；另加 2 个用例

## Screenshots / preview
<img width="1516" height="447" alt="2026-08_13_18-57-32" src="https://github.com/user-attachments/assets/4cf1ba9b-367e-4681-83e9-dbf61b0ade98" />

<!-- 前后对比：before = 退避期间点停止后 Vibing 持续旋转；after = 同一操作下状态行落终态、spinner 消失 -->

## 验证

| 检查 | 结果 |
| --- | --- |
| `node --test crates/agent-gui/test/providers/stream-retry.test.mjs` | 14/14 通过 |
| `pnpm test:gui`（全量 1666 例） | 1661 通过 / 5 失败，均为基线既有失败 |
| `npx tsc --noEmit`（agent-gui） | 通过 |
| `git diff --check` | 干净 |

- 新断言非空跑：stash 掉 src 改动后，`backoff aborted before it can fire` 与 `resolves an aborted backoff to an aborted final message` 两条确实失败。
- 那 5 个失败（`edit-resend-atomic`、`mention-composer-selection`、`mention-refetch`、`provider-usage-query-form`）在移除本 PR 的 src 改动后同样失败，属 `upstream/main` 基线既有问题，与本改动无关。

### 未在本地运行的项

- `pnpm lint:gui`：本地 Windows 检出为 CRLF（`core.autocrlf=true`，仓库无 `.gitattributes`），biome 对全部 242 个文件报格式错，含本 PR 未触碰的文件。单独 lint 本 PR 的 3 个文件为「3 个文件 3 个错」，即每个文件仅那一条 CRLF 格式错，无 lint 规则违规。CI 在 LF 环境下不受影响。
- `pnpm check:ui-boundaries`：本地失败项全部落在本 PR 未触碰的共享兼容入口文件上，且基线同样失败，对应已有 issue #456（Windows 误报）。
- 镜像范围：本 PR 只改 GUI 侧 provider 运行时与 GUI 专属组件。WebUI 侧无自己的重试实现（`withStreamRetry` / `isRetryableAssistantError` 在 `crates/agent-gateway/web/src` 零命中，其 `lib/providers/llm.ts` 仅 9 行重导出），无镜像文件需同步。

## 人工验收

桌面客户端（`start-tauri-dev.bat`，与本 PR 同一 HEAD）+ Gateway（`:50052`）+ WebUI（`:5173`）三端实机验收，用户确认通过。

用 Base URL 指向 `http://127.0.0.1:9/v1` 的供应商造确定性可重试失败（`connection refused` 在 pi-ai 的可重试白名单内），退避依次约 0.2/0.4/0.8/1.6/3.2s。

桌面端：

1. 不点停止、等重试耗尽 → 状态行依次显示 `连接已断开，正在重试 (1/5)…(5/5)`，最终显示连接失败错误，未被误报成已取消
2. 退避期间点停止 → 转圈状态行消失，不再回落 `Vibing...` 常驻旋转，不弹 provider 错误，发送按钮恢复
3. 退避期间连点两次停止（force）→ 干净结束，无重复错误气泡、无残留旋转行
4. 停止后立刻再发一条 → 新一轮正常开始，未复活上一轮 live 状态
5. 正常输出到一半点停止 → 保留已输出内容，原有行为无回归
6. 场景 5 后关闭再重开会话 → 内容仍在，底部无旋转状态行

Web 端（镜像链路）：

1. WebUI 发消息、不点停止 → 重试状态同步，最终为错误而非已取消
2. WebUI 退避期间点停止 → 转圈消失、无 `Vibing...` 残留、不弹 provider 错误
3. 桌面点停止 → WebUI 同步落终态，无「桌面已停、Web 还在转」的分叉
4. 停止后刷新浏览器 → 无幽灵运行态
5. 停止后在 WebUI 发新消息 → 正常开始新一轮

<img width="1864" height="1000" alt="2026-08-13_21-25-23" src="https://github.com/user-attachments/assets/59c5e6aa-e8a7-4c71-a166-c1f56655a3a1" />


## 已知遗留（不在本 PR 范围）

无产出的取消目前不入库（`toPersistableAbortedAssistant` 会丢弃无内容的 aborted 消息，`uiMessages` 也会丢弃无内容的 round），所以停止后助手侧不留可回溯记录。修法应当是「取消上下文以结构化数据入库、文案在渲染时由 i18n 生成」，涉及持久化字段扩展与两端渲染，单独一个 PR 处理，不在此混入。

Closes #457

Depends-On: none
Stack-Root: #458
