### PR TITLE
fix(mobile): 增加顶部padding，避免工具栏与系统状态栏重合

### DIFF
--- a/crates/agent-mobile/src/styles.css
+++ b/crates/agent-mobile/src/styles.css
@@ -581,6 +581,15 @@ html[data-liveagent-webui="gateway"] [role="textbox"]:focus-visible {
   --gateway-chat-composer-bottom: 16px;
   --gateway-chat-composer-overlay-height: 176px;
 }
+/*
+ * 聊天顶部栏避开系统状态栏（刘海/挖孔屏安全区）。移动端 WebView 采用
+ * edge-to-edge 布局，ChatHeader 只有 py-2.5 的固定内边距，未叠加安全区时
+ * 标题栏内容会与时间/电量重叠。底值 0.625rem 对应 ChatHeader 的 py-2.5，
+ * 桌面窗口安全区为 0 时行为不变。
+ */
+.gateway-chat-frame header[data-tauri-drag-region] {
+  padding-top: max(env(safe-area-inset-top, 0px), 0.625rem);
+}
 
 .history-share-frame {
   position: relative;


### PR DESCRIPTION
## Linked issue

Closes #464

## Summary

修复移动端 WebView 下聊天顶部工具栏与系统状态栏（时间/电量等）重叠的问题。

在移动端 edge-to-edge 布局中，`ChatHeader` 组件原先仅使用 `py-2.5` 的固定内边距，未考虑系统安全区（如刘海屏、挖孔屏），导致标题栏内容与状态栏重叠。本次改动为 `gateway-chat-frame` 的 header 区域叠加了 `safe-area-inset-top`，确保顶部内边距至少为 `0.625rem`（对应 `py-2.5`），桌面端安全区为 0 时行为不变。

## Change scope

- Modules: crates/agent-mobile


## Screenshots / preview


| 修复前 | 修复后 |
|--------|--------|
| <img width="1084" height="2412" alt="fa1" src="https://github.com/user-attachments/assets/74548a95-23e7-4712-b816-9be50ccdc0b7" /> | <img width="1084" height="2412" alt="fa2" src="https://github.com/user-attachments/assets/12f7d540-2203-4c15-bcde-95cef0a00fc1" /> |

> 移动端 WebView 下标题栏与状态栏不再重叠，顶部留有安全区边距。

## Verification

- 在移动端 WebView 中验证标题栏与系统状态栏无重叠；
- 在桌面端（安全区为 0）验证样式无回归，header 内边距保持原有 `py-2.5` 效果；
- 手动测试不同屏幕尺寸下的安全区适配表现。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.