### PR TITLE
fix(webui): 优化移动端设置页面布局

### DIFF
--- a/crates/agent-gateway/web/src/pages/settings/DevicesSection.tsx
+++ b/crates/agent-gateway/web/src/pages/settings/DevicesSection.tsx
@@ -660,7 +660,7 @@ function DeviceRow(props: {
 
   return (
     <div className="group rounded-xl border border-border/60 bg-card transition-colors hover:border-border hover:bg-accent/20">
-      <div className="settings-card-row flex items-center gap-3 px-4 py-3">
+      <div className="settings-card-row settings-devices-card-row flex items-center gap-3 px-4 py-3">
         <div
           className={
             agent.online
@@ -675,10 +675,13 @@ function DeviceRow(props: {
           )}
         </div>
 
-        <div className="min-w-0 flex-1">
+        <div className="settings-devices-card-main min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
             <span
-              className={cn("truncate text-sm font-medium", displayName ? "" : "font-mono")}
+              className={cn(
+                "min-w-0 max-w-full truncate text-sm font-medium",
+                displayName ? "" : "font-mono",
+              )}
               title={displayName || agent.agent_id}
             >
               {displayName || agent.agent_id}
@@ -695,8 +698,12 @@ function DeviceRow(props: {
                 : t("settings.devicesOfflineStatus")}
             </span>
           </div>
-          <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-            {displayName ? <span className="font-mono">{agent.agent_id}</span> : null}
+          <div className="settings-devices-card-meta mt-1 flex min-w-0 flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            {displayName ? (
+              <span className="settings-devices-card-agent-id min-w-0 max-w-full truncate font-mono">
+                {agent.agent_id}
+              </span>
+            ) : null}
             {agent.agent_version ? <span>{agent.agent_version}</span> : null}
             <span>
               {t(
@@ -709,7 +716,7 @@ function DeviceRow(props: {
           </div>
         </div>
 
-        <div className="flex shrink-0 flex-wrap items-center justify-end gap-1">
+        <div className="settings-devices-card-actions flex shrink-0 flex-wrap items-center justify-end gap-1">
           {agent.has_token ? (
             <ConfirmActionPopover
               title={t("settings.devicesRotateTitle")}

--- a/crates/agent-gateway/web/src/styles/responsive.css
+++ b/crates/agent-gateway/web/src/styles/responsive.css
@@ -715,6 +715,23 @@
     line-height: 1.5;
   }
 
+  html[data-liveagent-webui="gateway"] .settings-hooks-detail-heading {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  html[data-liveagent-webui="gateway"]
+    .settings-hooks-detail-heading
+    .settings-section-title-group {
+    min-width: 0;
+  }
+
+  html[data-liveagent-webui="gateway"] .settings-hooks-detail-add {
+    flex: 0 0 auto;
+    align-self: flex-start;
+  }
+
   html[data-liveagent-webui="gateway"] .settings-hooks-card {
     padding: 12px;
     border-radius: 12px;
@@ -740,6 +757,34 @@
   html[data-liveagent-webui="gateway"] .settings-hooks-card-desc {
     font-size: 12.5px;
     line-height: 1.5;
+  }
+
+  html[data-liveagent-webui="gateway"] .settings-devices-card-row {
+    display: grid;
+    grid-template-columns: 36px minmax(0, 1fr);
+    align-items: start;
+    gap: 10px 12px;
+  }
+
+  html[data-liveagent-webui="gateway"] .settings-devices-card-main,
+  html[data-liveagent-webui="gateway"] .settings-devices-card-meta {
+    min-width: 0;
+  }
+
+  html[data-liveagent-webui="gateway"] .settings-devices-card-actions {
+    grid-column: 1 / -1;
+    width: 100%;
+    justify-content: stretch;
+    gap: 6px;
+    border-top: 1px solid hsl(var(--border) / 0.5);
+    padding-top: 8px;
+  }
+
+  html[data-liveagent-webui="gateway"] .settings-devices-card-actions > button {
+    min-width: 0;
+    flex: 1 1 0;
+    justify-content: center;
+    padding-inline: 8px;
   }
 
   html[data-liveagent-webui="gateway"] .settings-log-row {
@@ -1140,6 +1185,41 @@
     flex-wrap: wrap;
   }
 
+  html[data-liveagent-webui="gateway"] .settings-log-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 10px;
+  }
+
+  html[data-liveagent-webui="gateway"] .settings-log-row > span {
+    width: auto !important;
+    min-width: 0;
+  }
+
+  html[data-liveagent-webui="gateway"] .settings-log-row > span:first-of-type {
+    flex: initial;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  html[data-liveagent-webui="gateway"] .settings-log-row > span:nth-of-type(3) {
+    margin-left: 0 !important;
+  }
+
+  html[data-liveagent-webui="gateway"] .settings-provider-card-row {
+    display: grid;
+    grid-template-columns: 20px 20px minmax(0, 1fr) auto;
+    align-items: center;
+    flex-wrap: nowrap;
+  }
+
+  html[data-liveagent-webui="gateway"] .settings-provider-card-main {
+    min-width: 0;
+  }
+
   html[data-liveagent-webui="gateway"] .settings-hooks-card-row {
     grid-template-columns: 32px minmax(0, 1fr) auto;
   }
@@ -1178,6 +1258,15 @@
 }
 
 @media (max-width: 380px) {
+  html[data-liveagent-webui="gateway"] .settings-hooks-detail-heading {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  html[data-liveagent-webui="gateway"] .settings-hooks-detail-add {
+    align-self: flex-start;
+  }
+
   .gateway-chat-frame {
     --gateway-chat-column-gutter: 8px;
   }

--- a/crates/agent-gateway/web/test/mobile-settings-layout.test.mjs
+++ b/crates/agent-gateway/web/test/mobile-settings-layout.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const hooksSource = readFileSync(
+  new URL("../../../agent-ui/src/pages/settings/HooksSection.tsx", import.meta.url),
+  "utf8",
+);
+const devicesSource = readFileSync(
+  new URL("../src/pages/settings/DevicesSection.tsx", import.meta.url),
+  "utf8",
+);
+const cronSource = readFileSync(
+  new URL("../../../agent-ui/src/pages/settings/CronTaskViewModal.tsx", import.meta.url),
+  "utf8",
+);
+const responsiveStylesSource = readFileSync(
+  new URL("../src/styles/responsive.css", import.meta.url),
+  "utf8",
+);
+
+test("empty hook events render only the content-area add action", () => {
+  assert.match(hooksSource, /activeHooks\.length > 0 \? \([\s\S]*settings-hooks-detail-add/);
+  assert.match(hooksSource, /activeHooks\.length === 0 \? \([\s\S]*settings\.hooksAdd/);
+});
+
+test("mobile hook headers keep an existing hook action beside its title", () => {
+  assert.match(hooksSource, /settings-hooks-detail-heading/);
+  assert.match(responsiveStylesSource, /\.settings-hooks-detail-heading\s*\{[\s\S]*flex-direction:\s*row;/);
+  assert.match(responsiveStylesSource, /\.settings-hooks-detail-add\s*\{[\s\S]*flex:\s*0 0 auto;/);
+});
+
+test("mobile device rows move text actions below the client details", () => {
+  assert.match(devicesSource, /settings-devices-card-row/);
+  assert.match(devicesSource, /settings-devices-card-main min-w-0 flex-1/);
+  assert.match(devicesSource, /settings-devices-card-actions flex shrink-0/);
+  assert.match(
+    responsiveStylesSource,
+    /\.settings-devices-card-row\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-columns:\s*36px minmax\(0, 1fr\);/,
+  );
+  assert.match(
+    responsiveStylesSource,
+    /\.settings-devices-card-actions\s*\{[\s\S]*grid-column:\s*1 \/ -1;[\s\S]*width:\s*100%;/,
+  );
+});
+
+test("mobile cron details give configuration more room and compact log summaries", () => {
+  assert.match(cronSource, /max-\[820px\]:max-h-\[55%\]/);
+  assert.doesNotMatch(cronSource, /max-\[820px\]:max-h-\[42%\]/);
+  assert.match(
+    responsiveStylesSource,
+    /\.settings-log-row\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-columns:\s*auto minmax\(0, 1fr\) auto auto auto;/,
+  );
+  assert.match(
+    responsiveStylesSource,
+    /\.settings-log-row\s*> span:first-of-type\s*\{[\s\S]*text-overflow:\s*ellipsis;/,
+  );
+});

--- a/crates/agent-gateway/web/test/provider-model-refresh-button.test.mjs
+++ b/crates/agent-gateway/web/test/provider-model-refresh-button.test.mjs
@@ -10,6 +10,14 @@ const providersSectionSource = ["ProviderModal.tsx", "ProviderModalView.tsx"]
     ),
   )
   .join("\n");
+const providerListSource = readFileSync(
+  new URL("../../../agent-ui/src/pages/settings/ProvidersSection.tsx", import.meta.url),
+  "utf8",
+);
+const responsiveStylesSource = readFileSync(
+  new URL("../src/styles/responsive.css", import.meta.url),
+  "utf8",
+);
 
 test("WebUI provider model refresh only disables while a request is running", () => {
   const clickHandlerIndex = providersSectionSource.indexOf("onClick={handleRefresh}");
@@ -42,4 +50,21 @@ test("provider model refresh accepts a saved WebUI key without exposing it", () 
   assert.notEqual(reuseGuardEnd, -1);
   assert.doesNotMatch(providersSectionSource.slice(reuseGuardStart, reuseGuardEnd), /isFullUrl\s*===/);
   assert.match(providersSectionSource, /providerId: initialData\?\.id/);
+});
+
+test("provider cards keep their content and actions on one mobile row", () => {
+  assert.match(providerListSource, /settings-provider-card-row/);
+  assert.match(providerListSource, /settings-provider-card-main min-w-0 flex-1/);
+  assert.match(
+    responsiveStylesSource,
+    /\.settings-provider-card-row\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-columns:\s*20px 20px minmax\(0, 1fr\) auto;/,
+  );
+});
+
+test("provider request navigation label stays centered on mobile", () => {
+  assert.match(
+    providersSectionSource,
+    /min-w-0 flex-1 max-\[720px\]:flex-none max-\[720px\]:basis-auto/,
+  );
+  assert.doesNotMatch(providersSectionSource, /max-\[720px\]:basis-\[calc\(100%-3rem\)\]/);
 });

--- a/crates/agent-ui/src/pages/settings/CronTaskViewModal.tsx
+++ b/crates/agent-ui/src/pages/settings/CronTaskViewModal.tsx
@@ -782,7 +782,7 @@ export function CronTaskViewModal({ taskId, onClose }: CronTaskViewModalProps) {
         <DialogTitle className="sr-only">{task.name}</DialogTitle>
         {/* ── Left: task detail ── */}
         <DialogBody className="flex overflow-hidden p-0 max-[820px]:flex-col">
-          <div className="flex w-[380px] shrink-0 flex-col border-r border-border/40 bg-background max-[820px]:max-h-[42%] max-[820px]:w-full max-[820px]:border-b max-[820px]:border-r-0">
+          <div className="flex w-[380px] shrink-0 flex-col border-r border-border/40 bg-background max-[820px]:max-h-[55%] max-[820px]:w-full max-[820px]:border-b max-[820px]:border-r-0">
             <LeftPanel
               task={task}
               t={t}

--- a/crates/agent-ui/src/pages/settings/HooksSection.tsx
+++ b/crates/agent-ui/src/pages/settings/HooksSection.tsx
@@ -396,7 +396,7 @@ export function HooksSection(_props: SettingsSectionProps) {
 
         <section className="settings-hooks-detail flex flex-col overflow-hidden rounded-2xl border border-border/60 bg-card">
           <div className="settings-hooks-detail-header shrink-0 border-b border-border/40 px-5 py-4">
-            <div className="settings-section-heading-row flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="settings-section-heading-row settings-hooks-detail-heading flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div className="settings-section-title-group flex items-center gap-3">
                 {(() => {
                   const phase = orderedEvents.find((item) => item.event === activeEvent)?.phase;
@@ -424,10 +424,15 @@ export function HooksSection(_props: SettingsSectionProps) {
                   </p>
                 </div>
               </div>
-              <Button className="settings-section-action gap-1.5 self-start" onClick={openAdd}>
-                <Plus className="h-3.5 w-3.5" />
-                {t("settings.hooksAdd")}
-              </Button>
+              {activeHooks.length > 0 ? (
+                <Button
+                  className="settings-section-action settings-hooks-detail-add gap-1.5 self-start"
+                  onClick={openAdd}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  {t("settings.hooksAdd")}
+                </Button>
+              ) : null}
             </div>
           </div>
 

--- a/crates/agent-ui/src/pages/settings/ProviderModalView.tsx
+++ b/crates/agent-ui/src/pages/settings/ProviderModalView.tsx
@@ -247,7 +247,7 @@ export function ProviderModalView({ viewModel }: { viewModel: ProviderModalViewM
               aria-current={activePanel === "request" ? "page" : undefined}
             >
               <Globe className="h-4 w-4 shrink-0 max-[720px]:h-3.5 max-[720px]:w-3.5" />
-              <span className="min-w-0 flex-1 max-[720px]:basis-[calc(100%-3rem)]">
+              <span className="min-w-0 flex-1 max-[720px]:flex-none max-[720px]:basis-auto">
                 {t("settings.providerDialogRequest")}
               </span>
               {customHeaders.length > 0 ? (

--- a/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
@@ -563,7 +563,7 @@ function ProviderList(props: {
                     key={provider.id}
                     {...getProviderReorderProps(provider.id)}
                     className={cn(
-                      "settings-card-row group flex items-center gap-3 rounded-xl border bg-card px-4 py-3 transition-colors hover:bg-accent/30",
+                      "settings-card-row settings-provider-card-row group flex items-center gap-3 rounded-xl border bg-card px-4 py-3 transition-colors hover:bg-accent/30",
                       draggingProviderId === provider.id && "bg-accent shadow-lg",
                     )}
                   >
@@ -571,7 +571,7 @@ function ProviderList(props: {
                     <div className="flex w-5 shrink-0 items-center justify-center text-lg text-foreground">
                       <ProviderBrandIcon type={type} />
                     </div>
-                    <div className="min-w-0 flex-1 max-[720px]:basis-[calc(100%-3rem)]">
+                    <div className="settings-provider-card-main min-w-0 flex-1">
                       <div className="flex items-center gap-1.5">
                         <span className="truncate text-sm font-medium">{provider.name}</span>
                         {provider.useSystemProxy ? (


### PR DESCRIPTION
## Linked issue

Closes #550

## Summary

修复 WebUI 移动端设置页面的多处排版问题，并优化 Cron 定时任务详情页的执行日志占比。

## Change scope

- 供应商配置卡片：使用稳定的移动端网格布局，避免图标、正文和操作按钮挤压换行。
- 新增供应商模态框：修复“请求配置”导航标签在移动端的对齐问题。
- Hooks：无 Hook 时隐藏详情头部重复的新增按钮；存在 Hook 时优化标题与新增按钮排列，并兼容超窄屏。
- 多客户端管理：将客户端信息与操作按钮分行布局，增加长名称和 `agent_id` 的省略处理。
- Cron 详情：扩大移动端任务配置区域，压缩执行日志摘要行，保留日志展开和滚动能力。
- 增加移动端设置布局结构回归测试。

## Screenshots / preview

<!-- UI screenshots or a recording are required by repository governance. Please add before marking this PR ready for review. -->

## Verification

- `node --test test/mobile-settings-layout.test.mjs test/provider-model-refresh-button.test.mjs` — 8/8 passed
- WebUI tests — 616/616 passed
- GUI frontend tests — 2063/2063 passed
- GUI/WebUI TypeScript checks and builds passed
- `pnpm check:ui-boundaries` passed
- UI lint and `git diff --check` passed

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts at branch creation.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.
