### PR TITLE
fix(ui): 修复弹窗内 Portal 浮层无法交互

### DIFF
--- a/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
+++ b/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
@@ -136,7 +136,7 @@ test("branch selector reuses the model trigger visual language", () => {
 test("composer dropdown portals stay above the composer surface", () => {
   assert.match(popoverSource, /className="layer-popover isolate"/);
   assert.match(selectSource, /className="layer-popover"/);
-  assert.match(baseStylesSource, /--layer-popover: 9999;/);
+  assert.match(baseStylesSource, /--layer-popover: 10000;/);
   assert.match(baseStylesSource, /--layer-modal: 10000;/);
 });
 

--- a/crates/agent-gui/test/settings/portal-layering.test.mjs
+++ b/crates/agent-gui/test/settings/portal-layering.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+function readShared(path) {
+  return readFileSync(new URL(`../../../agent-ui/src/${path}`, import.meta.url), "utf8");
+}
+
+const providersSectionSource = readShared("pages/settings/ProvidersSection.tsx");
+const baseStylesSource = readShared("styles/base.css");
+
+const popupPortalSources = [
+  ["Select", readShared("components/ui/select.tsx")],
+  ["DropdownMenu", readShared("components/ui/dropdown-menu.tsx")],
+  ["Popover", readShared("components/ui/popover.tsx")],
+  ["Tooltip", readShared("components/ui/tooltip.tsx")],
+];
+
+const modalPortalSources = [
+  ["Dialog", readShared("components/ui/dialog.tsx")],
+  ["Sheet", readShared("components/ui/sheet.tsx")],
+  ["AlertDialog", readShared("components/ui/alert-dialog.tsx")],
+];
+
+function layerValue(name) {
+  const match = baseStylesSource.match(new RegExp(`${name}:\\s*(\\d+);`));
+  assert.ok(match, `${name} should be declared`);
+  return Number(match[1]);
+}
+
+function collectSourceFiles(directoryUrl) {
+  const files = [];
+  const pending = [fileURLToPath(directoryUrl)];
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = `${directory}/${entry.name}`;
+      if (entry.isDirectory()) pending.push(path);
+      else if (/\.[cm]?[jt]sx?$/.test(entry.name)) files.push(path);
+    }
+  }
+  return files;
+}
+
+test("the provider failover queue uses the shared portalled select", () => {
+  assert.match(providersSectionSource, /<Select value="" onValueChange=\{addQueueEntry\}>/);
+  assert.match(providersSectionSource, /aria-label=\{t\("settings\.failoverQueueAdd"\)\}/);
+  assert.match(providersSectionSource, /<SelectContent>/);
+});
+
+test("all shared popup primitives use the semantic popover layer", () => {
+  for (const [name, source] of popupPortalSources) {
+    assert.match(source, /<\w+(?:Primitive)?\.Portal>/, `${name} should render through a Portal`);
+    assert.match(source, /className="layer-popover(?: isolate)?"/, `${name} should use layer-popover`);
+  }
+});
+
+test("all shared modal primitives use the semantic modal layer", () => {
+  for (const [name, source] of modalPortalSources) {
+    assert.match(source, /Portal/, `${name} should render through a Portal`);
+    assert.match(source, /layer-modal fixed/, `${name} should use layer-modal`);
+  }
+});
+
+test("modal and nested popup portals share a DOM-ordered interaction plane", () => {
+  const popoverLayer = layerValue("--layer-popover");
+  const modalLayer = layerValue("--layer-modal");
+  const toastLayer = layerValue("--layer-toast");
+  const criticalLayer = layerValue("--layer-critical");
+
+  assert.equal(popoverLayer, modalLayer);
+  assert.ok(toastLayer > modalLayer);
+  assert.ok(criticalLayer > toastLayer);
+});
+
+test("custom React portals opt into a semantic overlay layer", () => {
+  const sourceRoots = [
+    new URL("../../../agent-ui/src/", import.meta.url),
+    new URL("../../src/", import.meta.url),
+    new URL("../../../agent-gateway/web/src/", import.meta.url),
+  ];
+  const portalFiles = sourceRoots
+    .flatMap(collectSourceFiles)
+    .map((path) => [path, readFileSync(path, "utf8")])
+    .filter(([, source]) => source.includes("createPortal("));
+
+  assert.ok(portalFiles.length > 0);
+  for (const [path, source] of portalFiles) {
+    const portalCalls = source.split("createPortal(").slice(1);
+    for (const [index, portalCall] of portalCalls.entries()) {
+      assert.match(
+        portalCall,
+        /layer-(?:popover|modal|toast|critical)/,
+        `${path} createPortal call ${index + 1} should use a semantic overlay layer`,
+      );
+    }
+  }
+});

--- a/crates/agent-ui/src/styles/base.css
+++ b/crates/agent-ui/src/styles/base.css
@@ -461,11 +461,11 @@
 
     --radius: 0.625rem;
 
-    /* Portal layers use semantic tokens and stay above page-local stacking contexts. */
+    /* Modal/popover portals share a plane so later nested portals stay interactive. */
     --layer-content: 1;
     --layer-raised: 10;
     --layer-panel: 20;
-    --layer-popover: 9999;
+    --layer-popover: 10000;
     --layer-modal: 10000;
     --layer-toast: 10010;
     --layer-critical: 10020;


### PR DESCRIPTION
## Linked issue

Closes #538

## Summary

- Fix portalled dropdowns and floating controls being rendered behind Dialog/Sheet modal layers.
- Keep modal and popover portals on the same DOM-ordered interaction plane while preserving higher toast and critical layers.
- Add regression coverage for shared Select, DropdownMenu, Popover, Tooltip, Dialog, Sheet, AlertDialog, and direct React portals across GUI, WebUI, and shared UI sources.

## Change scope

- Modules: `agent-ui`, `agent-gui` tests
- Key paths:
  - `crates/agent-ui/src/styles/base.css`
  - `crates/agent-gui/test/settings/portal-layering.test.mjs`
  - `crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs`

## Screenshots / preview


## Verification

- `node --test test/settings/portal-layering.test.mjs test/chat/execution-mode-model-picker.test.mjs` (14/14 passed)
- GUI full frontend test suite passed
- WebUI full test suite passed
- `pnpm build:gui`
- `pnpm build:webui`
- `pnpm check:ui-boundaries`
- Package-local Biome check passed with existing non-blocking warnings
- `node --check crates/agent-gui/test/settings/portal-layering.test.mjs`
- `git diff --check`

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts in the local baseline.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are not required because this fixes overlay behavior without changing configuration or workflows.
