### PR TITLE
fix(shell): Windows 下 PATH 扫描跳过 WSL 的 bash.exe 应用执行别名

### DIFF
--- a/crates/agent-gui/src-tauri/src/runtime/shell_runner.rs
+++ b/crates/agent-gui/src-tauri/src/runtime/shell_runner.rs
@@ -360,18 +360,34 @@ fn windows_cmd_command(cmd: &str) -> String {
 
 #[cfg(windows)]
 fn normalize_windows_dir_for_compare(p: &Path) -> String {
-    p.to_string_lossy()
+    strip_windows_verbatim_prefix(p.to_path_buf())
+        .to_string_lossy()
         .trim_end_matches(['\\', '/'])
         .to_ascii_lowercase()
 }
 
 #[cfg(windows)]
-fn is_windows_system32_dir(dir: &Path) -> bool {
+fn windows_dirs_equal(left: &Path, right: &Path) -> bool {
+    if normalize_windows_dir_for_compare(left) == normalize_windows_dir_for_compare(right) {
+        return true;
+    }
+    let Ok(left) = fs::canonicalize(left) else {
+        return false;
+    };
+    let Ok(right) = fs::canonicalize(right) else {
+        return false;
+    };
+    normalize_windows_dir_for_compare(&left) == normalize_windows_dir_for_compare(&right)
+}
+
+#[cfg(windows)]
+fn is_windows_system_bash_alias_dir(dir: &Path) -> bool {
     let Some(root) = std::env::var_os("SystemRoot") else {
         return false;
     };
-    normalize_windows_dir_for_compare(dir)
-        == normalize_windows_dir_for_compare(&Path::new(&root).join("System32"))
+    ["System32", "Sysnative"]
+        .iter()
+        .any(|name| windows_dirs_equal(dir, &Path::new(&root).join(name)))
 }
 
 #[cfg(windows)]
@@ -379,10 +395,10 @@ fn is_windows_apps_alias_dir(dir: &Path) -> bool {
     let Some(local) = std::env::var_os("LOCALAPPDATA") else {
         return false;
     };
-    normalize_windows_dir_for_compare(dir)
-        == normalize_windows_dir_for_compare(
-            &Path::new(&local).join("Microsoft").join("WindowsApps"),
-        )
+    windows_dirs_equal(
+        dir,
+        &Path::new(&local).join("Microsoft").join("WindowsApps"),
+    )
 }
 
 /// Store 应用注册的 App-Execution-Alias 是 0 字节的 reparse point，`is_file()`
@@ -393,18 +409,21 @@ fn is_app_execution_alias(path: &Path) -> bool {
 }
 
 #[cfg(windows)]
+fn is_git_bash_candidate(path: &Path) -> bool {
+    if !path.is_file() || is_app_execution_alias(path) {
+        return false;
+    }
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    !is_windows_system_bash_alias_dir(parent) && !is_windows_apps_alias_dir(parent)
+}
+
+#[cfg(windows)]
 fn find_git_bash_on_path(path_var: &std::ffi::OsStr) -> Option<PathBuf> {
     for dir in std::env::split_paths(path_var) {
-        // System32 下的 bash.exe 是 WSL 启动器，不是 Git Bash。
-        if is_windows_system32_dir(&dir) {
-            continue;
-        }
-        // WindowsApps 下的 bash.exe 是 Store 版 WSL 的 App-Execution-Alias。
-        if is_windows_apps_alias_dir(&dir) {
-            continue;
-        }
         let candidate = dir.join("bash.exe");
-        if candidate.is_file() && !is_app_execution_alias(&candidate) {
+        if is_git_bash_candidate(&candidate) {
             return Some(candidate);
         }
     }
@@ -419,7 +438,7 @@ fn find_git_bash() -> Option<PathBuf> {
             let trimmed = raw.trim().trim_matches('"');
             if !trimmed.is_empty() {
                 let path = expand_tilde_path(trimmed);
-                if path.is_file() {
+                if is_git_bash_candidate(&path) {
                     return Some(path);
                 }
             }
@@ -442,7 +461,7 @@ fn find_git_bash() -> Option<PathBuf> {
         // bin\bash.exe 是带 MSYS 环境注入的启动器，优先于 usr\bin 的裸 bash。
         for rel in [r"Git\bin\bash.exe", r"Git\usr\bin\bash.exe"] {
             let candidate = root.join(rel);
-            if candidate.is_file() {
+            if is_git_bash_candidate(&candidate) {
                 return Some(candidate);
             }
         }
@@ -968,7 +987,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn windows_path_scan_skips_windows_apps_alias_dir() {
+    fn windows_known_wsl_alias_dirs_are_rejected() {
         // 即使 WindowsApps 目录下出现非 0 字节的 bash.exe，也不应从该目录选取。
         let local_appdata = std::env::var_os("LOCALAPPDATA").expect("LOCALAPPDATA");
         let windows_apps = std::path::Path::new(&local_appdata)
@@ -980,6 +999,12 @@ mod tests {
         assert!(super::is_windows_apps_alias_dir(std::path::Path::new(
             &with_slash
         )));
+
+        let system_root = std::env::var_os("SystemRoot").expect("SystemRoot");
+        for name in ["System32", "Sysnative"] {
+            let alias_dir = std::path::Path::new(&system_root).join(name);
+            assert!(super::is_windows_system_bash_alias_dir(&alias_dir));
+        }
     }
 
     #[cfg(windows)]
@@ -989,12 +1014,18 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let liveagent_bash = dir.path().join("liveagent-bash.exe");
         let claude_bash = dir.path().join("claude-bash.exe");
-        fs::write(&liveagent_bash, b"").unwrap();
-        fs::write(&claude_bash, b"").unwrap();
+        let app_execution_alias = dir.path().join("wsl-bash.exe");
+        fs::write(&liveagent_bash, b"MZliveagent-git-bash").unwrap();
+        fs::write(&claude_bash, b"MZclaude-git-bash").unwrap();
+        fs::write(&app_execution_alias, b"").unwrap();
 
         std::env::set_var("LIVEAGENT_GIT_BASH_PATH", &liveagent_bash);
         std::env::set_var("CLAUDE_CODE_GIT_BASH_PATH", &claude_bash);
         assert_eq!(super::find_git_bash(), Some(liveagent_bash.clone()));
+
+        // LIVEAGENT 指向 App-Execution-Alias 时也必须回退 CLAUDE_CODE。
+        std::env::set_var("LIVEAGENT_GIT_BASH_PATH", &app_execution_alias);
+        assert_eq!(super::find_git_bash(), Some(claude_bash.clone()));
 
         // LIVEAGENT 指向不存在的文件时回退 CLAUDE_CODE。
         std::env::set_var(

--- a/crates/agent-gui/src-tauri/src/runtime/shell_runner.rs
+++ b/crates/agent-gui/src-tauri/src/runtime/shell_runner.rs
@@ -359,16 +359,56 @@ fn windows_cmd_command(cmd: &str) -> String {
 }
 
 #[cfg(windows)]
+fn normalize_windows_dir_for_compare(p: &Path) -> String {
+    p.to_string_lossy()
+        .trim_end_matches(['\\', '/'])
+        .to_ascii_lowercase()
+}
+
+#[cfg(windows)]
 fn is_windows_system32_dir(dir: &Path) -> bool {
     let Some(root) = std::env::var_os("SystemRoot") else {
         return false;
     };
-    let normalize = |p: &Path| {
-        p.to_string_lossy()
-            .trim_end_matches(['\\', '/'])
-            .to_ascii_lowercase()
+    normalize_windows_dir_for_compare(dir)
+        == normalize_windows_dir_for_compare(&Path::new(&root).join("System32"))
+}
+
+#[cfg(windows)]
+fn is_windows_apps_alias_dir(dir: &Path) -> bool {
+    let Some(local) = std::env::var_os("LOCALAPPDATA") else {
+        return false;
     };
-    normalize(dir) == normalize(&Path::new(&root).join("System32"))
+    normalize_windows_dir_for_compare(dir)
+        == normalize_windows_dir_for_compare(
+            &Path::new(&local).join("Microsoft").join("WindowsApps"),
+        )
+}
+
+/// Store 应用注册的 App-Execution-Alias 是 0 字节的 reparse point，`is_file()`
+/// 对它返回 true；真正的 Git Bash 可执行文件不可能是 0 字节。
+#[cfg(windows)]
+fn is_app_execution_alias(path: &Path) -> bool {
+    fs::metadata(path).is_ok_and(|md| md.len() == 0)
+}
+
+#[cfg(windows)]
+fn find_git_bash_on_path(path_var: &std::ffi::OsStr) -> Option<PathBuf> {
+    for dir in std::env::split_paths(path_var) {
+        // System32 下的 bash.exe 是 WSL 启动器，不是 Git Bash。
+        if is_windows_system32_dir(&dir) {
+            continue;
+        }
+        // WindowsApps 下的 bash.exe 是 Store 版 WSL 的 App-Execution-Alias。
+        if is_windows_apps_alias_dir(&dir) {
+            continue;
+        }
+        let candidate = dir.join("bash.exe");
+        if candidate.is_file() && !is_app_execution_alias(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 /// Git Bash 解析（对标 Claude Code）：env 覆盖 → PATH → Git for Windows 默认安装路径。
@@ -387,15 +427,8 @@ fn find_git_bash() -> Option<PathBuf> {
     }
 
     let path_var = std::env::var_os("PATH").unwrap_or_default();
-    for dir in std::env::split_paths(&path_var) {
-        // System32 下的 bash.exe 是 WSL 启动器，不是 Git Bash。
-        if is_windows_system32_dir(&dir) {
-            continue;
-        }
-        let candidate = dir.join("bash.exe");
-        if candidate.is_file() {
-            return Some(candidate);
-        }
+    if let Some(found) = find_git_bash_on_path(&path_var) {
+        return Some(found);
     }
 
     let roots = ["ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"]
@@ -908,6 +941,45 @@ mod tests {
             3 => assert_eq!(profiles[..], tail),
             other => panic!("unexpected windows candidate count: {other}"),
         }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_path_scan_skips_zero_byte_app_execution_alias() {
+        // WindowsApps 的 WSL bash.exe 别名是 0 字节 reparse point；用 0 字节
+        // 普通文件模拟“is_file() 为 true 但不是真 bash”的形态。
+        let alias_dir = tempfile::tempdir().expect("alias dir");
+        let real_dir = tempfile::tempdir().expect("real dir");
+        fs::write(alias_dir.path().join("bash.exe"), b"").unwrap();
+        fs::write(real_dir.path().join("bash.exe"), b"MZfake-git-bash").unwrap();
+
+        // 别名目录在前：应跳过 0 字节候选，命中后面的真实文件。
+        let path_var =
+            std::env::join_paths([alias_dir.path(), real_dir.path()]).expect("join paths");
+        assert_eq!(
+            super::find_git_bash_on_path(&path_var),
+            Some(real_dir.path().join("bash.exe"))
+        );
+
+        // 只有别名时不应误选，让候选链回退到 Program Files 探测 / PowerShell。
+        let alias_only = std::env::join_paths([alias_dir.path()]).expect("join paths");
+        assert_eq!(super::find_git_bash_on_path(&alias_only), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_path_scan_skips_windows_apps_alias_dir() {
+        // 即使 WindowsApps 目录下出现非 0 字节的 bash.exe，也不应从该目录选取。
+        let local_appdata = std::env::var_os("LOCALAPPDATA").expect("LOCALAPPDATA");
+        let windows_apps = std::path::Path::new(&local_appdata)
+            .join("Microsoft")
+            .join("WindowsApps");
+        assert!(super::is_windows_apps_alias_dir(&windows_apps));
+        // 大小写与结尾斜杠不影响判定。
+        let with_slash = format!("{}\\", windows_apps.display().to_string().to_uppercase());
+        assert!(super::is_windows_apps_alias_dir(std::path::Path::new(
+            &with_slash
+        )));
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
Store 版 WSL 会在 %LOCALAPPDATA%\Microsoft\WindowsApps 注册 bash.exe App-Execution-Alias（0 字节 reparse point，is_file() 返回 true）。当 Git Bash 的实际目录不在 PATH 上时（Git for Windows 默认安装只导出
Git\cmd，其中没有 bash.exe），find_git_bash 的 PATH 扫描会命中该别名， 把命令送进 WSL 默认发行版执行，结果头却仍标注 windows-git-bash。

修复：PATH 扫描同时跳过 WindowsApps 别名目录与 0 字节候选文件，使
候选链正确回退到 Program Files\Git 探测；并补充两项回归测试。

Fixes #454

<!--
Read .github/CONTRIBUTING.md before submitting.
A PR failing any of the following is automatically converted to draft:
  1. The body references an issue via Closes/Fixes/Resolves #123;
  2. UI / feature / backend behavior changes include screenshots or a runtime preview;
  3. No merge conflicts with the target branch.
-->

## Linked issue

<!-- Required. Feature and bug-fix PRs must reference an issue; use a closing keyword so it closes automatically on merge. -->

Closes #

## Summary

<!-- What problem does this solve and how. Keep the PR focused; no unrelated refactors. -->

## Change scope

<!-- List the affected modules and key files/directories so reviewers can locate the change quickly. -->

- Modules: <!-- e.g. agent-gui / agent-gateway / src-tauri -->
- Key paths:

## Screenshots / preview

<!-- Evidence of the change in action:
  - UI changes: before/after screenshots or a recording (required);
  - Backend/CLI changes: request-response examples or run logs (secrets removed);
  - Performance changes: before/after numbers (benchmark, latency, memory).
  For pure refactors/docs, write "N/A" with a reason. -->

## Verification

<!-- How you verified this change:
  - Checks you ran, e.g. cd crates/agent-gateway && go test ./...
  - Tests added or updated for behavior changes (or why none were needed).
-->

## Pre-submit checklist

- [ ] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [ ] Synced with the target branch; no merge conflicts.
- [ ] The change is focused, with no unrelated modifications.
- [ ] No secrets, tokens, or personal data included.
- [ ] Docs are updated for changes affecting user behavior, deployment, or configuration.
