### PR TITLE
fix(ui): keep composer dropdowns above prompt input

### DIFF
--- a/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
+++ b/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
@@ -20,6 +20,18 @@ const branchSelectorSource = readFileSync(
   new URL("../../../agent-ui/src/components/git/GitBranchSelector.tsx", import.meta.url),
   "utf8",
 );
+const popoverSource = readFileSync(
+  new URL("../../../agent-ui/src/components/ui/popover.tsx", import.meta.url),
+  "utf8",
+);
+const selectSource = readFileSync(
+  new URL("../../../agent-ui/src/components/ui/select.tsx", import.meta.url),
+  "utf8",
+);
+const baseStylesSource = readFileSync(
+  new URL("../../../agent-ui/src/styles/base.css", import.meta.url),
+  "utf8",
+);
 const iconSetSource = readFileSync(
   new URL("../../../agent-ui/src/components/IconSet.tsx", import.meta.url),
   "utf8",
@@ -119,6 +131,13 @@ test("branch selector reuses the model trigger visual language", () => {
   assert.match(branchSelectorSource, /data-\[popup-open\]:bg-muted\/60/);
   assert.match(branchSelectorSource, /menuOpen && "rotate-180"/);
   assert.doesNotMatch(branchSelectorSource, /border-emerald|bg-emerald/);
+});
+
+test("composer dropdown portals stay above the composer surface", () => {
+  assert.match(popoverSource, /className="layer-popover isolate"/);
+  assert.match(selectSource, /className="layer-popover"/);
+  assert.match(baseStylesSource, /--layer-popover: 9999;/);
+  assert.match(baseStylesSource, /--layer-modal: 10000;/);
 });
 
 test("DeepSeek provider icon uses the logo-only mark", () => {

--- a/crates/agent-ui/src/styles/base.css
+++ b/crates/agent-ui/src/styles/base.css
@@ -461,14 +461,14 @@
 
     --radius: 0.625rem;
 
-    /* Portal layers share one plane and rely on DOM order for nesting. */
+    /* Portal layers use semantic tokens and stay above page-local stacking contexts. */
     --layer-content: 1;
     --layer-raised: 10;
     --layer-panel: 20;
-    --layer-popover: 50;
-    --layer-modal: 50;
-    --layer-toast: 60;
-    --layer-critical: 70;
+    --layer-popover: 9999;
+    --layer-modal: 10000;
+    --layer-toast: 10010;
+    --layer-critical: 10020;
 
     /* Sidebar */
     --sidebar-bg: 220 14% 96%;


### PR DESCRIPTION
Closes #526

## Summary
The composer model picker and reasoning-level picker could be covered by the prompt input card near the bottom of the viewport. This raises the shared semantic Portal layer values while preserving the modal/toast/critical ordering.

## Change scope
- Modules: shared `agent-ui`, GUI regression tests
- Key paths:
  - `crates/agent-ui/src/styles/base.css`
  - `crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs`

## Screenshots / preview
<!-- TODO: Please add the real UI evidence before marking this PR ready. Do not replace these placeholders with invented links. -->

### GUI
- Before: <!-- drag or paste the pre-fix screenshot here -->
- After: <!-- drag or paste the post-fix screenshot here -->

### WebUI
- Before: <!-- drag or paste the pre-fix screenshot here -->
- After: <!-- drag or paste the post-fix screenshot here -->

This PR intentionally remains Draft until the reporter adds the screenshots or a recording.

## Verification
- `node --test test/chat/execution-mode-model-picker.test.mjs` (9/9)
- `pnpm check:ui-boundaries`
- `pnpm exec biome check src/components/ui/popover.tsx src/components/ui/select.tsx src/components/ui/dropdown-menu.tsx --diagnostic-level=error`
- `pnpm build:gui`
- `pnpm build:webui`
- `git diff --check`

## Pre-submit checklist
- [x] Issue #526 is linked.
- [x] The branch is based on and targets `main`.
- [x] The change is focused.
- [x] No secrets, tokens, or personal data are included.
- [ ] GUI screenshots/recording added by reporter.
- [ ] WebUI screenshots/recording added by reporter.