### PR TITLE
fix(chat): preserve history revision across compaction

### DIFF
--- a/crates/agent-gui/src/lib/chat/compaction/controller.ts
+++ b/crates/agent-gui/src/lib/chat/compaction/controller.ts
@@ -50,7 +50,15 @@ export type CompactionSinks = {
   publishStatus?: (status: CompactionStatus) => void;
   setBridgeToolStatus?: (status: string | null, isCompaction?: boolean) => void;
   queueCheckpoint?: (state: ConversationViewState, contextUsageTokens: number) => void;
-  persist?: (state: ConversationViewState) => Promise<boolean | undefined>;
+  // false/null 表示持久化失败（压缩中止回滚）。成功可返回"盖好 revision 的持
+  // 久化状态"——finalizeCheckpoint 会落地这一份而非入参状态：checkpoint 状态
+  // 出自 appendMessagesToConversation，revision 恒为 null，若照原样 apply，
+  // 运行时缓存会失去 replace/分页所需的 CAS 令牌（压缩后 edit-resend 报
+  // "历史会话缺少 revision"即源于此）。返回 true/undefined 则沿用入参状态
+  //（子代理的 fire-and-forget persist 走这条）。
+  persist?: (
+    state: ConversationViewState,
+  ) => Promise<ConversationViewState | boolean | null | undefined>;
   restoreComposer?: (
     composerText: string | undefined,
     uploadedFiles: PendingUploadedFile[],
@@ -178,11 +186,16 @@ export class CompactionController {
     return { compactionsApplied: this.pressure.compactionsApplied };
   }
 
-  private async persistCheckpoint(binding: CompactionTurnBinding, state: ConversationViewState) {
+  private async persistCheckpoint(
+    binding: CompactionTurnBinding,
+    state: ConversationViewState,
+  ): Promise<ConversationViewState> {
     const persisted = await binding.sinks.persist?.(state);
-    if (persisted === false) {
+    if (persisted === false || persisted === null) {
       throw new Error("compaction checkpoint persistence failed");
     }
+    // 持久化钩子返回的盖章状态（带重建的 revision）优先；布尔/undefined 回落入参。
+    return typeof persisted === "object" ? persisted : state;
   }
 
   // 压缩成功后的统一收尾（pre-send 与 during-run 共用同一顺序不变量）：
@@ -209,8 +222,10 @@ export class CompactionController {
     const checkpointTokens = deriveContextTokens(checkpointContext, {
       fixedTokens: params.fixedTokens,
     });
-    const checkpointState = withActiveSummaryContextTokens(params.state, checkpointTokens);
-    await this.persistCheckpoint(params.binding, checkpointState);
+    const checkpointState = await this.persistCheckpoint(
+      params.binding,
+      withActiveSummaryContextTokens(params.state, checkpointTokens),
+    );
     this.rollbackSnapshot = null;
     params.apply(checkpointState);
     this.settleCompleted(params.trigger, params.newSegmentIndex);
@@ -329,6 +344,16 @@ export class CompactionController {
         buildOptions,
         apply: (checkpointState) => {
           appliedState = presend.composeAppliedState(checkpointState);
+          // compose 走 appendMessagesToConversation 会把刚盖上的 revision 清掉。
+          // 追加只发生在内存，DB 仍停在 checkpoint 持久化那一刻，CAS 令牌依旧
+          // 指向当前库版本，补回；下一次成功 persist 会重新盖章。
+          const revision = checkpointState.transcript.revision;
+          if (revision && !appliedState.transcript.revision) {
+            appliedState = {
+              ...appliedState,
+              transcript: { ...appliedState.transcript, revision },
+            };
+          }
           binding.sinks.applyState?.(appliedState);
         },
       });

--- a/crates/agent-gui/src/pages/chat/history/useConversationHistoryActions.ts
+++ b/crates/agent-gui/src/pages/chat/history/useConversationHistoryActions.ts
@@ -51,6 +51,15 @@ export type PersistConversationParams = {
   titleLookahead?: boolean;
 };
 
+// 成功返回盖好 revision 的持久化状态（revision 是 replace/分页的 CAS 令牌，
+// 只能在写库成功后由 summary.updatedAt 重建），失败返回 null。调用方若要把
+// 本次持久化的状态落进运行时缓存（压缩收尾即是），必须落这份带章状态——
+// checkpoint 状态出自 appendMessagesToConversation，revision 恒为 null，照原
+// 样 apply 会把缓存里的 revision 永久清空，后续 edit-resend 直接失败。
+export type PersistConversationAction = (
+  params: PersistConversationParams,
+) => Promise<ConversationViewState | null>;
+
 type UseConversationHistoryActionsParams = {
   conversationState: ConversationViewState;
   currentConversationIdRef: MutableRefObject<string>;
@@ -375,7 +384,7 @@ export function useConversationHistoryActions(params: UseConversationHistoryActi
     }
   }
 
-  async function persistConversation(params: PersistConversationParams): Promise<boolean> {
+  const persistConversation: PersistConversationAction = async (params) => {
     const {
       conversationId,
       sessionId,
@@ -410,6 +419,7 @@ export function useConversationHistoryActions(params: UseConversationHistoryActi
       turnSelectedModel: selectedModel,
     });
 
+    let stampedState: ConversationViewState;
     try {
       const summary = await persistConversationRuntime({
         conversationId,
@@ -428,6 +438,22 @@ export function useConversationHistoryActions(params: UseConversationHistoryActi
           conversationPersistenceCursorRef.current.set(conversationId, cursor),
       });
       markLocalHistorySnapshotSynced(conversationId, summary.updatedAt);
+      // The write landed, so the durable row now matches `state` exactly —
+      // stamp the CAS revision the backend will derive for it. Callers that
+      // apply the persisted state afterwards (compaction finalize) must apply
+      // this stamped copy: the checkpoint state itself carries revision:null
+      // and would leave edit-resend/paging without a token.
+      const revision = buildChatHistoryRevision({
+        conversationId,
+        updatedAt: summary.updatedAt,
+        activeSegmentIndex: state.meta.activeSegmentIndex,
+        totalSegmentCount: state.meta.totalSegmentCount,
+        totalMessageCount: state.meta.totalMessageCount,
+      });
+      stampedState = {
+        ...state,
+        transcript: { ...state.transcript, revision },
+      };
       updateConversationRuntimeEntry(conversationId, (prev) => ({
         ...prev,
         state:
@@ -439,13 +465,7 @@ export function useConversationHistoryActions(params: UseConversationHistoryActi
                 ...prev.state,
                 transcript: {
                   ...prev.state.transcript,
-                  revision: buildChatHistoryRevision({
-                    conversationId,
-                    updatedAt: summary.updatedAt,
-                    activeSegmentIndex: state.meta.activeSegmentIndex,
-                    totalSegmentCount: state.meta.totalSegmentCount,
-                    totalMessageCount: state.meta.totalMessageCount,
-                  }),
+                  revision,
                 },
               }
             : prev.state,
@@ -463,10 +483,10 @@ export function useConversationHistoryActions(params: UseConversationHistoryActi
         ...prev,
         errorMessage: persistFailedMessage,
       }));
-      return false;
+      return null;
     }
 
-    if (!titlePromise) return true;
+    if (!titlePromise) return stampedState;
 
     const initialStoredTitle = titleToStore;
     void titlePromise
@@ -500,8 +520,8 @@ export function useConversationHistoryActions(params: UseConversationHistoryActi
         }
       });
 
-    return true;
-  }
+    return stampedState;
+  };
 
   return {
     startNewConversation,

--- a/crates/agent-gui/src/pages/chat/runtime/useManualCompaction.ts
+++ b/crates/agent-gui/src/pages/chat/runtime/useManualCompaction.ts
@@ -23,7 +23,7 @@ import type {
   FinishGatewayRunMirrorInput,
   RegisterGatewayRunMirrorInput,
 } from "../gateway/useGatewayRunMirrorCoordinator";
-import type { PersistConversationParams } from "../history/useConversationHistoryActions";
+import type { PersistConversationAction } from "../history/useConversationHistoryActions";
 import type { ConversationRuntimeEntry } from "./chatPageRuntime";
 import {
   buildPreparedContext as buildPreparedConversationContext,
@@ -123,7 +123,7 @@ export function useManualCompaction(params: {
   flushGatewayBridgeEventsForRequest: (requestId: string) => Promise<void>;
   registerGatewayRunMirror: (input: RegisterGatewayRunMirrorInput) => void;
   finishGatewayRunMirror: (input: FinishGatewayRunMirrorInput) => Promise<void>;
-  persistConversation: (params: PersistConversationParams) => Promise<boolean>;
+  persistConversation: PersistConversationAction;
   setErrorMessage: (message: string | null) => void;
   activeAgentPrompt: string;
   // 与发送链路同源的提示词构建：当前会话据当前工作区解析 skills/memory 提示词；

--- a/crates/agent-gui/src/pages/chat/runtime/useSendChatTurn.ts
+++ b/crates/agent-gui/src/pages/chat/runtime/useSendChatTurn.ts
@@ -94,7 +94,7 @@ import {
 import type { ActiveGatewayBridgeRequest } from "../gateway/gatewayBridgeTypes";
 import { createLocalGatewayChatRunId } from "../gateway/gatewayRuntimeStatusModel";
 import type { useGatewayRunMirrorCoordinator } from "../gateway/useGatewayRunMirrorCoordinator";
-import type { PersistConversationParams } from "../history/useConversationHistoryActions";
+import type { PersistConversationAction } from "../history/useConversationHistoryActions";
 import type { useChatPageRuntimeStore } from "../hooks/useChatPageRuntimeStore";
 import type { useLiveTranscriptController } from "../hooks/useLiveTranscriptController";
 import type { createChatRuntimeHost } from "./ChatRuntimeHost";
@@ -193,7 +193,7 @@ type UseSendChatTurnParams = {
   activeAgentPrompt: string;
   ensureTunnelToolTab: (projectPathKey?: string) => void;
   ensureSshTunnelToolTab: (projectPathKey?: string) => void;
-  persistConversation: (params: PersistConversationParams) => Promise<boolean>;
+  persistConversation: PersistConversationAction;
   replaceConversationAtMessage: (
     conversationId: string,
     messageRef: HistoryMessageRef,
@@ -278,9 +278,9 @@ export function useSendChatTurn(params: UseSendChatTurnParams) {
   // persist-driven upsert (locally and via sync events); no settings write,
   // no extra workdirs IPC.
   async function persistConversationWithHistorySync(
-    params: Parameters<typeof persistConversation>[0],
-  ) {
-    return await persistConversation(params);
+    params: Parameters<PersistConversationAction>[0],
+  ): Promise<boolean> {
+    return (await persistConversation(params)) !== null;
   }
 
   async function waitForTerminalHistoryPersist(persistPromise: Promise<boolean> | null) {

--- a/crates/agent-gui/test/chat/compaction-controller.test.mjs
+++ b/crates/agent-gui/test/chat/compaction-controller.test.mjs
@@ -866,3 +866,106 @@ test("compactManually reports aborted=true when the user stops mid-compaction", 
   assert.equal(recorder.byKind("persistRollback").length, 1);
   assert.equal(recorder.byKind("bridge").at(-1)[1], null);
 });
+
+// —— revision 盖章：persist sink 返回带 revision 的持久化状态时，落地（apply/
+// queueCheckpoint）的必须是那份盖章状态。压缩 checkpoint 状态出自
+// appendMessagesToConversation（revision 恒 null），若照原样 apply，运行时缓存
+// 失去 replace/分页的 CAS 令牌，压缩后 edit-resend 报"历史会话缺少 revision"。
+
+function stampingPersist(recorder, revision) {
+  recorder.sinks.persist = async (state) => {
+    recorder.events.push(["persist", state]);
+    return {
+      ...state,
+      transcript: { ...state.transcript, revision },
+    };
+  };
+}
+
+test("during-run compaction applies the revision-stamped state returned by persist", async () => {
+  const controller = new CompactionController();
+  const { recorder } = bindController(controller, {
+    complete: async () => summaryResponse(),
+  });
+  stampingPersist(recorder, "conv:100:1:2:4");
+
+  const result = await controller.compactDuringRun({
+    trigger: "post-tool",
+    state: bigState(),
+  });
+
+  assert.ok(result.context);
+  const [, persistedState] = recorder.byKind("persist")[0];
+  assert.equal(persistedState.transcript.revision, null);
+  const [, appliedState] = recorder.byKind("applyStateMidRun").at(-1);
+  assert.equal(appliedState.transcript.revision, "conv:100:1:2:4");
+  const [, checkpointState] = recorder.byKind("queueCheckpoint")[0];
+  assert.equal(checkpointState.transcript.revision, "conv:100:1:2:4");
+});
+
+test("pre-send compaction re-stamps the revision after composeAppliedState clears it", async () => {
+  const controller = new CompactionController();
+  const pendingUserMessage = user("next question", 9);
+  const baseState = bigState();
+  const { recorder } = bindController(controller, {
+    complete: async () => summaryResponse(),
+    presend: {
+      baseState,
+      pendingUserText: "next question",
+      composeAppliedState: (state) =>
+        conversationState.appendMessagesToConversation(state, [pendingUserMessage]),
+    },
+  });
+  stampingPersist(recorder, "conv:200:1:2:4");
+
+  const applied = await controller.maybeCompactPreSend({
+    budgetContext: conversationState.buildRequestContext(baseState),
+  });
+
+  assert.equal(applied, true);
+  const [, appliedState] = recorder.byKind("applyState")[0];
+  // compose 补回了用户消息（内存追加，DB 仍是 checkpoint 版本），revision 保留。
+  assert.equal(appliedState.segments.at(-1).messages.at(-1).content, "next question");
+  assert.equal(appliedState.transcript.revision, "conv:200:1:2:4");
+});
+
+test("boolean persist keeps the legacy pass-through contract", async () => {
+  const controller = new CompactionController();
+  const { recorder } = bindController(controller, {
+    complete: async () => summaryResponse(),
+  });
+
+  const result = await controller.compactDuringRun({
+    trigger: "post-tool",
+    state: bigState(),
+  });
+
+  assert.ok(result.context);
+  const [, persistedState] = recorder.byKind("persist")[0];
+  const [, appliedState] = recorder.byKind("applyStateMidRun").at(-1);
+  assert.equal(appliedState, persistedState);
+});
+
+test("a null persist result aborts the checkpoint like false", async () => {
+  const controller = new CompactionController();
+  const { recorder } = bindController(controller, {
+    complete: async () => summaryResponse(),
+  });
+  recorder.sinks.persist = async (state) => {
+    recorder.events.push(["persist", state]);
+    return null;
+  };
+
+  const result = await controller.compactDuringRun({
+    trigger: "post-tool",
+    state: bigState(),
+  });
+
+  assert.equal(result.context, null);
+  assert.equal(recorder.byKind("queueCheckpoint").length, 0);
+  assert.ok(
+    recorder
+      .byKind("applyStateMidRun")
+      .every(([, state]) => state.meta.activeSegmentIndex === 0),
+  );
+});


### PR DESCRIPTION
## Linked issue

Closes #531

## Summary

- Return the revision-stamped conversation state after durable history persistence.
- Apply that stamped checkpoint state across manual, pre-send, and during-run compaction.
- Preserve fail-closed behavior when checkpoint persistence fails.
- Add regression coverage for stamped revisions and legacy persist sinks.

## Change scope

- Modules: agent-gui / chat history / compaction
- Key paths:
  - crates/agent-gui/src/lib/chat/compaction/controller.ts
  - crates/agent-gui/src/pages/chat/history/useConversationHistoryActions.ts
  - crates/agent-gui/src/pages/chat/runtime/useManualCompaction.ts
  - crates/agent-gui/src/pages/chat/runtime/useSendChatTurn.ts
  - crates/agent-gui/test/chat/compaction-controller.test.mjs

## Screenshots / preview

N/A — this is a history persistence/CAS correctness fix with no visual UI change.

Runtime verification:
- Targeted compaction/history/edit-resend tests: 41/41 passed.
- Full GUI suite including Tauri backend: 1917/1917 passed.

## Verification

- `node --test test/chat/compaction-controller.test.mjs test/chat/chat-history-persist-queue.test.mjs test/chat/edit-resend-atomic.test.mjs`
- `pnpm --filter liveagent test`
- `pnpm --filter liveagent build`
- `pnpm --filter liveagent lint`
- `git diff --check`

Manual desktop reproduction was not performed in this environment.

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are not required because this fixes internal persistence behavior without changing user-facing configuration.
