### PR TITLE
fix(claude): preserve native web search round trips

### DIFF
--- a/crates/agent-gui/src/lib/chat/context/requestContextSanitizer.ts
+++ b/crates/agent-gui/src/lib/chat/context/requestContextSanitizer.ts
@@ -131,12 +131,10 @@ function sanitizeTextBlocksForModelContext(message: Message): Message {
       return [{ ...block, text }];
     }
 
-    if (block.type === "thinking" && typeof block.thinking === "string") {
-      const thinking = sanitizeModelText(block.thinking);
-      if (thinking !== block.thinking) changed = true;
-      if (!thinking.trim()) return [];
-      return [{ ...block, thinking }];
-    }
+    // Signed Anthropic thinking is opaque protocol state. Even text-like cleanup
+    // (including DSML stripping or surrogate replacement) invalidates its
+    // signature, so thinking/redacted-thinking blocks must pass through intact.
+    if (block.type === "thinking") return [block];
 
     return [block];
   });

--- a/crates/agent-gui/src/lib/chat/runner/seedToolCalls.ts
+++ b/crates/agent-gui/src/lib/chat/runner/seedToolCalls.ts
@@ -175,6 +175,15 @@ export function recoverAssistantSeedToolCalls(
 
   for (const block of assistant.content) {
     if (block.type === "thinking") {
+      // Anthropic thinking is signed protocol state. Never strip markup or
+      // re-order blocks inside a signed (or redacted) thinking block: either
+      // change makes the next request fail with "thinking blocks cannot be
+      // modified". Unsigned thinking from compatibility models can still use
+      // the legacy seed-call recovery below.
+      if (block.thinkingSignature || block.redacted) {
+        nextContent.push(block);
+        continue;
+      }
       const recovered = recoverToolCallsFromBlockText(block.thinking);
       if (recovered.cleanedText !== block.thinking) {
         changed = true;

--- a/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
+++ b/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
@@ -30,8 +30,7 @@ type FetchProbe = {
   sessionId?: string;
   requestId?: string;
   active: boolean;
-  claimed: boolean;
-  parseDone?: Promise<void>;
+  parseTasks: Promise<void>[];
   onRawEvent: (event: unknown) => void;
 };
 
@@ -166,7 +165,7 @@ function requestMatchesProbe(
   init: RequestInit | undefined,
   response: Response,
 ) {
-  if (!probe.active || probe.claimed || !isStreamLikeResponse(response)) return false;
+  if (!probe.active || !isStreamLikeResponse(response)) return false;
   const url = getRequestUrl(input);
   if (!url.includes(getProviderPath(probe.providerId))) return false;
   const requestId = getRequestHeader(input, init, HOSTED_SEARCH_PROBE_HEADER);
@@ -181,14 +180,16 @@ function installFetchProbe() {
   if (originalFetch || typeof globalThis.fetch !== "function") return;
   originalFetch = globalThis.fetch.bind(globalThis);
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const response = await originalFetch!(input, init);
+    const fetchImpl = originalFetch;
+    if (!fetchImpl) throw new Error("Hosted search fetch probe is not installed");
+    const response = await fetchImpl(input, init);
     const probe = [...activeFetchProbes].find((candidate) =>
       requestMatchesProbe(candidate, input, init, response),
     );
     if (probe) {
-      probe.claimed = true;
-      probe.parseDone = parseResponseClone(response, probe);
-      void probe.parseDone;
+      const parseTask = parseResponseClone(response, probe);
+      probe.parseTasks.push(parseTask);
+      void parseTask;
     }
     return response;
   }) as typeof globalThis.fetch;
@@ -272,7 +273,7 @@ export function startHostedSearchFetchProbe(params: {
     sessionId: params.sessionId,
     requestId: params.requestId,
     active: true,
-    claimed: false,
+    parseTasks: [],
     onRawEvent: params.onRawEvent,
   };
   activeFetchProbes.add(probe);
@@ -283,7 +284,7 @@ export function startHostedSearchFetchProbe(params: {
       probe.active = false;
       activeFetchProbes.delete(probe);
       uninstallFetchProbeIfIdle();
-      await probe.parseDone;
+      await Promise.all(probe.parseTasks);
     },
   };
 }

--- a/crates/agent-gui/src/lib/providers/nativeWebSearch.ts
+++ b/crates/agent-gui/src/lib/providers/nativeWebSearch.ts
@@ -1,8 +1,7 @@
-import type { Model, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
+import type { ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
 import type { HostedSearchBlock } from "@liveagent/ui/lib/chat/hostedSearch";
 import type { ProviderId } from "../settings";
 import { isRecord } from "./runtime/common";
-import { supportsAdaptiveAnthropicThinking } from "./runtime/thinkingLevels";
 
 export const HIDDEN_PROVIDER_NATIVE_WEB_SEARCH_TOOL_NAMES = [
   "WebSearch",
@@ -57,54 +56,10 @@ export function isProviderNativeWebFetchToolName(toolName: string | undefined) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Anthropic web search tool version: model-aware adaptive upgrade.
-// `dynamicFiltering` (20260318) is a superset of the 20260209 dynamic-filtering
-// capability plus `response_inclusion` control, and is the version the official
-// docs currently document/exemplify. Eligibility mirrors adaptive-thinking
-// support (`compat.forceAdaptiveThinking`) since both track the same "modern
-// Anthropic model" catalog boundary.
-// ---------------------------------------------------------------------------
-
-export const ANTHROPIC_WEB_SEARCH_TOOL_TYPES = {
-  legacy: "web_search_20250305",
-  dynamicFiltering: "web_search_20260318",
-} as const;
-
-export function supportsAnthropicDynamicFilteringWebSearch(model: Model<any>): boolean {
-  return supportsAdaptiveAnthropicThinking(model);
-}
-
-export function resolveAnthropicWebSearchToolType(
-  model: Model<any>,
-): (typeof ANTHROPIC_WEB_SEARCH_TOOL_TYPES)[keyof typeof ANTHROPIC_WEB_SEARCH_TOOL_TYPES] {
-  return supportsAnthropicDynamicFilteringWebSearch(model)
-    ? ANTHROPIC_WEB_SEARCH_TOOL_TYPES.dynamicFiltering
-    : ANTHROPIC_WEB_SEARCH_TOOL_TYPES.legacy;
-}
-
-// The web_fetch server tool (GA, no beta header) pairs with web_search: 20260318
-// matches the search version we request and is supported by exactly the
-// dynamic-filtering model set (Opus 4.6+/Sonnet 4.6+/Sonnet 5/Fable 5). It is
-// attached only for those models — older/unknown catalog entries (DeepSeek-style
-// relays running anthropic-messages) keep their current payload untouched and
-// rely on the hidden bridge when a model emits web_fetch anyway.
-export const ANTHROPIC_WEB_FETCH_TOOL_TYPES = {
-  legacy: "web_fetch_20250910",
-  dynamicFiltering: "web_fetch_20260318",
-} as const;
-
-export function supportsAnthropicNativeWebFetch(model: Model<any>): boolean {
-  return supportsAnthropicDynamicFilteringWebSearch(model);
-}
-
-export function resolveAnthropicWebFetchToolType(
-  model: Model<any>,
-): (typeof ANTHROPIC_WEB_FETCH_TOOL_TYPES)[keyof typeof ANTHROPIC_WEB_FETCH_TOOL_TYPES] {
-  return supportsAnthropicDynamicFilteringWebSearch(model)
-    ? ANTHROPIC_WEB_FETCH_TOOL_TYPES.dynamicFiltering
-    : ANTHROPIC_WEB_FETCH_TOOL_TYPES.legacy;
-}
+// Keep the Anthropic server tool on the stable GA contract. Dated dynamic
+// versions are intentionally not sent because compatible Claude relays do not
+// expose a reliable capability signal and reject unsupported versions with 400.
+export const ANTHROPIC_WEB_SEARCH_TOOL_TYPE = "web_search_20250305" as const;
 
 // ---------------------------------------------------------------------------
 // Request-payload tool detectors (single catalog source; consumed by
@@ -117,22 +72,9 @@ export function hasAnthropicWebSearchTool(tool: unknown) {
   const name = tool.name;
   return (
     name === "web_search" ||
-    type === ANTHROPIC_WEB_SEARCH_TOOL_TYPES.legacy ||
+    type === ANTHROPIC_WEB_SEARCH_TOOL_TYPE ||
     type === "web_search_20260209" ||
-    type === ANTHROPIC_WEB_SEARCH_TOOL_TYPES.dynamicFiltering
-  );
-}
-
-export function hasAnthropicWebFetchTool(tool: unknown) {
-  if (!isRecord(tool)) return false;
-  const type = tool.type;
-  const name = tool.name;
-  return (
-    name === "web_fetch" ||
-    type === ANTHROPIC_WEB_FETCH_TOOL_TYPES.legacy ||
-    type === "web_fetch_20260209" ||
-    type === "web_fetch_20260309" ||
-    type === ANTHROPIC_WEB_FETCH_TOOL_TYPES.dynamicFiltering
+    type === "web_search_20260318"
   );
 }
 

--- a/crates/agent-gui/src/lib/providers/runtime/nativeSearchPayload.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/nativeSearchPayload.ts
@@ -1,13 +1,10 @@
 import type { Model } from "@earendil-works/pi-ai";
 import type { ProviderId } from "../../settings";
 import {
-  hasAnthropicWebFetchTool,
+  ANTHROPIC_WEB_SEARCH_TOOL_TYPE,
   hasAnthropicWebSearchTool,
   hasOpenAIResponsesWebSearchTool,
   providerSupportsNativeWebSearch,
-  resolveAnthropicWebFetchToolType,
-  resolveAnthropicWebSearchToolType,
-  supportsAnthropicNativeWebFetch,
 } from "../nativeWebSearch";
 import { isRecord } from "./common";
 import { appendGeminiGoogleSearchToolToPayload } from "./geminiToolPayload";
@@ -184,30 +181,14 @@ export function attachProviderNativeWebSearch(
       }
 
       if (providerId === "claude_code") {
-        let anthropicPayload = appendUniqueTool(
+        return appendUniqueTool(
           nextPayload,
-          { type: resolveAnthropicWebSearchToolType(model), name: "web_search" },
+          {
+            type: ANTHROPIC_WEB_SEARCH_TOOL_TYPE,
+            name: "web_search",
+          },
           hasAnthropicWebSearchTool,
         );
-        // Claude models trained with the web_fetch server tool call it whenever
-        // native search is on; declaring it lets compliant endpoints execute the
-        // fetch server-side instead of leaking a client tool_use. Gated to the
-        // modern catalog so legacy/relay-only models keep their payload as-is.
-        // max_content_tokens bounds runaway page/PDF fetches (a 500 KB PDF is
-        // ~125K tokens without it); the limit only applies to text content.
-        if (supportsAnthropicNativeWebFetch(model)) {
-          anthropicPayload = appendUniqueTool(
-            anthropicPayload,
-            {
-              type: resolveAnthropicWebFetchToolType(model),
-              name: "web_fetch",
-              max_uses: 10,
-              max_content_tokens: 50_000,
-            },
-            hasAnthropicWebFetchTool,
-          );
-        }
-        return anthropicPayload;
       }
 
       if (providerId === "gemini") {

--- a/crates/agent-gui/test/chat/cancelled-history.test.mjs
+++ b/crates/agent-gui/test/chat/cancelled-history.test.mjs
@@ -258,8 +258,9 @@ test("model request sanitizer drops aborted hosted search rounds", () => {
   assert.doesNotMatch(JSON.stringify(context.messages), /call_01_PIQ9ADQKpEaBFU6f38f19272/);
 });
 
-test("model request sanitizer strips DSML from text and thinking blocks", () => {
+test("model request sanitizer strips DSML from text but preserves signed thinking", () => {
   const dsml = "\uFF5C\uFF5CDSML\uFF5C\uFF5C";
+  const thinking = `before <${dsml}tool_calls><${dsml}invoke name="Read"></${dsml}invoke></${dsml}tool_calls> after`;
   const context = requestContextSanitizer.sanitizeContextForModelRequest({
     messages: [
       user("search", 1),
@@ -268,7 +269,7 @@ test("model request sanitizer strips DSML from text and thinking blocks", () => 
         content: [
           {
             type: "thinking",
-            thinking: `before <${dsml}tool_calls><${dsml}invoke name="Read"></${dsml}invoke></${dsml}tool_calls> after`,
+            thinking,
           },
           {
             type: "text",
@@ -282,8 +283,8 @@ test("model request sanitizer strips DSML from text and thinking blocks", () => 
   });
 
   const serialized = JSON.stringify(context.messages);
-  assert.equal(serialized.includes("DSML"), false);
-  assert.equal(context.messages[1].content[0].thinking, "before  after");
+  assert.equal(serialized.includes("DSML"), true);
+  assert.equal(context.messages[1].content[0].thinking, thinking);
   assert.equal(context.messages[1].content[1].text, "visible  answer");
 });
 

--- a/crates/agent-gui/test/chat/messages.test.mjs
+++ b/crates/agent-gui/test/chat/messages.test.mjs
@@ -1836,6 +1836,21 @@ After`,
   assert.equal(seedToolCalls.stripSeedToolCallMarkup(assistant.content[0].text), "Before\n\nAfter");
 });
 
+test("seed tool call recovery leaves signed Anthropic thinking untouched", () => {
+  const thinking = `before\n<seed:tool_call><function name="Read"></function></seed:tool_call>\nafter`;
+  const assistant = {
+    role: "assistant",
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    content: [{ type: "thinking", thinking, thinkingSignature: "sig" }],
+    timestamp: 1,
+  };
+
+  assert.equal(seedToolCalls.recoverAssistantSeedToolCalls(assistant), null);
+  assert.equal(assistant.content[0].thinking, thinking);
+});
+
 test("seed tool call recovery does not infer flattened text from DeepSeek metadata", () => {
   const assistant = {
     role: "assistant",

--- a/crates/agent-gui/test/providers/hosted-search-events.test.mjs
+++ b/crates/agent-gui/test/providers/hosted-search-events.test.mjs
@@ -143,6 +143,59 @@ test("hosted search fetch probe finish waits for delayed clone parsing", async (
   }
 });
 
+test("hosted search fetch probes capture multiple continuation requests in one round", async () => {
+  const originalFetch = globalThis.fetch;
+  const events = [];
+  let callCount = 0;
+
+  globalThis.fetch = async () => {
+    callCount += 1;
+    return new Response(
+      sse({
+        type: "response.output_item.added",
+        item: {
+          type: "web_search_call",
+          id: `search-continuation-${callCount}`,
+          status: "completed",
+          action: { query: `continuation query ${callCount}` },
+        },
+      }),
+      { headers: { "content-type": "text/event-stream; charset=utf-8" } },
+    );
+  };
+
+  const probe = hostedSearchEvents.startHostedSearchFetchProbe({
+    providerId: "codex",
+    sessionId: "session-continuation",
+    requestId: "probe-continuation",
+    enabled: true,
+    onRawEvent: (event) => events.push(event),
+  });
+
+  try {
+    const request = () =>
+      fetch("http://127.0.0.1:18080/proxy/codex/v1/responses", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          [hostedSearchEvents.HOSTED_SEARCH_PROBE_HEADER]: "probe-continuation",
+        },
+        body: JSON.stringify({ prompt_cache_key: "session-continuation" }),
+      });
+    await request();
+    await request();
+    await probe.finish();
+
+    assert.deepEqual(
+      events.map((event) => event.item.id),
+      ["search-continuation-1", "search-continuation-2"],
+    );
+  } finally {
+    await probe.finish();
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("hosted search aggregation ignores ordinary text that only mentions search tokens", () => {
   const emitted = [];
   const aggregator = hostedSearchEvents.createHostedSearchEventAggregator({

--- a/crates/agent-gui/test/providers/native-web-search.test.mjs
+++ b/crates/agent-gui/test/providers/native-web-search.test.mjs
@@ -5,14 +5,8 @@ import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 
 const loader = createTsModuleLoader();
 const {
-  ANTHROPIC_WEB_SEARCH_TOOL_TYPES,
-  ANTHROPIC_WEB_FETCH_TOOL_TYPES,
-  resolveAnthropicWebSearchToolType,
-  resolveAnthropicWebFetchToolType,
-  supportsAnthropicDynamicFilteringWebSearch,
-  supportsAnthropicNativeWebFetch,
+  ANTHROPIC_WEB_SEARCH_TOOL_TYPE,
   hasAnthropicWebSearchTool,
-  hasAnthropicWebFetchTool,
   hasOpenAIResponsesWebSearchTool,
   hasGeminiGoogleSearchTool,
   isProviderNativeWebSearchToolName,
@@ -22,39 +16,8 @@ const {
   buildProviderNativeWebFetchBridgeResult,
 } = loader.loadModule("src/lib/providers/nativeWebSearch.ts");
 
-function createAnthropicModel(id, overrides = {}) {
-  return {
-    id,
-    name: id,
-    api: "anthropic-messages",
-    provider: "anthropic",
-    baseUrl: "https://api.anthropic.com",
-    reasoning: true,
-    input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 200_000,
-    maxTokens: 64_000,
-    ...overrides,
-  };
-}
-
-test("resolveAnthropicWebSearchToolType returns the dynamic-filtering version for adaptive-thinking models", () => {
-  const model = createAnthropicModel("claude-fable-5", { compat: { forceAdaptiveThinking: true } });
-  assert.equal(supportsAnthropicDynamicFilteringWebSearch(model), true);
-  assert.equal(resolveAnthropicWebSearchToolType(model), ANTHROPIC_WEB_SEARCH_TOOL_TYPES.dynamicFiltering);
-  assert.equal(resolveAnthropicWebSearchToolType(model), "web_search_20260318");
-});
-
-test("resolveAnthropicWebSearchToolType returns the legacy version for non-adaptive-thinking models", () => {
-  const model = createAnthropicModel("claude-opus-4-6", { compat: { forceAdaptiveThinking: false } });
-  assert.equal(supportsAnthropicDynamicFilteringWebSearch(model), false);
-  assert.equal(resolveAnthropicWebSearchToolType(model), ANTHROPIC_WEB_SEARCH_TOOL_TYPES.legacy);
-  assert.equal(resolveAnthropicWebSearchToolType(model), "web_search_20250305");
-});
-
-test("resolveAnthropicWebSearchToolType defaults to legacy when compat is absent", () => {
-  const model = createAnthropicModel("claude-custom-x");
-  assert.equal(resolveAnthropicWebSearchToolType(model), ANTHROPIC_WEB_SEARCH_TOOL_TYPES.legacy);
+test("Anthropic native search uses the stable GA version", () => {
+  assert.equal(ANTHROPIC_WEB_SEARCH_TOOL_TYPE, "web_search_20250305");
 });
 
 test("hasAnthropicWebSearchTool recognizes every live tool-type version plus the bare name", () => {
@@ -101,36 +64,6 @@ test("isProviderNativeWebSearchToolName recognizes xAI server-side search tool n
   assert.equal(isProviderNativeWebSearchToolName("x_search_call_output"), true);
   assert.equal(isProviderNativeWebSearchToolName("x_searcher"), false);
   assert.equal(isProviderNativeWebSearchToolName("x_unrelated_tool"), false);
-});
-
-test("resolveAnthropicWebFetchToolType mirrors the web_search dynamic-filtering gate", () => {
-  const modern = createAnthropicModel("claude-sonnet-5", {
-    compat: { forceAdaptiveThinking: true },
-  });
-  assert.equal(supportsAnthropicNativeWebFetch(modern), true);
-  assert.equal(
-    resolveAnthropicWebFetchToolType(modern),
-    ANTHROPIC_WEB_FETCH_TOOL_TYPES.dynamicFiltering,
-  );
-  assert.equal(resolveAnthropicWebFetchToolType(modern), "web_fetch_20260318");
-
-  const legacy = createAnthropicModel("claude-opus-4-6", {
-    compat: { forceAdaptiveThinking: false },
-  });
-  assert.equal(supportsAnthropicNativeWebFetch(legacy), false);
-  assert.equal(resolveAnthropicWebFetchToolType(legacy), ANTHROPIC_WEB_FETCH_TOOL_TYPES.legacy);
-  assert.equal(resolveAnthropicWebFetchToolType(legacy), "web_fetch_20250910");
-});
-
-test("hasAnthropicWebFetchTool recognizes every live tool-type version plus the bare name", () => {
-  assert.equal(hasAnthropicWebFetchTool({ type: "web_fetch_20250910", name: "web_fetch" }), true);
-  assert.equal(hasAnthropicWebFetchTool({ type: "web_fetch_20260209", name: "web_fetch" }), true);
-  assert.equal(hasAnthropicWebFetchTool({ type: "web_fetch_20260309", name: "web_fetch" }), true);
-  assert.equal(hasAnthropicWebFetchTool({ type: "web_fetch_20260318", name: "web_fetch" }), true);
-  assert.equal(hasAnthropicWebFetchTool({ type: "something_else", name: "web_fetch" }), true);
-  assert.equal(hasAnthropicWebFetchTool({ type: "function", name: "unrelated" }), false);
-  assert.equal(hasAnthropicWebFetchTool(null), false);
-  assert.equal(hasAnthropicWebFetchTool("web_fetch"), false);
 });
 
 test("isProviderNativeWebFetchToolName matches every hidden tool name, case-insensitively", () => {

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -796,8 +796,8 @@ test("provider payload finalization enables native web search for hosted search 
     { type: "web_search_20250305", name: "web_search" },
   ]);
 
-  // Modern Anthropic models get the paired web_fetch server tool alongside
-  // web_search; legacy/unknown catalog entries (above) keep search-only.
+  // Keep the stable GA tool for modern models too. This is accepted by the
+  // official API and avoids dated-tool incompatibilities in Anthropic relays.
   const anthropicModernPayload = await anthropicOptions.onPayload(
     { messages: [{ role: "user", content: "hello" }] },
     {
@@ -808,13 +808,26 @@ test("provider payload finalization enables native web search for hosted search 
     },
   );
   assert.deepEqual(anthropicModernPayload.tools, [
-    { type: "web_search_20260318", name: "web_search" },
+    { type: "web_search_20250305", name: "web_search" },
+  ]);
+
+  const anthropicRelayOptions = providers.finalizeProviderStreamOptions({
+    providerId: "claude_code",
+    baseUrl: "https://relay.example.test/v1",
+    nativeWebSearch: true,
+    options: {},
+  });
+  const anthropicRelayPayload = await anthropicRelayOptions.onPayload(
+    { messages: [{ role: "user", content: "hello" }] },
     {
-      type: "web_fetch_20260318",
-      name: "web_fetch",
-      max_uses: 10,
-      max_content_tokens: 50_000,
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-sonnet-5",
+      compat: { forceAdaptiveThinking: true },
     },
+  );
+  assert.deepEqual(anthropicRelayPayload.tools, [
+    { type: "web_search_20250305", name: "web_search" },
   ]);
 
   const geminiOptions = providers.finalizeProviderStreamOptions({


### PR DESCRIPTION
## Linked issue

Closes #546

## Summary

Claude 分组开启原生联网搜索后，部分 Anthropic-compatible 端点会因收到不支持的搜索工具版本而返回 400；后续请求还可能因为本地清理或 seed tool-call 恢复改写带签名的 Thinking 块而失败。

本 PR 将 Claude 自动注入的 Web Search 工具固定为 `web_search_20250305`，并修复搜索续传与 Thinking 协议状态处理。

## Change scope

- 将 Claude 原生搜索工具版本固定为 `web_search_20250305`，不再根据模型元数据动态切换。
- 保留旧版、动态版工具名称的识别能力，避免历史消息或已有工具重复注入。
- 带 `thinkingSignature` 或 `redacted` 的 Thinking 块保持完全不变。
- Hosted Search fetch probe 支持同一轮中的多个搜索续传请求，并等待所有解析任务完成。
- 增加 Thinking、搜索续传、工具版本和请求 payload 回归测试。

## Screenshots / preview


## Verification

- `pnpm --filter liveagent exec tsc --noEmit`
- `pnpm --filter liveagent lint`（0 errors；仓库既有 167 warnings）
- `pnpm --filter liveagent test:frontend`（1899 passed）
- `git diff --check`

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] No documentation update is required because this is a provider request compatibility fix.
