### PR TITLE
fix(models): 模型限额不再吃聚合商前缀和供应商真实数据的亏

### DIFF
--- a/crates/agent-gui/test/models/model-catalog.test.mjs
+++ b/crates/agent-gui/test/models/model-catalog.test.mjs
@@ -167,41 +167,11 @@ test("cross-provider lookup resolves models configured under a foreign provider"
   assert.equal(catalog.findCatalogModelAcrossProviders("longcat-2.0")?.id, "LongCat-2.0");
 });
 
-test("repairStaleCrossProviderLimits replaces only stale provider-fallback pairs", () => {
-  // grok-4.5 挂在 anthropic 类型下、存量恰为 claude_code 兜底对：判为跨供应商
-  // 回查上线前落库的坏默认值，替换为目录真实限额。
-  assert.deepEqual(
-    catalog.repairStaleCrossProviderLimits("claude_code", "grok-4.5", {
-      contextWindow: 200_000,
-      maxOutputToken: 32_000,
-    }),
-    { contextWindow: 500_000, maxOutputToken: 32_000 },
-  );
-  // 任一值偏离兜底对 = 用户显式配置，原样保留。
-  assert.deepEqual(
-    catalog.repairStaleCrossProviderLimits("claude_code", "grok-4.5", {
-      contextWindow: 200_000,
-      maxOutputToken: 31_000,
-    }),
-    { contextWindow: 200_000, maxOutputToken: 31_000 },
-  );
-  // 本供应商目录可命中的模型绝不跨供应商替换（claude-opus-4-1 真实限额恰为兜底对）。
-  assert.deepEqual(
-    catalog.repairStaleCrossProviderLimits("claude_code", "claude-opus-4-1", {
-      contextWindow: 200_000,
-      maxOutputToken: 32_000,
-    }),
-    { contextWindow: 200_000, maxOutputToken: 32_000 },
-  );
-  // 全目录未收录：兜底对本来就是正确默认值，保持不动。
-  assert.deepEqual(
-    catalog.repairStaleCrossProviderLimits("xai", "relay-custom-model", {
-      contextWindow: 258_000,
-      maxOutputToken: 142_000,
-    }),
-    { contextWindow: 258_000, maxOutputToken: 142_000 },
-  );
-});
+// repairStaleCrossProviderLimits（指纹匹配式的坏默认值修复）已被"方案乙"的
+// limitsSource 来源标记取代：settings/index.ts 的 normalizeProviderModelConfig
+// 按存量的 catalog/fallback/provider/user 来源判断是否重解析，不再靠数值指纹
+// 猜测。对应的来源感知测试见 crates/agent-gui/test/settings/normalization.test.mjs
+// 里的 "limitsSource" 相关用例。
 
 test("resolveModelLimits returns repaired catalog limits and undefined on miss", () => {
   // grok-4.5 是本次重构的起因：上游记 500K/500K，快照里已修复为 500K/32K。

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -863,6 +863,7 @@ test("gemini model list normalization uses models array metadata", () => {
       id: "gemini-3.5-flash",
       contextWindow: 1_048_576,
       maxOutputToken: 65_536,
+      limitsSource: "provider",
     },
   ]);
 });

--- a/crates/agent-gui/test/settings/normalization.test.mjs
+++ b/crates/agent-gui/test/settings/normalization.test.mjs
@@ -2602,31 +2602,103 @@ test("cross-provider models resolve real catalog limits instead of provider fall
 
 test("stale fallback limits persisted for cross-provider models are repaired on read", () => {
   // 跨供应商回查上线前，grok-4.5 挂 anthropic 下会以 200K/32K 兜底对落库：
-  // 读侧识别并替换为目录真实限额，不需要用户删除重加。
+  // 读侧识别并替换为目录真实限额，不需要用户删除重加。存量无 limitsSource
+  // 字段，推断规则判其为 fallback（落库值恰等于当时的兜底对），随即按
+  // catalog/fallback 重解析规则刷新为当前目录真值，来源改记 catalog。
   const repaired = settings.normalizeProviderModelConfig(
     { id: "grok-4.5", contextWindow: 200_000, maxOutputToken: 32_000 },
     "claude_code",
   );
   assert.equal(repaired.contextWindow, 500_000);
   assert.equal(repaired.maxOutputToken, 32_000);
-  // 任一值偏离兜底对 = 用户显式配置，原样保留。
+  assert.equal(repaired.limitsSource, "catalog");
+  // 任一值偏离兜底对 = 用户显式配置，推断为 user，原样保留、不重解析。
   const custom = settings.normalizeProviderModelConfig(
     { id: "grok-4.5", contextWindow: 200_000, maxOutputToken: 30_000 },
     "claude_code",
   );
   assert.equal(custom.contextWindow, 200_000);
   assert.equal(custom.maxOutputToken, 30_000);
-  // 本供应商目录内的模型不受存量修复影响（claude-opus-4-1 真实限额恰为兜底对）。
+  assert.equal(custom.limitsSource, "user");
+  // 目录外的本供应商 id（claude-opus-4-1 不在当前目录快照里）不受存量修复
+  // 误伤：落库值恰好等于兜底对，推断链判定为 fallback，数值不变、来源如实
+  // 记为 fallback（并非目录真值，只是巧合相等）。
   const native = settings.normalizeProviderModelConfig(
     { id: "claude-opus-4-1", contextWindow: 200_000, maxOutputToken: 32_000 },
     "claude_code",
   );
   assert.equal(native.contextWindow, 200_000);
   assert.equal(native.maxOutputToken, 32_000);
-  // 新增（无存量限额）直接拿跨供应商默认值。
+  assert.equal(native.limitsSource, "fallback");
+  // 新增（无存量限额）直接拿跨供应商默认值，来源记 catalog。
   const fresh = settings.normalizeProviderModelConfig("grok-4.5", "claude_code");
   assert.equal(fresh.contextWindow, 500_000);
   assert.equal(fresh.maxOutputToken, 32_000);
+  assert.equal(fresh.limitsSource, "catalog");
+});
+
+test("legacy configs without limitsSource infer catalog/fallback/user by matching stored value", () => {
+  // 推断规则 1：落库值等于当前目录解析结果 → catalog。
+  const catalogMatch = settings.normalizeProviderModelConfig(
+    { id: "grok-4.5", contextWindow: 500_000, maxOutputToken: 32_000 },
+    "xai",
+  );
+  assert.equal(catalogMatch.limitsSource, "catalog");
+  // 推断规则 2：落库值等于当前供应商兜底常量、且目录/跨供应商都查不到 → fallback。
+  const fallbackMatch = settings.normalizeProviderModelConfig(
+    { id: "relay-only-model", contextWindow: 258_000, maxOutputToken: 142_000 },
+    "xai",
+  );
+  assert.equal(fallbackMatch.limitsSource, "fallback");
+  // 推断规则 3：两者都不等 → user（无法证明不是用户手改，保守保留原值）。
+  const userMatch = settings.normalizeProviderModelConfig(
+    { id: "relay-only-model", contextWindow: 300_000, maxOutputToken: 50_000 },
+    "xai",
+  );
+  assert.equal(userMatch.contextWindow, 300_000);
+  assert.equal(userMatch.maxOutputToken, 50_000);
+  assert.equal(userMatch.limitsSource, "user");
+});
+
+test("provider-sourced limits are not reparsed on load; user-sourced limits are never touched", () => {
+  // provider 来源：供应商上次刷新自带的真实限额，加载阶段没有新的接口响应
+  // 可用，原样保留落库值，即使它和当前目录/兜底值都不一致。
+  const providerSourced = settings.normalizeProviderModelConfig(
+    { id: "grok-4.5", contextWindow: 999_000, maxOutputToken: 40_000, limitsSource: "provider" },
+    "xai",
+  );
+  assert.equal(providerSourced.contextWindow, 999_000);
+  assert.equal(providerSourced.maxOutputToken, 40_000);
+  assert.equal(providerSourced.limitsSource, "provider");
+  // user 来源：即使数值恰好等于当前目录真值，也保持 user 标记，不被目录更新
+  // 悄悄"升级"回 catalog（避免用户下次手动改动时被目录波动覆盖的假象）。
+  const userSourced = settings.normalizeProviderModelConfig(
+    { id: "grok-4.5", contextWindow: 500_000, maxOutputToken: 32_000, limitsSource: "user" },
+    "xai",
+  );
+  assert.equal(userSourced.contextWindow, 500_000);
+  assert.equal(userSourced.maxOutputToken, 32_000);
+  assert.equal(userSourced.limitsSource, "user");
+});
+
+test("provider-declared limits from a fresh /v1/models response are always tagged provider", () => {
+  // extractProviderDeclaredLimits 命中（如 OpenRouter 的 context_length）时
+  // 无条件记 provider，即使旧存档已有 limitsSource 也会被本次响应覆盖——
+  // 这是唯一比落库值更新鲜的数据源。
+  const declared = settings.normalizeProviderModelConfig(
+    {
+      id: "some-openrouter-model",
+      context_length: 300_000,
+      top_provider: { max_completion_tokens: 50_000 },
+      contextWindow: 200_000,
+      maxOutputToken: 32_000,
+      limitsSource: "user",
+    },
+    "codex",
+  );
+  assert.equal(declared.contextWindow, 300_000);
+  assert.equal(declared.maxOutputToken, 50_000);
+  assert.equal(declared.limitsSource, "provider");
 });
 
 test("persisted degenerate limits are repaired at normalize time for every provider", () => {

--- a/crates/agent-gui/test/settings/provider-models-fetch.test.mjs
+++ b/crates/agent-gui/test/settings/provider-models-fetch.test.mjs
@@ -531,6 +531,54 @@ test("mergeFetchedModels immediately normalizes a stale 1000K context to 1M", ()
   assert.equal(providerUtils.formatTokenCount(model.contextWindow), "1M");
 });
 
+test("mergeFetchedModels adopts fresh provider-declared limits over a stale stored value", () => {
+  const [model] = providerUtils.mergeFetchedModels(
+    [
+      {
+        id: "relay-model",
+        contextWindow: 300_000,
+        maxOutputToken: 50_000,
+        limitsSource: "provider",
+      },
+    ],
+    [
+      {
+        id: "relay-model",
+        contextWindow: 200_000,
+        maxOutputToken: 32_000,
+        limitsSource: "catalog",
+      },
+    ],
+  );
+  assert.equal(model.contextWindow, 300_000);
+  assert.equal(model.maxOutputToken, 50_000);
+  assert.equal(model.limitsSource, "provider");
+});
+
+test("mergeFetchedModels never overwrites a user-edited stored value with a fresh fetch", () => {
+  const [model] = providerUtils.mergeFetchedModels(
+    [
+      {
+        id: "relay-model",
+        contextWindow: 300_000,
+        maxOutputToken: 50_000,
+        limitsSource: "provider",
+      },
+    ],
+    [
+      {
+        id: "relay-model",
+        contextWindow: 999_000,
+        maxOutputToken: 1_000,
+        limitsSource: "user",
+      },
+    ],
+  );
+  assert.equal(model.contextWindow, 999_000);
+  assert.equal(model.maxOutputToken, 1_000);
+  assert.equal(model.limitsSource, "user");
+});
+
 test("model bulk helpers count and apply only selected active states", () => {
   const activeModels = new Set(["enabled-model", "untouched-model"]);
   const selectedModels = new Set(["enabled-model", "disabled-model"]);

--- a/crates/agent-ui/src/i18n/translations/enUSSettings.ts
+++ b/crates/agent-ui/src/i18n/translations/enUSSettings.ts
@@ -568,6 +568,7 @@ export const EN_US_SETTINGS_TRANSLATIONS = {
   "settings.modelSettings": "Model settings",
   "settings.modelName": "Model name",
   "settings.newModelBadge": "NEW",
+  "settings.estimatedLimitsBadge": "Estimated",
   "settings.contextWindow": "Context Window",
   "settings.maxOutputToken": "Max Output Token",
   "settings.positiveIntegerRequired": "Please enter a positive integer",

--- a/crates/agent-ui/src/i18n/translations/zhCNSettings.ts
+++ b/crates/agent-ui/src/i18n/translations/zhCNSettings.ts
@@ -548,6 +548,7 @@ export const ZH_CN_SETTINGS_TRANSLATIONS = {
   "settings.modelSettings": "模型参数",
   "settings.modelName": "模型名称",
   "settings.newModelBadge": "新增",
+  "settings.estimatedLimitsBadge": "估计值",
   "settings.contextWindow": "Context Window",
   "settings.maxOutputToken": "Max Output Token",
   "settings.positiveIntegerRequired": "请输入大于 0 的整数",

--- a/crates/agent-ui/src/lib/models/modelCatalog.ts
+++ b/crates/agent-ui/src/lib/models/modelCatalog.ts
@@ -67,6 +67,14 @@ export function normalizeModelIdCandidates(modelId: string): string[] {
   const withoutContextSuffix = withoutAtVersion.replace(/\[1m\]$/i, "");
   push(withoutContextSuffix);
   push(withoutContextSuffix.replace(/-20\d{6}$/, ""));
+  // 中转聚合商常在模型 id 前加自家路径前缀（bailian/deepseek-v4-pro、
+  // openrouter/xxx 等），目录里存的是裸 id。放链尾——所有精确形态、
+  // 全部分区都查空后才尝试剥前缀，避免裸段误撞目录里无关的同名模型。
+  const lastSegment = withoutContextSuffix.split("/").pop() ?? "";
+  if (lastSegment !== withoutContextSuffix) {
+    push(lastSegment);
+    push(lastSegment.replace(/-20\d{6}$/, ""));
+  }
   return candidates;
 }
 
@@ -164,4 +172,34 @@ export function resolveModelLimits(
 export function getProviderFallbackLimits(providerId: CatalogAppProviderId): ModelLimits {
   const fallback = PROVIDER_FALLBACK_LIMITS[providerId];
   return { contextWindow: fallback.contextWindow, maxOutputToken: fallback.maxOutputToken };
+}
+
+// 供应商 /v1/models 接口自带的真实限额字段——比本地静态目录更新、更准（目录是
+// 构建期快照，供应商接口是该次部署的实时数据）。识别几种真实世界常见写法：
+// OpenRouter 风格顶层 context_length，以及嵌套在 top_provider 下的同名字段。
+// 只在这些字段解析为正整数时才采信，识别不出来的字段名回退到目录/兜底流程，
+// 与 normalizeGeminiFetchedModels 读 inputTokenLimit/outputTokenLimit 同一思路。
+export function extractProviderDeclaredLimits(
+  obj: Record<string, unknown>,
+): ModelLimits | undefined {
+  const asPositiveInt = (value: unknown): number | undefined => {
+    const numeric = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+    return Number.isFinite(numeric) && numeric > 0 ? Math.floor(numeric) : undefined;
+  };
+  const topProvider =
+    obj.top_provider && typeof obj.top_provider === "object"
+      ? (obj.top_provider as Record<string, unknown>)
+      : undefined;
+
+  const contextWindow =
+    asPositiveInt(obj.context_length) ?? asPositiveInt(topProvider?.context_length);
+  if (!contextWindow) return undefined;
+
+  const maxOutputToken =
+    asPositiveInt(topProvider?.max_completion_tokens) ??
+    asPositiveInt(obj.max_completion_tokens) ??
+    // 部分中转商不单独公布输出上限，仅给窗口——按目录同一规则钳到保守预留值。
+    normalizeModelLimits({ contextWindow, maxOutputToken: contextWindow }).maxOutputToken;
+
+  return normalizeModelLimits({ contextWindow, maxOutputToken });
 }

--- a/crates/agent-ui/src/lib/models/modelCatalog.ts
+++ b/crates/agent-ui/src/lib/models/modelCatalog.ts
@@ -140,25 +140,6 @@ export function resolveModelLimitsAcrossProviders(
   return { contextWindow: entry.contextWindow, maxOutputToken: entry.maxOutputToken };
 }
 
-// 跨供应商回查上线前，别家模型挂在本供应商下会以本供应商兜底值落库。存量
-// 恰为兜底对、且模型只在其他供应商目录命中时视为坏默认值替换为目录真实限额；
-// 两值有一处偏离兜底对即视为用户显式配置，原样保留。
-export function repairStaleCrossProviderLimits(
-  providerId: CatalogAppProviderId,
-  modelId: string,
-  limits: ModelLimits,
-): ModelLimits {
-  const fallback = PROVIDER_FALLBACK_LIMITS[providerId];
-  if (
-    limits.contextWindow !== fallback.contextWindow ||
-    limits.maxOutputToken !== fallback.maxOutputToken
-  ) {
-    return limits;
-  }
-  if (findCatalogModel(providerId, modelId)) return limits;
-  return resolveModelLimitsAcrossProviders(modelId) ?? limits;
-}
-
 export function resolveModelLimits(
   providerId: CatalogAppProviderId,
   modelId: string | undefined,

--- a/crates/agent-ui/src/lib/settings/index.ts
+++ b/crates/agent-ui/src/lib/settings/index.ts
@@ -11,8 +11,8 @@ import {
 import {
   extractProviderDeclaredLimits,
   getProviderFallbackLimits,
+  type ModelLimits,
   normalizeModelLimits,
-  repairStaleCrossProviderLimits,
   resolveModelLimits,
   resolveModelLimitsAcrossProviders,
 } from "@liveagent/ui/lib/models/modelCatalog";
@@ -74,6 +74,7 @@ import type {
   McpSettings,
   McpTransport,
   MemorySettings,
+  ModelLimitsSource,
   PromptCacheHintMode,
   ProviderFailoverSettings,
   ProviderId,
@@ -582,9 +583,9 @@ export function getProviderModelDefaults(
   providerId: ProviderId,
   modelId?: string,
   baseUrl?: string,
-): Pick<ProviderModelConfig, "contextWindow" | "maxOutputToken"> {
+): Pick<ProviderModelConfig, "contextWindow" | "maxOutputToken"> & { source: ModelLimitsSource } {
   const known = getKnownModelLimits(providerId, modelId, baseUrl);
-  if (known) return known;
+  if (known) return { ...known, source: "catalog" };
 
   if (
     providerId === "claude_code" &&
@@ -599,6 +600,7 @@ export function getProviderModelDefaults(
           ? ANTHROPIC_STANDARD_CONTEXT_WINDOW
           : ANTHROPIC_LONG_CONTEXT_WINDOW,
       maxOutputToken: getProviderFallbackLimits(providerId).maxOutputToken,
+      source: "catalog",
     };
   }
 
@@ -606,9 +608,9 @@ export function getProviderModelDefaults(
   // 跨供应商回查真实限额，避免吃错本供应商兜底值。Anthropic 的 1M/adaptive
   // 窗口策略只约束目录内的 Anthropic 模型，跨供应商命中直接透传目录值。
   const crossProvider = resolveModelLimitsAcrossProviders(modelId);
-  if (crossProvider) return crossProvider;
+  if (crossProvider) return { ...crossProvider, source: "catalog" };
 
-  return getProviderFallbackLimits(providerId);
+  return { ...getProviderFallbackLimits(providerId), source: "fallback" };
 }
 
 export function createProviderModelConfig(
@@ -621,7 +623,17 @@ export function createProviderModelConfig(
     id,
     contextWindow: defaults.contextWindow,
     maxOutputToken: defaults.maxOutputToken,
+    limitsSource: defaults.source,
   };
+}
+
+const VALID_LIMITS_SOURCES: readonly ModelLimitsSource[] = ["catalog", "provider", "fallback", "user"];
+
+function normalizeLimitsSource(value: unknown): ModelLimitsSource | undefined {
+  return typeof value === "string" &&
+    (VALID_LIMITS_SOURCES as readonly string[]).includes(value)
+    ? (value as ModelLimitsSource)
+    : undefined;
 }
 
 export function normalizeProviderModelConfig(
@@ -642,26 +654,65 @@ export function normalizeProviderModelConfig(
         : "";
   if (!id) return null;
 
-  // 优先级：供应商 /v1/models 接口自带的真实限额（如 OpenRouter 的
-  // context_length）> 本地目录/兜底默认值。obj.contextWindow/maxOutputToken
-  // 仍是内部字段名，仅用于已落库配置的回填读取——原始 API 响应不会带这两个
-  // 字段，因此不会被 extractProviderDeclaredLimits 的结果覆盖。
-  const defaults = extractProviderDeclaredLimits(obj) ?? getProviderModelDefaults(providerId, id);
   const ownedBy =
     (typeof obj.ownedBy === "string" ? obj.ownedBy.trim() : "") ||
     (typeof obj.owned_by === "string" ? obj.owned_by.trim() : "");
-  const storedLimits = {
-    contextWindow: normalizePositiveInteger(obj.contextWindow, defaults.contextWindow),
-    maxOutputToken: normalizePositiveInteger(
-      obj.maxOutputToken ?? obj.maxTokens,
-      defaults.maxOutputToken,
-    ),
-  };
-  // 退化限额（输出吃满窗口）可能来自坏目录数据落库期或手工配置，读侧统一修复；
-  // 规则与目录生成期同源（normalizeModelLimits），对所有供应商一视同仁。
-  // 跨供应商回查上线前落库的别家模型吃过本供应商兜底值，同样读侧修复，
-  // 不需要用户删除重加（识别与替换规则见 repairStaleCrossProviderLimits）。
-  const limits = repairStaleCrossProviderLimits(providerId, id, normalizeModelLimits(storedLimits));
+
+  // 供应商 /v1/models 接口本次响应自带的真实限额（如 OpenRouter 的
+  // context_length）直接采信记 provider，不比对存量——这是唯一比落库
+  // 目录/兜底值更新鲜的数据源。
+  const providerDeclared = extractProviderDeclaredLimits(obj);
+  const catalogDefaults = getProviderModelDefaults(providerId, id);
+
+  let limits: ModelLimits;
+  let limitsSource: ModelLimitsSource;
+
+  if (providerDeclared) {
+    limits = providerDeclared;
+    limitsSource = "provider";
+  } else {
+    const storedSource = normalizeLimitsSource(obj.limitsSource);
+    // 退化限额（输出吃满窗口）可能来自坏目录数据落库期或手工配置，读侧统一
+    // 修复；规则与目录生成期同源（normalizeModelLimits），对所有来源一视同仁。
+    const storedLimits = normalizeModelLimits({
+      contextWindow: normalizePositiveInteger(obj.contextWindow, catalogDefaults.contextWindow),
+      maxOutputToken: normalizePositiveInteger(
+        obj.maxOutputToken ?? obj.maxTokens,
+        catalogDefaults.maxOutputToken,
+      ),
+    });
+    const hasStoredNumbers =
+      obj.contextWindow != null || obj.maxOutputToken != null || obj.maxTokens != null;
+    const fallbackPair = getProviderFallbackLimits(providerId);
+
+    // 存量（无 limitsSource 字段）一次性推断：落库值等于当前目录解析结果→
+    // catalog；等于当前供应商兜底常量→fallback（多为跨供应商回查上线前落
+    // 库的坏默认值，下方 catalog/fallback 分支会立即重解析修复）；其余→
+    // user（无法证明不是用户手改的，保守当作用户配置）。
+    const resolvedSource: ModelLimitsSource =
+      storedSource ??
+      (!hasStoredNumbers
+        ? catalogDefaults.source
+        : storedLimits.contextWindow === catalogDefaults.contextWindow &&
+            storedLimits.maxOutputToken === catalogDefaults.maxOutputToken
+          ? "catalog"
+          : storedLimits.contextWindow === fallbackPair.contextWindow &&
+              storedLimits.maxOutputToken === fallbackPair.maxOutputToken
+            ? "fallback"
+            : "user");
+
+    if (resolvedSource === "catalog" || resolvedSource === "fallback") {
+      // 加载时按当前目录/兜底重新解析，让目录更新自动传导。
+      limits = { contextWindow: catalogDefaults.contextWindow, maxOutputToken: catalogDefaults.maxOutputToken };
+      limitsSource = catalogDefaults.source;
+    } else {
+      // provider：供应商实时数据只在“刷新模型列表”那次抓取时存在，加载阶段
+      // 没有这份数据可用，保持落库值。user：永不自动覆盖。两者都原样保留。
+      limits = storedLimits;
+      limitsSource = resolvedSource;
+    }
+  }
+
   const promptCacheHintMode =
     providerId === "codex" ? normalizePromptCacheHintMode(obj.promptCacheHintMode) : undefined;
   return {
@@ -669,6 +720,7 @@ export function normalizeProviderModelConfig(
     ...(ownedBy ? { ownedBy } : {}),
     contextWindow: limits.contextWindow,
     maxOutputToken: limits.maxOutputToken,
+    limitsSource,
     ...(promptCacheHintMode ? { promptCacheHintMode } : {}),
   };
 }
@@ -703,6 +755,7 @@ export function findProviderModelConfig(
       id: normalizedId,
       contextWindow: defaults.contextWindow,
       maxOutputToken: defaults.maxOutputToken,
+      limitsSource: defaults.source,
     };
   }
   if (provider.type !== "claude_code") return matched;

--- a/crates/agent-ui/src/lib/settings/index.ts
+++ b/crates/agent-ui/src/lib/settings/index.ts
@@ -9,6 +9,7 @@ import {
   shouldSendAnthropicLongContextHeader,
 } from "@liveagent/ui/lib/models/anthropicContext";
 import {
+  extractProviderDeclaredLimits,
   getProviderFallbackLimits,
   normalizeModelLimits,
   repairStaleCrossProviderLimits,
@@ -641,7 +642,11 @@ export function normalizeProviderModelConfig(
         : "";
   if (!id) return null;
 
-  const defaults = getProviderModelDefaults(providerId, id);
+  // 优先级：供应商 /v1/models 接口自带的真实限额（如 OpenRouter 的
+  // context_length）> 本地目录/兜底默认值。obj.contextWindow/maxOutputToken
+  // 仍是内部字段名，仅用于已落库配置的回填读取——原始 API 响应不会带这两个
+  // 字段，因此不会被 extractProviderDeclaredLimits 的结果覆盖。
+  const defaults = extractProviderDeclaredLimits(obj) ?? getProviderModelDefaults(providerId, id);
   const ownedBy =
     (typeof obj.ownedBy === "string" ? obj.ownedBy.trim() : "") ||
     (typeof obj.owned_by === "string" ? obj.owned_by.trim() : "");

--- a/crates/agent-ui/src/lib/settings/types.ts
+++ b/crates/agent-ui/src/lib/settings/types.ts
@@ -295,12 +295,20 @@ export type SelectedModel = {
 
 export type PromptCacheHintMode = "auto" | "openai-key" | "openrouter-session" | "none";
 
+/**
+ * 限额来源：catalog（目录命中）> provider（供应商接口自带声明值）
+ * > fallback（兜底猜测）；user 是用户手改，任何时候都不被自动覆盖。
+ * 缺失时（旧存档）按 normalizeProviderModelConfig 的迁移推断规则一次性补齐。
+ */
+export type ModelLimitsSource = "catalog" | "provider" | "fallback" | "user";
+
 export type ProviderModelConfig = {
   id: string;
   /** /models 元数据；缺失时保持旧设置格式兼容。 */
   ownedBy?: string;
   contextWindow: number;
   maxOutputToken: number;
+  limitsSource?: ModelLimitsSource;
   /** OpenAI 兼容端点的缓存提示协议；缺失时继承供应商设置。 */
   promptCacheHintMode?: PromptCacheHintMode;
 };

--- a/crates/agent-ui/src/pages/settings/ProviderModal.tsx
+++ b/crates/agent-ui/src/pages/settings/ProviderModal.tsx
@@ -538,6 +538,7 @@ function useProviderModalController({ providerType, initialData, onSave, onClose
       ...editingModel.model,
       contextWindow: editingModelContextWindow,
       maxOutputToken: editingModelMaxOutputToken,
+      limitsSource: "user",
     };
     setModels((prev) => prev.map((item) => (item.id === nextModel.id ? nextModel : item)));
     setEditingModel(null);

--- a/crates/agent-ui/src/pages/settings/ProviderModalView.tsx
+++ b/crates/agent-ui/src/pages/settings/ProviderModalView.tsx
@@ -630,6 +630,11 @@ export function ProviderModalView({ viewModel }: { viewModel: ProviderModalViewM
                               <div className="shrink-0 whitespace-nowrap text-[11px] tabular-nums text-muted-foreground max-[720px]:col-[1/3] max-[720px]:row-start-2 max-[720px]:min-w-0">
                                 {formatTokenCount(model.contextWindow)} ctx ·{" "}
                                 {formatTokenCount(model.maxOutputToken)} out
+                                {model.limitsSource === "fallback" ? (
+                                  <span className="ml-1.5 rounded-full border border-border/70 bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                                    {t("settings.estimatedLimitsBadge")}
+                                  </span>
+                                ) : null}
                               </div>
                               <Button
                                 type="button"

--- a/crates/agent-ui/src/pages/settings/providerUtils.ts
+++ b/crates/agent-ui/src/pages/settings/providerUtils.ts
@@ -555,11 +555,14 @@ function normalizeGeminiFetchedModels(items: unknown): ProviderModelConfig[] {
     const ownedBy =
       (typeof obj.ownedBy === "string" ? obj.ownedBy.trim() : "") ||
       (typeof obj.owned_by === "string" ? obj.owned_by.trim() : "");
+    const contextWindow = normalizePositiveInteger(obj.inputTokenLimit);
+    const maxOutputToken = normalizePositiveInteger(obj.outputTokenLimit);
     out.push({
       id,
       ...(ownedBy ? { ownedBy } : {}),
-      contextWindow: normalizePositiveInteger(obj.inputTokenLimit) ?? draft.contextWindow,
-      maxOutputToken: normalizePositiveInteger(obj.outputTokenLimit) ?? draft.maxOutputToken,
+      contextWindow: contextWindow ?? draft.contextWindow,
+      maxOutputToken: maxOutputToken ?? draft.maxOutputToken,
+      limitsSource: contextWindow && maxOutputToken ? "provider" : draft.limitsSource,
     });
   }
 
@@ -583,11 +586,24 @@ export function mergeFetchedModels(
       model.contextWindow === 1_000_000 &&
       existingModel.contextWindow < 1_000_000 &&
       Math.round(existingModel.contextWindow / 1_000) === 1_000;
+    // 供应商本次响应自带真实限额字段（provider 来源）：比落库的目录/兜底值
+    // 更新鲜，直接采信；用户手改（user）来源任何时候都不被自动覆盖。
+    const shouldAdoptFreshProviderLimits =
+      existingModel !== undefined &&
+      model.limitsSource === "provider" &&
+      existingModel.limitsSource !== "user";
     merged.push(
       existingModel
         ? {
             ...existingModel,
             ...(shouldNormalizeOneMillion ? { contextWindow: model.contextWindow } : {}),
+            ...(shouldAdoptFreshProviderLimits
+              ? {
+                  contextWindow: model.contextWindow,
+                  maxOutputToken: model.maxOutputToken,
+                  limitsSource: "provider",
+                }
+              : {}),
             ...(model.ownedBy ? { ownedBy: model.ownedBy } : {}),
           }
         : model,


### PR DESCRIPTION
Closes #483

## 问题

同一个模型挂在不同类型的供应商下,限额显示不一样。根子是目录查询的候选链
不会剥掉 `bailian/` 这类聚合商路径前缀,查不到目录里的裸 id,就退到跟供应商
类型走的兜底数字。这个数字还会存进设置,后面拿这个模型发请求时,输出上限
直接被这个瞎编的数字卡住。

顺带发现一个相关但独立的漏洞:供应商的 `/v1/models` 接口如果自己带了真实
限额(比如 OpenRouter 的 `context_length`),现有代码只认 `contextWindow` /
`maxOutputToken` 这几个内部字段名,认不出别的写法就当没有,一样退到目录
和兜底,供应商已经给出的准确数据被白白扔掉。

## 方案甲(最小改动止血)

- `normalizeModelIdCandidates` 候选链末尾加一步,剥掉路径前缀取最后一段再查
- 新增 `extractProviderDeclaredLimits`,识别几种常见的供应商声明字段
- `normalizeProviderModelConfig` 里,供应商声明的限额排在目录查询前面

存量里恰好等于兜底值的旧数据下次加载会自动纠正,已手动验证同一模型加到
不同供应商下限额一致。

## 方案乙(限额来源追溯)

方案甲修好了限额计算本身,但写回配置的值不带来源信息,分不清是目录查到的、
供应商接口自己报的、通用兜底凑的,还是用户手改的。加载时想重新校验限额,
却可能把用户手改的值悄悄冲掉;界面上也没法告诉用户这个数字是真实值还是
猜的。

- 给 `ProviderModelConfig` 加 `limitsSource` 字段(`catalog`/`provider`/
  `fallback`/`user`),按来源分流:catalog、fallback 来源加载时用当前数据
  重新校验刷新,provider 来源保持存量不动,user 来源永远不碰
- 旧配置没有这个字段的,按推断规则补全:存量值等于当前目录解析结果判
  catalog,等于当前供应商兜底常量判 fallback,两者都不等就保守判 user
- Gemini 模型拉取和 `mergeFetchedModels` 合并逻辑接入 provider 标记,刷新
  模型列表时新鲜的供应商数据能覆盖旧的 catalog/fallback 值,但不覆盖用户
  手改的值
- 界面给来源为 fallback 的模型加"估计值"角标

已在 UI 里手动验证四个场景全部通过:跨供应商目录命中标 catalog;手改后
变 user 且免疫后续目录刷新;供应商声明的真实限额标 provider 且不带估计值
角标;查不到目录也没供应商声明的模型标 fallback 且显示估计值角标。

修复截图:
**Anthropic Compatable**
<img width="1291" height="901" alt="image" src="https://github.com/user-attachments/assets/79fbceb1-bf41-4c8f-b7ef-c5d73f26e648" />

**OpenAI Response API**
<img width="1291" height="901" alt="image" src="https://github.com/user-attachments/assets/b0dfb085-e932-4aea-861f-4e7445f19a4d" />

方案乙完善后截图:
<img width="1291" height="901" alt="image" src="https://github.com/user-attachments/assets/0b1caeca-53e8-4928-b372-9c1423d7770f" />

<img width="1031" height="699" alt="image" src="https://github.com/user-attachments/assets/6ee005a9-25ca-4dfe-8a74-84a23b809c97" />

<img width="948" height="86" alt="image" src="https://github.com/user-attachments/assets/150ca42a-9096-4a91-a5c1-4bc271e2e367" />

<img width="948" height="86" alt="image" src="https://github.com/user-attachments/assets/6c707841-16e5-4c98-b4c6-441335cc6c02" />

<img width="1291" height="901" alt="image" src="https://github.com/user-attachments/assets/33ce7ce8-c159-4b79-bc0c-826de7e1ff13" />

<img width="948" height="86" alt="image" src="https://github.com/user-attachments/assets/8cbbac48-3e57-44b4-a76c-faf5421bc802" />

<img width="971" height="277" alt="image" src="https://github.com/user-attachments/assets/7be7bb46-d725-4555-a931-2138f81ef724" />
