### PR TITLE
fix(ui): align DeepSeek and branch selector visuals

### DIFF
--- a/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
+++ b/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
@@ -16,6 +16,14 @@ const composerSource = readFileSync(
   new URL("../../../agent-ui/src/pages/chat/ChatComposerBar.tsx", import.meta.url),
   "utf8",
 );
+const branchSelectorSource = readFileSync(
+  new URL("../../../agent-ui/src/components/git/GitBranchSelector.tsx", import.meta.url),
+  "utf8",
+);
+const iconSetSource = readFileSync(
+  new URL("../../../agent-ui/src/components/IconSet.tsx", import.meta.url),
+  "utf8",
+);
 
 test("model pickers use popover semantics instead of menu semantics", () => {
   for (const source of pickerSources) {
@@ -100,4 +108,17 @@ test("upload stays leftmost before model controls in the composer toolbar", () =
     assert.match(source, /reasoningOptions\.length > 0 \? "grid-cols-3" : "grid-cols-2"/);
     assert.match(source, /className="h-8 w-full min-w-0 gap-0\.5/);
   }
+});
+
+test("branch selector reuses the model trigger visual language", () => {
+  assert.match(branchSelectorSource, /COMPOSER_CONTROL_TRIGGER_CLASS/);
+  assert.match(branchSelectorSource, /COMPOSER_CONTROL_LABEL_CLASS/);
+  assert.match(branchSelectorSource, /data-\[popup-open\]:bg-muted\/60/);
+  assert.match(branchSelectorSource, /menuOpen && "rotate-180"/);
+  assert.doesNotMatch(branchSelectorSource, /border-emerald|bg-emerald/);
+});
+
+test("DeepSeek provider icon uses the logo-only mark", () => {
+  assert.match(iconSetSource, /~icons\/logos\/deepseek-icon/);
+  assert.doesNotMatch(iconSetSource, /~icons\/logos\/deepseek["']/);
 });

--- a/crates/agent-ui/src/components/IconSet.tsx
+++ b/crates/agent-ui/src/components/IconSet.tsx
@@ -2,7 +2,7 @@ import { type ComponentType, type SVGProps, useId } from "react";
 import McpLogoSource from "~icons/gravity-ui/logo-mcp";
 import ConnectionIconSource from "~icons/gravity-ui/plug-connection";
 import ClaudeSource from "~icons/logos/claude-icon";
-import DeepseekSource from "~icons/logos/deepseek";
+import DeepseekSource from "~icons/logos/deepseek-icon";
 import GrokSource from "~icons/logos/grok-icon";
 import OpenAISource from "~icons/logos/openai-icon";
 import ActivitySource from "~icons/lucide/activity";

--- a/crates/agent-ui/src/components/chat/ComposerModelControls.tsx
+++ b/crates/agent-ui/src/components/chat/ComposerModelControls.tsx
@@ -36,6 +36,11 @@ import {
   SelectValue,
 } from "@liveagent/ui/components/ui/select";
 import { useLocale } from "@liveagent/ui/i18n/index";
+import {
+  COMPOSER_CONTROL_CHEVRON_CLASS,
+  COMPOSER_CONTROL_LABEL_CLASS,
+  COMPOSER_CONTROL_TRIGGER_CLASS,
+} from "@liveagent/ui/lib/chat/composerControlStyles";
 import type { SharedModelOption } from "@liveagent/ui/lib/models/modelOptions";
 import {
   groupModelOptionsByProvider,
@@ -185,10 +190,7 @@ export const ComposerModelControls = memo(function ComposerModelControls(
             disabled={disabled || !hasModels}
             title={currentModelLabel}
             aria-label={`${t("chat.selectModel")}: ${currentModelLabel}`}
-            className={cn(
-              "composer-model-trigger h-8 min-w-8 max-w-[10.5rem] shrink-0 justify-start gap-1.5 overflow-hidden rounded-full px-2 text-xs font-medium text-foreground shadow-none transition-colors hover:bg-muted/60 focus-visible:bg-muted/60 disabled:opacity-40 max-[480px]:w-8 max-[480px]:px-0",
-              isModelPickerOpen && "bg-muted/60",
-            )}
+            className={cn(COMPOSER_CONTROL_TRIGGER_CLASS, isModelPickerOpen && "bg-muted/60")}
           />
         }
       >
@@ -197,14 +199,9 @@ export const ComposerModelControls = memo(function ComposerModelControls(
         ) : (
           <Sparkle className="h-4 w-4 shrink-0 text-violet-500 dark:text-violet-400" />
         )}
-        <span className="composer-model-label min-w-0 truncate max-[480px]:hidden">
-          {triggerLabel}
-        </span>
+        <span className={COMPOSER_CONTROL_LABEL_CLASS}>{triggerLabel}</span>
         <ChevronDown
-          className={cn(
-            "h-3 w-3 shrink-0 text-muted-foreground transition-transform duration-200 max-[480px]:hidden",
-            isModelPickerOpen && "rotate-180",
-          )}
+          className={cn(COMPOSER_CONTROL_CHEVRON_CLASS, isModelPickerOpen && "rotate-180")}
         />
       </Popover.Trigger>
 

--- a/crates/agent-ui/src/components/git/GitBranchSelector.tsx
+++ b/crates/agent-ui/src/components/git/GitBranchSelector.tsx
@@ -1,5 +1,6 @@
 import {
   Check,
+  ChevronDown,
   ChevronRight,
   CloudDownload,
   Download,
@@ -14,6 +15,7 @@ import {
   Search,
   Upload,
 } from "@liveagent/ui/components/IconSet";
+import { Button } from "@liveagent/ui/components/ui/button";
 import { useConfirmDialog } from "@liveagent/ui/components/ui/confirm-dialog";
 import {
   DropdownMenu,
@@ -28,6 +30,11 @@ import {
 } from "@liveagent/ui/components/ui/dropdown-menu";
 import { Input } from "@liveagent/ui/components/ui/input";
 import { useLocale } from "@liveagent/ui/i18n/index";
+import {
+  COMPOSER_CONTROL_CHEVRON_CLASS,
+  COMPOSER_CONTROL_LABEL_CLASS,
+  COMPOSER_CONTROL_TRIGGER_CLASS,
+} from "@liveagent/ui/lib/chat/composerControlStyles";
 import { cn } from "@liveagent/ui/lib/shared/utils";
 import type { WorkspaceActivityClient } from "@liveagent/ui/lib/workspace-activity/types";
 import { useWorkspaceInvalidation } from "@liveagent/ui/lib/workspace-activity/useWorkspaceInvalidation";
@@ -1004,22 +1011,26 @@ export function GitBranchSelector(props: {
     <>
       <DropdownMenu open={menuOpen} onOpenChange={handleMenuOpenChange}>
         <DropdownMenuTrigger
-          disabled={disabled || !gitClient || !workdir.trim()}
-          className={cn(
-            "composer-reasoning-trigger inline-flex h-8 min-w-0 max-w-[13rem] items-center gap-1 rounded-full border px-2 text-xs font-medium outline-hidden transition-colors",
-            noRepo
-              ? "border-transparent bg-foreground/[0.04] text-muted-foreground"
-              : "border-emerald-300/25 bg-emerald-50/65 text-foreground hover:bg-emerald-50 dark:border-emerald-300/15 dark:bg-emerald-400/[0.08] dark:hover:bg-emerald-400/[0.13]",
-            "disabled:pointer-events-none disabled:opacity-45",
-          )}
+          render={
+            <Button
+              variant="ghost"
+              disabled={disabled || !gitClient || !workdir.trim()}
+              className={cn(
+                COMPOSER_CONTROL_TRIGGER_CLASS,
+                "data-[popup-open]:bg-muted/60",
+                noRepo && "text-muted-foreground",
+              )}
+            />
+          }
           title={visibleError || (!canWrite ? disabledMessage : "") || label}
         >
           {loading || mutating || initializing ? (
-            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />
+            <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
           ) : (
-            <GitBranch className="h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-300" />
+            <GitBranch className="h-4 w-4 shrink-0 text-muted-foreground" />
           )}
-          <span className="min-w-0 truncate">{label}</span>
+          <span className={COMPOSER_CONTROL_LABEL_CLASS}>{label}</span>
+          <ChevronDown className={cn(COMPOSER_CONTROL_CHEVRON_CLASS, menuOpen && "rotate-180")} />
         </DropdownMenuTrigger>
         <DropdownMenuContent
           className="composer-branch-dropdown flex w-72 flex-col overflow-hidden p-0"

--- a/crates/agent-ui/src/lib/chat/composerControlStyles.ts
+++ b/crates/agent-ui/src/lib/chat/composerControlStyles.ts
@@ -1,0 +1,8 @@
+export const COMPOSER_CONTROL_TRIGGER_CLASS =
+  "composer-model-trigger inline-flex h-8 min-w-8 max-w-[10.5rem] shrink-0 items-center justify-start gap-1.5 overflow-hidden rounded-full px-2 text-xs font-medium text-foreground shadow-none transition-colors hover:bg-muted/60 focus-visible:bg-muted/60 disabled:opacity-40 max-[480px]:w-8 max-[480px]:px-0";
+
+export const COMPOSER_CONTROL_LABEL_CLASS =
+  "composer-model-label min-w-0 truncate max-[480px]:hidden";
+
+export const COMPOSER_CONTROL_CHEVRON_CLASS =
+  "h-3 w-3 shrink-0 text-muted-foreground transition-transform duration-200 max-[480px]:hidden";


### PR DESCRIPTION
## Linked issue

Closes #516

## Summary

- replace the DeepSeek wordmark with the logo-only brand icon across shared provider surfaces
- make the composer Git branch trigger reuse the model selector's dimensions, spacing, hover/focus treatment, mobile collapse behavior, and open-state chevron
- keep the implementation in shared `agent-ui` so GUI and Gateway WebUI render the same controls
- add source-level regression coverage for the shared trigger styling and DeepSeek icon choice

## Change scope

- Modules: `agent-ui`, `agent-gui` tests
- Key paths:
  - `crates/agent-ui/src/components/IconSet.tsx`
  - `crates/agent-ui/src/components/chat/ComposerModelControls.tsx`
  - `crates/agent-ui/src/components/git/GitBranchSelector.tsx`
  - `crates/agent-ui/src/lib/chat/composerControlStyles.ts`
  - `crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs`

## Screenshots / preview

待上传：GUI 与 WebUI 修改前后对比图或录屏。

<!-- 请补充真实 UI 证据后，再将此 PR 标记为 Ready for review。 -->

## Verification

- `pnpm --dir crates/agent-gui exec node --test test/chat/execution-mode-model-picker.test.mjs` (`8/8` passed)
- `pnpm --dir crates/agent-gui exec tsc --noEmit`
- `pnpm --dir crates/agent-gateway/web exec tsc --noEmit`
- `pnpm --dir crates/agent-gui build`
- `pnpm --dir crates/agent-gateway/web build`
- `pnpm check:ui-boundaries` (`8/8` passed)
- package-local Biome check for changed shared UI files (no errors; existing warnings remain in `GitBranchSelector.tsx`)
- `git diff --check`

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts in the submitted topology.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] No documentation update is required for this visual consistency fix.
