### PR TITLE
fix(tunnel): 移除公开隧道固定连接数限制

### DIFF
--- a/crates/agent-gateway/internal/server/tunnel_proxy.go
+++ b/crates/agent-gateway/internal/server/tunnel_proxy.go
@@ -542,8 +542,6 @@ func writeTunnelAcquireError(w http.ResponseWriter, err error) {
 		writeTunnelError(w, http.StatusNotFound, "tunnel not found")
 	case errors.Is(err, session.ErrAgentOffline):
 		writeTunnelError(w, http.StatusServiceUnavailable, "agent offline")
-	case errors.Is(err, session.ErrTunnelOverLimit):
-		writeTunnelError(w, http.StatusTooManyRequests, "tunnel connection limit exceeded")
 	default:
 		writeTunnelError(w, http.StatusBadGateway, err.Error())
 	}

--- a/crates/agent-gateway/internal/server/tunnel_proxy_test.go
+++ b/crates/agent-gateway/internal/server/tunnel_proxy_test.go
@@ -112,7 +112,6 @@ func TestWriteTunnelAcquireErrorStatusMapping(t *testing.T) {
 		{session.ErrTunnelNotFound, http.StatusNotFound},
 		{session.ErrTunnelExpired, http.StatusNotFound},
 		{session.ErrAgentOffline, http.StatusServiceUnavailable},
-		{session.ErrTunnelOverLimit, http.StatusTooManyRequests},
 	}
 	for _, tt := range tests {
 		recorder := httptest.NewRecorder()

--- a/crates/agent-gateway/internal/session/manager.go
+++ b/crates/agent-gateway/internal/session/manager.go
@@ -13,7 +13,6 @@ var ErrAgentOffline = errors.New("agent offline")
 var ErrChatProtocolIncompatible = errors.New("desktop chat protocol is incompatible; update LiveAgent desktop")
 var ErrTunnelNotFound = errors.New("tunnel not found")
 var ErrTunnelExpired = errors.New("tunnel expired")
-var ErrTunnelOverLimit = errors.New("tunnel connection limit exceeded")
 
 const (
 	chatRuntimeReadyTTL      = 15 * time.Second

--- a/crates/agent-gateway/internal/session/tunnel_state.go
+++ b/crates/agent-gateway/internal/session/tunnel_state.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	maxTunnelsPerAgent       = 5
-	maxTunnelConnections     = 20
 	tunnelSlugEntropyBytes   = 24
 	tunnelStreamChannelDepth = 256
 	tunnelAgentSendTimeout   = 10 * time.Second
@@ -442,9 +441,6 @@ func (m *Manager) AcquireTunnel(slug string, streamID string) (*TunnelStreamLeas
 	}
 	if !record.expiresAt.IsZero() && !record.expiresAt.After(now) {
 		return nil, ErrTunnelExpired
-	}
-	if record.activeConnections >= maxTunnelConnections {
-		return nil, ErrTunnelOverLimit
 	}
 	stream := &tunnelStream{
 		streamID: streamID,

--- a/crates/agent-gateway/internal/session/tunnel_state_test.go
+++ b/crates/agent-gateway/internal/session/tunnel_state_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -131,7 +132,7 @@ func TestSnapshotRevisionIsMonotonic(t *testing.T) {
 	}
 }
 
-func TestAcquireTunnelLifecycleAndLimits(t *testing.T) {
+func TestAcquireTunnelLifecycle(t *testing.T) {
 	m := newTunnelTestManager(t)
 	m.ApplyDesiredState("test-agent", desiredState(
 		&gatewayv2.TunnelSpec{Id: "tun-a", TargetUrl: "http://localhost:3000"},
@@ -142,19 +143,17 @@ func TestAcquireTunnelLifecycleAndLimits(t *testing.T) {
 		t.Fatalf("acquire missing = %v, want ErrTunnelNotFound", err)
 	}
 
-	leases := make([]*TunnelStreamLease, 0, maxTunnelConnections)
-	for i := 0; i < maxTunnelConnections; i++ {
-		lease, err := m.AcquireTunnel(slug, "s-"+string(rune('a'+i)))
+	const concurrentConnections = 64
+	leases := make([]*TunnelStreamLease, 0, concurrentConnections)
+	for i := 0; i < concurrentConnections; i++ {
+		lease, err := m.AcquireTunnel(slug, "s-"+strconv.Itoa(i))
 		if err != nil {
 			t.Fatalf("acquire %d: %v", i, err)
 		}
 		leases = append(leases, lease)
 	}
-	if _, err := m.AcquireTunnel(slug, "s-over"); err != ErrTunnelOverLimit {
-		t.Fatalf("over-limit acquire = %v, want ErrTunnelOverLimit", err)
-	}
-	if got := m.TunnelStateSnapshot("test-agent").GetTunnels()[0].GetActiveConnections(); got != maxTunnelConnections {
-		t.Fatalf("active connections = %d, want %d", got, maxTunnelConnections)
+	if got := m.TunnelStateSnapshot("test-agent").GetTunnels()[0].GetActiveConnections(); got != concurrentConnections {
+		t.Fatalf("active connections = %d, want %d", got, concurrentConnections)
 	}
 	for _, lease := range leases {
 		lease.Release()


### PR DESCRIPTION
## Linked issue

Closes #542

## Summary

公开 Web Tunnel 当前把每个 HTTP 请求和 WebSocket 都计为独立隧道流，并对单条隧道硬编码 20 条活跃流上限。多人同时加载包含多个静态资源或长连接的页面时，第 21 条流会收到 HTTP 429 和 tunnel connection limit exceeded。

本 PR 移除该固定并发拒绝逻辑及其专用错误映射，同时保留活跃连接计数和正常释放机制。

## Change scope

- Modules: agent-gateway
- Key paths:
  - crates/agent-gateway/internal/session/tunnel_state.go
  - crates/agent-gateway/internal/session/manager.go
  - crates/agent-gateway/internal/server/tunnel_proxy.go
  - corresponding session and server tests

## Screenshots / preview

N/A：纯后端网关行为修复，没有 UI 变化。

运行验证：

    cd crates/agent-gateway
    go test ./... -count=1

结果：所有 Go 单元测试及 test/tunnel 隧道端到端测试通过。

## Verification

- 删除 maxTunnelConnections = 20 以及 AcquireTunnel 中的超限拒绝分支。
- 删除 ErrTunnelOverLimit 和 HTTP 429 专用映射。
- 更新生命周期测试，同一隧道同时创建 64 条流均成功，释放后活跃连接计数归零。
- 执行 git diff --check，无格式错误。
- 执行 go test ./... -count=1，全部通过。

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] No documentation update is required because the removed hard-coded limit was not documented or configurable.
