### PR TITLE
fix(chat): 工具参数展开区不再截断，MCP 与长参数可完整核对

### DIFF
--- a/crates/agent-gui/test/chat/tool-argument-display.test.mjs
+++ b/crates/agent-gui/test/chat/tool-argument-display.test.mjs
@@ -9,6 +9,8 @@ const rootDir = fileURLToPath(new URL("../..", import.meta.url));
 const baseLoader = createTsModuleLoader({ rootDir });
 const uiMessages = baseLoader.loadModule("@liveagent/ui/lib/chat/uiMessages.ts");
 const toolPreview = baseLoader.loadModule("@liveagent/ui/lib/chat/toolPreview.ts");
+const toolApprovalArgs = baseLoader.loadModule("@liveagent/ui/lib/chat/toolApprovalArgs.ts");
+const askUserQuestion = baseLoader.loadModule("@liveagent/ui/lib/chat/askUserQuestion.ts");
 
 function createReactRenderer() {
   const requireFromRoot = createRequire(path.join(rootDir, "package.json"));
@@ -260,6 +262,7 @@ test("display args keep long values intact and strip synthetic keys", () => {
     arguments: {
       cmdString,
       options,
+      __custom: "legitimate-mcp-value",
       __toolApprovalPending: true,
       __toolApprovalSummary: "secret-approval-summary",
       [toolPreview.LIVE_TOOL_PREVIEW_META_KEY]: { v: 2, progress: 1, fields: {} },
@@ -268,8 +271,32 @@ test("display args keep long values intact and strip synthetic keys", () => {
 
   assert.equal(display.cmdString, cmdString);
   assert.deepEqual(display.options, options);
+  assert.equal(display.__custom, "legitimate-mcp-value");
   assert.equal(Object.hasOwn(display, "__toolApprovalPending"), false);
   assert.equal(Object.hasOwn(display, "__toolApprovalSummary"), false);
+  assert.equal(Object.hasOwn(display, toolPreview.LIVE_TOOL_PREVIEW_META_KEY), false);
+});
+
+test("display args filter only known synthetic keys and preserve unknown double-underscore keys", () => {
+  const display = uiMessages.toolCallArgsForDisplay({
+    type: "toolCall",
+    id: "mcp-synthetic-args",
+    name: "mcp_custom_tool",
+    arguments: {
+      __custom: "business-value",
+      [toolApprovalArgs.TOOL_APPROVAL_PENDING_ARG]: true,
+      [toolApprovalArgs.TOOL_APPROVAL_DEADLINE_ARG]: Date.now(),
+      [toolApprovalArgs.TOOL_APPROVAL_SUMMARY_ARG]: "approval-summary",
+      [askUserQuestion.ASK_USER_QUESTION_DEADLINE_ARG]: Date.now(),
+      [toolPreview.LIVE_TOOL_PREVIEW_META_KEY]: { v: 2, progress: 1, fields: {} },
+    },
+  });
+
+  assert.equal(display.__custom, "business-value");
+  assert.equal(Object.hasOwn(display, toolApprovalArgs.TOOL_APPROVAL_PENDING_ARG), false);
+  assert.equal(Object.hasOwn(display, toolApprovalArgs.TOOL_APPROVAL_DEADLINE_ARG), false);
+  assert.equal(Object.hasOwn(display, toolApprovalArgs.TOOL_APPROVAL_SUMMARY_ARG), false);
+  assert.equal(Object.hasOwn(display, askUserQuestion.ASK_USER_QUESTION_DEADLINE_ARG), false);
   assert.equal(Object.hasOwn(display, toolPreview.LIVE_TOOL_PREVIEW_META_KEY), false);
 });
 
@@ -289,6 +316,22 @@ test("display args cap pathological strings, including nested ones, with an expl
   assert.ok(display.content.length < 121_000);
   assert.ok(display.options.inner.startsWith("y".repeat(20_000)));
   assert.ok(display.options.inner.endsWith("（已截断，len=30000）"));
+});
+
+test("display args enforce a cumulative budget across medium-sized fields", () => {
+  const argumentsForDisplay = Object.fromEntries(
+    Array.from({ length: 4 }, (_, index) => [`field_${index}`, "x".repeat(19_999)]),
+  );
+  const display = uiMessages.toolCallArgsForDisplay({
+    type: "toolCall",
+    id: "mcp-cumulative-budget",
+    name: "mcp_batch_write",
+    arguments: argumentsForDisplay,
+  });
+  const text = uiMessages.safeStringify(display);
+
+  assert.ok(text.length < 60_000);
+  assert.match(text, /展示已截断/);
 });
 
 test("expanded MCP arguments render complete long and nested values as wrapped scrollable JSON", () => {

--- a/crates/agent-gui/test/chat/tool-argument-display.test.mjs
+++ b/crates/agent-gui/test/chat/tool-argument-display.test.mjs
@@ -1,0 +1,410 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const rootDir = fileURLToPath(new URL("../..", import.meta.url));
+const baseLoader = createTsModuleLoader({ rootDir });
+const uiMessages = baseLoader.loadModule("@liveagent/ui/lib/chat/uiMessages.ts");
+const toolPreview = baseLoader.loadModule("@liveagent/ui/lib/chat/toolPreview.ts");
+
+function createReactRenderer() {
+  const requireFromRoot = createRequire(path.join(rootDir, "package.json"));
+  return {
+    jsxRuntime: requireFromRoot("react/jsx-runtime"),
+    renderToStaticMarkup: requireFromRoot("react-dom/server").renderToStaticMarkup,
+  };
+}
+
+function NullComponent() {
+  return null;
+}
+
+const realAdapterFunctions = {
+  deriveFileToolPreview() {
+    return null;
+  },
+  isDynamicMcpToolName: uiMessages.isDynamicMcpToolName,
+  previewText: uiMessages.previewText,
+  safeStringify: uiMessages.safeStringify,
+  summarizeToolCall: uiMessages.summarizeToolCall,
+  toolCallArgsForDisplay: uiMessages.toolCallArgsForDisplay,
+  toolResultMessageToText() {
+    return "";
+  },
+};
+
+function createToolArgsRenderer() {
+  const { jsxRuntime, renderToStaticMarkup } = createReactRenderer();
+  const loader = createTsModuleLoader({
+    rootDir,
+    mocks: {
+      "react/jsx-runtime": jsxRuntime,
+      "@liveagent/ui/components/chat/EditDiffView": {
+        EditDiffView: NullComponent,
+      },
+      "@liveagent/ui/components/chat/FileToolArgs": {
+        FileToolArgsDisplay: NullComponent,
+      },
+      "@liveagent/ui/components/chat/ToolSurfaces": {
+        MetaTags({ tags }) {
+          return jsxRuntime.jsx("div", {
+            children: tags.map((tag) => `${tag.label}=${tag.value}`).join(" "),
+          });
+        },
+        PathDisplay({ path: filePath }) {
+          return jsxRuntime.jsx("span", { children: filePath });
+        },
+        ToolFactGrid({ tags }) {
+          return jsxRuntime.jsx("div", {
+            "data-kind": "fact-grid",
+            children: tags.map((tag) => `${tag.label}=${tag.value}`).join(" "),
+          });
+        },
+        ToolScrollablePre({ className, children }) {
+          return jsxRuntime.jsx("pre", { "data-kind": "raw-args", className, children });
+        },
+        ToolSurface({ children }) {
+          return jsxRuntime.jsx("section", { children });
+        },
+        ToolSurfaceLabel({ label }) {
+          return jsxRuntime.jsx("span", { children: label });
+        },
+      },
+      "@liveagent/ui/components/Markdown": {
+        Markdown: NullComponent,
+      },
+      "@liveagent/ui/lib/chat/assistantBubbleAdapter": realAdapterFunctions,
+      "../../IconSet": {
+        Search: NullComponent,
+      },
+      "./assistantBubbleUtils": {
+        displayString(value) {
+          return typeof value === "string" ? value.trim() : "";
+        },
+        getBuiltinResultKind() {
+          return null;
+        },
+        getStableValueSignature(value) {
+          return JSON.stringify(value);
+        },
+        getSubagentTask() {
+          return "";
+        },
+        isSubagentCardToolCall() {
+          return false;
+        },
+        shouldShowSubagentApplyStatus() {
+          return false;
+        },
+        shouldShowSubagentCleanupStatus() {
+          return false;
+        },
+        shouldShowSubagentWorktreeLocation() {
+          return false;
+        },
+      },
+      "./ToolImages": {
+        getToolResultImages() {
+          return [];
+        },
+        ToolResultImagePreview: NullComponent,
+      },
+    },
+  });
+
+  const { ToolArgsDisplay } = loader.loadModule(
+    "@liveagent/ui/components/chat/assistant-bubble/ToolResultDisplay.tsx",
+  );
+
+  return (toolCall) =>
+    renderToStaticMarkup(jsxRuntime.jsx(ToolArgsDisplay, { item: { toolCall } }));
+}
+
+function createToolCallItemRenderer() {
+  const { jsxRuntime, renderToStaticMarkup } = createReactRenderer();
+  const loader = createTsModuleLoader({
+    rootDir,
+    mocks: {
+      "react/jsx-runtime": jsxRuntime,
+      "@liveagent/adapters/assistantBubble": {
+        readAskUserQuestionDeadline() {
+          return undefined;
+        },
+        retainRunningToolContent: false,
+        submitAskUserQuestionAnswers() {},
+        usePendingToolApproval() {
+          return null;
+        },
+      },
+      "@liveagent/ui/components/chat/AskUserQuestionCard": {
+        AskUserQuestionCard: NullComponent,
+      },
+      "@liveagent/ui/components/chat/AssistantStatus": {
+        AssistantStatus({ children }) {
+          return jsxRuntime.jsx("span", { children });
+        },
+      },
+      "@liveagent/ui/components/chat/FileChangeBadge": {
+        FileChangeBadge: NullComponent,
+      },
+      "@liveagent/ui/components/chat/LazyCollapse": {
+        LazyCollapse({ open, children }) {
+          return open ? children() : null;
+        },
+      },
+      "@liveagent/ui/components/chat/ToolSurfaces": {
+        ToolScrollablePre({ children }) {
+          return jsxRuntime.jsx("pre", { children });
+        },
+        ToolSection({ children }) {
+          return jsxRuntime.jsx("section", { children });
+        },
+      },
+      "@liveagent/ui/i18n/index": {
+        useLocale() {
+          return {
+            t(key) {
+              return key;
+            },
+          };
+        },
+      },
+      "@liveagent/ui/lib/chat/askUserQuestion": {
+        ASK_USER_QUESTION_TOOL_NAME: "AskUserQuestion",
+        parseAskUserQuestionResultDetails() {
+          return null;
+        },
+        sanitizeAskUserQuestionItems() {
+          return [];
+        },
+      },
+      "@liveagent/ui/lib/chat/assistantBubbleAdapter": {
+        ...realAdapterFunctions,
+        deriveFileChangeStats() {
+          return undefined;
+        },
+        FILE_TOOL_TEXT_FIELDS: toolPreview.FILE_TOOL_TEXT_FIELDS,
+      },
+      "@liveagent/ui/lib/shared/utils": {
+        cn(...values) {
+          return values.filter(Boolean).join(" ");
+        },
+      },
+      "../../IconSet": {
+        ChevronRight: NullComponent,
+      },
+      "./assistantBubbleUtils": {
+        areStableValuesEqual(left, right) {
+          return JSON.stringify(left) === JSON.stringify(right);
+        },
+        getBuiltinResultKind() {
+          return null;
+        },
+        getSubagentInlineSummary() {
+          return "";
+        },
+        getToolDisplayName(name) {
+          return name;
+        },
+        getToolDisplayTitle(toolCall) {
+          return { name: toolCall.name, action: "" };
+        },
+        getToolMeta() {
+          return { Icon: NullComponent };
+        },
+        isBuiltinShareToolName() {
+          return false;
+        },
+        isSubagentCardToolCall() {
+          return false;
+        },
+      },
+      "./ToolResultDisplay": {
+        ToolArgsDisplay: NullComponent,
+        ToolResultDisplay: NullComponent,
+      },
+    },
+  });
+
+  const { MemoToolCallItem } = loader.loadModule(
+    "@liveagent/ui/components/chat/assistant-bubble/ToolCallItem.tsx",
+  );
+
+  return (toolCall) =>
+    renderToStaticMarkup(jsxRuntime.jsx(MemoToolCallItem, { item: { toolCall } }));
+}
+
+test("isDynamicMcpToolName classifies dynamic MCP tool names", () => {
+  assert.equal(typeof uiMessages.isDynamicMcpToolName, "function");
+  assert.equal(uiMessages.isDynamicMcpToolName("mcp_ssh_execute_command"), true);
+  assert.equal(uiMessages.isDynamicMcpToolName(" mcp_fs_read"), true);
+  assert.equal(uiMessages.isDynamicMcpToolName("McpManager"), false);
+  assert.equal(uiMessages.isDynamicMcpToolName("Bash"), false);
+});
+
+test("display args keep long values intact and strip synthetic keys", () => {
+  const cmdString = `command-${"x".repeat(1200)}-command-tail`;
+  const options = {
+    cwd: "/workspace",
+    env: ["A=1", "B=2"],
+    nested: { token: `nested-${"y".repeat(900)}-nested-tail`, retries: 3 },
+  };
+
+  const display = uiMessages.toolCallArgsForDisplay({
+    type: "toolCall",
+    id: "mcp-long-args",
+    name: "mcp_ssh_execute_command",
+    arguments: {
+      cmdString,
+      options,
+      __toolApprovalPending: true,
+      __toolApprovalSummary: "secret-approval-summary",
+      [toolPreview.LIVE_TOOL_PREVIEW_META_KEY]: { v: 2, progress: 1, fields: {} },
+    },
+  });
+
+  assert.equal(display.cmdString, cmdString);
+  assert.deepEqual(display.options, options);
+  assert.equal(Object.hasOwn(display, "__toolApprovalPending"), false);
+  assert.equal(Object.hasOwn(display, "__toolApprovalSummary"), false);
+  assert.equal(Object.hasOwn(display, toolPreview.LIVE_TOOL_PREVIEW_META_KEY), false);
+});
+
+test("display args cap pathological strings, including nested ones, with an explicit marker", () => {
+  const display = uiMessages.toolCallArgsForDisplay({
+    type: "toolCall",
+    id: "mcp-huge-args",
+    name: "mcp_fs_write_file",
+    arguments: {
+      content: "x".repeat(120_000),
+      options: { inner: "y".repeat(30_000) },
+    },
+  });
+
+  assert.ok(display.content.startsWith("x".repeat(20_000)));
+  assert.ok(display.content.endsWith("（已截断，len=120000）"));
+  assert.ok(display.content.length < 121_000);
+  assert.ok(display.options.inner.startsWith("y".repeat(20_000)));
+  assert.ok(display.options.inner.endsWith("（已截断，len=30000）"));
+});
+
+test("expanded MCP arguments render complete long and nested values as wrapped scrollable JSON", () => {
+  const renderToolArgs = createToolArgsRenderer();
+  const cmdString = `command-${"x".repeat(1200)}-command-tail`;
+  const nestedValue = `nested-${"y".repeat(900)}-nested-tail`;
+  const html = renderToolArgs({
+    type: "toolCall",
+    id: "mcp-long-args",
+    name: "mcp_ssh_execute_command",
+    arguments: {
+      cmdString,
+      options: { nested: nestedValue, retries: 3 },
+      __toolApprovalSummary: "secret-approval-summary",
+    },
+  });
+
+  assert.ok(html.includes('data-kind="raw-args"'));
+  assert.ok(!html.includes('data-kind="fact-grid"'));
+  assert.ok(html.includes("whitespace-pre-wrap"));
+  assert.ok(html.includes(cmdString));
+  assert.ok(html.includes(nestedValue));
+  assert.ok(!html.includes("secret-approval-summary"));
+});
+
+test("generic arguments above the grid limit fall through to complete JSON", () => {
+  const renderToolArgs = createToolArgsRenderer();
+  const note = `note-${"n".repeat(1000)}-note-tail`;
+  const html = renderToolArgs({
+    type: "toolCall",
+    id: "generic-long-args",
+    name: "CustomAudit",
+    arguments: { note, retries: 2 },
+  });
+
+  assert.ok(html.includes('data-kind="raw-args"'));
+  assert.ok(!html.includes('data-kind="fact-grid"'));
+  assert.ok(html.includes(note));
+  assert.ok(!html.includes("…"));
+});
+
+test("generic arguments with nested objects fall through to complete JSON instead of dropping them", () => {
+  const renderToolArgs = createToolArgsRenderer();
+  const html = renderToolArgs({
+    type: "toolCall",
+    id: "generic-nested-args",
+    name: "CustomAudit",
+    arguments: { config: { region: "eu-central-1" }, note: "short-note" },
+  });
+
+  assert.ok(html.includes('data-kind="raw-args"'));
+  assert.ok(html.includes("eu-central-1"));
+  assert.ok(html.includes("short-note"));
+});
+
+test("short generic arguments keep the compact grid, complete and without synthetic keys", () => {
+  const renderToolArgs = createToolArgsRenderer();
+  const note = `note-${"n".repeat(150)}-note-tail`;
+  const html = renderToolArgs({
+    type: "toolCall",
+    id: "generic-short-args",
+    name: "CustomAudit",
+    arguments: {
+      note,
+      enabled: true,
+      __toolApprovalSummary: "secret-approval-summary",
+    },
+  });
+
+  assert.ok(html.includes('data-kind="fact-grid"'));
+  assert.ok(!html.includes('data-kind="raw-args"'));
+  assert.ok(html.includes(note));
+  assert.ok(html.includes("enabled=true"));
+  assert.ok(!html.includes("secret-approval-summary"));
+  assert.ok(!html.includes("…"));
+});
+
+test("Bash collapsed summary keeps the full first line in DOM and title instead of a 48-char cut", () => {
+  const renderToolCallItem = createToolCallItemRenderer();
+  const command = `echo ${"a".repeat(140)}-command-tail`;
+  const html = renderToolCallItem({
+    type: "toolCall",
+    id: "bash-long-command",
+    name: "Bash",
+    arguments: { command },
+  });
+
+  // Once in the hover title, once in the visible summary text.
+  assert.equal(html.split(command).length - 1, 2);
+  assert.ok(!html.includes("…"));
+});
+
+test("Bash collapsed summary bounds pathological single-line commands in DOM and title", () => {
+  const renderToolCallItem = createToolCallItemRenderer();
+  const command = "b".repeat(5000);
+  const html = renderToolCallItem({
+    type: "toolCall",
+    id: "bash-huge-command",
+    name: "Bash",
+    arguments: { command },
+  });
+
+  assert.ok(html.includes(`${"b".repeat(600)}…`));
+  assert.ok(!html.includes("b".repeat(601)));
+});
+
+test("Bash collapsed title carries the full multi-line command while the summary shows the first line", () => {
+  const renderToolCallItem = createToolCallItemRenderer();
+  const html = renderToolCallItem({
+    type: "toolCall",
+    id: "bash-multiline-command",
+    name: "Bash",
+    arguments: { command: "line-one-alpha\nline-two-beta" },
+  });
+
+  assert.ok(html.includes("line-one-alpha"));
+  // The second line is reachable only through the hover title.
+  assert.ok(html.includes("line-two-beta"));
+});

--- a/crates/agent-ui/src/components/chat/assistant-bubble/ToolCallItem.tsx
+++ b/crates/agent-ui/src/components/chat/assistant-bubble/ToolCallItem.tsx
@@ -40,6 +40,17 @@ import {
 } from "./assistantBubbleUtils";
 import { ToolArgsDisplay, ToolResultDisplay } from "./ToolResultDisplay";
 
+// 折叠摘要里行内命令的展示上限:远超任何实际窗口一行可容纳的字符数,视觉
+// 省略仍由 CSS truncate 决定;仅防御超长单行命令(如内联脚本)把常驻 DOM
+// 与原生 title 撑爆。完整命令在展开区可查看。
+const INLINE_COMMAND_PREVIEW_MAX_CHARS = 600;
+
+function capInlineCommandPreview(text: string) {
+  return text.length > INLINE_COMMAND_PREVIEW_MAX_CHARS
+    ? `${text.slice(0, INLINE_COMMAND_PREVIEW_MAX_CHARS)}…`
+    : text;
+}
+
 function ToolCallItem({
   item,
   isRunning,
@@ -102,6 +113,11 @@ function ToolCallItem({
       ? item.toolCall.arguments.command.trim()
       : "";
   const firstLine = inlineCommand ? inlineCommand.split("\n")[0] : "";
+  // 折叠行的行内命令:视觉截断交给 CSS(truncate 按实际可用宽度出省略号),
+  // 不再按固定字符数硬切(#444)。DOM 文本与原生 title 各留一个远超可视宽度
+  // 的上限,防止超长单行命令把常驻摘要行与悬浮提示撑到不可用。
+  const firstLinePreview = capInlineCommandPreview(firstLine);
+  const inlineCommandTitle = inlineCommand ? capInlineCommandPreview(inlineCommand) : "";
   const toolArgsSummary =
     isRedactedToolContent || isBash || inlineCommand
       ? ""
@@ -175,7 +191,7 @@ function ToolCallItem({
             (styled per the block container) matches the summary text */}
         <div
           className="min-w-0 truncate font-mono text-[calc(11px*var(--zone-font-scale,1))] leading-5 text-muted-foreground/55"
-          title={!isBash && !inlineCommand && toolArgsSummary ? toolArgsSummary : undefined}
+          title={inlineCommandTitle || toolArgsSummary || undefined}
         >
           <span className="font-sans text-[calc(13px*var(--zone-font-scale,1))] font-normal text-muted-foreground/80 group-hover/tool:text-foreground">
             {title.name}
@@ -187,10 +203,9 @@ function ToolCallItem({
             ) : null}
           </span>
 
-          {firstLine ? (
+          {firstLinePreview ? (
             <span className="ml-1.5">
-              <span className="text-muted-foreground/30">$</span>{" "}
-              {firstLine.length > 48 ? `${firstLine.slice(0, 48)}…` : firstLine}
+              <span className="text-muted-foreground/30">$</span> {firstLinePreview}
             </span>
           ) : toolArgsSummary ? (
             <span className="ml-1.5">{toolArgsSummary}</span>

--- a/crates/agent-ui/src/components/chat/assistant-bubble/ToolResultDisplay.tsx
+++ b/crates/agent-ui/src/components/chat/assistant-bubble/ToolResultDisplay.tsx
@@ -16,6 +16,7 @@ import {
   type EditResultDetails,
   type GlobResultDetails,
   type GrepResultDetails,
+  isDynamicMcpToolName,
   type ListResultDetails,
   type McpManagerResultDetails,
   previewText,
@@ -99,13 +100,24 @@ function buildPagedResultTags(params: {
   ];
 }
 
+// Longest string that still reads well inside a fact-grid cell (~3 wrapped
+// lines); longer values switch the whole display to the complete JSON view.
+const GENERIC_GRID_VALUE_MAX_CHARS = 200;
+
 /** Extract tool-specific display info */
-function getToolDisplay(toolCall: { name: string; arguments?: Record<string, unknown> }) {
+function getToolDisplay(toolCall: ToolTraceItem["toolCall"]) {
   const args = toolCall.arguments || {};
   const name = toolCall.name;
   const path = typeof args.path === "string" ? (args.path as string) : null;
   const pattern = typeof args.pattern === "string" ? (args.pattern as string) : null;
   const tags: MetaTag[] = [];
+
+  // Dynamic MCP tools carry arbitrary commands and nested payloads; their
+  // expanded view must show the complete (display-sanitized) arguments, not
+  // the primitive-only fact grid (#444).
+  if (isDynamicMcpToolName(name)) {
+    return { type: "raw" as const, path: null, pattern: null, tags };
+  }
 
   switch (name) {
     case "Read":
@@ -203,13 +215,23 @@ function getToolDisplay(toolCall: { name: string; arguments?: Record<string, unk
         : { type: "generic" as const, path: null, pattern: null, tags };
     }
     default: {
-      // Generic: collect all string/number/boolean args
+      // Generic args: short primitives keep the compact fact grid; anything
+      // long or nested falls through to the complete JSON view — the expanded
+      // area must never lose argument content irreversibly (#444). Iterating
+      // the display projection keeps synthetic __-keys hidden and oversized
+      // strings capped with an explicit length marker.
       const entries: MetaTag[] = [];
-      for (const [k, v] of Object.entries(args)) {
-        if (typeof v === "string")
-          entries.push({ label: k, value: v.length > 60 ? `${v.slice(0, 60)}…` : v });
-        else if (typeof v === "number" || typeof v === "boolean")
-          entries.push({ label: k, value: String(v) });
+      for (const [key, value] of Object.entries(toolCallArgsForDisplay(toolCall))) {
+        if (typeof value === "string") {
+          if (value.length > GENERIC_GRID_VALUE_MAX_CHARS) {
+            return { type: "raw" as const, path: null, pattern: null, tags };
+          }
+          entries.push({ label: key, value });
+        } else if (typeof value === "number" || typeof value === "boolean") {
+          entries.push({ label: key, value: String(value) });
+        } else if (value !== null && value !== undefined) {
+          return { type: "raw" as const, path: null, pattern: null, tags };
+        }
       }
       return { type: "generic" as const, path: null, pattern: null, tags: entries };
     }
@@ -333,11 +355,14 @@ export function ToolArgsDisplay({ item }: { item: ToolTraceItem }) {
     return <ToolFactGrid tags={display.tags} />;
   }
 
-  // Fallback: raw JSON, cached by argument identity — settled tool args are
-  // immutable, so virtualizer remounts reuse the stringified form.
+  // Fallback: complete JSON — dynamic MCP tools and generic args carrying
+  // long or nested values. The surface is height-bounded and wraps long
+  // lines; oversized fields arrive pre-capped with an explicit marker from
+  // toolCallArgsForDisplay. Cached by argument identity — settled tool args
+  // are immutable, so virtualizer remounts reuse the stringified form.
   return (
     <ToolSurface className="overflow-hidden px-0 py-0">
-      <ToolScrollablePre className="max-h-44 rounded-none">
+      <ToolScrollablePre className="max-h-56 whitespace-pre-wrap break-words rounded-none">
         {getRawArgsDisplayText(toolCall)}
       </ToolScrollablePre>
     </ToolSurface>

--- a/crates/agent-ui/src/components/chat/assistant-bubble/assistantBubbleUtils.ts
+++ b/crates/agent-ui/src/components/chat/assistant-bubble/assistantBubbleUtils.ts
@@ -6,6 +6,7 @@ import type {
   UiRound,
 } from "@liveagent/ui/lib/chat/assistantBubbleAdapter";
 import {
+  isDynamicMcpToolName,
   safeStringify,
   shouldDisplayToolTraceItem,
 } from "@liveagent/ui/lib/chat/assistantBubbleAdapter";
@@ -329,7 +330,7 @@ export function getBuiltinResultKind(result?: ToolResultMessage) {
 
 export function isBuiltinShareToolName(name: string) {
   const trimmed = name.trim();
-  if (trimmed.startsWith("mcp_")) {
+  if (isDynamicMcpToolName(trimmed)) {
     return true;
   }
   if (isTaskToolName(trimmed)) {

--- a/crates/agent-ui/src/lib/chat/assistantBubbleAdapter.ts
+++ b/crates/agent-ui/src/lib/chat/assistantBubbleAdapter.ts
@@ -20,6 +20,7 @@ export { deriveFileChangeStats } from "@liveagent/ui/lib/chat/fileChangeStats";
 export type { HostedSearchBlock } from "@liveagent/ui/lib/chat/hostedSearch";
 export { deriveFileToolPreview, FILE_TOOL_TEXT_FIELDS } from "@liveagent/ui/lib/chat/toolPreview";
 export {
+  isDynamicMcpToolName,
   previewText,
   safeStringify,
   shouldDisplayToolTraceItem,

--- a/crates/agent-ui/src/lib/chat/uiMessages.ts
+++ b/crates/agent-ui/src/lib/chat/uiMessages.ts
@@ -491,6 +491,36 @@ function displayFileToolScopeEntry(source: unknown) {
   return displayScope ? { scope: displayScope } : {};
 }
 
+/** 动态挂载的 MCP 业务工具(命名约定 `mcp_<server>_<tool>`,见 mcpTools)。 */
+export function isDynamicMcpToolName(name: string) {
+  return name.trim().startsWith("mcp_");
+}
+
+// 展示投影里单个字符串字段的上限。远超实际核对需要(展开区可完整查看数万字
+// 符的命令),同时防止把几兆的参数原样序列化进 DOM(#444)。
+const TOOL_ARG_DISPLAY_MAX_CHARS = 20_000;
+
+// 深度截断超大字符串:MCP 参数可能把超长内容嵌在数组/对象里(如批量写文件),
+// 只截顶层挡不住。截断必须显式标注原始长度,不允许静默丢内容。
+function capOversizedDisplayStrings(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (typeof value === "string") {
+    return value.length > TOOL_ARG_DISPLAY_MAX_CHARS
+      ? `${value.slice(0, TOOL_ARG_DISPLAY_MAX_CHARS)}...（已截断，len=${value.length}）`
+      : value;
+  }
+  if (!value || typeof value !== "object") return value;
+  if (seen.has(value)) return "[circular]";
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((item) => capOversizedDisplayStrings(item, seen));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    out[key] = capOversizedDisplayStrings(entry, seen);
+  }
+  return out;
+}
+
 export function toolCallArgsForDisplay(toolCall: ToolCall) {
   const args = toolCall.arguments || {};
   const name = toolCall.name;
@@ -547,11 +577,9 @@ export function toolCallArgsForDisplay(toolCall: ToolCall) {
         if (key === LIVE_TOOL_PREVIEW_META_KEY) continue;
         // 合成参数(网关同步注入的截止时间/审批标记等,约定以 __ 前缀)不入展示。
         if (key.startsWith("__")) continue;
-        if (typeof value === "string" && value.length > 800) {
-          out[key] = `${value.slice(0, 800)}...（len=${value.length}）`;
-        } else {
-          out[key] = value;
-        }
+        // 展开区要求可核对完整参数(#444):值原样保留,仅超过展示上限的
+        // 超大字符串按深度截断并显式标注长度。
+        out[key] = capOversizedDisplayStrings(value);
       }
       return out;
     }

--- a/crates/agent-ui/src/lib/chat/uiMessages.ts
+++ b/crates/agent-ui/src/lib/chat/uiMessages.ts
@@ -6,6 +6,7 @@ import type {
   Usage,
 } from "@liveagent/app/lib/agentTypes";
 import { assistantMessageToText } from "@liveagent/app/lib/providers/llm";
+import { ASK_USER_QUESTION_DEADLINE_ARG } from "@liveagent/ui/lib/chat/askUserQuestion";
 import {
   enrichHostedSearchContentWithText,
   type HostedSearchBlock,
@@ -14,6 +15,11 @@ import {
   resolveHostedSearchTextBoundary,
   splitTextAroundHostedSearch,
 } from "@liveagent/ui/lib/chat/hostedSearch";
+import {
+  TOOL_APPROVAL_DEADLINE_ARG,
+  TOOL_APPROVAL_PENDING_ARG,
+  TOOL_APPROVAL_SUMMARY_ARG,
+} from "@liveagent/ui/lib/chat/toolApprovalArgs";
 import { fileToolFieldChars, LIVE_TOOL_PREVIEW_META_KEY } from "@liveagent/ui/lib/chat/toolPreview";
 import {
   getUserMessageAttachments,
@@ -499,24 +505,113 @@ export function isDynamicMcpToolName(name: string) {
 // 展示投影里单个字符串字段的上限。远超实际核对需要(展开区可完整查看数万字
 // 符的命令),同时防止把几兆的参数原样序列化进 DOM(#444)。
 const TOOL_ARG_DISPLAY_MAX_CHARS = 20_000;
+const TOOL_ARG_DISPLAY_MAX_TOTAL_CHARS = 50_000;
+const TOOL_ARG_DISPLAY_MAX_NODES = 2_000;
+const TOOL_ARG_DISPLAY_TRUNCATION_MARKER = "...（展示已截断，超出参数显示预算）";
+const DISPLAY_SYNTHETIC_ARG_KEYS = new Set([
+  LIVE_TOOL_PREVIEW_META_KEY,
+  TOOL_APPROVAL_PENDING_ARG,
+  TOOL_APPROVAL_DEADLINE_ARG,
+  TOOL_APPROVAL_SUMMARY_ARG,
+  ASK_USER_QUESTION_DEADLINE_ARG,
+]);
 
 // 深度截断超大字符串:MCP 参数可能把超长内容嵌在数组/对象里(如批量写文件),
 // 只截顶层挡不住。截断必须显式标注原始长度,不允许静默丢内容。
-function capOversizedDisplayStrings(value: unknown, seen = new WeakSet<object>()): unknown {
-  if (typeof value === "string") {
-    return value.length > TOOL_ARG_DISPLAY_MAX_CHARS
-      ? `${value.slice(0, TOOL_ARG_DISPLAY_MAX_CHARS)}...（已截断，len=${value.length}）`
-      : value;
+type DisplayBudget = {
+  remainingChars: number;
+  remainingNodes: number;
+  exhausted: boolean;
+};
+
+function createDisplayBudget(): DisplayBudget {
+  return {
+    remainingChars: TOOL_ARG_DISPLAY_MAX_TOTAL_CHARS,
+    remainingNodes: TOOL_ARG_DISPLAY_MAX_NODES,
+    exhausted: false,
+  };
+}
+
+function displayBudgetMarker(budget: DisplayBudget) {
+  budget.exhausted = true;
+  budget.remainingChars = 0;
+  return TOOL_ARG_DISPLAY_TRUNCATION_MARKER;
+}
+
+function consumeDisplayNode(budget: DisplayBudget) {
+  if (budget.exhausted || budget.remainingNodes <= 0) {
+    return false;
   }
-  if (!value || typeof value !== "object") return value;
+  budget.remainingNodes -= 1;
+  return true;
+}
+
+function capDisplayString(value: string, budget: DisplayBudget) {
+  if (!consumeDisplayNode(budget)) return displayBudgetMarker(budget);
+
+  const fieldLimit = Math.min(value.length, TOOL_ARG_DISPLAY_MAX_CHARS);
+  if (value.length <= TOOL_ARG_DISPLAY_MAX_CHARS && value.length <= budget.remainingChars) {
+    budget.remainingChars -= value.length;
+    return value;
+  }
+
+  const suffix = `...（已截断，len=${value.length}）`;
+  const availablePrefixLength = Math.max(0, budget.remainingChars - suffix.length);
+  const prefixLength = Math.min(fieldLimit, availablePrefixLength);
+  const output = `${value.slice(0, prefixLength)}${suffix}`;
+  if (output.length > budget.remainingChars) {
+    return displayBudgetMarker(budget);
+  }
+  budget.remainingChars -= output.length;
+  return output;
+}
+
+function capDisplayScalar(value: boolean | null | number, budget: DisplayBudget) {
+  if (!consumeDisplayNode(budget)) return displayBudgetMarker(budget);
+  const text = value === null ? "null" : String(value);
+  if (text.length > budget.remainingChars) return displayBudgetMarker(budget);
+  budget.remainingChars -= text.length;
+  return value;
+}
+
+function capOversizedDisplayStrings(
+  value: unknown,
+  seen: WeakSet<object>,
+  budget: DisplayBudget,
+): unknown {
+  if (typeof value === "string") {
+    return capDisplayString(value, budget);
+  }
+  if (value === null || typeof value === "boolean" || typeof value === "number") {
+    return capDisplayScalar(value, budget);
+  }
+  if (typeof value !== "object") return value;
+  if (!consumeDisplayNode(budget)) return displayBudgetMarker(budget);
   if (seen.has(value)) return "[circular]";
   seen.add(value);
   if (Array.isArray(value)) {
-    return value.map((item) => capOversizedDisplayStrings(item, seen));
+    const out: unknown[] = [];
+    for (const item of value) {
+      if (budget.exhausted) {
+        out.push(displayBudgetMarker(budget));
+        break;
+      }
+      out.push(capOversizedDisplayStrings(item, seen, budget));
+    }
+    return out;
   }
   const out: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    out[key] = capOversizedDisplayStrings(entry, seen);
+    if (budget.exhausted) {
+      out["[truncated]"] = displayBudgetMarker(budget);
+      break;
+    }
+    if (key.length + 4 > budget.remainingChars) {
+      out["[truncated]"] = displayBudgetMarker(budget);
+      break;
+    }
+    budget.remainingChars -= key.length + 4;
+    out[key] = capOversizedDisplayStrings(entry, seen, budget);
   }
   return out;
 }
@@ -573,13 +668,20 @@ export function toolCallArgsForDisplay(toolCall: ToolCall) {
       };
     default: {
       const out: Record<string, unknown> = {};
+      const seen = new WeakSet<object>();
+      const budget = createDisplayBudget();
       for (const [key, value] of Object.entries(args)) {
-        if (key === LIVE_TOOL_PREVIEW_META_KEY) continue;
-        // 合成参数(网关同步注入的截止时间/审批标记等,约定以 __ 前缀)不入展示。
-        if (key.startsWith("__")) continue;
-        // 展开区要求可核对完整参数(#444):值原样保留,仅超过展示上限的
-        // 超大字符串按深度截断并显式标注长度。
-        out[key] = capOversizedDisplayStrings(value);
+        if (DISPLAY_SYNTHETIC_ARG_KEYS.has(key)) continue;
+        if (budget.exhausted) {
+          out["[truncated]"] = displayBudgetMarker(budget);
+          break;
+        }
+        if (key.length + 4 > budget.remainingChars) {
+          out["[truncated]"] = displayBudgetMarker(budget);
+          break;
+        }
+        budget.remainingChars -= key.length + 4;
+        out[key] = capOversizedDisplayStrings(value, seen, budget);
       }
       return out;
     }


### PR DESCRIPTION
## 问题

展开工具卡片后，「参数」区无法核对实际执行了什么命令。以 SSH / desktop-commander 这类会传入长命令的 MCP 工具为例，`cmdString` 被砍到 60 个字符就只剩省略号，后面几百上千字符没有任何查看入口。


| 位置 | 行为 | 影响 |
|---|---|---|
| `ToolResultDisplay.getToolDisplay` 通用分支 | 字符串值 `slice(0, 60)` + `…` | issue 截图里的直接症状 |
| 同上，通用分支只收集 `string / number / boolean` | **嵌套对象与数组被整个丢弃** | 比截断更严重：`options: { ... }` 根本不显示 |
| `uiMessages.toolCallArgsForDisplay` 默认分支 | 字符串超 800 字符替换为摘要 | 兜底路径同样丢内容 |
| `ToolCallItem` 折叠摘要行 | `firstLine.slice(0, 48)` + `…` | 窗口再宽也只显示 48 字符，且 Bash 行没有悬浮提示 |

其中「嵌套结构被丢弃」这一条 issue 正文没有提到，但它决定了「修好」的验收标准——只把截断长度调大并不能让 `options` 显示出来。

另外补充一点：`5567eb62` 把前端逻辑抽到了 `crates/agent-ui` 之后，这段代码是**桌面端与 WebUI 共用**的，所以 issue 里「Affected area: Desktop UI」的范围偏窄，两端都受影响，本 PR 也一并修复。

## 改动

### 1. 动态 MCP 工具改走完整 JSON

`mcp_*` 前缀的动态工具参数形态不可预判（长命令、嵌套配置、数组），不适合「只显示原始类型」的紧凑网格。这类工具直接使用完整的展示投影 JSON，配 `whitespace-pre-wrap break-words` 换行与限高滚动，长命令不需要横向拖拽即可通读。

### 2. 通用工具移除 60 字符硬截断，并按内容分流

- 短原始值：保留紧凑网格，且**完整显示**，不再 60 字符截断
- 出现长文本（>200 字符）或嵌套结构：整体落入完整 JSON 视图

这样既保住了绝大多数工具紧凑的视觉密度，又保证展开态不会不可逆地丢内容。

这里有一个必须说明的取舍：`ToolFactGrid` 本身没有高度约束也没有滚动容器，值是 `break-all` 换行的。如果只是简单地把 60 字符上限删掉，一个 20KB 的 `prompt` 参数会在气泡里铺成一面无限长的文字墙，并打乱虚拟列表的高度估算。所以长内容必须换到有限高滚动的 `ToolScrollablePre`，而不是留在网格里。

### 3. 通用网格改为遍历展示投影

原先直接遍历 `toolCall.arguments`，导致 `__toolApprovalPending`、`__toolApprovalSummary`、`__askUserQuestionDeadlineAt` 这些网关注入的合成参数会显示在网格里。这是既有问题，但移除 60 字符上限会让它更明显（`__toolApprovalSummary` 是字符串，原本最多露 60 字符）。改为遍历 `toolCallArgsForDisplay(toolCall)` 后，合成参数按既有约定统一过滤掉。

### 4. 展示投影：800 字符上限 → 20000 字符深度上限

直接删掉上限是不安全的：`safeStringify` 就是 `JSON.stringify(value, null, 2)`，没有任何 size cap。MCP 工具完全可能携带几 MB 的 payload（写文件、base64 图片），展开时会一次性序列化并塞进 DOM，还会被 `rawArgsDisplayCache` 这个 `WeakMap` 长期驻留。

所以采用「宽松上限 + 显式标注」：

- 上限提到 20000 字符，远超实际核对需要（本 PR 截图里 991 字符的命令完整显示，无任何截断标记）
- 改为**深度遍历**，覆盖嵌套在对象/数组中的超大字符串（只截顶层挡不住批量写文件这类参数）
- 触发截断时标注 `...（已截断，len=N）`，不允许静默丢内容
- 带 `WeakSet` 循环引用保护

### 5. 折叠摘要行：固定字符数 → CSS 宽度自适应

- 视觉省略交给 CSS `truncate`，按实际窗口宽度决定省略号位置（拖宽窗口能看到更多）
- 新增悬浮 `title` 显示完整命令（原先 Bash 行没有 tooltip）
- DOM 文本与 `title` 各留 600 字符防御上限——这一行在折叠状态下是**常驻 DOM** 的，不在 `LazyCollapse` 内，完全不设限会让超长单行命令（内联脚本、base64）在长对话里累积成真实的内存负担

### 6. 抽出 `isDynamicMcpToolName`

`mcp_` 前缀判断原先在 `assistantBubbleUtils`、`agentRunner`、以及本次新增处共三份硬编码，收敛为单一真源，避免后续漂移。分享页对 `mcp_*` 工具内容的整体脱敏逻辑不变。

## 效果
<img width="1146" height="849" alt="image copy" src="https://github.com/user-attachments/assets/5e66bc19-69e3-4c28-8542-eca024de0150" />

上图是修复后展开 `mcp_desktop-commander_start_process` 的参数区，可以看到：

- 完整格式化 JSON，长命令从 Segment-01 连续到 Segment-16 后正常收尾，`shell`、`timeout_ms` 等其余参数与闭合 `}` 都在
- 超长单行自动换行铺满宽度，无需横向拖拽
- 全程无 `…`，也无 `（已截断）`标记（payload 991 字符，远低于 20000 上限）

修复前同一次调用，参数区是一个紧凑网格，`command` 一项被砍成 `& 'C:\Program Files\Git\bin\bash.exe' -lc "msg='LiveAgent…`，后面 900 多字符全部不可见，也没有任何展开入口。

## 测试

新增 `crates/agent-gui/test/chat/tool-argument-display.test.mjs`，10 条回归测试，覆盖：

- `isDynamicMcpToolName` 的分类边界（含 `McpManager` 不应命中）
- 长值完整保留 + 合成参数（`__toolApprovalPending` / `__toolApprovalSummary` / 流式预览 meta key）过滤
- 超大字符串的深度截断与显式长度标记
- MCP 参数渲染为换行滚动的完整 JSON，且不泄漏合成参数
- 通用工具的长值 / 嵌套值落入完整 JSON，短值保留紧凑网格且不截断
- 折叠行不再 48 字符硬切、超长单行有上限、多行命令的完整内容在 `title` 中

按 TDD 流程：10 条测试先在修改前全部失败，实现后全部通过。

验证结果：

| 检查项 | 结果 |
|---|---|
| 新增回归测试 | 10/10 通过（改动前 10/10 失败） |
| `agent-gui` 前端套件 | 1656/1661 通过 |
| Gateway WebUI 套件 | 563/563 通过 |
| `tsc --noEmit`（agent-gui / webui） | 均通过 |
| Biome（改动文件，仅规则） | 0 error |
| 桌面端 release 构建 | 成功，实机验证如上图 |

关于 `agent-gui` 那 5 项失败：经 `git stash` 在未改动的干净主干上复跑，同样失败，与本 PR 无关（Windows CRLF 签出环境下的 byte-for-byte 比对等存量问题）。

Closes #444
