### PR TITLE
fix(repo): 恢复被 gitignore 吞掉的 test/workspace 目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ workspace
 !crates/agent-gui/src-tauri/src/commands/workspace/**
 !crates/agent-gui/src/pages/chat/workspace/
 !crates/agent-gui/src/pages/chat/workspace/**
+!crates/agent-gui/test/workspace/
+!crates/agent-gui/test/workspace/**
 cert/
 node_modules
 dist

--- a/crates/agent-gui/test/workspace/markdown-assets.test.mjs
+++ b/crates/agent-gui/test/workspace/markdown-assets.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const assets = loader.loadModule(
+  "@liveagent/ui/components/workspace-editor/workspaceMarkdownAssets.ts",
+);
+
+test("resolves markdown-relative asset paths against the file directory", () => {
+  assert.equal(
+    assets.resolveWorkspaceMarkdownPath("docs/guide/intro.md", "./images/a.png"),
+    "docs/guide/images/a.png",
+  );
+  assert.equal(
+    assets.resolveWorkspaceMarkdownPath("docs/guide/intro.md", "images/a.png"),
+    "docs/guide/images/a.png",
+  );
+  assert.equal(
+    assets.resolveWorkspaceMarkdownPath("docs/guide/intro.md", "../shared/b.png"),
+    "docs/shared/b.png",
+  );
+  assert.equal(assets.resolveWorkspaceMarkdownPath("README.md", "assets/logo.svg"), "assets/logo.svg");
+});
+
+test("treats leading-slash targets as workspace-root relative", () => {
+  assert.equal(
+    assets.resolveWorkspaceMarkdownPath("docs/guide/intro.md", "/assets/root.png"),
+    "assets/root.png",
+  );
+});
+
+test("strips query and fragment and decodes percent-encoded segments", () => {
+  assert.equal(
+    assets.resolveWorkspaceMarkdownPath("docs/intro.md", "img/dark.png#gh-dark-mode-only"),
+    "docs/img/dark.png",
+  );
+  assert.equal(
+    assets.resolveWorkspaceMarkdownPath("docs/intro.md", "img/pic.png?raw=true"),
+    "docs/img/pic.png",
+  );
+  assert.equal(
+    assets.resolveWorkspaceMarkdownPath("docs/intro.md", "my%20images/a%20b.png"),
+    "docs/my images/a b.png",
+  );
+});
+
+test("rejects targets that escape the workspace root", () => {
+  assert.equal(assets.resolveWorkspaceMarkdownPath("README.md", "../outside.png"), null);
+  assert.equal(assets.resolveWorkspaceMarkdownPath("docs/intro.md", "../../outside.png"), null);
+  assert.equal(assets.resolveWorkspaceMarkdownPath("docs/intro.md", ""), null);
+});
+
+test("classifies external, inline, hash, and workspace targets", () => {
+  assert.deepEqual(assets.classifyWorkspaceMarkdownTarget("docs/intro.md", "https://example.com/x"), {
+    kind: "external",
+    url: "https://example.com/x",
+  });
+  assert.deepEqual(assets.classifyWorkspaceMarkdownTarget("docs/intro.md", "mailto:a@b.c"), {
+    kind: "external",
+    url: "mailto:a@b.c",
+  });
+  assert.deepEqual(
+    assets.classifyWorkspaceMarkdownTarget("docs/intro.md", "//cdn.example.com/x.png"),
+    { kind: "external", url: "https://cdn.example.com/x.png" },
+  );
+  assert.deepEqual(
+    assets.classifyWorkspaceMarkdownTarget("docs/intro.md", "data:image/png;base64,AAAA"),
+    { kind: "inline", url: "data:image/png;base64,AAAA" },
+  );
+  assert.deepEqual(assets.classifyWorkspaceMarkdownTarget("docs/intro.md", "#quick-start"), {
+    kind: "hash",
+    fragment: "quick-start",
+  });
+  assert.deepEqual(assets.classifyWorkspaceMarkdownTarget("docs/intro.md", "./other.md#section"), {
+    kind: "workspace",
+    path: "docs/other.md",
+  });
+});
+
+test("classifies scriptable and unresolvable targets as unsupported", () => {
+  assert.deepEqual(assets.classifyWorkspaceMarkdownTarget("docs/intro.md", "javascript:alert(1)"), {
+    kind: "unsupported",
+  });
+  assert.deepEqual(assets.classifyWorkspaceMarkdownTarget("docs/intro.md", "file:///etc/passwd"), {
+    kind: "unsupported",
+  });
+  assert.deepEqual(assets.classifyWorkspaceMarkdownTarget("docs/intro.md", "../../escape.md"), {
+    kind: "unsupported",
+  });
+  assert.deepEqual(assets.classifyWorkspaceMarkdownTarget("docs/intro.md", undefined), {
+    kind: "unsupported",
+  });
+});
+
+test("heading slugs approximate the GitHub anchor format", () => {
+  assert.equal(assets.workspaceMarkdownHeadingSlug("Quick Start"), "quick-start");
+  assert.equal(assets.workspaceMarkdownHeadingSlug("  A & B  "), "a--b");
+  assert.equal(assets.workspaceMarkdownHeadingSlug("使用说明"), "使用说明");
+  assert.equal(assets.workspaceMarkdownHeadingSlug("v1.2.3 (beta)"), "v123-beta");
+});


### PR DESCRIPTION
## Linked issue

Closes #493

## Summary

根 `.gitignore` 第 15 行的裸 `workspace` 规则把 `crates/agent-gui/test/workspace/` **整个目录**吞掉了。后果是三重的：文件从未入库、biome 从不检查、CI 也就永远发现不了里面的错误——所以这个目录里的测试可以长期引用一个**根本不存在的包**而无人察觉。

本 PR 按既有写法补上负向排除，并修正被掩盖的两处 specifier 笔误。

`crates/agent-gui/src/pages/chat/workspace/` 当初踩过同一个坑，靠 `.gitignore` 第 18-19 行的 `!` 条目才被跟踪；这是同一规则的**第二次复发**。

## Change scope

- Modules: agent-gui（测试）/ 仓库配置
- Key paths:
  - `.gitignore` —— 补 `!crates/agent-gui/test/workspace/` 与 `/**` 两行
  - `crates/agent-gui/test/workspace/markdown-assets.test.mjs` —— 首次入库 + 修正 import

两处笔误：

1. `@liveagent/ui-core` → `@liveagent/ui`。`ui-core` 来自 `frontend/packages/ui-core/`，那是前端统一方案废弃后留下的空壳（只剩 `node_modules`，git 零跟踪文件），该包名从不存在；
2. 补 `.ts` 后缀 —— 本仓 `loadModule` 一律带扩展名（参见 `test/workspace-image-viewer.test.mjs` 等既有用法）。

测试断言本身是对的，未作任何改动。

## Screenshots / preview

N/A —— 纯测试基础设施修复，无用户可见行为变化。修复前后对比见下方验证。

**修复前**：

```console
$ git check-ignore -v crates/agent-gui/test/workspace/markdown-assets.test.mjs
.gitignore:15:workspace   crates/agent-gui/test/workspace/markdown-assets.test.mjs

$ node --test test/workspace/markdown-assets.test.mjs
Error: Cannot find module '@liveagent/ui-core/components/workspace-editor/workspaceMarkdownAssets'
```

**修复后**：

```console
$ git check-ignore -v crates/agent-gui/test/workspace/markdown-assets.test.mjs
.gitignore:21:!crates/agent-gui/test/workspace/**   （最后命中的是负向规则）

$ node --test test/workspace/markdown-assets.test.mjs
ℹ tests 7
ℹ pass 7
ℹ fail 0
```

## Verification

- `cd crates/agent-gui && npm test` —— **1747/1747 通过，0 失败**（此前 1740/1741，唯一失败即本例）
- `npx biome check crates/agent-gui/test/workspace/markdown-assets.test.mjs` —— 干净（这是 biome 第一次真正检查该文件）
- 7 条断言指向真实模块后一次通过，未修改任何断言
- `git status --short --ignored=matching -uall | grep '^!!'` 全仓审计：除本例外无其他误吞；根目录 `workspace/` 仍按预期忽略（那是该规则的真实目标）

未新增测试：本 PR 恢复的正是 7 条既有测试。

## Pre-submit checklist

- [x] A requirement issue is linked (#493).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.（N/A —— 无用户可见变化）
