### PR TITLE
fix(chat): scope file uploads to the composer

### DIFF
--- a/crates/agent-gateway/web/src/app/GatewayAppView.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayAppView.tsx
@@ -513,7 +513,6 @@ export function GatewayAppView({ viewModel }: { viewModel: GatewayAppViewModel }
 
                       <section
                         ref={transcriptStageRef}
-                        data-file-upload-drop-zone=""
                         className="gateway-transcript-stage"
                         // Preferred (persisted) width, so a fresh mount paints at
                         // the user's width instead of the default.
@@ -762,15 +761,18 @@ export function GatewayAppView({ viewModel }: { viewModel: GatewayAppViewModel }
                             />
                           }
                           approvalBar={approvalBar}
+                          fileDropOverlay={
+                            isFileDropActive ? (
+                              <FileDropOverlay
+                                variant="composer"
+                                canDropUpload={canDropUpload}
+                                title={fileDropTitle}
+                                description={fileDropDescription}
+                                limitHint={fileDropLimitHint}
+                              />
+                            ) : null
+                          }
                         />
-                        {isFileDropActive ? (
-                          <FileDropOverlay
-                            canDropUpload={canDropUpload}
-                            title={fileDropTitle}
-                            description={fileDropDescription}
-                            limitHint={fileDropLimitHint}
-                          />
-                        ) : null}
                       </section>
                     </>
                   ),

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -1801,10 +1801,7 @@ export function ChatPage(props: ChatPageProps) {
             headerClassName: "relative z-20",
             headerOverlay: <NotifyToast items={notifyItems} onDismiss={dismissNotify} />,
             content: (
-              <div
-                data-file-upload-drop-zone=""
-                className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
-              >
+              <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
                 <ChangedFilesActionsProvider value={changedFilesActions}>
                   <ChatTranscript
                     conversationId={currentConversationId}
@@ -1888,15 +1885,18 @@ export function ChatPage(props: ChatPageProps) {
                     />
                   }
                   approvalBar={approvalBar}
+                  fileDropOverlay={
+                    isFileDropActive ? (
+                      <FileDropOverlay
+                        variant="composer"
+                        canDropUpload={canDropUpload}
+                        title={fileDropTitle}
+                        description={fileDropDescription}
+                        limitHint={fileDropLimitHint}
+                      />
+                    ) : null
+                  }
                 />
-                {isFileDropActive ? (
-                  <FileDropOverlay
-                    canDropUpload={canDropUpload}
-                    title={fileDropTitle}
-                    description={fileDropDescription}
-                    limitHint={fileDropLimitHint}
-                  />
-                ) : null}
               </div>
             ),
           }}

--- a/crates/agent-gui/src/pages/chat/hooks/nativeFileDropRouting.ts
+++ b/crates/agent-gui/src/pages/chat/hooks/nativeFileDropRouting.ts
@@ -97,7 +97,7 @@ export function resolveNativeFileDropTarget(
   // The business boundary comes entirely from the currently rendered page
   // frames. No sidebar width, composer position, or application pixel range is
   // hard-coded here. Workspace wins only if the live workspace frame contains
-  // the point; uploads use the exact live chat-panel frame with no tolerance.
+  // the point; uploads use the exact live composer dialog with no tolerance.
   if (
     pointIntersectsSelector(point, targetDocument, WORKSPACE_FOLDER_DROP_ZONE_SELECTOR, 0, true)
   ) {

--- a/crates/agent-gui/src/pages/chat/hooks/useTauriFileDrop.ts
+++ b/crates/agent-gui/src/pages/chat/hooks/useTauriFileDrop.ts
@@ -15,7 +15,7 @@ type UseTauriFileDropParams = {
 
 /**
  * Tauri webview drag-drop listener: routes native paths by their visual drop
- * target. Workspace-zone drops add folders as projects, the chat-panel zone
+ * target. Workspace-zone drops add folders as projects, the composer dialog
  * hands the mixed payload to the upload-zone dispatcher (files become
  * attachments, folders become project roots), and every other application
  * surface ignores the drop.

--- a/crates/agent-gui/test/chat/native-file-drop-routing.test.mjs
+++ b/crates/agent-gui/test/chat/native-file-drop-routing.test.mjs
@@ -79,7 +79,7 @@ test("native drop routing ignores unmarked application surfaces", () => {
   );
 });
 
-test("native drop routing accepts uploads only inside the marked chat zone", () => {
+test("native drop routing accepts uploads only inside the marked composer zone", () => {
   const fakeDocument = {
     querySelectorAll(selector) {
       if (selector === routing.WORKSPACE_FOLDER_DROP_ZONE_SELECTOR) return [];
@@ -201,7 +201,7 @@ test("workspace rectangle fallback joins the header and project list into one dr
   );
 });
 
-test("upload rectangle fallback does not widen beyond the chat zone", () => {
+test("upload rectangle fallback does not widen beyond the composer zone", () => {
   const fakeDocument = {
     querySelectorAll(selector) {
       if (selector === routing.WORKSPACE_FOLDER_DROP_ZONE_SELECTOR) return [];
@@ -232,10 +232,13 @@ test("upload rectangle fallback does not widen beyond the chat zone", () => {
   );
 });
 
-test("native upload marker covers the desktop chat panel instead of only the composer", () => {
+test("native upload marker covers only the composer dialog", () => {
   const chatPage = readFileSync("src/pages/ChatPage.tsx", "utf8");
   const composer = readFileSync("../agent-ui/src/pages/chat/ChatComposerBar.tsx", "utf8");
 
-  assert.match(chatPage, /data-file-upload-drop-zone/);
-  assert.doesNotMatch(composer, /data-file-upload-drop-zone/);
+  assert.doesNotMatch(chatPage, /data-file-upload-drop-zone/);
+  assert.match(
+    composer,
+    /ref=\{glassCardRef\}[\s\S]*?data-file-upload-drop-zone=""/,
+  );
 });

--- a/crates/agent-ui/src/components/chat/FileDropOverlay.tsx
+++ b/crates/agent-ui/src/components/chat/FileDropOverlay.tsx
@@ -5,10 +5,63 @@ type FileDropOverlayProps = {
   title: string;
   description: string;
   limitHint: string;
+  variant?: "panel" | "composer";
 };
 
 export function FileDropOverlay(props: FileDropOverlayProps) {
-  const { canDropUpload, title, description, limitHint } = props;
+  const { canDropUpload, title, description, limitHint, variant = "panel" } = props;
+  if (variant === "composer") {
+    return (
+      <div
+        className={`file-drop-overlay pointer-events-none absolute inset-0 z-30 flex items-center justify-center rounded-[24px] border border-dashed px-5 py-3 backdrop-blur-xl ${
+          canDropUpload
+            ? "border-foreground/25 bg-background/92 dark:border-white/20 dark:bg-zinc-950/90"
+            : "border-destructive/40 bg-background/94 dark:bg-zinc-950/92"
+        }`}
+        aria-hidden="true"
+      >
+        <div className="file-drop-overlay-card flex min-w-0 items-center gap-3 text-left">
+          <div
+            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ring-1 ring-inset ${
+              canDropUpload
+                ? "bg-foreground/[0.05] text-foreground/85 ring-foreground/10 dark:bg-white/[0.07] dark:text-white/90 dark:ring-white/10"
+                : "bg-destructive/[0.08] text-destructive/90 ring-destructive/15"
+            }`}
+          >
+            {canDropUpload ? (
+              <Upload className="h-5 w-5" strokeWidth={1.75} />
+            ) : (
+              <Ban className="h-5 w-5" strokeWidth={1.75} />
+            )}
+          </div>
+          <div className="min-w-0">
+            <div className="truncate text-[calc(14px*var(--zone-font-scale,1))] font-semibold leading-5 text-foreground">
+              {title}
+            </div>
+            <div className="hidden max-w-[420px] truncate text-xs leading-5 text-muted-foreground sm:block">
+              {description}
+            </div>
+          </div>
+          <div
+            className={`hidden shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[calc(11px*var(--zone-font-scale,1))] font-medium md:inline-flex ${
+              canDropUpload
+                ? "border-foreground/[0.08] bg-foreground/[0.03] text-muted-foreground dark:border-white/10 dark:bg-white/[0.04]"
+                : "border-destructive/20 bg-destructive/[0.05] text-destructive/80"
+            }`}
+          >
+            <span
+              aria-hidden="true"
+              className={`inline-flex h-1.5 w-1.5 rounded-full ${
+                canDropUpload ? "bg-foreground/35 dark:bg-white/50" : "bg-destructive/55"
+              }`}
+            />
+            {limitHint}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className="file-drop-overlay pointer-events-none absolute inset-0 z-30 flex items-center justify-center p-4 sm:p-6 bg-white/30 backdrop-blur-md dark:bg-black/30"

--- a/crates/agent-ui/src/pages/chat/ChatComposerBar.tsx
+++ b/crates/agent-ui/src/pages/chat/ChatComposerBar.tsx
@@ -284,6 +284,8 @@ export type ChatComposerBarProps = {
   taskProgressBar?: ReactNode;
   /** 输入框上方的集中审批栏(待审批时由上层注入,渲染在队列面板之上)。 */
   approvalBar?: ReactNode;
+  /** 文件拖入命中输入框时显示的局部反馈层。 */
+  fileDropOverlay?: ReactNode;
 };
 
 export const ChatComposerBar = memo(function ChatComposerBar(props: ChatComposerBarProps) {
@@ -330,6 +332,7 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: ChatComposer
     onHeightChange,
     taskProgressBar,
     approvalBar,
+    fileDropOverlay,
   } = props;
   const { t } = useLocale();
   const [composerIsEmpty, setComposerIsEmpty] = useState(true);
@@ -861,6 +864,7 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: ChatComposer
         {/* biome-ignore lint/a11y/noStaticElementInteractions: Escape 捕获仅在展开态生效，焦点始终在内部 textbox 上，包装层不参与 Tab 序。 */}
         <div
           ref={glassCardRef}
+          data-file-upload-drop-zone=""
           onKeyDown={
             isComposerExpanded
               ? (event) => {
@@ -1207,6 +1211,7 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: ChatComposer
               </Button>
             </div>
           </div>
+          {fileDropOverlay}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Scope native file upload hit-testing to the composer dialog in desktop and Gateway WebUI. Keep upload feedback inside the composer and update routing regression tests. Validation: 11/11 native-file-drop-routing tests, WebUI tests/build/lint, and changed-file Biome checks pass. No docs or unrelated Workbench changes included.