### PR TITLE
fix(providers): pi 0.84.2 升级并修复三处语义回归

### DIFF
--- a/crates/agent-gateway/web/package.json
+++ b/crates/agent-gateway/web/package.json
@@ -16,7 +16,6 @@
     "@liveagent/ui": "workspace:*",
     "@base-ui/react": "^1.6.0",
     "@bufbuild/protobuf": "^2.12.1",
-    "@earendil-works/pi-ai": "^0.80.6",
     "@git-diff-view/file": "^0.1.3",
     "@git-diff-view/react": "^0.1.3",
     "@iconify-json/gravity-ui": "^1.2.12",
@@ -43,6 +42,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@bufbuild/protoc-gen-es": "2.12.1",
+    "@earendil-works/pi-ai": "^0.84.2",
     "@iconify-json/logos": "^1.2.11",
     "@iconify-json/lucide": "^1.2.108",
     "@iconify-json/material-icon-theme": "1.2.67",

--- a/crates/agent-gateway/web/src/lib/agentTypes.ts
+++ b/crates/agent-gateway/web/src/lib/agentTypes.ts
@@ -25,6 +25,7 @@ export type ToolCall = {
   name: string;
   arguments: Record<string, unknown>;
   thoughtSignature?: string;
+  namespace?: string;
 };
 
 export type HostedSearchContent = {
@@ -48,10 +49,29 @@ export type Usage = {
   output: number;
   cacheRead: number;
   cacheWrite: number;
+  cacheWrite1h?: number;
+  reasoning?: number;
   totalTokens: number;
 };
 
-export type StopReason = "stop" | "length" | "toolUse" | "error" | "aborted";
+export type StopReason =
+  | "pending"
+  | "stop"
+  | "length"
+  | "toolUse"
+  | "error"
+  | "aborted"
+  | "deferred";
+
+export type DeferredHandle = {
+  provider: string;
+  modelId: string;
+  api: string;
+  id: string;
+  expiresAt?: number;
+  pollAfterMs?: number;
+  data?: unknown;
+};
 
 export type UserMessage = {
   role: "user";
@@ -66,10 +86,15 @@ export type AssistantMessage = {
   api: string;
   provider: string;
   model: string;
+  responseModel?: string;
   responseId?: string;
+  diagnostics?: unknown[];
   usage: Usage;
   stopReason: StopReason;
+  deferred?: DeferredHandle;
   errorMessage?: string;
+  rawStopReason?: string;
+  endTurn?: boolean;
   timestamp: number;
 };
 
@@ -79,6 +104,8 @@ export type ToolResultMessage<TDetails = unknown> = {
   toolName: string;
   content: (TextContent | ImageContent)[];
   details?: TDetails;
+  usage?: Usage;
+  addedToolNames?: string[];
   isError: boolean;
   timestamp: number;
 };
@@ -89,6 +116,10 @@ export type Tool<TParameters extends TSchema = TSchema> = {
   name: string;
   description: string;
   parameters: TParameters;
+  constrainedSampling?:
+    | false
+    | { type: "json_schema"; strict: "prefer" | "require" }
+    | { type: "grammar"; variants: Partial<Record<"openai_lark" | "openai_regex", string>> };
 };
 
 export type Context = {

--- a/crates/agent-gui/package.json
+++ b/crates/agent-gui/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "@liveagent/ui": "workspace:*",
     "@base-ui/react": "^1.6.0",
-    "@earendil-works/pi-agent-core": "^0.80.6",
-    "@earendil-works/pi-ai": "^0.80.6",
+    "@earendil-works/pi-agent-core": "^0.84.2",
+    "@earendil-works/pi-ai": "^0.84.2",
     "@git-diff-view/file": "^0.1.3",
     "@git-diff-view/react": "^0.1.3",
     "@iconify-json/gravity-ui": "^1.2.12",
@@ -43,7 +43,7 @@
     "remark-breaks": "^4.0.0",
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.5.0",
-    "typebox": "1.1.38",
+    "typebox": "1.3.7",
     "yet-another-react-lightbox": "^3.31.0"
   },
   "devDependencies": {

--- a/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
+++ b/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
@@ -1,4 +1,4 @@
-import { Agent, type AgentTool } from "@earendil-works/pi-agent-core";
+import { Agent, type AgentContext, type AgentTool } from "@earendil-works/pi-agent-core";
 import type {
   AssistantMessage,
   Context,
@@ -824,7 +824,6 @@ export async function runAssistantWithTools(params: {
       params.additionalRoots,
     );
     let currentSystemPrompt = params.context.systemPrompt;
-    let pendingTurnOverridePromise: Promise<TurnContextOverride> | null = null;
     let emittedBaselineIndex = params.context.messages.length;
     let latestAgentEndMessages: Message[] = [];
     let agentTools: AgentTool<any>[] = [];
@@ -1017,15 +1016,10 @@ export async function runAssistantWithTools(params: {
       }
     }
 
-    async function consumePendingTurnOverride(): Promise<TurnContextOverride> {
-      const pending = pendingTurnOverridePromise;
-      if (!pending) return null;
-      pendingTurnOverridePromise = null;
-      return pending;
-    }
-
-    function applyTurnContextOverride(override: Exclude<TurnContextOverride, null>) {
-      if (!agent) return;
+    function applyTurnContextOverride(
+      override: Exclude<TurnContextOverride, null>,
+    ): AgentContext | undefined {
+      if (!agent) return undefined;
       currentSystemPrompt = override.context.systemPrompt;
       agent.state.systemPrompt = buildSystemPrompt(currentSystemPrompt, toolsSuffix);
       agent.state.messages = override.context.messages.slice();
@@ -1035,6 +1029,11 @@ export async function runAssistantWithTools(params: {
         override.context.messages.length - override.emittedMessages.length,
       );
       latestAgentEndMessages = [];
+      return {
+        systemPrompt: agent.state.systemPrompt,
+        messages: agent.state.messages.slice(),
+        tools: agentTools,
+      };
     }
 
     const visibleAgentTools: AgentTool<any>[] = llmTools.map((tool) => ({
@@ -1342,7 +1341,7 @@ export async function runAssistantWithTools(params: {
     // model would see a schema error blaming its own call. Rewrite such tool
     // results into the truthful transport-error teaching before the next turn.
     const reconcileTruncatedToolResults = () => {
-      if (incompleteToolCallArguments.size === 0) return;
+      if (incompleteToolCallArguments.size === 0) return false;
       const messages = getAgentMessages(agent);
       let changed = false;
       const next = messages.map((message) => {
@@ -1362,6 +1361,7 @@ export async function runAssistantWithTools(params: {
       if (changed && agent) {
         agent.state.messages = next;
       }
+      return changed;
     };
 
     agent = new Agent({
@@ -1439,13 +1439,55 @@ export async function runAssistantWithTools(params: {
         }
         return undefined;
       },
-      transformContext: async (_messages, _signal) => {
-        const override = await consumePendingTurnOverride();
-        if (override) {
-          applyTurnContextOverride(override);
+      // 0.84 起 pi-agent-core 用 prepareNextTurnWithContext 取代了原先靠
+      // transformContext 顺带做的 turn 间改写。二者的关键差异:transformContext
+      // 拿不到 loop 的 context,只能读回 agent.state.messages;而 loop 的
+      // currentContext.messages 是 createContextSnapshot() 切出的**另一个数组**,
+      // agent.state 上的改写不会自动回流。所以这里必须显式把改写后的消息作为
+      // context 返回,否则 message_end 里对 assistant 的规范化(工具名归一、
+      // hostedSearch 块回填、seed 工具调用去重)和截断结果重写全部只活在
+      // agent.state,下一轮请求仍按旧快照发出。
+      prepareNextTurnWithContext: async ({ message, toolResults, context }, signal) => {
+        const reconciled = reconcileTruncatedToolResults();
+        // agent.state 是 message_end 规范化后的权威副本;只要它与 loop 快照长度
+        // 一致,就以它为准(内容可能已被就地替换,长度相同不代表内容相同)。
+        const stateMessages = getAgentMessages(agent);
+        const currentContext: AgentContext =
+          agent && stateMessages.length === context.messages.length
+            ? { ...context, messages: stateMessages.slice() }
+            : reconciled
+              ? { ...context, messages: agent ? stateMessages.slice() : context.messages }
+              : context;
+        const contextChanged = currentContext !== context;
+        if (
+          !params.onBeforeNextTurn ||
+          message.stopReason !== "toolUse" ||
+          toolResults.length === 0
+        ) {
+          return contextChanged ? { context: currentContext } : undefined;
         }
-        reconcileTruncatedToolResults();
-        return getAgentMessages(agent).slice();
+
+        const runtimeMessages = currentContext.messages as Message[];
+        const override = await params.onBeforeNextTurn({
+          round: currentRound,
+          assistant: message,
+          toolResults,
+          runtimeContext: {
+            systemPrompt: currentSystemPrompt,
+            messages: runtimeMessages.slice(),
+            tools: llmTools,
+          },
+          emittedMessages:
+            emittedBaselineIndex <= 0
+              ? runtimeMessages.slice()
+              : runtimeMessages.slice(emittedBaselineIndex),
+          signal: signal ?? params.signal,
+        });
+        if (!override) {
+          return contextChanged ? { context: currentContext } : undefined;
+        }
+        const nextContext = applyTurnContextOverride(override);
+        return nextContext ? { context: nextContext } : undefined;
       },
     });
 
@@ -1611,35 +1653,6 @@ export async function runAssistantWithTools(params: {
             }
           }
           break;
-        case "turn_end": {
-          const toolResults = event.toolResults.filter(
-            (message): message is ToolResultMessage => message.role === "toolResult",
-          );
-          if (
-            params.onBeforeNextTurn &&
-            event.message.role === "assistant" &&
-            event.message.stopReason === "toolUse" &&
-            toolResults.length > 0
-          ) {
-            const runtimeMessages = getAgentMessages(agent);
-            const runtimeSnapshot: Context = {
-              systemPrompt: currentSystemPrompt,
-              messages: runtimeMessages.slice(),
-              tools: llmTools,
-            };
-            const emittedSnapshot = getMessagesSinceBaseline(agent, emittedBaselineIndex);
-            const assistant = event.message;
-            pendingTurnOverridePromise = params.onBeforeNextTurn({
-              round: currentRound,
-              assistant,
-              toolResults,
-              runtimeContext: runtimeSnapshot,
-              emittedMessages: emittedSnapshot,
-              signal: params.signal,
-            });
-          }
-          break;
-        }
         case "tool_execution_start": {
           nativeWebSearchStatusController.pause();
           const toolCall =
@@ -1697,12 +1710,6 @@ export async function runAssistantWithTools(params: {
         throwIfRunnerCancelled(params.signal);
         await agent.continue();
         throwIfRunnerCancelled(params.signal);
-
-        const override = await consumePendingTurnOverride();
-        throwIfRunnerCancelled(params.signal);
-        if (override) {
-          applyTurnContextOverride(override);
-        }
 
         const recoveredSeedTurn = pendingRecoveredSeedTurnRef.current;
         pendingRecoveredSeedTurnRef.current = null;
@@ -1762,7 +1769,7 @@ export async function runAssistantWithTools(params: {
 
         if (params.onBeforeNextTurn) {
           throwIfRunnerCancelled(params.signal);
-          pendingTurnOverridePromise = params.onBeforeNextTurn({
+          const override = await params.onBeforeNextTurn({
             round: recoveredSeedRound,
             assistant: recoveredSeedAssistant,
             toolResults: syntheticToolResults,
@@ -1774,6 +1781,10 @@ export async function runAssistantWithTools(params: {
             emittedMessages: getMessagesSinceBaseline(agent, emittedBaselineIndex),
             signal: params.signal,
           });
+          throwIfRunnerCancelled(params.signal);
+          if (override) {
+            applyTurnContextOverride(override);
+          }
         }
       }
 

--- a/crates/agent-gui/src/lib/providers/deepSeekProviderAdapter.ts
+++ b/crates/agent-gui/src/lib/providers/deepSeekProviderAdapter.ts
@@ -78,6 +78,7 @@ export function resolveDeepSeekOpenAICompletionsOverrides(): {
     compat: {
       supportsStore: false,
       supportsDeveloperRole: false,
+      supportsFinishReason: false,
       supportsReasoningEffort: true,
       maxTokensField: "max_tokens",
       requiresReasoningContentOnAssistantMessages: true,

--- a/crates/agent-gui/src/lib/providers/runtime/codexPromptCache.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/codexPromptCache.ts
@@ -1,3 +1,4 @@
+import type { Api, Model, OpenAIResponsesCompat } from "@earendil-works/pi-ai";
 import type { CodexRequestFormat, PromptCacheHintMode, ProviderId } from "../../settings";
 import { isRecord, normalizeSessionId } from "./common";
 import type { StreamOptionsEx } from "./types";
@@ -32,15 +33,22 @@ function parseHostname(baseUrl: string): string | undefined {
   }
 }
 
+function isOfficialOpenAIHostname(hostname: string | undefined): boolean {
+  return hostname === "api.openai.com" || Boolean(hostname?.endsWith(".api.openai.com"));
+}
+
 export function resolvePromptCacheHintMode(
   configuredMode: PromptCacheHintMode | undefined,
   baseUrl: string,
   modelApi?: CodexRequestFormat,
 ): Exclude<PromptCacheHintMode, "auto"> {
   if (configuredMode && configuredMode !== "auto") return configuredMode;
+  // Responses 链路对齐 Codex CLI：CLI 对所有端点都发会话级 prompt_cache_key，
+  // 服务 Codex 流量的中转站必然兼容。严格校验的第三方 Responses 端点若报 400,
+  // 逃生通道是供应商级/模型级设 none，而不是把这里翻回保守值（PR#436）。
   if (modelApi === "openai-responses") return "openai-key";
   const hostname = parseHostname(baseUrl);
-  if (hostname === "api.openai.com" || hostname?.endsWith(".api.openai.com")) {
+  if (isOfficialOpenAIHostname(hostname)) {
     return "openai-key";
   }
   if (hostname === "openrouter.ai" || hostname?.endsWith(".openrouter.ai")) {
@@ -49,12 +57,48 @@ export function resolvePromptCacheHintMode(
   return "none";
 }
 
-function stripOpenAIPromptCacheFields(payload: Record<string, unknown>) {
+function isExplicitNoCacheOptions(value: unknown): boolean {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as Record<string, unknown>).mode === "explicit"
+  );
+}
+
+/**
+ * `prompt_cache_options: { mode: "explicit" }` 是 GPT-5.6+ 显式关闭隐式前缀缓存
+ * 的**唯一**手段（pi-ai 仅在 cacheRetention=none 且模型声明该能力时生成）。剥掉
+ * 它等于"用户要求不缓存，wire 上却仍在隐式缓存"，所以 none 模式下要放行。
+ *
+ * 仅限官方 host：该字段和 prompt_cache_key 一样是 OpenAI 私有扩展，严格校验的
+ * 中转端点会直接 400（#307 那一类）。中转站上宁可退回隐式缓存，也不能为了关缓存
+ * 把整个请求打死——那是本文件存在的理由。
+ */
+function supportsExplicitNoCache(baseUrl: string, model: Model<Api> | undefined): boolean {
+  if (!model || model.api !== "openai-responses") return false;
+  if (!isOfficialOpenAIHostname(parseHostname(baseUrl))) return false;
+  const compat = model.compat as OpenAIResponsesCompat | undefined;
+  return compat?.supportsExplicitPromptCacheMode === true;
+}
+
+function stripOpenAIPromptCacheFields(
+  payload: Record<string, unknown>,
+  preserveExplicitNoCache: boolean,
+) {
   // pi-ai 的 completions buildParams 恒显式写 prompt_cache_key: undefined；
   // 按值判断，undefined 序列化时本就会被丢弃，不值得为它每请求拷贝 payload。
-  if (!OPENAI_PROMPT_CACHE_PAYLOAD_KEYS.some((key) => payload[key] !== undefined)) return payload;
+  const keysToStrip = OPENAI_PROMPT_CACHE_PAYLOAD_KEYS.filter((key) => {
+    if (payload[key] === undefined) return false;
+    return !(
+      key === "prompt_cache_options" &&
+      preserveExplicitNoCache &&
+      isExplicitNoCacheOptions(payload[key])
+    );
+  });
+  if (keysToStrip.length === 0) return payload;
   const nextPayload = { ...payload };
-  for (const key of OPENAI_PROMPT_CACHE_PAYLOAD_KEYS) delete nextPayload[key];
+  for (const key of keysToStrip) delete nextPayload[key];
   return nextPayload;
 }
 
@@ -67,15 +111,16 @@ export function attachCodexPromptCacheHint(
   providerId: ProviderId,
   baseUrl: string,
   configuredMode: PromptCacheHintMode | undefined,
-  modelApi: CodexRequestFormat | undefined,
+  model: Model<Api> | undefined,
   options: StreamOptionsEx,
 ): StreamOptionsEx {
   if (providerId !== "codex") return options;
   const mode =
     options.cacheRetention === "none"
       ? "none"
-      : resolvePromptCacheHintMode(configuredMode, baseUrl, modelApi);
+      : resolvePromptCacheHintMode(configuredMode, baseUrl, model?.api as CodexRequestFormat);
   const sessionId = normalizeSessionId(options.sessionId);
+  const effectiveCacheRetention = mode === "none" ? "none" : options.cacheRetention;
 
   const previousOnPayload = options.onPayload;
   return {
@@ -83,7 +128,7 @@ export function attachCodexPromptCacheHint(
     // mode=none 时把 retention 一并压成 none：让 pi-ai 从源头不生成任何缓存
     // 提示（responses 链路会按 retention 注入 prompt_cache_key），而不是依赖
     // 事后剥离已知字段兜底。
-    cacheRetention: mode === "none" ? "none" : options.cacheRetention,
+    cacheRetention: effectiveCacheRetention,
     headers:
       mode === "openrouter-session" && sessionId && !hasHeader(options.headers, "x-session-id")
         ? { ...options.headers, "x-session-id": clampOpenRouterSessionId(sessionId) }
@@ -111,7 +156,12 @@ export function attachCodexPromptCacheHint(
         };
       }
 
-      return mode === "openai-key" ? nextPayload : stripOpenAIPromptCacheFields(nextPayload);
+      return mode === "openai-key"
+        ? nextPayload
+        : stripOpenAIPromptCacheFields(
+            nextPayload,
+            effectiveCacheRetention === "none" && supportsExplicitNoCache(baseUrl, model),
+          );
     },
   };
 }

--- a/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
@@ -247,6 +247,7 @@ function resolveCodexOpenAICompletionsOverrides(params: {
   const compat: OpenAICompletionsCompat = {
     supportsStore: false,
     supportsDeveloperRole: false,
+    supportsFinishReason: false,
   };
 
   if (isXai || isZai) {

--- a/crates/agent-gui/src/lib/providers/runtime/openAICompletionsStream.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/openAICompletionsStream.ts
@@ -3,87 +3,75 @@ import {
   type AssistantMessageEventStream,
   createAssistantMessageEventStream,
 } from "@earendil-works/pi-ai";
-import type { ProviderId } from "../../settings";
-import type { StreamOptionsEx } from "./types";
 
-const MISSING_FINISH_REASON_ERROR = "Stream ended without finish_reason";
+// 措辞必须命中 pi-ai `isRetryableAssistantError` 的 `provider.?returned.?error`
+// 模式：空响应是典型的上游瞬时抖动，应当由 withStreamRetry 重试掉，而不是直接
+// 把一轮打死。改这句文案前先跑 utils/retry.ts 的模式表。
+const EMPTY_RESPONSE_ERROR =
+  "Provider returned error: the response contained no content (empty response)";
 
-function isOfficialOpenAIBaseUrl(baseUrl: string) {
-  try {
-    return new URL(baseUrl).hostname.toLowerCase() === "api.openai.com";
-  } catch {
-    return false;
-  }
-}
-
-function recoverMissingFinishReasonMessage(
-  message: AssistantMessage,
-): { message: AssistantMessage; reason: "stop" | "toolUse" } | undefined {
-  if (
-    message.stopReason !== "error" ||
-    !message.errorMessage?.includes(MISSING_FINISH_REASON_ERROR)
-  ) {
-    return undefined;
-  }
-
+function hasUsableAssistantContent(message: AssistantMessage): boolean {
   const hasToolCall = message.content.some(
     (block) => block.type === "toolCall" && Boolean(block.id && block.name),
   );
   const hasText = message.content.some(
     (block) => block.type === "text" && block.text.trim().length > 0,
   );
-  if (!hasToolCall && !hasText) return undefined;
+  // 思考块也算"上游确实产出了内容"。推理模型可能把 max_tokens 全烧在
+  // reasoning 上、只留思考不留正文（pi-ai 的 supportsThinkingTokenBudget 就是
+  // 为此而设）——那是预算问题，不是空响应，重试只会再烧一遍推理预算。
+  const hasThinking = message.content.some(
+    (block) => block.type === "thinking" && block.thinking.trim().length > 0,
+  );
+  return hasToolCall || hasText || hasThinking;
+}
 
-  const reason = hasToolCall ? "toolUse" : "stop";
-  const recovered: AssistantMessage = {
+/**
+ * 只有"正常终止但一个字都没吐"才算空响应。
+ *
+ * - `length`：截断是真实终止语义，下游截断工具调用链路要读它，不能改写。
+ * - `aborted`：用户主动停止，改写会把取消伪装成上游故障（streamRetry 专门
+ *   保住的那条语义）。
+ * - `error`：上游已经给出真实错误，保留原文比换成"空响应"更有信息量。
+ */
+function shouldRejectAsEmptyResponse(message: AssistantMessage): boolean {
+  if (message.stopReason === "length" || message.stopReason === "aborted") return false;
+  if (message.stopReason === "error") return false;
+  return !hasUsableAssistantContent(message);
+}
+
+function buildEmptyResponseError(message: AssistantMessage): AssistantMessage {
+  return {
     ...message,
-    stopReason: reason,
+    stopReason: "error",
+    errorMessage: EMPTY_RESPONSE_ERROR,
   };
-  delete recovered.errorMessage;
-  return { message: recovered, reason };
 }
 
-export function attachOpenAICompletionsFinishReasonCompatibility(
-  options: StreamOptionsEx,
-  params: {
-    providerId: ProviderId;
-    baseUrl: string;
-    modelApi?: string;
-  },
-): StreamOptionsEx {
-  if (
-    options.recoverMissingFinishReason !== undefined ||
-    params.providerId !== "codex" ||
-    params.modelApi !== "openai-completions" ||
-    isOfficialOpenAIBaseUrl(params.baseUrl)
-  ) {
-    return options;
-  }
-  return { ...options, recoverMissingFinishReason: true };
-}
-
-export function recoverOpenAICompletionsMissingFinishReason(
+export function rejectEmptyOpenAICompletionsResponse(
   source: AssistantMessageEventStream,
 ): AssistantMessageEventStream {
   const output = createAssistantMessageEventStream();
 
   void (async () => {
     for await (const event of source) {
-      if (event.type === "error") {
-        const recovery = recoverMissingFinishReasonMessage(event.error);
-        if (recovery) {
-          output.push({ type: "done", reason: recovery.reason, message: recovery.message });
-        } else {
-          output.push(event);
-        }
+      if (event.type === "done" && shouldRejectAsEmptyResponse(event.message)) {
+        const error = buildEmptyResponseError(event.message);
+        output.push({ type: "error", reason: "error", error });
         return;
       }
 
       output.push(event);
-      if (event.type === "done") return;
+      if (event.type === "done" || event.type === "error") return;
     }
 
-    output.end(await source.result());
+    const result = await source.result();
+    if (shouldRejectAsEmptyResponse(result)) {
+      const error = buildEmptyResponseError(result);
+      output.push({ type: "error", reason: "error", error });
+      return;
+    }
+    output.end(result);
   })();
 
   return output;

--- a/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
@@ -14,7 +14,6 @@ import { attachCodexPromptCacheHint } from "./codexPromptCache";
 import { attachCodexResponsesStorage } from "./codexStorage";
 import { attachGeminiThoughtSignatureGuard } from "./geminiToolPayload";
 import { attachProviderNativeWebSearch } from "./nativeSearchPayload";
-import { attachOpenAICompletionsFinishReasonCompatibility } from "./openAICompletionsStream";
 import type { StreamOptionsEx } from "./types";
 import { attachXaiResponsesPayloadCompat } from "./xaiResponsesPayload";
 
@@ -99,15 +98,9 @@ const finalizePayloadMiddlewares = composePayloadMiddlewares([
       params.providerId,
       params.baseUrl,
       params.promptCacheHintMode,
-      params.model?.api,
+      params.model,
       options,
     ),
-  (options, params) =>
-    attachOpenAICompletionsFinishReasonCompatibility(options, {
-      providerId: params.providerId,
-      baseUrl: params.baseUrl,
-      modelApi: params.model?.api,
-    }),
   (options, params) =>
     attachProviderNativeWebSearch(params.providerId, options, params.nativeWebSearch, {
       baseUrl: params.baseUrl,

--- a/crates/agent-gui/src/lib/providers/runtime/streamByApi.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/streamByApi.ts
@@ -20,7 +20,7 @@ import {
   mapDeepSeekReasoningEffort,
 } from "../deepSeekProviderAdapter";
 import { resolveMaxTokens } from "./common";
-import { recoverOpenAICompletionsMissingFinishReason } from "./openAICompletionsStream";
+import { rejectEmptyOpenAICompletionsResponse } from "./openAICompletionsStream";
 import { withStreamRetry } from "./streamRetry";
 import { normalizeStructuredToolCallHistoryForDeepSeek } from "./textModeToolRecovery";
 import {
@@ -162,14 +162,9 @@ export function streamSimpleByApi(model: Model<any>, context: Context, options: 
       };
       return withStreamRetry(
         () => {
-          const source = streamOpenAICompletions(
-            model as any,
-            openAICompletionsContext,
-            openAIOptions,
+          return rejectEmptyOpenAICompletionsResponse(
+            streamOpenAICompletions(model as any, openAICompletionsContext, openAIOptions),
           );
-          return openAICompletionsOptions.recoverMissingFinishReason
-            ? recoverOpenAICompletionsMissingFinishReason(source)
-            : source;
         },
         { signal: openAICompletionsOptions.signal, ...openAICompletionsOptions.streamRetry },
       );

--- a/crates/agent-gui/src/lib/providers/runtime/types.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/types.ts
@@ -63,5 +63,4 @@ export type StreamOptionsEx = SimpleStreamOptions & {
   deepSeekAnthropicPayloadToolBlockFlattening?: boolean;
   /** Escape hatch for the unified provider stream retry in streamByApi.ts. */
   streamRetry?: StreamRetryConfig;
-  recoverMissingFinishReason?: boolean;
 };

--- a/crates/agent-gui/src/lib/tools/builtinRegistry.ts
+++ b/crates/agent-gui/src/lib/tools/builtinRegistry.ts
@@ -51,6 +51,19 @@ export type BuiltinToolRegistry = {
 // 内置工具那样 throw 打断整轮——那等于让一个坏插件废掉整个对话。改为:先到先
 // 得、跳过后来者并告警;仅当两侧都是可信内置组时才 throw(那是编译期的开发 bug)。
 const UNTRUSTED_TOOL_GROUPS: ReadonlySet<BuiltinToolBundle["groupId"]> = new Set(["mcp"]);
+// 内置工具的 schema 由我们自己维护,让供应商开启 JSON-schema 约束采样(OpenAI
+// strict / Gemini VALIDATED)能直接消灭一整类"参数名写错、必填漏传"的坏调用。
+//
+// 必须是 "prefer" 而不是 "require":pi-ai 的 makeStrictJsonSchema 只接受严格子集,
+// 我们有工具(CronTaskManager / McpManager 的 propertyNames、MemoryManager 的
+// 对象联合)天然落在子集之外。"prefer" 下这些工具静默退回普通函数工具;"require"
+// 会让 pi-ai 直接 throw,一个工具的 schema 形状就能打死整轮请求。
+//
+// MCP/插件工具的 schema 不受我们控制,不代它们做这个声明。
+const PREFERRED_JSON_SCHEMA_SAMPLING = {
+  type: "json_schema",
+  strict: "prefer",
+} as const;
 
 function createBuiltinToolRegistry(bundles: BuiltinToolBundle[]): BuiltinToolRegistry {
   const tools: BuiltinToolBundle["tools"] = [];
@@ -95,7 +108,13 @@ function createBuiltinToolRegistry(bundles: BuiltinToolBundle[]): BuiltinToolReg
         );
         continue;
       }
-      tools.push(tool);
+      const registeredTool = UNTRUSTED_TOOL_GROUPS.has(bundle.groupId)
+        ? tool
+        : {
+            ...tool,
+            constrainedSampling: tool.constrainedSampling ?? PREFERRED_JSON_SCHEMA_SAMPLING,
+          };
+      tools.push(registeredTool);
       executorsByName.set(tool.name, bundle.executeToolCall);
       groupIdByToolName.set(tool.name, bundle.groupId);
       registerCanonicalToolName(tool.name);

--- a/crates/agent-gui/test/chat/agent-runner.test.mjs
+++ b/crates/agent-gui/test/chat/agent-runner.test.mjs
@@ -1211,6 +1211,21 @@ arguments: {"pattern": "express", "file_pattern": "**/*.js", "ignore_case": true
     result.emittedMessages.map((message) => message.role),
     ["assistant", "toolResult", "assistant"],
   );
+
+  // 剥离 seed 标记会**替换**整条 assistant 消息对象(而不是就地改写),而
+  // pi-agent-core 的 loop 持有 createContextSnapshot() 切出的另一个数组——
+  // 替换只落在 agent.state 上。prepareNextTurnWithContext 必须把规范化后的
+  // 消息作为 context 交还,否则下一轮仍把这段"历史工具调用"文本发回给模型,
+  // 模型会照着它再调一次工具(重复执行的根源)。
+  const followUpAssistant = observedStreamContexts
+    .at(-1)
+    .messages.find((message) => message.role === "assistant");
+  assert.ok(followUpAssistant);
+  const followUpText = followUpAssistant.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+  assert.equal(followUpText.includes("Historical tool call"), false);
 });
 
 test("runAssistantWithTools dedupes recovered lowercase tool text against canonical structured calls", async () => {

--- a/crates/agent-gui/test/providers/openai-completions-stream.test.mjs
+++ b/crates/agent-gui/test/providers/openai-completions-stream.test.mjs
@@ -13,7 +13,7 @@ function createUsage() {
   };
 }
 
-function createAssistant(content, errorMessage = "Stream ended without finish_reason") {
+function createAssistant(content, stopReason = "stop", errorMessage) {
   return {
     role: "assistant",
     content,
@@ -21,18 +21,20 @@ function createAssistant(content, errorMessage = "Stream ended without finish_re
     provider: "openai",
     model: "compatible-model",
     usage: createUsage(),
-    stopReason: "error",
-    errorMessage,
+    stopReason,
+    ...(errorMessage ? { errorMessage } : {}),
     timestamp: 1,
   };
 }
 
-function createErrorSource(assistant, events = []) {
+function createTerminalSource(assistant, events = [], terminalType = "done") {
   return {
     async *[Symbol.asyncIterator]() {
       yield { type: "start", partial: { ...assistant, content: [] } };
       for (const event of events) yield event;
-      yield { type: "error", reason: "error", error: assistant };
+      yield terminalType === "done"
+        ? { type: "done", reason: assistant.stopReason, message: assistant }
+        : { type: "error", reason: "error", error: assistant };
     },
     async result() {
       return assistant;
@@ -58,16 +60,17 @@ function createModel() {
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 8192,
     maxTokens: 1024,
+    compat: { supportsFinishReason: false },
   };
 }
 
-test("openai-completions: compatible endpoint recovers usable text missing finish_reason", async () => {
+test("openai-completions: upstream finish-reason compatibility preserves usable text", async () => {
   const assistant = createAssistant([{ type: "text", text: "complete answer" }]);
   const loader = createTsModuleLoader({
     mocks: {
       "@earendil-works/pi-ai/api/openai-completions": {
         stream() {
-          return createErrorSource(assistant, [
+          return createTerminalSource(assistant, [
             {
               type: "text_delta",
               contentIndex: 0,
@@ -88,7 +91,6 @@ test("openai-completions: compatible endpoint recovers usable text missing finis
   const { streamSimpleByApi } = loader.loadModule("src/lib/providers/runtime/streamByApi.ts");
 
   const stream = streamSimpleByApi(createModel(), { messages: [] }, {
-    recoverMissingFinishReason: true,
     streamRetry: { disabled: true },
   });
   const events = await collectEvents(stream);
@@ -103,13 +105,13 @@ test("openai-completions: compatible endpoint recovers usable text missing finis
   assert.equal(result.content[0].text, "complete answer");
 });
 
-test("openai-completions: empty stream still fails when finish_reason is missing", async () => {
+test("openai-completions: empty successful stream is rejected", async () => {
   const loader = createTsModuleLoader();
-  const { recoverOpenAICompletionsMissingFinishReason } = loader.loadModule(
+  const { rejectEmptyOpenAICompletionsResponse } = loader.loadModule(
     "src/lib/providers/runtime/openAICompletionsStream.ts",
   );
   const assistant = createAssistant([]);
-  const stream = recoverOpenAICompletionsMissingFinishReason(createErrorSource(assistant));
+  const stream = rejectEmptyOpenAICompletionsResponse(createTerminalSource(assistant));
   const events = await collectEvents(stream);
 
   assert.deepEqual(
@@ -117,27 +119,80 @@ test("openai-completions: empty stream still fails when finish_reason is missing
     ["start", "error"],
   );
   assert.equal((await stream.result()).stopReason, "error");
+  // 措辞必须继续命中 pi-ai 的可重试模式,否则空响应会直接打死一轮而不是重试。
+  assert.match((await stream.result()).errorMessage, /provider returned error/i);
+});
+
+test("openai-completions: empty response error stays retryable for withStreamRetry", async () => {
+  const { isRetryableAssistantError } = await import("@earendil-works/pi-ai");
+  const loader = createTsModuleLoader();
+  const { rejectEmptyOpenAICompletionsResponse } = loader.loadModule(
+    "src/lib/providers/runtime/openAICompletionsStream.ts",
+  );
+  const stream = rejectEmptyOpenAICompletionsResponse(
+    createTerminalSource(createAssistant([])),
+  );
+  await collectEvents(stream);
+
+  // 空响应是上游抖动,必须能被统一重试链路吃掉;文案一旦偏离 pi-ai 的模式表,
+  // 一次空回复就会直接终结整轮对话。
+  assert.equal(isRetryableAssistantError(await stream.result()), true);
+});
+
+test("openai-completions: truncated and aborted turns are never rewritten as empty", async () => {
+  const loader = createTsModuleLoader();
+  const { rejectEmptyOpenAICompletionsResponse } = loader.loadModule(
+    "src/lib/providers/runtime/openAICompletionsStream.ts",
+  );
+
+  // length = 输出被 token 上限截断,是真实终止语义(下游据此拒绝可能截断的工具
+  // 调用);aborted = 用户主动停止。两者都不能被改写成"空响应"。
+  for (const stopReason of ["length", "aborted"]) {
+    const stream = rejectEmptyOpenAICompletionsResponse(
+      createTerminalSource(createAssistant([], stopReason)),
+    );
+    const events = await collectEvents(stream);
+    assert.equal(events.at(-1).type, "done", stopReason);
+    assert.equal((await stream.result()).stopReason, stopReason);
+  }
+});
+
+test("openai-completions: thinking-only turns are not treated as empty", async () => {
+  const loader = createTsModuleLoader();
+  const { rejectEmptyOpenAICompletionsResponse } = loader.loadModule(
+    "src/lib/providers/runtime/openAICompletionsStream.ts",
+  );
+  // 推理模型可能把预算全烧在 thinking 上;重试只会再烧一遍,不是空响应。
+  const assistant = createAssistant([{ type: "thinking", thinking: "long chain" }]);
+  const stream = rejectEmptyOpenAICompletionsResponse(createTerminalSource(assistant));
+  const events = await collectEvents(stream);
+
+  assert.equal(events.at(-1).type, "done");
+  assert.equal((await stream.result()).stopReason, "stop");
 });
 
 test("openai-completions: unrelated errors are never recovered", async () => {
   const loader = createTsModuleLoader();
-  const { recoverOpenAICompletionsMissingFinishReason } = loader.loadModule(
+  const { rejectEmptyOpenAICompletionsResponse } = loader.loadModule(
     "src/lib/providers/runtime/openAICompletionsStream.ts",
   );
   const assistant = createAssistant(
     [{ type: "text", text: "partial" }],
+    "error",
     "503 service unavailable",
   );
-  const stream = recoverOpenAICompletionsMissingFinishReason(createErrorSource(assistant));
+  const stream = rejectEmptyOpenAICompletionsResponse(
+    createTerminalSource(assistant, [], "error"),
+  );
   const events = await collectEvents(stream);
 
   assert.equal(events.at(-1).type, "error");
   assert.equal((await stream.result()).stopReason, "error");
 });
 
-test("openai-completions: recovered tool calls retain truncation guard coverage", async () => {
+test("openai-completions: inferred tool calls retain truncation guard coverage", async () => {
   const loader = createTsModuleLoader();
-  const { recoverOpenAICompletionsMissingFinishReason } = loader.loadModule(
+  const { rejectEmptyOpenAICompletionsResponse } = loader.loadModule(
     "src/lib/providers/runtime/openAICompletionsStream.ts",
   );
   const { wrapStreamWithToolCallArgumentGuard } = loader.loadModule(
@@ -149,8 +204,8 @@ test("openai-completions: recovered tool calls retain truncation guard coverage"
     name: "read_file",
     arguments: { path: "/tmp" },
   };
-  const assistant = createAssistant([toolCall]);
-  const source = createErrorSource(assistant, [
+  const assistant = createAssistant([toolCall], "toolUse");
+  const source = createTerminalSource(assistant, [
     { type: "toolcall_start", contentIndex: 0, partial: assistant },
     {
       type: "toolcall_delta",
@@ -161,8 +216,8 @@ test("openai-completions: recovered tool calls retain truncation guard coverage"
     { type: "toolcall_end", contentIndex: 0, toolCall, partial: assistant },
   ]);
   const incomplete = [];
-  const recovered = recoverOpenAICompletionsMissingFinishReason(source);
-  const guarded = wrapStreamWithToolCallArgumentGuard(recovered, (call, reason) => {
+  const validated = rejectEmptyOpenAICompletionsResponse(source);
+  const guarded = wrapStreamWithToolCallArgumentGuard(validated, (call, reason) => {
     incomplete.push({ call, reason });
   });
   const events = await collectEvents(guarded);
@@ -175,33 +230,33 @@ test("openai-completions: recovered tool calls retain truncation guard coverage"
   assert.match(incomplete[0].reason, /before it was complete/);
 });
 
-test("openai-completions: compatibility is enabled only for non-official endpoints", () => {
+test("openai-completions: model compat infers finish reasons only for non-official endpoints", () => {
   const loader = createTsModuleLoader();
-  const { finalizeProviderStreamOptions } = loader.loadModule(
-    "src/lib/providers/runtime/payloadPipeline.ts",
+  const { createModelFromConfig } = loader.loadModule(
+    "src/lib/providers/runtime/modelFactory.ts",
   );
-  const model = createModel();
+  const compatible = createModelFromConfig(
+    "codex",
+    "compatible-model",
+    "https://relay.example.com/v1",
+    "openai-completions",
+  );
+  const official = createModelFromConfig(
+    "codex",
+    "compatible-model",
+    "http://127.0.0.1:18080/proxy/codex/v1",
+    "openai-completions",
+    undefined,
+    "https://api.openai.com/v1",
+  );
+  const deepSeek = createModelFromConfig(
+    "codex",
+    "deepseek-chat",
+    "https://api.deepseek.com/v1",
+    "openai-completions",
+  );
 
-  const compatible = finalizeProviderStreamOptions({
-    providerId: "codex",
-    baseUrl: "https://relay.example.com/v1",
-    options: {},
-    model,
-  });
-  const official = finalizeProviderStreamOptions({
-    providerId: "codex",
-    baseUrl: "https://api.openai.com/v1",
-    options: {},
-    model,
-  });
-  const explicitStrict = finalizeProviderStreamOptions({
-    providerId: "codex",
-    baseUrl: "https://relay.example.com/v1",
-    options: { recoverMissingFinishReason: false },
-    model,
-  });
-
-  assert.equal(compatible.recoverMissingFinishReason, true);
-  assert.equal(official.recoverMissingFinishReason, undefined);
-  assert.equal(explicitStrict.recoverMissingFinishReason, false);
+  assert.equal(compatible.compat.supportsFinishReason, false);
+  assert.notEqual(official.compat?.supportsFinishReason, false);
+  assert.equal(deepSeek.compat.supportsFinishReason, false);
 });

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -1489,11 +1489,10 @@ test("codex automatic cache hint resolution follows request format before endpoi
     "openrouter-session",
   );
   assert.equal(resolve("auto", "https://relay.example/v1", "openai-completions"), "none");
+  // Responses 链路对齐 Codex CLI:所有端点都发会话级 key(PR#436 的有意选择,
+  // 逃生通道是供应商级/模型级显式设 none)。
   assert.equal(resolve("auto", "https://relay.example/v1", "openai-responses"), "openai-key");
-  assert.equal(
-    resolve("auto", "https://openrouter.ai/api/v1", "openai-responses"),
-    "openai-key",
-  );
+  assert.equal(resolve("auto", "https://openrouter.ai/api/v1", "openai-responses"), "openai-key");
   assert.equal(resolve("auto", "not-a-url", "openai-completions"), "none");
   assert.equal(
     resolve("openrouter-session", "https://relay.example/v1", "openai-responses"),
@@ -1634,6 +1633,56 @@ test("codex explicit cache hints respect overrides, user values, and limits", as
     );
     assert.equal(Object.hasOwn(payload, "prompt_cache_key"), false);
   }
+
+  const explicitNoCacheModel = {
+    api: "openai-responses",
+    provider: "openai",
+    id: "gpt-5.6-sol",
+    compat: { supportsExplicitPromptCacheMode: true },
+  };
+  const explicitNoCache = providers.finalizeProviderStreamOptions({
+    providerId: "codex",
+    baseUrl: "https://api.openai.com/v1",
+    promptCacheHintMode: "auto",
+    model: explicitNoCacheModel,
+    options: {
+      sessionId: "conv-1234",
+      cacheRetention: "none",
+      onPayload: async (payload) => ({
+        ...payload,
+        prompt_cache_key: "library-key",
+        prompt_cache_retention: "24h",
+        prompt_cache_options: { mode: "explicit" },
+      }),
+    },
+  });
+  const explicitNoCachePayload = await explicitNoCache.onPayload(
+    { input: "hello" },
+    explicitNoCacheModel,
+  );
+  assert.equal(Object.hasOwn(explicitNoCachePayload, "prompt_cache_key"), false);
+  assert.equal(Object.hasOwn(explicitNoCachePayload, "prompt_cache_retention"), false);
+  assert.deepEqual(explicitNoCachePayload.prompt_cache_options, { mode: "explicit" });
+
+  const relayExplicitNoCache = providers.finalizeProviderStreamOptions({
+    providerId: "codex",
+    baseUrl: "https://relay.example/v1",
+    promptCacheHintMode: "auto",
+    model: explicitNoCacheModel,
+    options: {
+      sessionId: "conv-1234",
+      cacheRetention: "none",
+      onPayload: async (payload) => ({
+        ...payload,
+        prompt_cache_options: { mode: "explicit" },
+      }),
+    },
+  });
+  const relayExplicitNoCachePayload = await relayExplicitNoCache.onPayload(
+    { input: "hello" },
+    explicitNoCacheModel,
+  );
+  assert.equal(Object.hasOwn(relayExplicitNoCachePayload, "prompt_cache_options"), false);
 
   // mode=none 必须把 retention 一并压成 none：pi-ai 会按 retention 生成缓存
   // 提示（如 OpenRouter anthropic/* 的 cache_control 断点），剥 payload 拦不住。

--- a/crates/agent-gui/test/tools/builtin-registry-subagent-mcp.test.mjs
+++ b/crates/agent-gui/test/tools/builtin-registry-subagent-mcp.test.mjs
@@ -156,6 +156,14 @@ test("registry without a subagent runtime exposes neither Agent nor SendMessage"
   // Sanity: the base surface is otherwise intact.
   assert.ok(names.includes("Read"));
   assert.ok(names.includes("mcp_docs_search"));
+  assert.deepEqual(registry.tools.find((tool) => tool.name === "Read").constrainedSampling, {
+    type: "json_schema",
+    strict: "prefer",
+  });
+  assert.equal(
+    registry.tools.find((tool) => tool.name === "mcp_docs_search").constrainedSampling,
+    undefined,
+  );
 });
 
 test("registry with a subagent runtime exposes Agent and the parent SendMessage", async () => {
@@ -168,6 +176,10 @@ test("registry with a subagent runtime exposes Agent and the parent SendMessage"
   assert.equal(registry.metadataByName.get("Agent").isReadOnly, false);
   assert.equal(registry.metadataByName.get("SendMessage").isReadOnly, true);
   assert.ok(registry.hasTool("agent"));
+  assert.deepEqual(
+    registry.tools.find((tool) => tool.name === "Agent").constrainedSampling,
+    { type: "json_schema", strict: "prefer" },
+  );
 });
 
 test("Agent tool description embeds the hydrated roster and enabled templates", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ importers:
       '@bufbuild/protobuf':
         specifier: 2.12.1
         version: 2.12.1
-      '@earendil-works/pi-ai':
-        specifier: ^0.80.6
-        version: 0.80.10(ws@8.21.3)(zod@4.4.3)
       '@git-diff-view/file':
         specifier: 0.1.3
         version: 0.1.3
@@ -115,6 +112,9 @@ importers:
       '@bufbuild/protoc-gen-es':
         specifier: 2.12.1
         version: 2.12.1(@bufbuild/protobuf@2.12.1)
+      '@earendil-works/pi-ai':
+        specifier: ^0.84.2
+        version: 0.84.2(ws@8.21.3)(zod@4.4.3)
       '@iconify-json/logos':
         specifier: 1.2.11
         version: 1.2.11
@@ -167,11 +167,11 @@ importers:
         specifier: 1.6.0
         version: 1.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@earendil-works/pi-agent-core':
-        specifier: ^0.80.6
-        version: 0.80.10(ws@8.21.3)(zod@4.4.3)
+        specifier: ^0.84.2
+        version: 0.84.2(ws@8.21.3)(zod@4.4.3)
       '@earendil-works/pi-ai':
-        specifier: ^0.80.6
-        version: 0.80.10(ws@8.21.3)(zod@4.4.3)
+        specifier: ^0.84.2
+        version: 0.84.2(ws@8.21.3)(zod@4.4.3)
       '@git-diff-view/file':
         specifier: 0.1.3
         version: 0.1.3
@@ -239,8 +239,8 @@ importers:
         specifier: ^3.5.0
         version: 3.6.0
       typebox:
-        specifier: 1.1.38
-        version: 1.1.38
+        specifier: 1.3.7
+        version: 1.3.7
       yet-another-react-lightbox:
         specifier: 3.31.0
         version: 3.31.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -671,14 +671,18 @@ packages:
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
-  '@earendil-works/pi-agent-core@0.80.10':
-    resolution: {integrity: sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg==}
+  '@earendil-works/pi-agent-core@0.84.2':
+    resolution: {integrity: sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.80.10':
-    resolution: {integrity: sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==}
+  '@earendil-works/pi-ai@0.84.2':
+    resolution: {integrity: sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==}
     engines: {node: '>=22.19.0'}
     hasBin: true
+
+  '@earendil-works/pi-telemetry@0.84.2':
+    resolution: {integrity: sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==}
+    engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.11.3':
     resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
@@ -765,14 +769,6 @@ packages:
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
-  '@mistralai/mistralai@2.2.6':
-    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-
   '@napi-rs/wasm-runtime@1.2.2':
     resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
@@ -783,10 +779,6 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/semantic-conventions@1.43.0':
-    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
-    engines: {node: '>=14'}
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
@@ -2591,9 +2583,8 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
-  openai@6.26.0:
-    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
-    hasBin: true
+  openai@6.40.0:
+    resolution: {integrity: sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==}
     peerDependencies:
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
@@ -2883,8 +2874,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typebox@1.1.38:
-    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+  typebox@1.3.7:
+    resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
 
   typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
@@ -3084,11 +3075,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
-    peerDependencies:
-      zod: ^3.25.28 || ^4
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -3149,7 +3135,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.7.3
+      '@smithy/node-http-handler': 4.9.13
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -3506,11 +3492,13 @@ snapshots:
 
   '@chevrotain/types@11.1.2': {}
 
-  '@earendil-works/pi-agent-core@0.80.10(ws@8.21.3)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.84.2(ws@8.21.3)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.80.10(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.2(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-telemetry': 0.84.2
+      diff: 8.0.4
       ignore: 7.0.5
-      typebox: 1.1.38
+      typebox: 1.3.7
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -3520,19 +3508,19 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.80.10(ws@8.21.3)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.84.2(ws@8.21.3)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.84.2
       '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.21.3)(zod@4.4.3)
+      openai: 6.40.0(ws@8.21.3)(zod@4.4.3)
       partial-json: 0.1.7
-      typebox: 1.1.38
+      typebox: 1.3.7
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -3540,6 +3528,8 @@ snapshots:
       - utf-8-validate
       - ws
       - zod
+
+  '@earendil-works/pi-telemetry@0.84.2': {}
 
   '@emnapi/core@1.11.3':
     dependencies:
@@ -3665,18 +3655,6 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/semantic-conventions': 1.43.0
-      ws: 8.21.3
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
       '@emnapi/core': 1.11.3
@@ -3685,8 +3663,6 @@ snapshots:
     optional: true
 
   '@opentelemetry/api@1.9.0': {}
-
-  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-project/types@0.122.0': {}
 
@@ -5657,7 +5633,7 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.26.0(ws@8.21.3)(zod@4.4.3):
+  openai@6.40.0(ws@8.21.3)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.3
       zod: 4.4.3
@@ -6039,7 +6015,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typebox@1.1.38: {}
+  typebox@1.3.7: {}
 
   typescript@5.4.5: {}
 
@@ -6223,10 +6199,7 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
-
-  zod@4.4.3: {}
+  zod@4.4.3:
+    optional: true
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Linked issue

Closes #492

## Summary

把 `@earendil-works/pi-ai` 与 `pi-agent-core` 从 `0.80.6` 升到 `0.84.2`，改用四个新特性（`prepareNextTurnWithContext`、`compat.supportsFinishReason`、`compat.supportsExplicitPromptCacheMode`、`Tool.constrainedSampling`），并修掉迁移过程中引入的三处语义回归。

新 API 的形状本身用得对，问题都出在语义边界上。

### 回归 1：turn 间的消息规范化丢失（最严重）

0.84 之前，`agentRunner` 借 `transformContext` 的 `return getAgentMessages(agent)` 把 `agent.state` 上的改写喂回每轮请求。改用 `prepareNextTurnWithContext` 后只在 `reconciled` 为真时回传 context——但两者持有的是**不同数组**：

```js
// pi-agent-core/dist/agent.js — loop 拿到的是 slice() 出来的副本
createContextSnapshot() {
  return { ..., messages: this._state.messages.slice(), ... };
}
```

于是 `agent.state` 上的替换不会回流。seed 标记剥离、hostedSearch 块回填、seed 工具调用去重全部只活在 `agent.state`，下一轮仍按旧快照发出——模型照着未剥离的「历史工具调用」文本**再调用一次工具**。

工具名大小写归一之所以侥幸没暴露，是因为 `normalizeAssistantToolCallNames` 是就地改对象；凡是**替换**消息对象的路径都会丢。

修复：以 `agent.state` 为权威副本回传 context。

### 回归 2：空响应错误不再可重试

新增校验的文案 `"Provider returned an empty response"` 命不中 pi-ai `isRetryableAssistantError` 的 `provider.?returned.?error` 模式（`an` 挡住了）:

```js
> /provider.?returned.?error/i.test("Provider returned an empty response")
false
```

原本能被 `withStreamRetry` 吃掉的上游抖动，变成**一次空回复直接打死整轮**。改为命中模式的措辞，并加断言直接钉住 `isRetryableAssistantError(...) === true`，避免后人改文案时再次踩中。

同时收窄了过宽的判定：
- 不再把 `stopReason: "length"`（截断，下游截断工具链路要读它）和 `"aborted"`（用户主动停止）改写成「空响应」——后者会把取消伪装成上游故障；
- thinking-only 不算空：推理模型可能把预算全烧在 reasoning 上，那是预算问题，重试只会再烧一遍。

### 回归 3：Codex Responses 缓存提示回退

`resolvePromptCacheHintMode` 删掉了 `openai-responses → openai-key` 分支。这是 PR #436 的**有意选择**（Responses 对齐 Codex CLI，服务 Codex 流量的中转站必然兼容；严格端点报 400 时的逃生通道是显式设 `none`）。回退会让所有第三方 Responses 端点静默丢失前缀缓存命中率。已恢复，并回滚随之改写的 3 处测试断言。

## Change scope

- Modules: agent-gui（providers / chat runner / tools）、agent-gateway/web（类型镜像）
- Key paths:
  - `src/lib/chat/runner/agentRunner.ts` —— `prepareNextTurnWithContext` 接线（回归 1）
  - `src/lib/providers/runtime/openAICompletionsStream.ts` —— 空响应校验（回归 2）
  - `src/lib/providers/runtime/codexPromptCache.ts` —— 缓存提示 + 显式关缓存（回归 3）
  - `src/lib/providers/runtime/{modelFactory,streamByApi,payloadPipeline,types}.ts`、`deepSeekProviderAdapter.ts` —— `supportsFinishReason` 迁移
  - `src/lib/tools/builtinRegistry.ts` —— `constrainedSampling`
  - `crates/agent-gateway/web/src/lib/agentTypes.ts` —— 手工镜像类型对齐 0.84

### 两处刻意保留原状（复核后未改）

- **`supportsExplicitNoCache` 的官方 host 限制是对的**，予以保留：`prompt_cache_options` 和 `prompt_cache_key` 一样是 OpenAI 私有扩展，严格校验的中转端点会 400（#307 那一类）。仅把内联 `as {...}` 断言换成 pi-ai 导出的 `OpenAIResponsesCompat`。
- **`constrainedSampling` 必须是 `"prefer"` 而非 `"require"`**：实测 14 个内置工具中有 **3 个**不满足 pi-ai 严格子集（`CronTaskManager`/`McpManager` 的 `propertyNames`、`MemoryManager` 的对象联合）。若写成 `"require"`，pi-ai 会直接 throw——一个 schema 形状就能打死整轮请求。已把该约束写进注释。
- gateway/web 把 pi-ai 移到 `devDependencies` 正确：该包在 web 侧只有手工镜像的类型文件，全仓零运行时 import（已 grep 确认）。

## Screenshots / preview

N/A —— 无 UI 变化。行为回归以可判别的回归测试作为证据（见下）。

回归 1 的判别性验证（同一测试，仅切换该处实现）：

```console
# 改动版本（未修复）
✖ runAssistantWithTools strips repeated historical tool call text without duplicate execution
ℹ pass 36   ℹ fail 1

# 修复后
✔ runAssistantWithTools strips repeated historical tool call text without duplicate execution
ℹ pass 37   ℹ fail 0
```

回归 2 的可重试性验证：

```js
> /provider.?returned.?error/i.test("Provider returned an empty response")           // 改动版本
false
> /provider.?returned.?error/i.test("Provider returned error: the response ...")     // 修复后
true
```

## Verification

- `cd crates/agent-gui && npm test` —— **1740/1740 通过，0 失败**
- `npx tsc --noEmit -p tsconfig.json` —— 干净
- `npx biome check` 覆盖全部改动文件 —— 干净

新增/更新的测试：

- `test/chat/agent-runner.test.mjs` —— 回归 1 判别性断言（钉住下一轮 wire context 已剥离 seed 文本）
- `test/providers/openai-completions-stream.test.mjs` —— 新增 3 条：空响应可重试性、`length`/`aborted` 不被改写、thinking-only 不算空
- `test/providers/request-options.test.mjs` —— 回滚回归 3 相关的 3 处断言至 PR #436 既定行为
- `test/tools/builtin-registry-subagent-mcp.test.mjs` —— `constrainedSampling` 只加在可信内置工具、MCP 工具不代为声明

## Pre-submit checklist

- [x] A requirement issue is linked (#492).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.（N/A —— 依赖升级与回归修复，无用户可见配置变化）
