### PR TITLE
fix(webui): preserve checkpoint hashes during rewind

### DIFF
--- a/crates/agent-gateway/internal/protocol/pbws/guard.go
+++ b/crates/agent-gateway/internal/protocol/pbws/guard.go
@@ -145,7 +145,11 @@ func vetCheckpoint(req *gatewayv2.CheckpointRequest) error {
 		return errors.New("too many checkpoint expected entries")
 	}
 	for _, entry := range req.GetExpected() {
-		if entry == nil || strings.TrimSpace(entry.GetKey()) == "" || len(entry.GetKey()) > 65536 || len(entry.GetCurrentHash()) > 256 {
+		if entry == nil ||
+			strings.TrimSpace(entry.GetKey()) == "" ||
+			len(entry.GetKey()) > 65536 ||
+			strings.TrimSpace(entry.GetCurrentHash()) == "" ||
+			len(entry.GetCurrentHash()) > 256 {
 			return errors.New("checkpoint expected entry is invalid")
 		}
 	}

--- a/crates/agent-gateway/internal/protocol/pbws/guard_test.go
+++ b/crates/agent-gateway/internal/protocol/pbws/guard_test.go
@@ -178,6 +178,12 @@ func TestVetAgentRequestRejectsMalformedCheckpoint(t *testing.T) {
 			TurnSeq:        1,
 			Expected:       []*gatewayv2.CheckpointExpectedEntry{{Key: " ", CurrentHash: "abc"}},
 		},
+		{
+			Action:         "rewind",
+			ConversationId: "conversation-1",
+			TurnSeq:        1,
+			Expected:       []*gatewayv2.CheckpointExpectedEntry{{Key: "/work\x01a.txt"}},
+		},
 	}
 
 	for _, request := range requests {

--- a/crates/agent-gateway/web/src/lib/gatewaySocketRpc.ts
+++ b/crates/agent-gateway/web/src/lib/gatewaySocketRpc.ts
@@ -1143,7 +1143,10 @@ export class GatewayWebSocketRpcClient extends GatewayWebSocketTransport {
       conversation_id: params.conversationId,
       turn_seq: params.turnSeq,
       authorized_roots: params.authorizedRoots,
-      expected: params.expected,
+      expected: params.expected.map((entry) => ({
+        key: entry.key,
+        current_hash: entry.currentHash,
+      })),
     });
   }
 

--- a/crates/agent-gateway/web/test/checkpoint-rewind-rpc.test.mjs
+++ b/crates/agent-gateway/web/test/checkpoint-rewind-rpc.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createWebModuleLoader } from "../../test/helpers/load-web-module.mjs";
+
+const loader = createWebModuleLoader({
+  rootDir: fileURLToPath(new URL("../", import.meta.url)),
+});
+const rpc = loader.loadModule("src/lib/gatewaySocketRpc.ts");
+
+test("checkpoint rewind preserves preview hashes across the WebUI RPC boundary", async () => {
+  const client = Object.create(rpc.GatewayWebSocketRpcClient.prototype);
+  client.request = async (method, payload) => {
+    assert.equal(method, "checkpoint.rewind");
+    assert.deepEqual(payload, {
+      conversation_id: "conversation-1",
+      turn_seq: 7,
+      authorized_roots: ["/work/project"],
+      expected: [
+        {
+          key: "/work/project\u0001src/a.ts",
+          current_hash: "hash-at-preview",
+        },
+      ],
+    });
+    return {
+      turnSeq: 7,
+      restoredFiles: 1,
+      deletedFiles: 0,
+      cleanFiles: 0,
+      skippedDirs: 0,
+      captureErrors: 0,
+      conflicts: [],
+      failed: [],
+    };
+  };
+
+  const result = await client.rewindCheckpoint({
+    conversationId: "conversation-1",
+    turnSeq: 7,
+    authorizedRoots: ["/work/project"],
+    expected: [
+      {
+        key: "/work/project\u0001src/a.ts",
+        currentHash: "hash-at-preview",
+      },
+    ],
+  });
+
+  assert.equal(result.restoredFiles, 1);
+  assert.deepEqual(result.conflicts, []);
+});

--- a/crates/agent-gateway/web/test/gateway-v2-adapters.test.mjs
+++ b/crates/agent-gateway/web/test/gateway-v2-adapters.test.mjs
@@ -271,6 +271,18 @@ test("checkpoint requests and responses round-trip through the agent-scoped gate
     assert.equal(Number(frame.payload.value.payload.value.turnSeq), common.turn_seq);
     assert.deepEqual(frame.payload.value.payload.value.authorizedRoots, common.authorized_roots);
     assert.equal(frame.payload.value.payload.value.expected.length, expectedCount);
+    if (expectedCount > 0) {
+      assert.deepEqual(
+        {
+          key: frame.payload.value.payload.value.expected[0].key,
+          currentHash: frame.payload.value.payload.value.expected[0].currentHash,
+        },
+        {
+          key: "C:/work/project\u0001src/a.ts",
+          currentHash: "hash-at-preview",
+        },
+      );
+    }
   }
 
   const decoded = decodeServerFrame(


### PR DESCRIPTION
## Linked issue

Closes #533

## Summary

- Preserve preview-time checkpoint hashes when WebUI serializes a rewind request.
- Prevent unchanged files from being reported as conflicts solely because the RPC boundary dropped `currentHash`.
- Reject empty expected hashes at the Gateway guard so transport regressions fail explicitly instead of masquerading as file conflicts.
- Add RPC and protobuf round-trip coverage for the expected-hash contract.

## Change scope

- Modules: agent-gateway / Gateway WebUI
- Key paths:
  - `crates/agent-gateway/web/src/lib/gatewaySocketRpc.ts`
  - `crates/agent-gateway/web/test/checkpoint-rewind-rpc.test.mjs`
  - `crates/agent-gateway/web/test/gateway-v2-adapters.test.mjs`
  - `crates/agent-gateway/internal/protocol/pbws/guard.go`
  - `crates/agent-gateway/internal/protocol/pbws/guard_test.go`

## Screenshots / preview


## Verification

- `node --test test/checkpoint-rewind-rpc.test.mjs test/gateway-v2-adapters.test.mjs` — 11/11 passed.
- `pnpm --filter @liveagent/gateway-webui test` — 588/588 passed.
- `go test ./...` from `crates/agent-gateway` — passed.
- `cargo test --manifest-path crates/agent-gui/src-tauri/Cargo.toml commands::workspace_commands::checkpoint::tests` — 36/36 passed.
- GUI and WebUI TypeScript checks and production builds — passed.
- `pnpm check:ui-boundaries` — 8/8 passed.
- Targeted Biome checks and `git diff --check` — passed.
- Isolated latest-`main` merge-tree check — passed.

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] No documentation update is required; this restores the existing rewind contract without changing configuration or documented behavior.