### PR TITLE
fix(settings): prevent WebUI save status wrapping

### DIFF
--- a/crates/agent-ui/src/pages/settings/SettingsShell.tsx
+++ b/crates/agent-ui/src/pages/settings/SettingsShell.tsx
@@ -216,10 +216,10 @@ export function SettingsShell<Context>(props: SettingsShellProps<Context>) {
             </div>
             {web && showSaveIndicator ? (
               <div
-                className="settings-save-indicator flex items-center gap-1.5 text-xs text-muted-foreground"
+                className="settings-save-indicator flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground"
                 title={saveIndicator.title}
               >
-                <div className={cn("h-1.5 w-1.5 rounded-full", saveIndicator.dotClass)} />
+                <div className={cn("h-1.5 w-1.5 shrink-0 rounded-full", saveIndicator.dotClass)} />
                 {saveIndicator.text}
               </div>
             ) : null}


### PR DESCRIPTION
## Linked issue

Closes #465

## Summary

Prevent the Gateway WebUI settings save-status indicator from wrapping Chinese text between characters when horizontal space is constrained.

The indicator and its status dot now keep their intrinsic width, while the save-status text remains on one line.

## Change scope

- Modules: `agent-ui` / Gateway WebUI settings
- Key paths: `crates/agent-ui/src/pages/settings/SettingsShell.tsx`

## Screenshots / preview

<!-- The reporter will add the before/after screenshots here before marking this PR ready for review. -->

## Verification

- `cd crates/agent-ui && pnpm exec biome check src/pages/settings/SettingsShell.tsx --diagnostic-level=error --max-diagnostics=20`
- `pnpm check:ui-boundaries`
- `cd crates/agent-gateway/web && pnpm build`
- `cd crates/agent-gui && pnpm build`
- `git diff --check`

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are not required for this localized layout correction.
- [ ] Before/after screenshots are attached before marking the PR ready for review.
