### PR TITLE
fix(settings): align provider credential fields

### DIFF
--- a/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
@@ -1199,7 +1199,7 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
 
                 <div className="mt-4 grid grid-cols-2 gap-3 max-[720px]:grid-cols-1">
                   <div className="space-y-1.5">
-                    <div className="flex flex-wrap items-center gap-2.5">
+                    <div className="flex min-h-7 flex-wrap items-center gap-2.5">
                       <Label htmlFor="modal-baseurl">{t("settings.baseUrl")}</Label>
                       <div className="flex items-center gap-1.5 rounded-full border border-border/70 bg-muted/30 px-2 py-0.5">
                         <Link2
@@ -1237,7 +1237,9 @@ function ProviderModal({ providerType, initialData, onSave, onClose }: ModalProp
                   </div>
 
                   <div className="space-y-1.5">
-                    <Label htmlFor="modal-apikey">API Key</Label>
+                    <div className="flex min-h-7 items-center">
+                      <Label htmlFor="modal-apikey">API Key</Label>
+                    </div>
                     <div className="relative">
                       <Input
                         id="modal-apikey"


### PR DESCRIPTION
## What changed

- Give the Base URL header row a consistent minimum height.
- Wrap the API Key label in a matching header row so both credential inputs share the same vertical baseline.

## Root cause

The Base URL column includes the Full URL pill and switch, which makes its header row taller than the plain API Key label. Because each column laid out its label and input independently, the API Key input started higher than the Base URL input.

## Impact

The Base URL and API Key inputs are aligned in the provider settings form while preserving the existing two-column layout and responsive single-column behavior.

## Screenshots / preview

<img width="876" height="627" alt="image" src="https://github.com/user-attachments/assets/6ac2b7ab-a8b7-40d7-a17a-640fdd83bfe9" />


## Validation

- 12 related provider settings tests passed.
- Targeted Biome check completed successfully; existing unrelated diagnostics in the file remain unchanged.
- `git diff --check` passed.
- Tauri development build launched successfully with the updated shared UI.
