### PR TITLE
fix(ui): 修复 Mermaid 全屏缩放模糊

### DIFF
--- a/crates/agent-gui/test/chat/mermaid-viewbox.test.mjs
+++ b/crates/agent-gui/test/chat/mermaid-viewbox.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const { panMermaidViewBox, zoomMermaidViewBox } = loader.loadModule(
+  "@liveagent/ui/lib/mermaidViewBox.ts",
+);
+
+test("Mermaid viewBox zoom keeps the center and avoids CSS scaling", () => {
+  const source = { x: 10, y: 20, width: 200, height: 100 };
+
+  assert.deepEqual(zoomMermaidViewBox(source, 1), source);
+  assert.deepEqual(zoomMermaidViewBox(source, 2), {
+    x: 60,
+    y: 45,
+    width: 100,
+    height: 50,
+  });
+});
+
+test("Mermaid viewBox pan converts screen pixels to SVG units", () => {
+  assert.deepEqual(
+    panMermaidViewBox(
+      { x: 0, y: 0, width: 100, height: 50 },
+      { x: 20, y: -10 },
+      { width: 200, height: 100 },
+    ),
+    { x: -10, y: 5, width: 100, height: 50 },
+  );
+});

--- a/crates/agent-ui/src/components/Markdown.tsx
+++ b/crates/agent-ui/src/components/Markdown.tsx
@@ -37,6 +37,7 @@ import {
 } from "../lib/markdownCodeBlockPolicy";
 import { normalizeLatexDelimiters } from "../lib/normalizeLatexDelimiters";
 import { cn } from "../lib/shared/utils";
+import { MermaidFullscreenButton } from "./MarkdownMermaidFullscreen";
 import { Button } from "./ui/button";
 import { CopyButton } from "./ui/copy-button";
 import {
@@ -362,6 +363,7 @@ function MarkdownReadOnlyLink(props: MarkdownAnchorFallbackProps) {
 export const markdownReadOnlyComponents: Components = {
   ...markdownComponents,
   a: MarkdownReadOnlyLink,
+  pre: ReadOnlyCollapsibleCodePre,
 };
 
 function MarkdownExternalLink(props: MarkdownAnchorFallbackProps) {
@@ -441,7 +443,16 @@ function CodeBlockActions({ code }: { code: string }) {
   );
 }
 
-export function CollapsibleCodePre({ children }: MarkdownPreProps) {
+type CollapsibleCodePreProps = MarkdownPreProps & { allowMermaidFullscreen?: boolean };
+
+function ReadOnlyCollapsibleCodePre(props: MarkdownPreProps) {
+  return <CollapsibleCodePre {...props} allowMermaidFullscreen={false} />;
+}
+
+export function CollapsibleCodePre({
+  children,
+  allowMermaidFullscreen = true,
+}: CollapsibleCodePreProps) {
   const { t } = useLocale();
   const childElement = isValidElement<StreamdownCodeChildProps>(children)
     ? ensureCodeBlockLanguage(children)
@@ -450,6 +461,7 @@ export function CollapsibleCodePre({ children }: MarkdownPreProps) {
   const language = childElement ? getCodeLanguage(childElement.props.className) : "";
   const { lineCount, shouldCollapse } = resolveCodeBlockRenderPolicy(codeContent);
   const isMermaid = language === "mermaid" || language === "mmd";
+  const isRenderedMermaid = language === "mermaid";
   const isCollapsible = Boolean(childElement && !isMermaid && shouldCollapse);
   const [expanded, setExpanded] = useState(false);
 
@@ -459,6 +471,9 @@ export function CollapsibleCodePre({ children }: MarkdownPreProps) {
     const codeBlock = cloneElement(childElement, { "data-block": "true" });
     return (
       <div className="relative w-full">
+        {isRenderedMermaid && allowMermaidFullscreen ? (
+          <MermaidFullscreenButton chart={codeContent} className="absolute right-7 top-1.5 z-30" />
+        ) : null}
         {isMermaid ? null : <CodeBlockActions code={codeContent} />}
         {codeBlock}
       </div>
@@ -720,7 +735,7 @@ export const Markdown = memo(function Markdown(props: MarkdownProps) {
           mermaid: {
             copy: !readOnly,
             download: false,
-            fullscreen: !readOnly,
+            fullscreen: false,
             panZoom: !readOnly,
           },
           table: false,

--- a/crates/agent-ui/src/components/MarkdownMermaidFullscreen.tsx
+++ b/crates/agent-ui/src/components/MarkdownMermaidFullscreen.tsx
@@ -1,0 +1,298 @@
+import { Loader2, Maximize2, Minus, Plus, RefreshCw, X } from "@liveagent/ui/components/IconSet";
+import { useLocale } from "@liveagent/ui/i18n/index";
+import { mermaid } from "@streamdown/mermaid";
+import {
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import {
+  formatMermaidViewBox,
+  type MermaidViewBox,
+  panMermaidViewBox,
+  parseMermaidViewBox,
+  zoomMermaidViewBox,
+} from "../lib/mermaidViewBox";
+import { cn } from "../lib/shared/utils";
+
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 3;
+const ZOOM_STEP = 0.1;
+
+type MermaidViewportState = {
+  zoom: number;
+  viewBox: MermaidViewBox;
+};
+
+type MermaidFullscreenButtonProps = {
+  chart: string;
+  className?: string;
+};
+
+function MermaidControlButton(props: {
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  const { children, disabled = false, label, onClick } = props;
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      onClick={onClick}
+      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-foreground/75 transition-colors hover:bg-foreground/[0.08] hover:text-foreground disabled:cursor-not-allowed disabled:opacity-35"
+    >
+      {children}
+    </button>
+  );
+}
+
+function MermaidFullscreenDialog({ chart, onClose }: { chart: string; onClose: () => void }) {
+  const { t } = useLocale();
+  const renderId = useId().replace(/[^a-zA-Z0-9_-]/g, "");
+  const svgHostRef = useRef<HTMLDivElement>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const originalViewBoxRef = useRef<MermaidViewBox | null>(null);
+  const dragRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
+  const [svg, setSvg] = useState("");
+  const [error, setError] = useState("");
+  const [viewportState, setViewportState] = useState<MermaidViewportState | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  useEffect(() => {
+    let active = true;
+    svgHostRef.current?.replaceChildren();
+    setSvg("");
+    setError("");
+    setViewportState(null);
+    originalViewBoxRef.current = null;
+    void mermaid
+      .getMermaid()
+      .render(`mermaid-fullscreen-${renderId}-${Date.now()}`, chart)
+      .then(({ svg: renderedSvg }) => {
+        if (active) setSvg(renderedSvg);
+      })
+      .catch((reason: unknown) => {
+        if (!active) return;
+        setError(reason instanceof Error ? reason.message : "Failed to render Mermaid chart");
+      });
+    return () => {
+      active = false;
+    };
+  }, [chart, renderId]);
+
+  useLayoutEffect(() => {
+    if (!svg) return;
+    const host = svgHostRef.current;
+    if (!host) return;
+    const parsedDocument = new DOMParser().parseFromString(svg, "image/svg+xml");
+    if (
+      parsedDocument.querySelector("parsererror") ||
+      parsedDocument.documentElement.localName !== "svg"
+    ) {
+      setError("Mermaid returned invalid SVG");
+      return;
+    }
+    const element = document.importNode(parsedDocument.documentElement, true);
+    host.replaceChildren(element);
+    const originalViewBox = parseMermaidViewBox(element?.getAttribute("viewBox") ?? null);
+    if (!originalViewBox) {
+      setError("Mermaid chart is missing a valid viewBox");
+      return;
+    }
+    element.setAttribute("preserveAspectRatio", "xMidYMid meet");
+    originalViewBoxRef.current = originalViewBox;
+    setViewportState({ zoom: 1, viewBox: originalViewBox });
+  }, [svg]);
+
+  useLayoutEffect(() => {
+    if (!viewportState) return;
+    svgHostRef.current
+      ?.querySelector("svg")
+      ?.setAttribute("viewBox", formatMermaidViewBox(viewportState.viewBox));
+  }, [viewportState]);
+
+  const changeZoom = useCallback((delta: number) => {
+    setViewportState((current) => {
+      if (!current) return current;
+      const zoom = Math.max(
+        MIN_ZOOM,
+        Math.min(MAX_ZOOM, Number((current.zoom + delta).toFixed(1))),
+      );
+      if (zoom === current.zoom) return current;
+      return {
+        zoom,
+        viewBox: zoomMermaidViewBox(current.viewBox, zoom / current.zoom),
+      };
+    });
+  }, []);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY === 0) return;
+      event.preventDefault();
+      changeZoom(event.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP);
+    };
+    viewport.addEventListener("wheel", handleWheel, { passive: false });
+    return () => viewport.removeEventListener("wheel", handleWheel);
+  }, [changeZoom]);
+
+  const resetView = useCallback(() => {
+    const originalViewBox = originalViewBoxRef.current;
+    if (originalViewBox) setViewportState({ zoom: 1, viewBox: originalViewBox });
+  }, []);
+
+  const finishDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (dragRef.current?.pointerId !== event.pointerId) return;
+    dragRef.current = null;
+    setDragging(false);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("chat.imageViewer.fullscreen")}
+      className="fixed inset-0 z-[120] flex bg-background"
+      data-liveagent-mermaid-fullscreen="true"
+    >
+      <div
+        ref={viewportRef}
+        role="application"
+        aria-label="Mermaid chart"
+        className={cn(
+          "relative min-h-0 flex-1 touch-none select-none overflow-hidden",
+          dragging ? "cursor-grabbing" : "cursor-grab",
+        )}
+        onPointerDown={(event) => {
+          if (
+            event.button !== 0 ||
+            !viewportState ||
+            (event.target instanceof Element && event.target.closest("button"))
+          ) {
+            return;
+          }
+          dragRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+          event.currentTarget.setPointerCapture(event.pointerId);
+          setDragging(true);
+        }}
+        onPointerMove={(event) => {
+          const drag = dragRef.current;
+          if (!drag || drag.pointerId !== event.pointerId) return;
+          const delta = { x: event.clientX - drag.x, y: event.clientY - drag.y };
+          drag.x = event.clientX;
+          drag.y = event.clientY;
+          const svgRect = svgHostRef.current?.querySelector("svg")?.getBoundingClientRect();
+          if (!svgRect) return;
+          setViewportState((current) =>
+            current
+              ? {
+                  ...current,
+                  viewBox: panMermaidViewBox(current.viewBox, delta, {
+                    width: svgRect.width,
+                    height: svgRect.height,
+                  }),
+                }
+              : current,
+          );
+        }}
+        onPointerUp={finishDrag}
+        onPointerCancel={finishDrag}
+      >
+        <div
+          ref={svgHostRef}
+          className="absolute inset-4 flex items-center justify-center [&_svg]:!h-full [&_svg]:!w-full [&_svg]:!max-w-none"
+        />
+        {!svg && !error ? (
+          <Loader2 className="absolute left-1/2 top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 animate-spin text-muted-foreground" />
+        ) : null}
+        {error ? (
+          <div
+            role="alert"
+            className="absolute left-1/2 top-1/2 max-w-[min(36rem,calc(100%-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-md border border-destructive/30 bg-background px-4 py-3 text-sm text-destructive shadow-lg"
+          >
+            {error}
+          </div>
+        ) : null}
+        <div className="absolute bottom-4 left-4 z-10 flex items-center rounded-md border border-border bg-background/95 p-1 shadow-md">
+          <MermaidControlButton
+            label={t("chat.imageViewer.zoomOut")}
+            disabled={!viewportState || viewportState.zoom <= MIN_ZOOM}
+            onClick={() => changeZoom(-ZOOM_STEP)}
+          >
+            <Minus className="h-4 w-4" />
+          </MermaidControlButton>
+          <span className="w-12 text-center text-[11px] tabular-nums text-muted-foreground">
+            {Math.round((viewportState?.zoom ?? 1) * 100)}%
+          </span>
+          <MermaidControlButton
+            label={t("chat.imageViewer.zoomIn")}
+            disabled={!viewportState || viewportState.zoom >= MAX_ZOOM}
+            onClick={() => changeZoom(ZOOM_STEP)}
+          >
+            <Plus className="h-4 w-4" />
+          </MermaidControlButton>
+          <MermaidControlButton label={t("chat.imageViewer.reset")} onClick={resetView}>
+            <RefreshCw className="h-4 w-4" />
+          </MermaidControlButton>
+        </div>
+        <div className="absolute right-4 top-4 z-10 rounded-md border border-border bg-background/95 p-1 shadow-md">
+          <MermaidControlButton label={t("chat.imageViewer.exitFullscreen")} onClick={onClose}>
+            <X className="h-4 w-4" />
+          </MermaidControlButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function MermaidFullscreenButton({ chart, className }: MermaidFullscreenButtonProps) {
+  const { t } = useLocale();
+  const [open, setOpen] = useState(false);
+  const close = useCallback(() => setOpen(false), []);
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={t("chat.imageViewer.fullscreen")}
+        title={t("chat.imageViewer.fullscreen")}
+        onClick={() => setOpen(true)}
+        className={cn(
+          "flex h-6 w-6 items-center justify-center rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+          className,
+        )}
+      >
+        <Maximize2 className="h-3.5 w-3.5" />
+      </button>
+      {open && typeof document !== "undefined"
+        ? createPortal(<MermaidFullscreenDialog chart={chart} onClose={close} />, document.body)
+        : null}
+    </>
+  );
+}

--- a/crates/agent-ui/src/components/MarkdownMermaidFullscreen.tsx
+++ b/crates/agent-ui/src/components/MarkdownMermaidFullscreen.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Maximize2, Minus, Plus, RefreshCw, X } from "@liveagent/ui/components/IconSet";
+import { Loader2, Maximize2, Minus, Plus, RefreshCw } from "@liveagent/ui/components/IconSet";
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { mermaid } from "@streamdown/mermaid";
 import {
@@ -10,7 +10,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { createPortal } from "react-dom";
 import {
   formatMermaidViewBox,
   type MermaidViewBox,
@@ -19,6 +18,7 @@ import {
   zoomMermaidViewBox,
 } from "../lib/mermaidViewBox";
 import { cn } from "../lib/shared/utils";
+import { Dialog, DialogContent, DialogTitle } from "./ui/dialog";
 
 const MIN_ZOOM = 0.5;
 const MAX_ZOOM = 3;
@@ -66,19 +66,6 @@ function MermaidFullscreenDialog({ chart, onClose }: { chart: string; onClose: (
   const [error, setError] = useState("");
   const [viewportState, setViewportState] = useState<MermaidViewportState | null>(null);
   const [dragging, setDragging] = useState(false);
-
-  useEffect(() => {
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.body.style.overflow = previousOverflow;
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [onClose]);
 
   useEffect(() => {
     let active = true;
@@ -175,100 +162,98 @@ function MermaidFullscreenDialog({ chart, onClose }: { chart: string; onClose: (
   };
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={t("chat.imageViewer.fullscreen")}
-      className="fixed inset-0 z-[120] flex bg-background"
-      data-liveagent-mermaid-fullscreen="true"
-    >
-      <div
-        ref={viewportRef}
-        role="application"
-        aria-label="Mermaid chart"
-        className={cn(
-          "relative min-h-0 flex-1 touch-none select-none overflow-hidden",
-          dragging ? "cursor-grabbing" : "cursor-grab",
-        )}
-        onPointerDown={(event) => {
-          if (
-            event.button !== 0 ||
-            !viewportState ||
-            (event.target instanceof Element && event.target.closest("button"))
-          ) {
-            return;
-          }
-          dragRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
-          event.currentTarget.setPointerCapture(event.pointerId);
-          setDragging(true);
-        }}
-        onPointerMove={(event) => {
-          const drag = dragRef.current;
-          if (!drag || drag.pointerId !== event.pointerId) return;
-          const delta = { x: event.clientX - drag.x, y: event.clientY - drag.y };
-          drag.x = event.clientX;
-          drag.y = event.clientY;
-          const svgRect = svgHostRef.current?.querySelector("svg")?.getBoundingClientRect();
-          if (!svgRect) return;
-          setViewportState((current) =>
-            current
-              ? {
-                  ...current,
-                  viewBox: panMermaidViewBox(current.viewBox, delta, {
-                    width: svgRect.width,
-                    height: svgRect.height,
-                  }),
-                }
-              : current,
-          );
-        }}
-        onPointerUp={finishDrag}
-        onPointerCancel={finishDrag}
+    <Dialog open disablePointerDismissal onOpenChange={(open) => !open && onClose()}>
+      <DialogContent
+        className="fixed inset-0 m-0 flex h-full w-screen max-w-none overflow-hidden rounded-none border-0 bg-background p-0 shadow-none transition-none"
+        closeLabel={t("chat.imageViewer.exitFullscreen")}
+        data-liveagent-mermaid-fullscreen="true"
+        showCloseButton
+        style={{ opacity: 1, scale: "none", transform: "none" }}
       >
+        <DialogTitle className="sr-only">{t("chat.imageViewer.fullscreen")}</DialogTitle>
         <div
-          ref={svgHostRef}
-          className="absolute inset-4 flex items-center justify-center [&_svg]:!h-full [&_svg]:!w-full [&_svg]:!max-w-none"
-        />
-        {!svg && !error ? (
-          <Loader2 className="absolute left-1/2 top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 animate-spin text-muted-foreground" />
-        ) : null}
-        {error ? (
+          ref={viewportRef}
+          role="application"
+          aria-label="Mermaid chart"
+          className={cn(
+            "relative min-h-0 flex-1 touch-none select-none overflow-hidden",
+            dragging ? "cursor-grabbing" : "cursor-grab",
+          )}
+          onPointerDown={(event) => {
+            if (
+              event.button !== 0 ||
+              !viewportState ||
+              (event.target instanceof Element && event.target.closest("button"))
+            ) {
+              return;
+            }
+            dragRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+            event.currentTarget.setPointerCapture(event.pointerId);
+            setDragging(true);
+          }}
+          onPointerMove={(event) => {
+            const drag = dragRef.current;
+            if (!drag || drag.pointerId !== event.pointerId) return;
+            const delta = { x: event.clientX - drag.x, y: event.clientY - drag.y };
+            drag.x = event.clientX;
+            drag.y = event.clientY;
+            const svgRect = svgHostRef.current?.querySelector("svg")?.getBoundingClientRect();
+            if (!svgRect) return;
+            setViewportState((current) =>
+              current
+                ? {
+                    ...current,
+                    viewBox: panMermaidViewBox(current.viewBox, delta, {
+                      width: svgRect.width,
+                      height: svgRect.height,
+                    }),
+                  }
+                : current,
+            );
+          }}
+          onPointerUp={finishDrag}
+          onPointerCancel={finishDrag}
+        >
           <div
-            role="alert"
-            className="absolute left-1/2 top-1/2 max-w-[min(36rem,calc(100%-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-md border border-destructive/30 bg-background px-4 py-3 text-sm text-destructive shadow-lg"
-          >
-            {error}
+            ref={svgHostRef}
+            className="absolute inset-4 flex items-center justify-center [&_svg]:!h-full [&_svg]:!w-full [&_svg]:!max-w-none"
+          />
+          {!svg && !error ? (
+            <Loader2 className="absolute left-1/2 top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 animate-spin text-muted-foreground" />
+          ) : null}
+          {error ? (
+            <div
+              role="alert"
+              className="absolute left-1/2 top-1/2 max-w-[min(36rem,calc(100%-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-md border border-destructive/30 bg-background px-4 py-3 text-sm text-destructive shadow-lg"
+            >
+              {error}
+            </div>
+          ) : null}
+          <div className="absolute bottom-4 left-4 z-10 flex items-center rounded-md border border-border bg-background/95 p-1 shadow-md">
+            <MermaidControlButton
+              label={t("chat.imageViewer.zoomOut")}
+              disabled={!viewportState || viewportState.zoom <= MIN_ZOOM}
+              onClick={() => changeZoom(-ZOOM_STEP)}
+            >
+              <Minus className="h-4 w-4" />
+            </MermaidControlButton>
+            <span className="w-12 text-center text-[11px] tabular-nums text-muted-foreground">
+              {Math.round((viewportState?.zoom ?? 1) * 100)}%
+            </span>
+            <MermaidControlButton
+              label={t("chat.imageViewer.zoomIn")}
+              disabled={!viewportState || viewportState.zoom >= MAX_ZOOM}
+              onClick={() => changeZoom(ZOOM_STEP)}
+            >
+              <Plus className="h-4 w-4" />
+            </MermaidControlButton>
+            <MermaidControlButton label={t("chat.imageViewer.reset")} onClick={resetView}>
+              <RefreshCw className="h-4 w-4" />
+            </MermaidControlButton>
           </div>
-        ) : null}
-        <div className="absolute bottom-4 left-4 z-10 flex items-center rounded-md border border-border bg-background/95 p-1 shadow-md">
-          <MermaidControlButton
-            label={t("chat.imageViewer.zoomOut")}
-            disabled={!viewportState || viewportState.zoom <= MIN_ZOOM}
-            onClick={() => changeZoom(-ZOOM_STEP)}
-          >
-            <Minus className="h-4 w-4" />
-          </MermaidControlButton>
-          <span className="w-12 text-center text-[11px] tabular-nums text-muted-foreground">
-            {Math.round((viewportState?.zoom ?? 1) * 100)}%
-          </span>
-          <MermaidControlButton
-            label={t("chat.imageViewer.zoomIn")}
-            disabled={!viewportState || viewportState.zoom >= MAX_ZOOM}
-            onClick={() => changeZoom(ZOOM_STEP)}
-          >
-            <Plus className="h-4 w-4" />
-          </MermaidControlButton>
-          <MermaidControlButton label={t("chat.imageViewer.reset")} onClick={resetView}>
-            <RefreshCw className="h-4 w-4" />
-          </MermaidControlButton>
         </div>
-        <div className="absolute right-4 top-4 z-10 rounded-md border border-border bg-background/95 p-1 shadow-md">
-          <MermaidControlButton label={t("chat.imageViewer.exitFullscreen")} onClick={onClose}>
-            <X className="h-4 w-4" />
-          </MermaidControlButton>
-        </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -290,9 +275,7 @@ export function MermaidFullscreenButton({ chart, className }: MermaidFullscreenB
       >
         <Maximize2 className="h-3.5 w-3.5" />
       </button>
-      {open && typeof document !== "undefined"
-        ? createPortal(<MermaidFullscreenDialog chart={chart} onClose={close} />, document.body)
-        : null}
+      {open ? <MermaidFullscreenDialog chart={chart} onClose={close} /> : null}
     </>
   );
 }

--- a/crates/agent-ui/src/lib/mermaidViewBox.ts
+++ b/crates/agent-ui/src/lib/mermaidViewBox.ts
@@ -1,0 +1,56 @@
+export type MermaidViewBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type MermaidPoint = { x: number; y: number };
+export type MermaidViewport = { width: number; height: number };
+
+export function parseMermaidViewBox(value: string | null): MermaidViewBox | null {
+  if (!value) return null;
+  const values = value
+    .trim()
+    .split(/[\s,]+/)
+    .map(Number);
+  if (
+    values.length !== 4 ||
+    values.some((part) => !Number.isFinite(part)) ||
+    values[2] <= 0 ||
+    values[3] <= 0
+  ) {
+    return null;
+  }
+  return { x: values[0], y: values[1], width: values[2], height: values[3] };
+}
+
+export function zoomMermaidViewBox(viewBox: MermaidViewBox, factor: number): MermaidViewBox {
+  if (!Number.isFinite(factor) || factor <= 0) return viewBox;
+  const width = viewBox.width / factor;
+  const height = viewBox.height / factor;
+  return {
+    x: viewBox.x + (viewBox.width - width) / 2,
+    y: viewBox.y + (viewBox.height - height) / 2,
+    width,
+    height,
+  };
+}
+
+export function panMermaidViewBox(
+  viewBox: MermaidViewBox,
+  delta: MermaidPoint,
+  viewport: MermaidViewport,
+): MermaidViewBox {
+  const scale = Math.min(viewport.width / viewBox.width, viewport.height / viewBox.height);
+  if (!Number.isFinite(scale) || scale <= 0) return viewBox;
+  return {
+    ...viewBox,
+    x: viewBox.x - delta.x / scale,
+    y: viewBox.y - delta.y / scale,
+  };
+}
+
+export function formatMermaidViewBox(viewBox: MermaidViewBox): string {
+  return `${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`;
+}


### PR DESCRIPTION
## Linked issue

Closes #522

## Summary

修复 macOS Tauri WKWebView 中 Mermaid 全屏缩放后文字、边框和连线整体模糊的问题。

Streamdown 原有 PanZoom 即使在 `1x` 也通过 CSS `transform` 缩放 SVG，WKWebView 会将其提前栅格化为低分辨率合成纹理。本次关闭 Streamdown 自带 Mermaid 全屏入口，仅在全屏模式中改用 SVG `viewBox` 完成缩放和平移；全屏弹层复用共享 `Dialog` 和 `layer-modal` 语义层级，并保留内嵌 Mermaid、复制、只读限制和 strict 安全渲染链路。

## Change scope

- Modules: `agent-ui` / `agent-gui` tests（GUI 与 Gateway Web 共用 Markdown 实现）
- Key paths:
  - `crates/agent-ui/src/components/Markdown.tsx`
  - `crates/agent-ui/src/components/MarkdownMermaidFullscreen.tsx`
  - `crates/agent-ui/src/lib/mermaidViewBox.ts`
  - `crates/agent-gui/test/chat/mermaid-viewbox.test.mjs`

## Screenshots / preview

修复后全屏运行预览：

<img width="2560" height="1410" alt="Mermaid 全屏 viewBox 矢量缩放运行预览" src="https://github.com/user-attachments/assets/ae2380c0-20f9-4a3d-b2aa-2fd2e26d50c2" />

说明：原问题仅在实际 Tauri WKWebView 中稳定复现，Chromium 无法复现相同的低分辨率栅格化；Chromium 用于验证缩放和拖动只修改 `viewBox`，SVG 与容器的计算样式始终为 `transform: none`。修复后的静止、连续放大、拖动及松开状态已在实际 WKWebView 中确认清晰。

## Verification

- 根目录未定义 `pnpm lint` 脚本；按现有 workspace 脚本执行 `pnpm -r --if-present lint` 通过（3 个 workspace 均完成，仅有仓库既有 warning）。
- `pnpm check:ui-boundaries` 通过。
- `pnpm --filter @liveagent/ui exec biome check src/components/Markdown.tsx src/components/MarkdownMermaidFullscreen.tsx src/lib/mermaidViewBox.ts` 通过。
- `node --test crates/agent-gui/test/chat/markdown-code-collapse.test.mjs crates/agent-gui/test/chat/mermaid-viewbox.test.mjs`：6/6 通过。
- `pnpm build:gui` 与 `pnpm build:webui` 通过，包含 TypeScript 类型检查和生产构建。
- `git diff --check upstream/main...HEAD` 通过。
- Chromium 完整 Markdown 链路验证：共享 Dialog 全屏覆盖视口，Popup/viewport/SVG 容器/SVG 均为 `transform: none`，Popup 为 `scale: none`；`1x`、连续放大、拖动和重置均只改变 SVG `viewBox`。
- 实际 Tauri WKWebView 回归验证：静止、拖动和松开后图表均保持清晰。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.（无需更新：操作方式和配置未变，仅修复全屏渲染实现）
