### PR TITLE
fix(ui): 修复移动端提示词控件与侧栏交互

### DIFF
--- a/crates/agent-gateway/web/src/styles/base-chat.css
+++ b/crates/agent-gateway/web/src/styles/base-chat.css
@@ -44,6 +44,23 @@ html[data-liveagent-webui="gateway"] .model-selector-group-label {
   line-height: 1.3;
 }
 
+@media (max-width: 480px) {
+  html[data-liveagent-webui="gateway"] .composer-model-trigger {
+    flex: 1 1 0;
+    width: auto;
+    min-width: 0;
+    padding-inline: 0.5rem;
+  }
+
+  html[data-liveagent-webui="gateway"] .composer-model-label {
+    display: block;
+  }
+
+  html[data-liveagent-webui="gateway"] .composer-model-trigger > svg:last-child {
+    display: block;
+  }
+}
+
 html[data-liveagent-webui="gateway"] .chat-history-sidebar {
   contain: layout paint style;
 }

--- a/crates/agent-gateway/web/src/styles/responsive.css
+++ b/crates/agent-gateway/web/src/styles/responsive.css
@@ -57,6 +57,10 @@
     width: 100%;
   }
 
+  .gateway-main-shell [data-app-workbench-chrome] {
+    z-index: var(--layer-raised);
+  }
+
   .gateway-chat-frame {
     height: 100%;
     --gateway-chat-column-gutter: 12px;

--- a/crates/agent-gateway/web/test/mobile-composer-controls.test.mjs
+++ b/crates/agent-gateway/web/test/mobile-composer-controls.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const stylesSource = readFileSync(new URL("../src/styles/base-chat.css", import.meta.url), "utf8");
+const controlStylesSource = readFileSync(
+  new URL("../../../agent-ui/src/lib/chat/composerControlStyles.ts", import.meta.url),
+  "utf8",
+);
+
+test("mobile composer model and branch controls keep truncated labels visible", () => {
+  assert.match(
+    stylesSource,
+    /@media \(max-width: 480px\) \{[\s\S]*?\.composer-model-trigger \{[\s\S]*?flex: 1 1 0;[\s\S]*?width: auto;[\s\S]*?min-width: 0;/,
+  );
+  assert.match(
+    stylesSource,
+    /@media \(max-width: 480px\) \{[\s\S]*?\.composer-model-label \{\s*display: block;/,
+  );
+  assert.match(controlStylesSource, /composer-model-label min-w-0 truncate/);
+  assert.match(
+    stylesSource,
+    /@media \(max-width: 480px\) \{[\s\S]*?\.composer-model-trigger > svg:last-child \{\s*display: block;/,
+  );
+});

--- a/crates/agent-gateway/web/test/workbench-chrome.test.mjs
+++ b/crates/agent-gateway/web/test/workbench-chrome.test.mjs
@@ -10,6 +10,10 @@ const baseChatStyles = readFileSync(
   new URL("../src/styles/base-chat.css", import.meta.url),
   "utf8",
 );
+const responsiveStyles = readFileSync(
+  new URL("../src/styles/responsive.css", import.meta.url),
+  "utf8",
+);
 
 test("gateway mounts workbench chrome outside the shared application view", () => {
   assert.match(gatewayAppViewSource, /<main className="gateway-main-shell">/);
@@ -19,4 +23,15 @@ test("gateway mounts workbench chrome outside the shared application view", () =
   );
   assert.doesNotMatch(gatewayAppViewSource, /chat=\{\{[\s\S]*?headerOverlay:/);
   assert.match(baseChatStyles, /\.gateway-main-shell \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;/);
+});
+
+test("mobile sidebar stays above the interactive workbench header", () => {
+  assert.match(
+    responsiveStyles,
+    /@media \(max-width: 820px\) \{[\s\S]*?\.gateway-main-shell \[data-app-workbench-chrome\] \{\s*z-index: var\(--layer-raised\);/,
+  );
+  assert.match(
+    responsiveStyles,
+    /@media \(max-width: 820px\) \{[\s\S]*?\.gateway-editor-host > \.chat-history-sidebar \{[\s\S]*?z-index: var\(--layer-panel\);/,
+  );
 });

--- a/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
+++ b/crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
@@ -63,7 +63,7 @@ test("execution mode switchers expose a native radio group", () => {
   }
 });
 
-test("popover interactions preserve mode and model changes until an outside dismissal", () => {
+test("model selection closes the popover while group controls keep it open", () => {
   for (const source of pickerSources) {
     assert.match(source, /onClick=\{\(\) => toggleGroup\(group\.id\)\}/);
     assert.match(source, /const \[expandedGroupId, setExpandedGroupId\] = useState/);
@@ -74,8 +74,7 @@ test("popover interactions preserve mode and model changes until an outside dism
       source,
       /<Popover open=\{isModelPickerOpen\} onOpenChange=\{setIsModelPickerOpen\}>/,
     );
-    assert.match(source, /onSelectModel\(parsed\);/);
-    assert.doesNotMatch(source, /onSelectModel\(parsed\);\s+setIsModelPickerOpen\(false\);/);
+    assert.match(source, /onSelectModel\(parsed\);\s+setIsModelPickerOpen\(false\);/);
   }
 });
 

--- a/crates/agent-ui/src/components/chat/ComposerModelControls.tsx
+++ b/crates/agent-ui/src/components/chat/ComposerModelControls.tsx
@@ -378,6 +378,7 @@ export const ComposerModelControls = memo(function ComposerModelControls(
                                 const parsed = parseModelValue(option.value);
                                 if (!parsed) return;
                                 onSelectModel(parsed);
+                                setIsModelPickerOpen(false);
                               }}
                               className={cn(
                                 "model-selector-item flex h-[30px] w-full max-w-full shrink-0 cursor-pointer items-center justify-between gap-3 overflow-hidden rounded-md py-0 pl-6 pr-2 text-left text-xs font-normal leading-5 text-foreground transition-none hover:bg-foreground/[0.05] focus-visible:bg-foreground/[0.05] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 dark:text-white",


### PR DESCRIPTION
## Linked issue

Closes #548

## Summary

- 在 GUI 与 WebUI 选择模型后自动关闭模型下拉框。
- WebUI 移动端恢复模型名称和 Git 分支名称，并在空间不足时使用省略号，避免工具栏溢出。
- 调整移动端工作台顶栏层级，使左侧抽屉位于顶栏之上，恢复右上角折叠按钮点击。
- 增加模型选择、移动端控件布局和抽屉层级回归测试。

## Change scope

- Modules: agent-ui / agent-gui / agent-gateway WebUI
- Key paths:
  - crates/agent-ui/src/components/chat/ComposerModelControls.tsx
  - crates/agent-gateway/web/src/styles/base-chat.css
  - crates/agent-gateway/web/src/styles/responsive.css
  - crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs
  - crates/agent-gateway/web/test/mobile-composer-controls.test.mjs
  - crates/agent-gateway/web/test/workbench-chrome.test.mjs

## Screenshots / preview

按本次提交要求忽略截图，未提供截图或录屏。

## Verification

- `node --test crates/agent-gui/test/chat/execution-mode-model-picker.test.mjs crates/agent-gateway/web/test/mobile-composer-controls.test.mjs crates/agent-gateway/web/test/workbench-chrome.test.mjs`（12 项通过）
- `pnpm --filter @liveagent/gateway-webui test`（590 项通过）
- `pnpm --filter liveagent test:frontend`（1899 项通过）
- `pnpm --filter @liveagent/gateway-webui build`
- `pnpm --filter liveagent build`
- `git diff --check origin/main...HEAD`

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are not required because this is a UI interaction bug fix without configuration or deployment changes.
