### PR TITLE
feat(deepseek): 正式供应商改走 Responses 协议并支持原生搜索

### DIFF
--- a/crates/agent-gateway/test/webui/web-settings.test.mjs
+++ b/crates/agent-gateway/test/webui/web-settings.test.mjs
@@ -459,7 +459,7 @@ test("web chat runtime controls default and follow model-aware reasoning support
     ["minimal", "low", "medium", "high"],
   );
   // 中转挂载的国产厂商模型走跨供应商回查命中真实形态；DeepSeek 正式供应商
-  // 直接读取自己的目录。
+  // 只暴露 Responses V4 模型，档位为官方 none/low/high/max 映射。
   assert.deepEqual(
     settings.getChatRuntimeReasoningLevelsForProvider({
       providerId: "codex",
@@ -471,17 +471,17 @@ test("web chat runtime controls default and follow model-aware reasoning support
   assert.deepEqual(
     settings.getChatRuntimeReasoningLevelsForProvider({
       providerId: "deepseek",
-      modelId: "deepseek-reasoner",
+      modelId: "deepseek-v4-flash",
     }),
-    [],
+    ["low", "high", "max"],
   );
-  assert.equal(settings.isThinkingAlwaysOnForModel("deepseek", "deepseek-reasoner"), true);
+  assert.equal(settings.isThinkingAlwaysOnForModel("deepseek", "deepseek-v4-flash"), false);
   assert.deepEqual(
     settings.getChatRuntimeReasoningLevelsForProvider({
       providerId: "deepseek",
-      modelId: "deepseek-chat",
+      modelId: "deepseek-v4-pro",
     }),
-    [],
+    ["low", "high", "max"],
   );
 
   assert.equal(settings.isThinkingAlwaysOnForModel("claude_code", "claude-fable-5"), true);

--- a/crates/agent-gateway/web/test/model-thinking.test.mjs
+++ b/crates/agent-gateway/web/test/model-thinking.test.mjs
@@ -34,9 +34,13 @@ test("web thinking wrappers delegate to the shared resolver", () => {
   assert.equal(settings.isThinkingAlwaysOnForModel("xai", "grok-4.5"), true);
   assert.equal(settings.isThinkingAlwaysOnForModel("codex", "gpt-5"), true);
   assert.deepEqual(settings.getKnownModelThinkingLevels("codex", "gpt-4o"), []);
-  // DeepSeek 正式供应商的恒开不可调模型：无档位但思考恒开。
-  assert.deepEqual(settings.getKnownModelThinkingLevels("deepseek", "deepseek-reasoner"), []);
-  assert.equal(settings.isThinkingAlwaysOnForModel("deepseek", "deepseek-reasoner"), true);
+  // DeepSeek 正式供应商的 V4 Responses 模型：low/high/max，思考可关。
+  assert.deepEqual(settings.getKnownModelThinkingLevels("deepseek", "deepseek-v4-flash"), [
+    "low",
+    "high",
+    "max",
+  ]);
+  assert.equal(settings.isThinkingAlwaysOnForModel("deepseek", "deepseek-v4-flash"), false);
 });
 
 test("web resolver honors decorated ids and heuristics like the GUI", () => {

--- a/crates/agent-gui/src/agent-ui-adapters/providerSettings.tsx
+++ b/crates/agent-gui/src/agent-ui-adapters/providerSettings.tsx
@@ -153,7 +153,7 @@ export function providerFromCcs(
       item.providerType !== "gemini" &&
       item.providerType !== "xai" &&
       item.providerType !== "deepseek",
-    nativeWebSearchEnabled: item.providerType !== "deepseek",
+    nativeWebSearchEnabled: true,
     useSystemProxy: false,
     usageQuery: getDefaultUsageQueryConfig(),
   };
@@ -213,8 +213,7 @@ export function providerFromCherry(
         ? false
         : (existing?.promptCachingEnabled ??
           (item.providerType !== "gemini" && item.providerType !== "xai")),
-    nativeWebSearchEnabled:
-      item.providerType === "deepseek" ? false : (existing?.nativeWebSearchEnabled ?? true),
+    nativeWebSearchEnabled: existing?.nativeWebSearchEnabled ?? true,
     useSystemProxy: existing?.useSystemProxy ?? false,
     usageQuery: existing?.usageQuery ?? getDefaultUsageQueryConfig(),
   };

--- a/crates/agent-gui/src/lib/providers/deepSeekNative.ts
+++ b/crates/agent-gui/src/lib/providers/deepSeekNative.ts
@@ -1,221 +1,115 @@
 import {
-  type Api,
   type AssistantMessage,
+  type AssistantMessageEvent,
   type AssistantMessageEventStream,
   type Context,
   createAssistantMessageEventStream,
   type Model,
-  parseStreamingJson,
-  type ToolCall,
 } from "@earendil-works/pi-ai";
-import { createParser, type ParseError } from "eventsource-parser";
+import {
+  type OpenAIResponsesOptions,
+  stream as streamOpenAIResponses,
+} from "@earendil-works/pi-ai/api/openai-responses";
+import { createParser } from "eventsource-parser";
 import { inlineDeepSeekLargePastes } from "./deepSeekAttachments";
 import { resolveMaxTokens } from "./runtime/common";
+import { clampOpenAIReasoningEffort } from "./runtime/thinkingLevels";
 import type { StreamOptionsEx, ToolChoice } from "./runtime/types";
 
-export const DEEPSEEK_CHAT_COMPLETIONS_API = "deepseek-chat-completions";
+export const DEEPSEEK_RESPONSES_API = "deepseek-responses";
 
-const DEEPSEEK_STREAM_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
-const DEEPSEEK_SSE_BUFFER_LIMIT = 1024 * 1024;
-
-type DeepSeekModel = Model<Api> & {
-  deepSeekThinkingAlwaysOn?: boolean;
+export type DeepSeekResponseState = {
+  output: Record<string, unknown>[];
 };
 
-type DeepSeekWireMessage =
-  | { role: "system" | "user"; content: string }
-  | {
-      role: "assistant";
-      content: string;
-      reasoning_content?: string;
-      tool_calls?: Array<{
-        id: string;
-        type: "function";
-        function: { name: string; arguments: string };
-      }>;
-    }
-  | { role: "tool"; tool_call_id: string; content: string };
-
-type DeepSeekWireToolChoice =
-  | "auto"
-  | "none"
-  | "required"
-  | { type: "function"; function: { name: string } };
-
-type DeepSeekWireRequest = {
-  model: string;
-  messages: DeepSeekWireMessage[];
-  stream: true;
-  stream_options: { include_usage: true };
-  thinking: { type: "enabled" | "disabled" };
-  reasoning_effort?: "high" | "max";
-  tools?: Array<{
-    type: "function";
-    function: {
-      name: string;
-      description: string;
-      parameters: Record<string, unknown>;
-    };
-  }>;
-  tool_choice?: DeepSeekWireToolChoice;
-  temperature?: number;
-  max_tokens?: number;
+export type DeepSeekAssistantMessage = AssistantMessage & {
+  deepSeekResponseState?: DeepSeekResponseState;
 };
 
-type DeepSeekWireUsage = {
-  prompt_tokens?: number;
-  completion_tokens?: number;
-  prompt_cache_hit_tokens?: number;
-  prompt_tokens_details?: { cached_tokens?: number };
-  completion_tokens_details?: { reasoning_tokens?: number };
-};
+const OFFICIAL_DEEPSEEK_HOST = "api.deepseek.com";
+const API_VERSION_SUFFIX_RE = /\/v\d+(?:beta)?$/i;
 
-type DeepSeekWireToolCallDelta = {
-  index?: number;
-  id?: string;
-  function?: { name?: string; arguments?: string };
-};
-
-type DeepSeekWireChunk = {
-  id?: string;
-  model?: string;
-  choices?: Array<{
-    delta?: {
-      content?: string | null;
-      reasoning_content?: string | null;
-      tool_calls?: DeepSeekWireToolCallDelta[];
-    };
-    finish_reason?: string | null;
-  }>;
-  usage?: DeepSeekWireUsage | null;
-};
-
-type StreamingToolCall = ToolCall & {
-  partialArguments: string;
-  wireIndex: number;
-};
-
-function textFromContent(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  let text = "";
-  for (const block of content) {
-    if (!block || typeof block !== "object") continue;
-    if ((block as { type?: string }).type === "image") {
-      throw new Error("The DeepSeek chat-completions adapter does not support image content.");
-    }
-    if ((block as { type?: string }).type === "text") {
-      text += String((block as { text?: unknown }).text ?? "");
-    }
-  }
-  return text;
+function stripEndpointSuffix(pathname: string) {
+  const withoutTrailingSlash = pathname.replace(/\/+$/, "");
+  return withoutTrailingSlash.replace(/\/(?:chat\/completions|responses?)$/i, "");
 }
 
-export function serializeDeepSeekMessages(context: Context): DeepSeekWireMessage[] {
-  const messages: DeepSeekWireMessage[] = [];
-  if (context.systemPrompt !== undefined) {
-    messages.push({ role: "system", content: context.systemPrompt });
-  }
-
-  for (const message of context.messages) {
-    if (message.role === "user") {
-      messages.push({ role: "user", content: textFromContent(message.content) });
-      continue;
-    }
-    if (message.role === "toolResult") {
-      messages.push({
-        role: "tool",
-        tool_call_id: message.toolCallId,
-        content: textFromContent(message.content) || "(no output)",
-      });
-      continue;
-    }
-
-    const text = message.content
-      .filter((block) => block.type === "text")
-      .map((block) => block.text)
-      .join("");
-    const reasoning = message.content
-      .filter((block) => block.type === "thinking")
-      .map((block) => block.thinking)
-      .join("");
-    const toolCalls = message.content
-      .filter((block) => block.type === "toolCall")
-      .map((block) => ({
-        id: block.id,
-        type: "function" as const,
-        function: {
-          name: block.name,
-          arguments: JSON.stringify(block.arguments),
-        },
-      }));
-    messages.push({
-      role: "assistant",
-      content: text,
-      ...(toolCalls.length > 0 && reasoning ? { reasoning_content: reasoning } : {}),
-      ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
-    });
-  }
-  return messages;
+function hasApiVersionSuffix(pathname: string) {
+  return API_VERSION_SUFFIX_RE.test(pathname);
 }
 
-function mapToolChoice(toolChoice: ToolChoice | undefined): DeepSeekWireToolChoice | undefined {
+export function isOfficialDeepSeekBaseUrl(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl.trim()).hostname.toLowerCase() === OFFICIAL_DEEPSEEK_HOST;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Normalize a DeepSeek Responses SDK base URL.
+ * Official api.deepseek.com stays at the root (no /v1). Relays without a
+ * version segment get /v1 appended so one-api/new-api style gateways resolve.
+ */
+export function normalizeDeepSeekResponsesBaseUrl(
+  baseUrl: string,
+  options?: { officialHost?: boolean },
+): string {
+  const trimmed = baseUrl.trim().replace(/\/+$/, "");
+  try {
+    const url = new URL(trimmed);
+    let pathname = stripEndpointSuffix(url.pathname);
+    const official = options?.officialHost ?? url.hostname.toLowerCase() === OFFICIAL_DEEPSEEK_HOST;
+    if (official) {
+      pathname = pathname.replace(API_VERSION_SUFFIX_RE, "");
+    } else if (!hasApiVersionSuffix(pathname)) {
+      pathname = `${pathname}/v1`;
+    }
+    url.pathname = pathname || "/";
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return trimmed;
+  }
+}
+
+/** Convert a full endpoint URL to the corresponding DeepSeek /responses URL. */
+export function normalizeDeepSeekResponsesEndpoint(endpoint: string): string {
+  const normalizedBaseUrl = normalizeDeepSeekResponsesBaseUrl(endpoint);
+  try {
+    const url = new URL(normalizedBaseUrl);
+    url.pathname = `${url.pathname.replace(/\/+$/, "")}/responses`;
+    return url.toString();
+  } catch {
+    return `${normalizedBaseUrl.replace(/\/+$/, "")}/responses`;
+  }
+}
+
+function mapToolChoice(
+  toolChoice: ToolChoice | undefined,
+): OpenAIResponsesOptions["toolChoice"] | undefined {
   if (!toolChoice) return undefined;
   if (toolChoice === "any") return "required";
   if (toolChoice === "auto" || toolChoice === "none") return toolChoice;
-  return { type: "function", function: { name: toolChoice.name } };
+  return { type: "function", name: toolChoice.name };
 }
 
-function resolveThinking(model: DeepSeekModel, options: StreamOptionsEx) {
-  if (options.deepSeekThinking === "disabled") {
-    return { thinking: { type: "disabled" as const } };
+function assertTextOnlyContext(context: Context) {
+  for (const message of context.messages) {
+    if (message.role === "user" && Array.isArray(message.content)) {
+      if (message.content.some((block) => block.type === "image")) {
+        throw new Error("DeepSeek Responses does not support image input.");
+      }
+    }
+    if (
+      message.role === "toolResult" &&
+      message.content.some((block) => block.type === "image")
+    ) {
+      throw new Error("DeepSeek Responses does not support image tool results.");
+    }
   }
-  const reasoning = options.reasoning;
-  if (reasoning !== undefined) {
-    const reasoningEffort: "high" | "max" =
-      reasoning === "max" || reasoning === "xhigh" ? "max" : "high";
-    return {
-      thinking: { type: "enabled" as const },
-      reasoning_effort: reasoningEffort,
-    };
-  }
-  if (model.deepSeekThinkingAlwaysOn) {
-    return {
-      thinking: { type: "enabled" as const },
-      reasoning_effort: "high" as const,
-    };
-  }
-  return { thinking: { type: "disabled" as const } };
 }
 
-export function serializeDeepSeekRequest(
-  model: DeepSeekModel,
-  context: Context,
-  options: StreamOptionsEx,
-): DeepSeekWireRequest {
-  const tools = context.tools?.map((tool) => ({
-    type: "function" as const,
-    function: {
-      name: tool.name,
-      description: tool.description,
-      parameters: tool.parameters as Record<string, unknown>,
-    },
-  }));
-  const toolChoice = tools?.length ? mapToolChoice(options.toolChoice) : undefined;
-  return {
-    model: model.id,
-    messages: serializeDeepSeekMessages(context),
-    stream: true,
-    stream_options: { include_usage: true },
-    ...resolveThinking(model, options),
-    ...(tools?.length ? { tools } : {}),
-    ...(toolChoice ? { tool_choice: toolChoice } : {}),
-    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
-    max_tokens: resolveMaxTokens(options.maxTokens, model.maxTokens),
-  };
-}
-
-function createEmptyAssistant(model: DeepSeekModel): AssistantMessage {
+function createErrorAssistant(model: Model<any>, error: unknown, aborted: boolean): AssistantMessage {
   return {
     role: "assistant",
     content: [],
@@ -230,365 +124,180 @@ function createEmptyAssistant(model: DeepSeekModel): AssistantMessage {
       totalTokens: 0,
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     },
-    stopReason: "pending",
+    stopReason: aborted ? "aborted" : "error",
+    errorMessage: error instanceof Error ? error.message : String(error),
     timestamp: Date.now(),
   };
 }
 
-function mapUsage(usage: DeepSeekWireUsage): AssistantMessage["usage"] {
-  const promptTokens = usage.prompt_tokens ?? 0;
-  const output = usage.completion_tokens ?? 0;
-  const cacheRead =
-    usage.prompt_tokens_details?.cached_tokens ?? usage.prompt_cache_hit_tokens ?? 0;
-  const input = Math.max(0, promptTokens - cacheRead);
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+const DEEPSEEK_REPLAYABLE_OUTPUT_TYPES = new Set([
+  "reasoning",
+  "message",
+  "function_call",
+  "web_search_call",
+]);
+
+type DeepSeekResponseCapture = {
+  outputByIndex: Map<number, Record<string, unknown>>;
+  terminalOutput?: Record<string, unknown>[];
+};
+
+function toReplayableOutputItem(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value) || !DEEPSEEK_REPLAYABLE_OUTPUT_TYPES.has(String(value.type))) {
+    return undefined;
+  }
+  return value;
+}
+
+function captureDeepSeekResponseEvent(
+  capture: DeepSeekResponseCapture,
+  event: unknown,
+) {
+  if (!isRecord(event)) return;
+  if (event.type === "response.output_item.added" || event.type === "response.output_item.done") {
+    const item = toReplayableOutputItem(event.item);
+    if (item && typeof event.output_index === "number") {
+      capture.outputByIndex.set(event.output_index, item);
+    }
+  }
+  if (
+    (event.type === "response.completed" ||
+      event.type === "response.incomplete" ||
+      event.type === "response.failed") &&
+    isRecord(event.response) &&
+    Array.isArray(event.response.output)
+  ) {
+    capture.terminalOutput = event.response.output.flatMap((item) => {
+      const replayable = toReplayableOutputItem(item);
+      return replayable ? [replayable] : [];
+    });
+  }
+}
+
+async function captureDeepSeekResponse(
+  response: Response,
+  capture: DeepSeekResponseCapture,
+) {
+  const reader = response.clone().body?.getReader();
+  if (!reader) return;
+  const decoder = new TextDecoder();
+  const parser = createParser({
+    onEvent(event) {
+      if (!event.data.trim() || event.data.trim() === "[DONE]") return;
+      try {
+        captureDeepSeekResponseEvent(capture, JSON.parse(event.data));
+      } catch {
+        // Response parsing remains owned by pi-ai; capture is best-effort state preservation.
+      }
+    },
+  });
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      parser.feed(decoder.decode(value, { stream: true }));
+    }
+    parser.feed(decoder.decode());
+  } catch {
+    // A failed clone must not interfere with the actual provider stream.
+  }
+}
+
+function capturedDeepSeekOutput(capture: DeepSeekResponseCapture) {
+  return (
+    capture.terminalOutput ??
+    [...capture.outputByIndex.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([, item]) => item)
+  );
+}
+
+function buildResponsesOptions(
+  model: Model<any>,
+  options: StreamOptionsEx,
+  fetch: typeof globalThis.fetch,
+): OpenAIResponsesOptions {
+  const reasoningEffort =
+    options.deepSeekThinking === "disabled"
+      ? undefined
+      : clampOpenAIReasoningEffort(model, options.reasoning);
   return {
-    input,
-    output,
-    cacheRead,
-    cacheWrite: 0,
-    reasoning: usage.completion_tokens_details?.reasoning_tokens,
-    totalTokens: input + output + cacheRead,
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    temperature: options.temperature,
+    maxTokens: resolveMaxTokens(options.maxTokens, model.maxTokens),
+    signal: options.signal,
+    apiKey: options.apiKey,
+    headers: options.headers,
+    fetch,
+    onPayload: options.onPayload,
+    onResponse: options.onResponse,
+    maxRetries: options.maxRetries,
+    maxRetryDelayMs: options.maxRetryDelayMs,
+    timeoutMs: options.timeoutMs,
+    samplingParams: options.samplingParams,
+    reasoningEffort,
+    toolChoice: mapToolChoice(options.toolChoice),
   };
 }
 
-function mapFinishReason(reason: string | undefined): AssistantMessage["stopReason"] {
-  if (reason === undefined || reason === "stop") return "stop";
-  if (reason === "tool_calls") return "toolUse";
-  if (reason === "length") return "length";
-  throw new Error(`DeepSeek model stopped with unsupported finish reason: ${reason}`);
-}
-
-function buildEndpoint(baseUrl: string) {
-  const normalized = baseUrl.trim().replace(/\/+$/, "");
-  return normalized.toLowerCase().endsWith("/chat/completions")
-    ? normalized
-    : `${normalized}/chat/completions`;
-}
-
 /**
- * DeepSeek 生态的 chat-completions 挂在 /v1 下。官方域名对裸路径有意兼容
- * （/chat/completions 与 /v1/chat/completions 都通），但 one-api/new-api 系
- * 中转只认 /v1——裸域名的 /chat/completions 会被前置 SPA 以 200+HTML 兜底，
- * SSE 解析零事件后报出误导性的 "ended without [DONE]"。与 codex 的
- * maybeAppendCodexApiVersion 同约定：已带版本段或完整端点路径的配置原样
- * 保留，其余补 /v1。
+ * DeepSeek's native Responses adapter. pi-ai owns OpenAI-compatible request and
+ * SSE mechanics; this boundary adds DeepSeek attachment rules and preserves
+ * server-side web_search_call items for stateless multi-turn replay.
  */
-export function normalizeDeepSeekBaseUrl(baseUrl: string): string {
-  const trimmed = baseUrl.trim().replace(/\/+$/, "");
-  try {
-    const url = new URL(trimmed);
-    const pathname = url.pathname.replace(/\/+$/, "");
-    if (/\/chat\/completions$/i.test(pathname) || /\/v\d+(?:beta)?$/i.test(pathname)) {
-      return trimmed;
-    }
-    url.pathname = `${pathname}/v1`;
-    return url.toString().replace(/\/+$/, "");
-  } catch {
-    return trimmed;
-  }
-}
-
-function buildHeaders(model: DeepSeekModel, options: StreamOptionsEx) {
-  const headers = new Headers({
-    Accept: "text/event-stream",
-    "Content-Type": "application/json",
-  });
-  if (options.apiKey) headers.set("Authorization", `Bearer ${options.apiKey}`);
-  for (const [key, value] of Object.entries(model.headers ?? {})) headers.set(key, value);
-  for (const [key, value] of Object.entries(options.headers ?? {})) {
-    if (value === null) headers.delete(key);
-    else headers.set(key, value);
-  }
-  return headers;
-}
-
-async function providerErrorMessage(response: Response) {
-  const text = await response.text().catch(() => "");
-  let detail = text.trim();
-  try {
-    const body = JSON.parse(text) as { error?: { message?: unknown } };
-    if (typeof body.error?.message === "string") detail = body.error.message.trim();
-  } catch {}
-  return detail
-    ? `DeepSeek API error (HTTP ${response.status}): ${detail}`
-    : `DeepSeek API error (HTTP ${response.status})`;
-}
-
-function responseHeaders(headers: Headers): Record<string, string> {
-  const result: Record<string, string> = {};
-  headers.forEach((value, key) => {
-    result[key] = value;
-  });
-  return result;
-}
-
-function forwardAbort(source: AbortSignal, target: AbortController): () => void {
-  if (source.aborted) {
-    target.abort(source.reason);
-    return () => {};
-  }
-  const onAbort = () => target.abort(source.reason);
-  source.addEventListener("abort", onAbort, { once: true });
-  return () => source.removeEventListener("abort", onAbort);
-}
-
-export function streamDeepSeekNative(
-  model: DeepSeekModel,
+export function streamDeepSeekResponses(
+  model: Model<any>,
   context: Context,
   options: StreamOptionsEx,
 ): AssistantMessageEventStream {
-  const stream = createAssistantMessageEventStream();
-  const output = createEmptyAssistant(model);
+  const output = createAssistantMessageEventStream();
 
   void (async () => {
-    const idleController = new AbortController();
-    const requestController = new AbortController();
-    let releaseCallerAbort = () => {};
-    let releaseIdleAbort = () => {};
-    let idleTimedOut = false;
-    let idleTimer: ReturnType<typeof setTimeout> | undefined;
-    const armIdleTimer = () => {
-      if (idleTimer) clearTimeout(idleTimer);
-      idleTimer = setTimeout(() => {
-        idleTimedOut = true;
-        idleController.abort(new Error("DeepSeek stream idle timeout"));
-      }, DEEPSEEK_STREAM_IDLE_TIMEOUT_MS);
-    };
-
     try {
-      if (options.signal) releaseCallerAbort = forwardAbort(options.signal, requestController);
-      releaseIdleAbort = forwardAbort(idleController.signal, requestController);
-
+      assertTextOnlyContext(context);
       const preparedContext = await inlineDeepSeekLargePastes(context, options.workdir);
-      let payload: unknown = serializeDeepSeekRequest(model, preparedContext, options);
-      const replacement = await options.onPayload?.(payload, model);
-      if (replacement !== undefined) payload = replacement;
-
-      armIdleTimer();
-      const response = await (options.fetch ?? globalThis.fetch)(buildEndpoint(model.baseUrl), {
-        method: "POST",
-        headers: buildHeaders(model, options),
-        body: JSON.stringify(payload),
-        signal: requestController.signal,
-      });
-      armIdleTimer();
-      await options.onResponse?.(
-        { status: response.status, headers: responseHeaders(response.headers) },
-        model,
+      const responseCapture: DeepSeekResponseCapture = { outputByIndex: new Map() };
+      const captureTasks: Promise<void>[] = [];
+      const baseFetch = options.fetch ?? globalThis.fetch;
+      const fetchWithStateCapture: typeof globalThis.fetch = async (input, init) => {
+        const response = await baseFetch(input, init);
+        const task = captureDeepSeekResponse(response, responseCapture);
+        captureTasks.push(task);
+        void task;
+        return response;
+      };
+      const inner = streamOpenAIResponses(
+        model as Model<"openai-responses">,
+        preparedContext,
+        buildResponsesOptions(model, options, fetchWithStateCapture),
       );
-      if (!response.ok) throw new Error(await providerErrorMessage(response));
-      if (!response.body) throw new Error("DeepSeek API returned no response body");
-      // one-api/new-api 系中转把未命中的 API 路径交给前置 SPA 以 200+HTML 兜底；
-      // HTML 喂进 SSE 解析器是零事件，最终只会报出误导性的 "ended without
-      // [DONE]"。凡带明确非流 content-type 的 200 响应都在这里 fail fast，把
-      // 真实载荷片段带进错误信息。
-      const contentType = (response.headers.get("content-type") ?? "").toLowerCase();
-      if (contentType && !contentType.includes("event-stream")) {
-        const snippet = (await response.text().catch(() => "")).trim().slice(0, 200);
-        throw new Error(
-          `DeepSeek endpoint returned "${contentType.split(";")[0].trim()}" instead of an SSE stream — check that the Base URL points to a DeepSeek chat-completions API${
-            snippet ? `. Response: ${snippet}` : ""
-          }`,
-        );
-      }
 
-      stream.push({ type: "start", partial: output });
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      const eventQueue: string[] = [];
-      let parserError: ParseError | undefined;
-      const parser = createParser({
-        maxBufferSize: DEEPSEEK_SSE_BUFFER_LIMIT,
-        onEvent: (event) => eventQueue.push(event.data),
-        onError: (error) => {
-          // SSE 规范要求忽略未知字段（部分中转会夹带非标准字段行），只有缓冲
-          // 超限才是必须终止流的硬错误——与 harness 的 EventSourceParserStream
-          // 默认忽略语义对齐。
-          if (error.type === "max-buffer-size-exceeded") parserError = error;
-        },
-      });
-      let sawDone = false;
-      let finishReason: string | undefined;
-      let textBlock: Extract<AssistantMessage["content"][number], { type: "text" }> | undefined;
-      let thinkingBlock:
-        | Extract<AssistantMessage["content"][number], { type: "thinking" }>
-        | undefined;
-      const toolCalls = new Map<number, StreamingToolCall>();
-
-      const contentIndex = (block: AssistantMessage["content"][number]) =>
-        output.content.indexOf(block);
-      const ensureTextBlock = () => {
-        if (!textBlock) {
-          textBlock = { type: "text", text: "" };
-          output.content.push(textBlock);
-          stream.push({
-            type: "text_start",
-            contentIndex: contentIndex(textBlock),
-            partial: output,
-          });
-        }
-        return textBlock;
-      };
-      const ensureThinkingBlock = () => {
-        if (!thinkingBlock) {
-          thinkingBlock = { type: "thinking", thinking: "" };
-          output.content.push(thinkingBlock);
-          stream.push({
-            type: "thinking_start",
-            contentIndex: contentIndex(thinkingBlock),
-            partial: output,
-          });
-        }
-        return thinkingBlock;
-      };
-      const ensureToolCall = (delta: DeepSeekWireToolCallDelta) => {
-        const wireIndex = typeof delta.index === "number" ? delta.index : 0;
-        let block = toolCalls.get(wireIndex);
-        if (!block) {
-          block = {
-            type: "toolCall",
-            id: delta.id ?? "",
-            name: delta.function?.name ?? "",
-            arguments: {},
-            partialArguments: "",
-            wireIndex,
-          };
-          toolCalls.set(wireIndex, block);
-          output.content.push(block);
-          stream.push({
-            type: "toolcall_start",
-            contentIndex: contentIndex(block),
-            partial: output,
-          });
-        }
-        if (delta.id) block.id = delta.id;
-        if (delta.function?.name) block.name = delta.function.name;
-        return block;
-      };
-
-      while (!sawDone) {
-        armIdleTimer();
-        const { value, done } = await reader.read();
-        if (done) break;
-        armIdleTimer();
-        parser.feed(decoder.decode(value, { stream: true }));
-        if (parserError) throw parserError;
-
-        for (const data of eventQueue.splice(0)) {
-          if (data === "[DONE]") {
-            sawDone = true;
-            break;
-          }
-          let chunk: DeepSeekWireChunk;
-          try {
-            chunk = JSON.parse(data) as DeepSeekWireChunk;
-          } catch {
-            throw new Error(`Malformed DeepSeek SSE payload: ${data.slice(0, 120)}`);
-          }
-          output.responseId ||= chunk.id;
-          if (chunk.model && chunk.model !== model.id) output.responseModel ||= chunk.model;
-          if (chunk.usage) output.usage = mapUsage(chunk.usage);
-          for (const choice of chunk.choices ?? []) {
-            if (typeof choice.finish_reason === "string") finishReason = choice.finish_reason;
-            const reasoning = choice.delta?.reasoning_content;
-            if (typeof reasoning === "string" && reasoning.length > 0) {
-              const block = ensureThinkingBlock();
-              block.thinking += reasoning;
-              stream.push({
-                type: "thinking_delta",
-                contentIndex: contentIndex(block),
-                delta: reasoning,
-                partial: output,
-              });
-            }
-            const content = choice.delta?.content;
-            if (typeof content === "string" && content.length > 0) {
-              const block = ensureTextBlock();
-              block.text += content;
-              stream.push({
-                type: "text_delta",
-                contentIndex: contentIndex(block),
-                delta: content,
-                partial: output,
-              });
-            }
-            for (const toolCallDelta of choice.delta?.tool_calls ?? []) {
-              const block = ensureToolCall(toolCallDelta);
-              const fragment = toolCallDelta.function?.arguments ?? "";
-              block.partialArguments += fragment;
-              block.arguments = parseStreamingJson(block.partialArguments);
-              stream.push({
-                type: "toolcall_delta",
-                contentIndex: contentIndex(block),
-                delta: fragment,
-                partial: output,
-              });
-            }
+      for await (const event of inner) {
+        if (event.type === "done") {
+          await Promise.allSettled(captureTasks);
+          const responseOutput = capturedDeepSeekOutput(responseCapture);
+          if (responseOutput.some((item) => item.type === "web_search_call")) {
+            (event.message as DeepSeekAssistantMessage).deepSeekResponseState = {
+              output: responseOutput,
+            };
           }
         }
+        output.push(event as AssistantMessageEvent);
       }
-
-      if (!sawDone) throw new Error("DeepSeek SSE stream ended without [DONE]");
-      await reader.cancel().catch(() => undefined);
-      if (output.content.length === 0) {
-        throw new Error("DeepSeek model returned a completed response with no content");
-      }
-      output.stopReason = mapFinishReason(finishReason);
-      output.rawStopReason = finishReason;
-      for (const [contentIndex, block] of output.content.entries()) {
-        if (block.type === "thinking") {
-          stream.push({
-            type: "thinking_end",
-            contentIndex,
-            content: block.thinking,
-            partial: output,
-          });
-        } else if (block.type === "text") {
-          stream.push({
-            type: "text_end",
-            contentIndex,
-            content: block.text,
-            partial: output,
-          });
-        } else if (block.type === "toolCall") {
-          delete (block as Partial<StreamingToolCall>).partialArguments;
-          delete (block as Partial<StreamingToolCall>).wireIndex;
-          stream.push({
-            type: "toolcall_end",
-            contentIndex,
-            toolCall: block,
-            partial: output,
-          });
-        }
-      }
-      stream.push({
-        type: "done",
-        reason: output.stopReason as "stop" | "length" | "toolUse",
-        message: output,
-      });
-      stream.end(output);
     } catch (error) {
-      output.stopReason = options.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = idleTimedOut
-        ? `DeepSeek stream idle timeout after ${DEEPSEEK_STREAM_IDLE_TIMEOUT_MS}ms`
-        : error instanceof Error
-          ? error.message
-          : String(error);
-      stream.push({
+      const aborted = options.signal?.aborted === true;
+      output.push({
         type: "error",
-        reason: output.stopReason,
-        error: output,
+        reason: aborted ? "aborted" : "error",
+        error: createErrorAssistant(model, error, aborted),
       });
-      stream.end(output);
     } finally {
-      if (idleTimer) clearTimeout(idleTimer);
-      releaseCallerAbort();
-      releaseIdleAbort();
-      requestController.abort();
-      idleController.abort();
+      output.end();
     }
   })();
 
-  return stream;
+  return output;
 }

--- a/crates/agent-gui/src/lib/providers/deepSeekNative.ts
+++ b/crates/agent-gui/src/lib/providers/deepSeekNative.ts
@@ -100,16 +100,17 @@ function assertTextOnlyContext(context: Context) {
         throw new Error("DeepSeek Responses does not support image input.");
       }
     }
-    if (
-      message.role === "toolResult" &&
-      message.content.some((block) => block.type === "image")
-    ) {
+    if (message.role === "toolResult" && message.content.some((block) => block.type === "image")) {
       throw new Error("DeepSeek Responses does not support image tool results.");
     }
   }
 }
 
-function createErrorAssistant(model: Model<any>, error: unknown, aborted: boolean): AssistantMessage {
+function createErrorAssistant(
+  model: Model<any>,
+  error: unknown,
+  aborted: boolean,
+): AssistantMessage {
   return {
     role: "assistant",
     content: [],
@@ -153,10 +154,7 @@ function toReplayableOutputItem(value: unknown): Record<string, unknown> | undef
   return value;
 }
 
-function captureDeepSeekResponseEvent(
-  capture: DeepSeekResponseCapture,
-  event: unknown,
-) {
+function captureDeepSeekResponseEvent(capture: DeepSeekResponseCapture, event: unknown) {
   if (!isRecord(event)) return;
   if (event.type === "response.output_item.added" || event.type === "response.output_item.done") {
     const item = toReplayableOutputItem(event.item);
@@ -178,10 +176,7 @@ function captureDeepSeekResponseEvent(
   }
 }
 
-async function captureDeepSeekResponse(
-  response: Response,
-  capture: DeepSeekResponseCapture,
-) {
+async function captureDeepSeekResponse(response: Response, capture: DeepSeekResponseCapture) {
   const reader = response.clone().body?.getReader();
   if (!reader) return;
   const decoder = new TextDecoder();

--- a/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
+++ b/crates/agent-gui/src/lib/providers/hostedSearchEvents.ts
@@ -146,6 +146,10 @@ function requestBodyMatchesProbe(probe: FetchProbe, body: unknown) {
     return userId === probe.sessionId;
   }
 
+  // DeepSeek Responses strips prompt_cache_key / metadata. When the probe
+  // header is absent, accept the stream rather than dropping search events.
+  if (probe.providerId === "deepseek") return true;
+
   return false;
 }
 
@@ -201,37 +205,51 @@ function uninstallFetchProbeIfIdle() {
   originalFetch = null;
 }
 
-function emitJsonCandidate(text: string, probe: FetchProbe) {
+function attachSseEventType(value: unknown, sseEventType: string): unknown {
+  if (!sseEventType || !isRecord(value)) return value;
+  if (readString(value.type) || readString(value.event)) return value;
+  return { ...value, type: sseEventType };
+}
+
+function emitJsonCandidate(text: string, probe: FetchProbe, sseEventType = "") {
   const trimmed = text.trim();
   if (!trimmed || trimmed === "[DONE]") return;
   const parsed = maybeParseJson(trimmed);
   if (Array.isArray(parsed)) {
     parsed.forEach((item) => {
-      probe.onRawEvent(item);
+      probe.onRawEvent(attachSseEventType(item, sseEventType));
     });
     return;
   }
   if (parsed !== undefined) {
-    probe.onRawEvent(parsed);
+    probe.onRawEvent(attachSseEventType(parsed, sseEventType));
   }
 }
 
 function consumeTextBuffer(buffer: string, probe: FetchProbe, final = false): string {
   const lines = buffer.split(/\r?\n/g);
   const tail = final ? "" : (lines.pop() ?? "");
+  let sseEventType = "";
   for (const line of lines) {
     const trimmed = line.trim();
-    if (!trimmed) continue;
+    if (!trimmed) {
+      sseEventType = "";
+      continue;
+    }
+    if (trimmed.startsWith("event:")) {
+      sseEventType = trimmed.slice(6).trim();
+      continue;
+    }
     if (trimmed.startsWith("data:")) {
-      emitJsonCandidate(trimmed.slice(5), probe);
+      emitJsonCandidate(trimmed.slice(5), probe, sseEventType);
       continue;
     }
     if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
-      emitJsonCandidate(trimmed, probe);
+      emitJsonCandidate(trimmed, probe, sseEventType);
     }
   }
   if (final && tail.trim()) {
-    emitJsonCandidate(tail, probe);
+    emitJsonCandidate(tail, probe, sseEventType);
   }
   return tail;
 }
@@ -324,6 +342,11 @@ function mapOpenAIWebSearchCallStatus(rawStatus: string, isDoneEvent: boolean): 
 }
 
 function extractResponsesSourceList(raw: unknown): HostedSearchSource[] {
+  if (typeof raw === "string") {
+    const url = raw.trim();
+    return url && isHttpUrl(url) ? [{ url, sourceType: "source" }] : [];
+  }
+  if (isRecord(raw)) return extractResponsesSourceList([raw]);
   if (!Array.isArray(raw)) return [];
   const sources: HostedSearchSource[] = [];
   for (const entry of raw) {
@@ -333,11 +356,79 @@ function extractResponsesSourceList(raw: unknown): HostedSearchSource[] {
       continue;
     }
     if (!isRecord(entry)) continue;
-    const url = readString(entry.url ?? entry.uri);
+    const url = readString(entry.url ?? entry.uri ?? entry.link);
     if (!url || !isHttpUrl(url)) continue;
-    const title = readString(entry.title);
+    const title = readString(entry.title ?? entry.name);
     sources.push({ url, ...(title ? { title } : {}), sourceType: "source" });
   }
+  return sources;
+}
+
+function resolveResponsesAction(value: unknown): Record<string, unknown> {
+  if (isRecord(value)) return value;
+  if (typeof value !== "string") return {};
+  const parsed = maybeParseJson(value);
+  return isRecord(parsed) ? parsed : {};
+}
+
+function readSearchQueries(item: Record<string, unknown>, action: Record<string, unknown>) {
+  const queries: string[] = [];
+  const add = (value: unknown) => {
+    if (typeof value === "string") {
+      const text = value.trim();
+      if (text && !queries.includes(text)) queries.push(text);
+      return;
+    }
+    if (Array.isArray(value)) value.forEach(add);
+  };
+  add(action.query);
+  add(action.queries);
+  add(action.search_query);
+  add(item.query);
+  add(item.queries);
+  return queries;
+}
+
+function extractResponsesActionSources(
+  item: Record<string, unknown>,
+  action: Record<string, unknown>,
+) {
+  const sources = [
+    ...extractResponsesSourceList(action.sources),
+    ...extractResponsesSourceList(action.output),
+    ...extractResponsesSourceList(action.results),
+    ...extractResponsesSourceList(item.sources),
+    ...extractResponsesSourceList(item.output),
+    ...extractResponsesSourceList(item.results),
+  ];
+  const pageUrl = readString(action.url ?? action.uri ?? item.url ?? item.uri);
+  if (pageUrl && isHttpUrl(pageUrl)) {
+    const title = readString(action.title ?? item.title);
+    sources.push({ url: pageUrl, ...(title ? { title } : {}), sourceType: "source" });
+  }
+  return sources;
+}
+
+function extractUrlCitationSources(value: unknown): HostedSearchSource[] {
+  if (Array.isArray(value)) return value.flatMap(extractUrlCitationSources);
+  if (!isRecord(value)) return [];
+  const type = readString(value.type).toLowerCase();
+  if (type && type !== "url_citation" && type !== "citation") return [];
+  const url = readString(value.url ?? value.uri ?? value.link);
+  if (!url || !isHttpUrl(url)) return [];
+  const title = readString(value.title ?? value.name);
+  return [{ url, ...(title ? { title } : {}), sourceType: "citation" }];
+}
+
+function extractMessageAnnotationSources(item: Record<string, unknown>): HostedSearchSource[] {
+  const content = Array.isArray(item.content) ? item.content : [];
+  const sources: HostedSearchSource[] = [];
+  for (const part of content) {
+    if (!isRecord(part)) continue;
+    sources.push(...extractUrlCitationSources(part.annotations));
+    sources.push(...extractUrlCitationSources(part.annotation));
+  }
+  sources.push(...extractUrlCitationSources(item.annotations));
   return sources;
 }
 
@@ -356,6 +447,57 @@ function readXaiCustomSearchQuery(item: Record<string, unknown>) {
   return isRecord(parsed) ? readString(parsed.query) : "";
 }
 
+function parseResponsesSearchCallItem(
+  item: Record<string, unknown>,
+  isDoneEvent: boolean,
+): HostedSearchUpdate | null {
+  const itemType = readString(item.type);
+  if (itemType === "web_search_call" || isXaiSearchCallItemType(itemType)) {
+    const action = resolveResponsesAction(item.action);
+    const id = readString(item.id) || readString(item.call_id) || readString(item.x_search_call_id);
+    return {
+      ...(id ? { id } : {}),
+      provider: "codex",
+      status: mapOpenAIWebSearchCallStatus(
+        readString(item.status),
+        isDoneEvent || itemType.endsWith("_output"),
+      ),
+      queries: readSearchQueries(item, action),
+      sources: extractResponsesActionSources(item, action),
+    };
+  }
+
+  if (itemType === "custom_tool_call" && isXaiCustomSearchToolName(readString(item.name))) {
+    const query = readXaiCustomSearchQuery(item);
+    const id = readString(item.id) || readString(item.call_id) || readString(item.item_id);
+    return {
+      ...(id ? { id } : {}),
+      provider: "codex",
+      status: mapOpenAIWebSearchCallStatus(readString(item.status), isDoneEvent),
+      queries: query ? [query] : [],
+      sources: [],
+    };
+  }
+
+  return null;
+}
+
+function parseResponsesOutputItem(item: Record<string, unknown>, isDoneEvent: boolean) {
+  const updates: HostedSearchUpdate[] = [];
+  const searchUpdate = parseResponsesSearchCallItem(item, isDoneEvent);
+  if (searchUpdate) updates.push(searchUpdate);
+  const citations = extractMessageAnnotationSources(item);
+  if (citations.length > 0) {
+    updates.push({
+      provider: "codex",
+      status: "completed",
+      queries: [],
+      sources: citations,
+    });
+  }
+  return updates;
+}
+
 const RESPONSES_SEARCH_CALL_LIFECYCLE_PREFIXES = [
   "response.web_search_call.",
   "response.x_search_call.",
@@ -363,94 +505,81 @@ const RESPONSES_SEARCH_CALL_LIFECYCLE_PREFIXES = [
 
 function parseOpenAIResponsesSearchEvent(raw: unknown): HostedSearchUpdate[] {
   if (!isRecord(raw)) return [];
-  const type = readString(raw.type);
+  const type = readString(raw.type) || readString(raw.event);
 
   if (type === "response.output_item.added" || type === "response.output_item.done") {
     const item = isRecord(raw.item) ? raw.item : {};
-    const itemType = readString(item.type);
-    const isDoneEvent = type.endsWith(".done");
-
-    if (itemType === "web_search_call" || isXaiSearchCallItemType(itemType)) {
-      const action = isRecord(item.action) ? item.action : {};
-      const query = readString(action.query);
-      const id =
-        readString(item.id) || readString(item.call_id) || readString(item.x_search_call_id);
-      return [
-        {
-          ...(id ? { id } : {}),
-          provider: "codex",
-          status: mapOpenAIWebSearchCallStatus(
-            readString(item.status),
-            isDoneEvent || itemType.endsWith("_output"),
-          ),
-          queries: query ? [query] : [],
-          sources: [
-            ...extractResponsesSourceList(action.sources),
-            ...extractResponsesSourceList(item.sources),
-          ],
-        },
-      ];
-    }
-
-    if (itemType === "custom_tool_call" && isXaiCustomSearchToolName(readString(item.name))) {
-      const query = readXaiCustomSearchQuery(item);
-      const id = readString(item.id) || readString(item.call_id) || readString(item.item_id);
-      return [
-        {
-          ...(id ? { id } : {}),
-          provider: "codex",
-          status: mapOpenAIWebSearchCallStatus(readString(item.status), isDoneEvent),
-          queries: query ? [query] : [],
-          sources: [],
-        },
-      ];
-    }
-
-    return [];
+    return parseResponsesOutputItem(item, type.endsWith(".done"));
   }
 
   // Defensive coverage for the dedicated response.web_search_call.* /
   // response.x_search_call.* lifecycle events (in_progress/searching/completed)
   // some OpenAI-compatible gateways emit alongside (or instead of) output_item
-  // add/done.
+  // add/done. DeepSeek in particular often puts query/sources on `item` here
+  // and never emits response.output_text.annotation.added.
   const lifecyclePrefix = RESPONSES_SEARCH_CALL_LIFECYCLE_PREFIXES.find((prefix) =>
     type.startsWith(prefix),
   );
   if (lifecyclePrefix) {
     const suffix = type.slice(lifecyclePrefix.length).toLowerCase();
-    const id = readString(raw.item_id) || readString(raw.output_item_id);
+    const item = isRecord(raw.item) ? raw.item : {};
+    const action = resolveResponsesAction(item.action ?? raw.action);
+    const id =
+      readString(raw.item_id) ||
+      readString(raw.output_item_id) ||
+      readString(item.id) ||
+      readString(item.call_id);
+    const status = /fail|error|cancel/.test(suffix)
+      ? "failed"
+      : /complete|completed|done/.test(suffix)
+        ? "completed"
+        : "searching";
     return [
       {
         ...(id ? { id } : {}),
         provider: "codex",
-        status: /fail|error|cancel/.test(suffix)
-          ? "failed"
-          : /complete|completed|done/.test(suffix)
-            ? "completed"
-            : "searching",
-        queries: [],
-        sources: [],
+        status: mapOpenAIWebSearchCallStatus(
+          readString(item.status) || status,
+          status === "completed",
+        ),
+        queries: readSearchQueries(item, action),
+        sources: extractResponsesActionSources(item, action),
       },
     ];
   }
 
-  if (type === "response.output_text.annotation.added") {
-    const annotation = isRecord(raw.annotation) ? raw.annotation : {};
-    if (readString(annotation.type) !== "url_citation") return [];
-    const url = readString(annotation.url ?? annotation.uri);
-    if (!url || !isHttpUrl(url)) return [];
-    const title = readString(annotation.title);
-    return [
-      {
-        provider: "codex",
-        status: "completed",
-        queries: [],
-        sources: [{ url, ...(title ? { title } : {}), sourceType: "citation" }],
-      },
-    ];
+  if (
+    type === "response.completed" ||
+    type === "response.incomplete" ||
+    type === "response.failed"
+  ) {
+    const response = isRecord(raw.response) ? raw.response : {};
+    const output = Array.isArray(response.output) ? response.output : [];
+    return output.flatMap((item) => (isRecord(item) ? parseResponsesOutputItem(item, true) : []));
   }
 
-  return [];
+  if (type === "response.content_part.added" || type === "response.content_part.done") {
+    const part = isRecord(raw.part) ? raw.part : {};
+    const sources = extractMessageAnnotationSources({ content: [part] });
+    if (sources.length === 0) return [];
+    return [{ provider: "codex", status: "completed", queries: [], sources }];
+  }
+
+  if (type === "response.output_text.annotation.added" || type === "response.output_text.done") {
+    const sources = [
+      ...extractUrlCitationSources(raw.annotation),
+      ...extractUrlCitationSources(raw.annotations),
+    ];
+    if (sources.length === 0) return [];
+    return [{ provider: "codex", status: "completed", queries: [], sources }];
+  }
+
+  if (isRecord(raw.item)) {
+    const nested = parseResponsesOutputItem(raw.item, true);
+    if (nested.length > 0) return nested;
+  }
+
+  return parseResponsesOutputItem(raw, readString(raw.status) === "completed");
 }
 
 function createOpenAIResponsesSearchEventParser(): SearchEventParser {
@@ -731,6 +860,15 @@ function createGeminiSearchEventParser(): SearchEventParser {
 function createHostedSearchEventParser(providerId: ProviderId): SearchEventParser {
   if (providerId === "codex" || providerId === "xai") {
     return createOpenAIResponsesSearchEventParser();
+  }
+  if (providerId === "deepseek") {
+    return {
+      parse: (raw) =>
+        parseOpenAIResponsesSearchEvent(raw).map((update) => ({
+          ...update,
+          provider: "deepseek",
+        })),
+    };
   }
   if (providerId === "claude_code") return createAnthropicSearchEventParser();
   if (providerId === "gemini") return createGeminiSearchEventParser();

--- a/crates/agent-gui/src/lib/providers/nativeWebSearch.ts
+++ b/crates/agent-gui/src/lib/providers/nativeWebSearch.ts
@@ -219,6 +219,7 @@ export function providerSupportsNativeWebSearch(
   return (
     (providerId === "codex" && api === "openai-responses") ||
     (providerId === "xai" && api === "openai-responses") ||
+    (providerId === "deepseek" && api === "deepseek-responses") ||
     (providerId === "claude_code" && api === "anthropic-messages") ||
     (providerId === "gemini" && api === "google-generative-ai")
   );

--- a/crates/agent-gui/src/lib/providers/runtime/deepSeekResponsesPayload.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/deepSeekResponsesPayload.ts
@@ -1,0 +1,182 @@
+import type { Context, Model } from "@earendil-works/pi-ai";
+import type { ProviderId } from "../../settings";
+import {
+  DEEPSEEK_RESPONSES_API,
+  type DeepSeekAssistantMessage,
+} from "../deepSeekNative";
+import { isRecord } from "./common";
+import type { StreamOptionsEx } from "./types";
+
+const DEEPSEEK_UNSUPPORTED_RESPONSES_FIELDS = [
+  "previous_response_id",
+  "conversation",
+  "store",
+  "background",
+  "metadata",
+  "include",
+  "prompt",
+  "truncation",
+  "service_tier",
+  "safety_identifier",
+  "prompt_cache_key",
+  "prompt_cache_retention",
+  "prompt_cache_options",
+  "context_management",
+  "stream_options",
+] as const;
+
+function responseOutput(message: DeepSeekAssistantMessage) {
+  if (
+    message.provider !== "deepseek" ||
+    message.api !== DEEPSEEK_RESPONSES_API ||
+    !Array.isArray(message.deepSeekResponseState?.output)
+  ) {
+    return undefined;
+  }
+  const output = message.deepSeekResponseState.output.filter(isRecord);
+  return output.some((item) => item.type === "web_search_call") ? output : undefined;
+}
+
+function transformedAssistantItemCount(message: DeepSeekAssistantMessage, model: Model<any>) {
+  const isSameModel =
+    message.provider === model.provider && message.api === model.api && message.model === model.id;
+  let count = 0;
+  for (const block of message.content) {
+    if (block.type === "text" || block.type === "toolCall") {
+      count += 1;
+      continue;
+    }
+    if (block.type !== "thinking") continue;
+    if (isSameModel) {
+      if (block.thinkingSignature) count += 1;
+    } else if (!block.redacted && block.thinking.trim()) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function collectFunctionCallIdMappings(
+  generatedItems: unknown[],
+  originalOutput: Record<string, unknown>[],
+  mappings: Map<string, string>,
+) {
+  const generatedCalls = generatedItems.filter(
+    (item): item is Record<string, unknown> => isRecord(item) && item.type === "function_call",
+  );
+  const originalCalls = originalOutput.filter((item) => item.type === "function_call");
+  for (let index = 0; index < Math.min(generatedCalls.length, originalCalls.length); index += 1) {
+    const generatedId = generatedCalls[index]?.call_id;
+    const originalId = originalCalls[index]?.call_id;
+    if (typeof generatedId === "string" && typeof originalId === "string") {
+      mappings.set(generatedId, originalId);
+    }
+  }
+}
+
+function replayDeepSeekResponseOutput(
+  payload: Record<string, unknown>,
+  context: Context | undefined,
+  model: Model<any> | undefined,
+) {
+  if (!Array.isArray(payload.input) || !context || !model) return payload;
+
+  const input = [...payload.input];
+  const functionCallIdMappings = new Map<string, string>();
+  let cursor = context.systemPrompt ? 1 : 0;
+  let pendingToolCallIds: string[] = [];
+  let existingToolResultIds = new Set<string>();
+
+  const flushSyntheticToolResults = () => {
+    for (const toolCallId of pendingToolCallIds) {
+      if (!existingToolResultIds.has(toolCallId)) cursor += 1;
+    }
+    pendingToolCallIds = [];
+    existingToolResultIds = new Set();
+  };
+
+  for (const message of context.messages) {
+    if (message.role === "user") {
+      flushSyntheticToolResults();
+      if (typeof message.content === "string" || message.content.length > 0) cursor += 1;
+      continue;
+    }
+    if (message.role === "toolResult") {
+      existingToolResultIds.add(message.toolCallId);
+      cursor += 1;
+      continue;
+    }
+    flushSyntheticToolResults();
+    if (message.stopReason === "error" || message.stopReason === "aborted") continue;
+
+    const assistant = message as DeepSeekAssistantMessage;
+    const generatedCount = transformedAssistantItemCount(assistant, model);
+    const originalOutput = responseOutput(assistant);
+    pendingToolCallIds = assistant.content.flatMap((block) =>
+      block.type === "toolCall" ? [block.id] : [],
+    );
+    if (!originalOutput) {
+      cursor += generatedCount;
+      continue;
+    }
+
+    const generatedItems = input.slice(cursor, cursor + generatedCount);
+    collectFunctionCallIdMappings(generatedItems, originalOutput, functionCallIdMappings);
+    input.splice(cursor, generatedCount, ...originalOutput);
+    cursor += originalOutput.length;
+  }
+  flushSyntheticToolResults();
+
+  const remappedInput = input.map((item) => {
+    if (!isRecord(item) || item.type !== "function_call_output") return item;
+    const mappedId =
+      typeof item.call_id === "string" ? functionCallIdMappings.get(item.call_id) : undefined;
+    return mappedId ? { ...item, call_id: mappedId } : item;
+  });
+  return { ...payload, input: remappedInput };
+}
+
+export function normalizeDeepSeekResponsesPayload(
+  payload: unknown,
+  context?: Context,
+  model?: Model<any>,
+): unknown {
+  if (!isRecord(payload)) return payload;
+  const next: Record<string, unknown> = { ...payload };
+  for (const field of DEEPSEEK_UNSUPPORTED_RESPONSES_FIELDS) delete next[field];
+
+  if (isRecord(next.reasoning)) {
+    const effort = next.reasoning.effort;
+    if (typeof effort === "string" && effort) {
+      next.reasoning = { effort };
+    } else {
+      delete next.reasoning;
+    }
+  }
+  return replayDeepSeekResponseOutput(next, context, model);
+}
+
+export function attachDeepSeekResponsesPayloadCompat(
+  options: StreamOptionsEx,
+  params: {
+    providerId: ProviderId;
+    model?: Model<any>;
+    context?: Context;
+  },
+): StreamOptionsEx {
+  if (params.providerId !== "deepseek" || params.model?.api !== DEEPSEEK_RESPONSES_API) {
+    return options;
+  }
+  const previousOnPayload = options.onPayload;
+  return {
+    ...options,
+    onPayload: async (payload, model) => {
+      let nextPayload = payload;
+      if (previousOnPayload) {
+        const overridden = await previousOnPayload(nextPayload, model);
+        if (overridden !== undefined) nextPayload = overridden;
+      }
+      return normalizeDeepSeekResponsesPayload(nextPayload, params.context, params.model);
+    },
+  };
+}

--- a/crates/agent-gui/src/lib/providers/runtime/deepSeekResponsesPayload.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/deepSeekResponsesPayload.ts
@@ -1,9 +1,6 @@
 import type { Context, Model } from "@earendil-works/pi-ai";
 import type { ProviderId } from "../../settings";
-import {
-  DEEPSEEK_RESPONSES_API,
-  type DeepSeekAssistantMessage,
-} from "../deepSeekNative";
+import { DEEPSEEK_RESPONSES_API, type DeepSeekAssistantMessage } from "../deepSeekNative";
 import { isRecord } from "./common";
 import type { StreamOptionsEx } from "./types";
 

--- a/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
@@ -18,7 +18,11 @@ import {
   resolveAnthropicContextWindow,
   resolveAnthropicWireModelId,
 } from "../anthropicModels";
-import { DEEPSEEK_CHAT_COMPLETIONS_API, normalizeDeepSeekBaseUrl } from "../deepSeekNative";
+import {
+  DEEPSEEK_RESPONSES_API,
+  isOfficialDeepSeekBaseUrl,
+  normalizeDeepSeekResponsesBaseUrl,
+} from "../deepSeekNative";
 import { isXaiProviderTarget } from "./xaiResponsesPayload";
 
 // ---------------------------------------------------------------------------
@@ -30,6 +34,14 @@ import { isXaiProviderTarget } from "./xaiResponsesPayload";
 /** Grok / xAI wire 值：官方 effort 无 minimal，向上取 low。 */
 const XAI_THINKING_WIRE_VALUES: ThinkingLevelMap = {
   minimal: "low",
+};
+
+/** DeepSeek Responses accepts none/low/high/max; medium/xhigh map to high. */
+const DEEPSEEK_THINKING_WIRE_VALUES: ThinkingLevelMap = {
+  off: "none",
+  minimal: "low",
+  medium: "high",
+  xhigh: "high",
 };
 
 function resolveModelThinkingFields(
@@ -328,15 +340,21 @@ export function createModelFromConfig(
     return {
       id: modelId,
       name: modelId,
-      api: DEEPSEEK_CHAT_COMPLETIONS_API,
+      api: DEEPSEEK_RESPONSES_API,
       provider: "deepseek",
-      baseUrl: normalizeDeepSeekBaseUrl(baseUrl),
-      ...resolveModelThinkingFields(thinking),
+      baseUrl: normalizeDeepSeekResponsesBaseUrl(baseUrl, {
+        officialHost: isOfficialDeepSeekBaseUrl(upstreamBaseUrl?.trim() || baseUrl),
+      }),
+      ...resolveModelThinkingFields(thinking, DEEPSEEK_THINKING_WIRE_VALUES),
       input: ["text"],
       cost: zeroCost,
       contextWindow,
       maxTokens,
-      deepSeekThinkingAlwaysOn: thinking.alwaysOn,
+      compat: {
+        supportsDeveloperRole: true,
+        supportsLongCacheRetention: false,
+        supportsStrictMode: false,
+      },
     } as Model<any>;
   }
 

--- a/crates/agent-gui/src/lib/providers/runtime/nativeSearchPayload.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/nativeSearchPayload.ts
@@ -165,7 +165,7 @@ export function attachProviderNativeWebSearch(
         return nextPayload;
       }
 
-      if (providerId === "codex" || providerId === "xai") {
+      if (providerId === "codex" || providerId === "xai" || providerId === "deepseek") {
         if (model.api === "openai-completions") {
           return appendOpenAIChatCompletionsNativeWebSearch(nextPayload, {
             baseUrl: params?.baseUrl,

--- a/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
@@ -11,6 +11,7 @@ import { attachAnthropicAutomaticCaching } from "./anthropicCache";
 import { attachAnthropicLongContextBeta } from "./anthropicLongContext";
 import { attachCodexPromptCacheHint } from "./codexPromptCache";
 import { attachCodexResponsesStorage } from "./codexStorage";
+import { attachDeepSeekResponsesPayloadCompat } from "./deepSeekResponsesPayload";
 import { attachGeminiThoughtSignatureGuard } from "./geminiToolPayload";
 import { attachProviderNativeWebSearch } from "./nativeSearchPayload";
 import type { StreamOptionsEx } from "./types";
@@ -108,6 +109,12 @@ const finalizePayloadMiddlewares = composePayloadMiddlewares([
     attachXaiResponsesPayloadCompat(options, {
       providerId: params.providerId,
       baseUrl: params.baseUrl,
+    }),
+  (options, params) =>
+    attachDeepSeekResponsesPayloadCompat(options, {
+      providerId: params.providerId,
+      model: params.model,
+      context: params.context,
     }),
   (options, params) => {
     if (!params.context || !params.model) return options;

--- a/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/requestOptions.ts
@@ -9,6 +9,10 @@ import {
 import { type PreparedProxyRequest, prepareProxyRequest } from "@liveagent/ui/lib/providers/proxy";
 import { createUuid } from "@liveagent/ui/lib/shared/id";
 import type { CodexRequestFormat, ProviderId, ReasoningLevel } from "../../settings";
+import {
+  normalizeDeepSeekResponsesBaseUrl,
+  normalizeDeepSeekResponsesEndpoint,
+} from "../deepSeekNative";
 import { normalizeSessionId } from "./common";
 import type { ProviderRuntimeConfig } from "./types";
 
@@ -78,9 +82,15 @@ export async function prepareProviderRequest(
   runtime: ProviderRuntimeConfig,
   options?: { sessionId?: string },
 ): Promise<PreparedProxyRequest> {
+  const upstreamBaseUrl =
+    providerId === "deepseek"
+      ? runtime.isFullUrl
+        ? normalizeDeepSeekResponsesEndpoint(runtime.baseUrl)
+        : normalizeDeepSeekResponsesBaseUrl(runtime.baseUrl)
+      : runtime.baseUrl;
   return prepareProxyRequest(
     providerId,
-    runtime.baseUrl.trim(),
+    upstreamBaseUrl.trim(),
     mergeCustomHeaders(
       buildProviderRequestHeaders(
         providerId,

--- a/crates/agent-gui/src/lib/providers/runtime/streamByApi.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/streamByApi.ts
@@ -12,7 +12,7 @@ import {
   type OpenAIResponsesOptions,
   stream as streamOpenAIResponses,
 } from "@earendil-works/pi-ai/api/openai-responses";
-import { DEEPSEEK_CHAT_COMPLETIONS_API, streamDeepSeekNative } from "../deepSeekNative";
+import { DEEPSEEK_RESPONSES_API, streamDeepSeekResponses } from "../deepSeekNative";
 import { resolveMaxTokens } from "./common";
 import { rejectEmptyOpenAICompletionsResponse } from "./openAICompletionsStream";
 import { withStreamRetry } from "./streamRetry";
@@ -110,8 +110,8 @@ export function streamSimpleByApi(model: Model<any>, context: Context, options: 
         { signal: options.signal, ...options.streamRetry },
       );
     }
-    case DEEPSEEK_CHAT_COMPLETIONS_API:
-      return withStreamRetry(() => streamDeepSeekNative(model, context, options), {
+    case DEEPSEEK_RESPONSES_API:
+      return withStreamRetry(() => streamDeepSeekResponses(model, context, options), {
         signal: options.signal,
         ...options.streamRetry,
       });

--- a/crates/agent-gui/test/models/model-catalog.test.mjs
+++ b/crates/agent-gui/test/models/model-catalog.test.mjs
@@ -13,7 +13,7 @@ const MIN_MODELS_PER_PROVIDER = {
   google: 15,
   openai: 20,
   xai: 3,
-  deepseek: 3,
+  deepseek: 2,
   zhipuai: 10,
   moonshotai: 8,
   minimax: 5,
@@ -95,6 +95,15 @@ test("openai catalog prefers Codex metadata and keeps models.dev supplements", (
   assert.equal(catalog.findCatalogModel("codex", "gpt-5.6")?.contextWindow, 1_050_000);
 });
 
+test("formal DeepSeek catalog only exposes models documented for Responses", () => {
+  assert.deepEqual(
+    catalog.MODEL_CATALOG.deepseek.map((entry) => entry.id),
+    ["deepseek-v4-flash", "deepseek-v4-pro"],
+  );
+  assert.equal(catalog.findCatalogModel("deepseek", "deepseek-chat"), undefined);
+  assert.equal(catalog.findCatalogModel("deepseek", "deepseek-reasoner"), undefined);
+});
+
 test("normalizeModelLimits repairs degenerate pairs uniformly and leaves valid pairs alone", () => {
   // 退化（输出吃满窗口）：钳到 min(32K, ⌊窗口/4⌋)。
   assert.deepEqual(
@@ -158,7 +167,7 @@ test("cross-provider lookup resolves models configured under a foreign provider"
   });
   assert.equal(catalog.resolveModelLimitsAcrossProviders("model-not-in-catalog"), undefined);
   // 国内厂商分区（无对应应用供应商类型）经跨供应商回查可命中。
-  assert.equal(catalog.findCatalogModelAcrossProviders("deepseek-chat")?.id, "deepseek-chat");
+  assert.equal(catalog.findCatalogModelAcrossProviders("deepseek-v4-pro")?.id, "deepseek-v4-pro");
   assert.equal(catalog.findCatalogModelAcrossProviders("glm-4.6")?.id, "glm-4.6");
   assert.equal(catalog.findCatalogModelAcrossProviders("qwen-max")?.id, "qwen-max");
   assert.equal(catalog.findCatalogModelAcrossProviders("kimi-k2.5")?.id, "kimi-k2.5");

--- a/crates/agent-gui/test/models/model-thinking.test.mjs
+++ b/crates/agent-gui/test/models/model-thinking.test.mjs
@@ -32,11 +32,15 @@ test("non-reasoning models expose no thinking controls", () => {
   assert.deepEqual(result, { reasoning: false, levels: [], alwaysOn: false, fromCatalog: true });
 });
 
-test("always-on non-tunable models: reasoning with empty levels", () => {
-  const reasoner = resolveModelThinking("deepseek", "deepseek-reasoner");
-  assert.equal(reasoner.reasoning, true);
-  assert.deepEqual(reasoner.levels, []);
-  assert.equal(reasoner.alwaysOn, true);
+test("DeepSeek Responses models expose their documented reasoning levels", () => {
+  const flash = resolveModelThinking("deepseek", "deepseek-v4-flash");
+  assert.equal(flash.reasoning, true);
+  assert.deepEqual(flash.levels, ["low", "high", "max"]);
+  assert.equal(flash.alwaysOn, false);
+
+  const pro = resolveModelThinking("deepseek", "deepseek-v4-pro");
+  assert.deepEqual(pro.levels, ["low", "high", "max"]);
+  assert.equal(pro.alwaysOn, false);
 });
 
 test("decorated ids resolve through the candidate chain", () => {

--- a/crates/agent-gui/test/providers/deepseek-attachments.test.mjs
+++ b/crates/agent-gui/test/providers/deepseek-attachments.test.mjs
@@ -2,10 +2,20 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 
+const realOpenAIResponses = await import(
+  new URL(
+    "../../node_modules/@earendil-works/pi-ai/dist/api/openai-responses.js",
+    import.meta.url,
+  ).href
+);
+
 function createLoader(contentsByPath) {
   const calls = [];
   const loader = createTsModuleLoader({
     mocks: {
+      "@earendil-works/pi-ai/api/openai-responses": {
+        stream: realOpenAIResponses.stream,
+      },
       "@tauri-apps/api/core": {
         async invoke(command, args) {
           calls.push({ command, args });
@@ -25,11 +35,11 @@ function createLoader(contentsByPath) {
 
 function createModel(api) {
   return {
-    id: "deepseek-chat",
-    name: "DeepSeek Chat",
+    id: "deepseek-v4-flash",
+    name: "DeepSeek V4 Flash",
     api,
     provider: "deepseek",
-    baseUrl: "https://api.deepseek.com/v1",
+    baseUrl: "https://api.deepseek.com",
     input: ["text"],
     reasoning: true,
     contextWindow: 128_000,
@@ -46,9 +56,6 @@ test("DeepSeek inlines multiple large pastes while preserving ordinary Read atta
   const uploadedFiles = loader.loadModule("@liveagent/ui/lib/chat/uploadedFiles.ts");
   const { inlineDeepSeekLargePastes } = loader.loadModule(
     "src/lib/providers/deepSeekAttachments.ts",
-  );
-  const { DEEPSEEK_CHAT_COMPLETIONS_API, serializeDeepSeekRequest } = loader.loadModule(
-    "src/lib/providers/deepSeekNative.ts",
   );
   const files = [
     {
@@ -103,12 +110,7 @@ test("DeepSeek inlines multiple large pastes while preserving ordinary Read atta
   assert.match(content, /\/workspace\/docs\/report\.pdf \(pdf\)/);
   assert.match(content, /\/workspace\/docs\/notes\.txt \(text\)/);
 
-  const request = serializeDeepSeekRequest(
-    createModel(DEEPSEEK_CHAT_COMPLETIONS_API),
-    context,
-    {},
-  );
-  const wire = JSON.stringify(request);
+  const wire = JSON.stringify(context);
   assert.doesNotMatch(wire, /input_file/);
   assert.doesNotMatch(wire, /file_data/);
   assert.match(wire, /first pasted body/);
@@ -178,7 +180,7 @@ test("DeepSeek native stream inlines a large paste before payload hooks and fetc
     "/workspace/.liveagent/paste.txt": "native stream pasted body",
   });
   const uploadedFiles = loader.loadModule("@liveagent/ui/lib/chat/uploadedFiles.ts");
-  const { DEEPSEEK_CHAT_COMPLETIONS_API, streamDeepSeekNative } = loader.loadModule(
+  const { DEEPSEEK_RESPONSES_API, streamDeepSeekResponses } = loader.loadModule(
     "src/lib/providers/deepSeekNative.ts",
   );
   const message = uploadedFiles.createUserMessageWithUploads(
@@ -198,8 +200,8 @@ test("DeepSeek native stream inlines a large paste before payload hooks and fetc
   );
   let hookPayload;
   let fetchPayload;
-  const stream = streamDeepSeekNative(
-    createModel(DEEPSEEK_CHAT_COMPLETIONS_API),
+  const stream = streamDeepSeekResponses(
+    createModel(DEEPSEEK_RESPONSES_API),
     { messages: [message] },
     {
       apiKey: "sk-test",
@@ -209,10 +211,29 @@ test("DeepSeek native stream inlines a large paste before payload hooks and fetc
       },
       async fetch(_url, options) {
         fetchPayload = JSON.parse(options.body);
+        const message = {
+          type: "message",
+          id: "msg_inlined",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "inlined", annotations: [] }],
+        };
         return new Response(
-          `data: ${JSON.stringify({
-            choices: [{ delta: { content: "inlined" }, finish_reason: "stop" }],
-          })}\n\ndata: [DONE]\n\n`,
+          [
+            { type: "response.output_item.added", output_index: 0, item: message },
+            { type: "response.output_item.done", output_index: 0, item: message },
+            {
+              type: "response.completed",
+              response: {
+                id: "resp_inlined",
+                status: "completed",
+                output: [message],
+                usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+              },
+            },
+          ]
+            .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+            .join(""),
           {
             status: 200,
             headers: { "Content-Type": "text/event-stream" },
@@ -227,8 +248,8 @@ test("DeepSeek native stream inlines a large paste before payload hooks and fetc
   }
   const result = await stream.result();
 
-  assert.match(hookPayload.messages[0].content, /native stream pasted body/);
-  assert.match(fetchPayload.messages[0].content, /native stream pasted body/);
+  assert.match(JSON.stringify(hookPayload.input), /native stream pasted body/);
+  assert.match(JSON.stringify(fetchPayload.input), /native stream pasted body/);
   assert.doesNotMatch(JSON.stringify(fetchPayload), /\[Pasted text|input_file|file_data/);
   assert.equal(result.stopReason, "stop");
   assert.equal(result.content[0].text, "inlined");

--- a/crates/agent-gui/test/providers/deepseek-native.test.mjs
+++ b/crates/agent-gui/test/providers/deepseek-native.test.mjs
@@ -2,29 +2,51 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 
-const loader = createTsModuleLoader();
-const {
-  DEEPSEEK_CHAT_COMPLETIONS_API,
-  normalizeDeepSeekBaseUrl,
-  serializeDeepSeekMessages,
-  serializeDeepSeekRequest,
-  streamDeepSeekNative,
-} = loader.loadModule("src/lib/providers/deepSeekNative.ts");
-const { createModelFromConfig } = loader.loadModule("src/lib/providers/runtime/modelFactory.ts");
-const { streamSimpleByApi } = loader.loadModule("src/lib/providers/runtime/streamByApi.ts");
+const realOpenAIResponses = await import(
+  new URL(
+    "../../node_modules/@earendil-works/pi-ai/dist/api/openai-responses.js",
+    import.meta.url,
+  ).href
+);
+const loader = createTsModuleLoader({
+  mocks: {
+    "@earendil-works/pi-ai/api/openai-responses": {
+      stream: realOpenAIResponses.stream,
+    },
+  },
+});
+const deepseek = loader.loadModule("src/lib/providers/deepSeekNative.ts");
+const payloadCompat = loader.loadModule(
+  "src/lib/providers/runtime/deepSeekResponsesPayload.ts",
+);
+const { createModelFromConfig } = loader.loadModule(
+  "src/lib/providers/runtime/modelFactory.ts",
+);
+const { finalizeProviderStreamOptions } = loader.loadModule(
+  "src/lib/providers/runtime/payloadPipeline.ts",
+);
+const { streamSimpleByApi } = loader.loadModule(
+  "src/lib/providers/runtime/streamByApi.ts",
+);
 
 function createModel(overrides = {}) {
   return {
-    id: "deepseek-chat",
-    name: "DeepSeek Chat",
-    api: DEEPSEEK_CHAT_COMPLETIONS_API,
+    id: "deepseek-v4-flash",
+    name: "DeepSeek V4 Flash",
+    api: deepseek.DEEPSEEK_RESPONSES_API,
     provider: "deepseek",
-    baseUrl: "https://api.deepseek.com/v1",
+    baseUrl: "https://api.deepseek.com",
     input: ["text"],
     reasoning: true,
-    contextWindow: 128_000,
-    maxTokens: 8_192,
+    thinkingLevelMap: { off: "none", low: "low", high: "high", max: "max" },
+    contextWindow: 1_000_000,
+    maxTokens: 384_000,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    compat: {
+      supportsDeveloperRole: true,
+      supportsLongCacheRetention: false,
+      supportsStrictMode: false,
+    },
     ...overrides,
   };
 }
@@ -32,35 +54,50 @@ function createModel(overrides = {}) {
 function createContext(overrides = {}) {
   return {
     systemPrompt: "You are precise.",
-    messages: [{ role: "user", content: [{ type: "text", text: "Hello" }], timestamp: 1 }],
+    messages: [{ role: "user", content: "Find current release news.", timestamp: 1 }],
     ...overrides,
   };
 }
 
-function sseData(payload) {
-  return `data: ${typeof payload === "string" ? payload : JSON.stringify(payload)}\n\n`;
-}
-
-function responseFromBytes(parts, init = {}) {
-  const { headers, ...responseInit } = init;
-  return new Response(
-    new ReadableStream({
-      start(controller) {
-        for (const part of parts) controller.enqueue(part);
-        controller.close();
-      },
-    }),
-    {
-      status: 200,
-      ...responseInit,
-      headers: { "Content-Type": "text/event-stream", ...headers },
+function assistant({
+  model = "deepseek-v4-flash",
+  content,
+  state,
+  provider = "deepseek",
+  api = deepseek.DEEPSEEK_RESPONSES_API,
+  stopReason = "stop",
+  timestamp = 2,
+}) {
+  return {
+    role: "assistant",
+    content,
+    api,
+    provider,
+    model,
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     },
-  );
+    stopReason,
+    timestamp,
+    ...(state ? { deepSeekResponseState: { output: state } } : {}),
+  };
 }
 
-function responseFromSse(parts, init = {}) {
-  const encoder = new TextEncoder();
-  return responseFromBytes(parts.map((part) => encoder.encode(part)), init);
+function sse(event) {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+function responseFromEvents(events, init = {}) {
+  return new Response(events.map(sse).join(""), {
+    status: 200,
+    headers: { "content-type": "text/event-stream; charset=utf-8" },
+    ...init,
+  });
 }
 
 async function consume(stream) {
@@ -69,258 +106,565 @@ async function consume(stream) {
   return { events, result: await stream.result() };
 }
 
-async function runStream({ model = createModel(), context = createContext(), fetch, ...options }) {
-  return consume(
-    streamDeepSeekNative(model, context, {
-      apiKey: "sk-test",
-      fetch,
-      ...options,
-    }),
-  );
+function completedSearchResponseEvents({ includeFunctionCall = true, terminalOutput = true } = {}) {
+  const reasoning = {
+    type: "reasoning",
+    id: "rs_1",
+    status: "completed",
+    summary: [],
+    content: [{ type: "reasoning_text", text: "Check current sources." }],
+  };
+  const search = {
+    type: "web_search_call",
+    id: "ws_1",
+    status: "completed",
+    action: {
+      type: "search",
+      query: "DeepSeek V4 release",
+      sources: [{ url: "https://api-docs.deepseek.com/news", title: "DeepSeek News" }],
+    },
+  };
+  const message = {
+    type: "message",
+    id: "msg_1",
+    role: "assistant",
+    status: "completed",
+    content: [
+      {
+        type: "output_text",
+        text: "The current V4 models support server-side search.",
+        annotations: [
+          {
+            type: "url_citation",
+            url: "https://api-docs.deepseek.com/guides/responses_api",
+            title: "Responses API",
+            start_index: 0,
+            end_index: 7,
+          },
+        ],
+      },
+    ],
+  };
+  const functionCall = {
+    type: "function_call",
+    id: "fc_1",
+    call_id: "call_1",
+    name: "lookup_local",
+    arguments: '{"key":"release"}',
+    status: "completed",
+  };
+  const output = includeFunctionCall
+    ? [reasoning, search, message, functionCall]
+    : [reasoning, search, message];
+  const events = [{ type: "response.created", response: { id: "resp_1" } }];
+  for (const [outputIndex, item] of output.entries()) {
+    events.push(
+      { type: "response.output_item.added", output_index: outputIndex, item },
+      { type: "response.output_item.done", output_index: outputIndex, item },
+    );
+  }
+  events.push({
+    type: "response.completed",
+    response: {
+      id: "resp_1",
+      model: "deepseek-v4-flash",
+      status: "completed",
+      ...(terminalOutput ? { output } : {}),
+      usage: {
+        input_tokens: 18,
+        output_tokens: 12,
+        total_tokens: 30,
+        input_tokens_details: { cached_tokens: 3 },
+        output_tokens_details: { reasoning_tokens: 4 },
+      },
+    },
+  });
+  return { events, output };
 }
 
-test("DeepSeek request serialization preserves native message and tool semantics", () => {
-  const context = createContext({
-    messages: [
-      {
-        role: "user",
-        content: [
-          { type: "text", text: "first" },
-          { type: "text", text: " second" },
-        ],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          { type: "thinking", thinking: "inspect" },
-          { type: "text", text: "calling" },
-          { type: "toolCall", id: "call-1", name: "lookup", arguments: { q: "value" } },
-        ],
-        api: DEEPSEEK_CHAT_COMPLETIONS_API,
-        provider: "deepseek",
-        model: "deepseek-chat",
-        usage: {
-          input: 1,
-          output: 1,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 2,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
-        stopReason: "toolUse",
-        timestamp: 2,
-      },
-      {
-        role: "toolResult",
-        toolCallId: "call-1",
-        toolName: "lookup",
-        content: [],
-        isError: false,
-        timestamp: 3,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "thinking", thinking: "private plain-turn reasoning" }],
-        api: DEEPSEEK_CHAT_COMPLETIONS_API,
-        provider: "deepseek",
-        model: "deepseek-chat",
-        usage: {
-          input: 1,
-          output: 1,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 2,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
-        stopReason: "stop",
-        timestamp: 4,
-      },
-    ],
-    tools: [
-      {
-        name: "lookup",
-        description: "Look up a value",
-        parameters: {
-          type: "object",
-          properties: { q: { type: "string" } },
-          required: ["q"],
-        },
-      },
-    ],
-  });
-
-  assert.deepEqual(serializeDeepSeekMessages(context), [
-    { role: "system", content: "You are precise." },
-    { role: "user", content: "first second" },
-    {
-      role: "assistant",
-      content: "calling",
-      reasoning_content: "inspect",
-      tool_calls: [
-        {
-          id: "call-1",
-          type: "function",
-          function: { name: "lookup", arguments: '{"q":"value"}' },
-        },
-      ],
-    },
-    { role: "tool", tool_call_id: "call-1", content: "(no output)" },
-    { role: "assistant", content: "" },
-  ]);
-
-  const request = serializeDeepSeekRequest(createModel(), context, {
-    reasoning: "xhigh",
-    maxTokens: 20_000,
-    temperature: 0.25,
-    toolChoice: { type: "tool", name: "lookup" },
-  });
-  assert.deepEqual(request.thinking, { type: "enabled" });
-  assert.equal(request.reasoning_effort, "max");
-  assert.equal(request.max_tokens, 8_192);
-  assert.equal(request.temperature, 0.25);
-  assert.deepEqual(request.tool_choice, {
-    type: "function",
-    function: { name: "lookup" },
-  });
-  assert.equal(request.tools?.[0].function.name, "lookup");
-  assert.equal("prompt_cache_key" in request, false);
-  assert.equal("cache_control" in request, false);
-});
-
-test("DeepSeek model factory is independent from Codex and Claude protocol selection", () => {
-  const deepseek = createModelFromConfig(
-    "deepseek",
-    "deepseek-reasoner",
-    "https://api.deepseek.com/v1/chat/completions/",
-    "openai-responses",
+test("DeepSeek formal provider normalizes onto the native Responses API", () => {
+  assert.equal(deepseek.DEEPSEEK_RESPONSES_API, "deepseek-responses");
+  assert.equal(
+    deepseek.normalizeDeepSeekResponsesBaseUrl("https://api.deepseek.com/v1/chat/completions/"),
+    "https://api.deepseek.com",
   );
-  assert.equal(deepseek.api, DEEPSEEK_CHAT_COMPLETIONS_API);
-  assert.equal(deepseek.provider, "deepseek");
-  assert.equal(deepseek.baseUrl, "https://api.deepseek.com/v1/chat/completions");
-  assert.deepEqual(deepseek.input, ["text"]);
-  assert.equal(deepseek.deepSeekThinkingAlwaysOn, true);
+  assert.equal(
+    deepseek.normalizeDeepSeekResponsesBaseUrl("https://api.deepseek.com/v1/responses"),
+    "https://api.deepseek.com",
+  );
+  assert.equal(
+    deepseek.normalizeDeepSeekResponsesBaseUrl("https://api.deepseek.com"),
+    "https://api.deepseek.com",
+  );
+  assert.equal(
+    deepseek.normalizeDeepSeekResponsesBaseUrl("https://relay.example.test"),
+    "https://relay.example.test/v1",
+  );
+  assert.equal(
+    deepseek.normalizeDeepSeekResponsesBaseUrl("https://relay.example.test/deepseek"),
+    "https://relay.example.test/deepseek/v1",
+  );
+  assert.equal(
+    deepseek.normalizeDeepSeekResponsesBaseUrl("https://relay.example.test/deepseek/v1"),
+    "https://relay.example.test/deepseek/v1",
+  );
+  assert.equal(
+    deepseek.normalizeDeepSeekResponsesBaseUrl(
+      "https://relay.example.test/deepseek/v1/chat/completions",
+    ),
+    "https://relay.example.test/deepseek/v1",
+  );
+  assert.equal(
+    deepseek.normalizeDeepSeekResponsesEndpoint("https://relay.example.test"),
+    "https://relay.example.test/v1/responses",
+  );
+  assert.equal(
+    deepseek.normalizeDeepSeekResponsesEndpoint(
+      "https://relay.example.test/deepseek/v1/chat/completions",
+    ),
+    "https://relay.example.test/deepseek/v1/responses",
+  );
+  assert.equal(
+    deepseek.normalizeDeepSeekResponsesBaseUrl("http://127.0.0.1:18080/proxy/deepseek", {
+      officialHost: true,
+    }),
+    "http://127.0.0.1:18080/proxy/deepseek",
+  );
+  assert.equal(
+    deepseek.normalizeDeepSeekResponsesBaseUrl("http://127.0.0.1:18080/proxy/deepseek", {
+      officialHost: false,
+    }),
+    "http://127.0.0.1:18080/proxy/deepseek/v1",
+  );
+
+  const model = createModelFromConfig(
+    "deepseek",
+    "deepseek-v4-pro",
+    "https://api.deepseek.com/v1/chat/completions/",
+    "openai-completions",
+  );
+  assert.equal(model.api, deepseek.DEEPSEEK_RESPONSES_API);
+  assert.equal(model.provider, "deepseek");
+  assert.equal(model.baseUrl, "https://api.deepseek.com");
+  assert.deepEqual(model.input, ["text"]);
+  assert.equal(model.compat.supportsStrictMode, false);
+
+  const officialViaProxy = createModelFromConfig(
+    "deepseek",
+    "deepseek-v4-flash",
+    "http://127.0.0.1:18080/proxy/deepseek",
+    "deepseek-responses",
+    undefined,
+    "https://api.deepseek.com",
+  );
+  assert.equal(officialViaProxy.baseUrl, "http://127.0.0.1:18080/proxy/deepseek");
+
+  const relayViaProxy = createModelFromConfig(
+    "deepseek",
+    "deepseek-v4-flash",
+    "http://127.0.0.1:18080/proxy/deepseek",
+    "deepseek-responses",
+    undefined,
+    "https://relay.example.test",
+  );
+  assert.equal(relayViaProxy.baseUrl, "http://127.0.0.1:18080/proxy/deepseek/v1");
+
+  const relayBare = createModelFromConfig(
+    "deepseek",
+    "deepseek-v4-flash",
+    "https://relay.example.test",
+  );
+  assert.equal(relayBare.baseUrl, "https://relay.example.test/v1");
 
   const codex = createModelFromConfig(
     "codex",
-    "deepseek-chat",
-    "https://api.deepseek.com/v1/chat/completions",
+    "deepseek-v4-flash",
+    "https://relay.example.test/v1",
     "openai-completions",
   );
   assert.equal(codex.api, "openai-completions");
   assert.equal(codex.provider, "openai");
-  assert.equal(codex.deepSeekThinkingAlwaysOn, undefined);
 
   const claude = createModelFromConfig(
     "claude_code",
-    "deepseek-chat",
+    "deepseek-v4-flash",
     "https://api.deepseek.com/anthropic",
   );
   assert.equal(claude.api, "anthropic-messages");
   assert.equal(claude.provider, "anthropic");
-  assert.equal(claude.deepSeekThinkingAlwaysOn, undefined);
 });
 
-test("streamSimpleByApi dispatches the formal DeepSeek API to the native stream", async () => {
-  const model = createModelFromConfig(
-    "deepseek",
-    "deepseek-chat",
-    "https://api.deepseek.com/v1",
-  );
-  const urls = [];
-  const stream = streamSimpleByApi(model, createContext(), {
-    apiKey: "sk-test",
-    streamRetry: { disabled: true },
-    fetch: async (url) => {
-      urls.push(String(url));
-      return responseFromSse([
-        sseData({ choices: [{ delta: { content: "native" }, finish_reason: "stop" }] }),
-        sseData("[DONE]"),
-      ]);
+test("DeepSeek streams official Responses SSE without DONE and preserves search output", async () => {
+  const model = createModel();
+  const context = createContext({
+    tools: [
+      {
+        name: "lookup_local",
+        description: "Look up local metadata",
+        parameters: {
+          type: "object",
+          properties: { key: { type: "string" } },
+          required: ["key"],
+        },
+      },
+    ],
+  });
+  const { events: wireEvents, output } = completedSearchResponseEvents();
+  const calls = [];
+  const responses = [];
+  const options = finalizeProviderStreamOptions({
+    providerId: "deepseek",
+    baseUrl: model.baseUrl,
+    model,
+    context,
+    nativeWebSearch: true,
+    options: {
+      apiKey: "sk-test",
+      reasoning: "high",
+      maxTokens: 4_096,
+      toolChoice: "auto",
+      streamRetry: { disabled: true },
+      onResponse(response) {
+        responses.push(response);
+      },
+      async fetch(url, init) {
+        calls.push({
+          url: String(url),
+          init,
+          payload: JSON.parse(String(init.body)),
+        });
+        return responseFromEvents(wireEvents);
+      },
     },
   });
 
-  const { result } = await consume(stream);
+  const { events, result } = await consume(streamSimpleByApi(model, context, options));
 
-  assert.deepEqual(urls, ["https://api.deepseek.com/v1/chat/completions"]);
-  assert.equal(result.content[0].text, "native");
-  assert.equal(result.provider, "deepseek");
-  assert.equal(result.api, DEEPSEEK_CHAT_COMPLETIONS_API);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.deepseek.com/responses");
+  assert.equal(new Headers(calls[0].init.headers).get("authorization"), "Bearer sk-test");
+  assert.equal(calls[0].payload.model, "deepseek-v4-flash");
+  assert.equal(calls[0].payload.stream, true);
+  assert.equal(calls[0].payload.max_output_tokens, 4_096);
+  assert.deepEqual(calls[0].payload.reasoning, { effort: "high" });
+  assert.deepEqual(
+    calls[0].payload.tools.map((tool) => tool.type),
+    ["function", "web_search"],
+  );
+  for (const unsupported of [
+    "store",
+    "include",
+    "prompt_cache_key",
+    "prompt_cache_retention",
+    "prompt_cache_options",
+    "stream_options",
+  ]) {
+    assert.equal(unsupported in calls[0].payload, false, unsupported);
+  }
+  assert.equal(responses.length, 1);
+  assert.equal(responses[0].status, 200);
+  assert.equal(events.at(-1).type, "done");
+  assert.equal(result.stopReason, "toolUse");
+  assert.equal(result.responseId, "resp_1");
+  assert.deepEqual(
+    result.content.map((block) => block.type),
+    ["thinking", "text", "toolCall"],
+  );
+  assert.equal(result.content[1].text, "The current V4 models support server-side search.");
+  assert.deepEqual(result.content[2].arguments, { key: "release" });
+  assert.deepEqual(result.deepSeekResponseState, { output });
+  assert.deepEqual(result.usage, {
+    input: 15,
+    output: 12,
+    cacheRead: 3,
+    cacheWrite: 0,
+    reasoning: 4,
+    totalTokens: 30,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  });
 });
 
-test("DeepSeek thinking mapping supports disabled, high, max, and always-on models", () => {
-  const context = createContext();
-  assert.deepEqual(serializeDeepSeekRequest(createModel(), context, {}).thinking, {
-    type: "disabled",
+test("DeepSeek disabled thinking sends official Responses effort none", async () => {
+  const model = createModelFromConfig(
+    "deepseek",
+    "deepseek-v4-flash",
+    "https://api.deepseek.com",
+  );
+  const calls = [];
+  const options = finalizeProviderStreamOptions({
+    providerId: "deepseek",
+    baseUrl: model.baseUrl,
+    model,
+    context: createContext(),
+    options: {
+      apiKey: "sk-test",
+      deepSeekThinking: "disabled",
+      streamRetry: { disabled: true },
+      async fetch(_url, init) {
+        calls.push(JSON.parse(String(init.body)));
+        return responseFromEvents(
+          completedSearchResponseEvents({ includeFunctionCall: false }).events,
+        );
+      },
+    },
   });
 
-  const high = serializeDeepSeekRequest(createModel(), context, { reasoning: "low" });
-  assert.deepEqual(high.thinking, { type: "enabled" });
-  assert.equal(high.reasoning_effort, "high");
+  await consume(streamSimpleByApi(model, createContext(), options));
 
-  const max = serializeDeepSeekRequest(createModel(), context, { reasoning: "max" });
-  assert.deepEqual(max.thinking, { type: "enabled" });
-  assert.equal(max.reasoning_effort, "max");
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].reasoning, { effort: "none" });
 
-  const alwaysOn = serializeDeepSeekRequest(
-    createModel({ id: "deepseek-reasoner", deepSeekThinkingAlwaysOn: true }),
-    context,
-    {},
-  );
-  assert.deepEqual(alwaysOn.thinking, { type: "enabled" });
-  assert.equal(alwaysOn.reasoning_effort, "high");
-
-  const explicitlyDisabled = serializeDeepSeekRequest(
-    createModel({ id: "deepseek-reasoner", deepSeekThinkingAlwaysOn: true }),
-    context,
-    { reasoning: "max", deepSeekThinking: "disabled" },
-  );
-  assert.deepEqual(explicitlyDisabled.thinking, { type: "disabled" });
-  assert.equal(explicitlyDisabled.reasoning_effort, undefined);
-
-  assert.equal(
-    serializeDeepSeekRequest(createModel(), { ...context, tools: [] }, { toolChoice: "any" })
-      .tool_choice,
-    undefined,
-  );
-  assert.equal(
-    serializeDeepSeekRequest(
-      createModel(),
-      {
-        ...context,
-        tools: [{ name: "lookup", description: "Lookup", parameters: { type: "object" } }],
+  // Agent path never sets deepSeekThinking; off is just a missing reasoning
+  // level. Responses still defaults to thinking=high unless effort is none.
+  calls.length = 0;
+  const agentOptions = finalizeProviderStreamOptions({
+    providerId: "deepseek",
+    baseUrl: model.baseUrl,
+    model,
+    context: createContext(),
+    options: {
+      apiKey: "sk-test",
+      streamRetry: { disabled: true },
+      async fetch(_url, init) {
+        calls.push(JSON.parse(String(init.body)));
+        return responseFromEvents(
+          completedSearchResponseEvents({ includeFunctionCall: false }).events,
+        );
       },
-      { toolChoice: "any" },
-    ).tool_choice,
-    "required",
-  );
+    },
+  });
+  await consume(streamSimpleByApi(model, createContext(), agentOptions));
+  assert.deepEqual(calls[0].reasoning, { effort: "none" });
 });
 
-test("DeepSeek serialization rejects images instead of silently dropping them", () => {
-  assert.throws(
-    () =>
-      serializeDeepSeekMessages(
-        createContext({
-          messages: [
-            {
-              role: "user",
-              content: [
-                { type: "text", text: "describe" },
-                { type: "image", data: "AAAA", mimeType: "image/png" },
-              ],
-              timestamp: 1,
-            },
-          ],
-        }),
-      ),
-    /does not support image content/,
-  );
+test("DeepSeek search capture falls back to ordered output-item events", async () => {
+  const model = createModel();
+  const context = createContext();
+  const { events, output } = completedSearchResponseEvents({
+    includeFunctionCall: false,
+    terminalOutput: false,
+  });
+  const stream = deepseek.streamDeepSeekResponses(model, context, {
+    apiKey: "sk-test",
+    streamRetry: { disabled: true },
+    fetch: async () => responseFromEvents(events),
+  });
+  const { result } = await consume(stream);
+
+  assert.equal(result.stopReason, "stop");
+  assert.deepEqual(result.deepSeekResponseState, { output });
 });
 
-test("DeepSeek native stream rejects images before fetch", async () => {
+test("DeepSeek payload replays complete search output and remaps orphaned tool results", () => {
+  const firstOutput = [
+    { type: "reasoning", id: "rs_first", content: [] },
+    {
+      type: "web_search_call",
+      id: "ws_first",
+      status: "completed",
+      action: { query: "first query" },
+    },
+    {
+      type: "message",
+      id: "msg_first",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: "first answer", annotations: [] }],
+    },
+    {
+      type: "function_call",
+      id: "fc_first",
+      call_id: "call_first",
+      name: "lookup_local",
+      arguments: '{"key":"first"}',
+    },
+  ];
+  const secondOutput = [
+    { type: "reasoning", id: "rs_second", content: [] },
+    {
+      type: "web_search_call",
+      id: "ws_second",
+      status: "completed",
+      action: { query: "second query" },
+    },
+    {
+      type: "message",
+      id: "msg_second",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: "second answer", annotations: [] }],
+    },
+  ];
+  const context = createContext({
+    messages: [
+      { role: "user", content: "first", timestamp: 1 },
+      assistant({
+        model: "deepseek-v4-flash",
+        content: [
+          {
+            type: "thinking",
+            thinking: "first reasoning",
+            thinkingSignature: JSON.stringify(firstOutput[0]),
+          },
+          { type: "text", text: "first answer" },
+          {
+            type: "toolCall",
+            id: "call_first|fc_first",
+            name: "lookup_local",
+            arguments: { key: "first" },
+          },
+        ],
+        state: firstOutput,
+      }),
+      { role: "user", content: "second", timestamp: 3 },
+      assistant({
+        model: "deepseek-v4-pro",
+        timestamp: 4,
+        content: [
+          {
+            type: "thinking",
+            thinking: "second reasoning",
+            thinkingSignature: JSON.stringify(secondOutput[0]),
+          },
+          { type: "text", text: "second answer" },
+        ],
+        state: secondOutput,
+      }),
+      { role: "user", content: "continue", timestamp: 5 },
+    ],
+  });
+  const generatedInput = [
+    { role: "developer", content: "You are precise." },
+    { role: "user", content: [{ type: "input_text", text: "first" }] },
+    {
+      type: "message",
+      id: "msg_pi_1",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: "first reasoning", annotations: [] }],
+    },
+    {
+      type: "message",
+      id: "msg_pi_1_1",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: "first answer", annotations: [] }],
+    },
+    {
+      type: "function_call",
+      call_id: "call_first_fc_first",
+      name: "lookup_local",
+      arguments: '{"key":"first"}',
+    },
+    {
+      type: "function_call_output",
+      call_id: "call_first_fc_first",
+      output: "No result provided",
+    },
+    { role: "user", content: [{ type: "input_text", text: "second" }] },
+    secondOutput[0],
+    {
+      type: "message",
+      id: "msg_pi_3",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: "second answer", annotations: [] }],
+    },
+    { role: "user", content: [{ type: "input_text", text: "continue" }] },
+  ];
+
+  const normalized = payloadCompat.normalizeDeepSeekResponsesPayload(
+    {
+      model: "deepseek-v4-pro",
+      input: generatedInput,
+      previous_response_id: "unsupported",
+      conversation: "unsupported",
+      store: false,
+      background: true,
+      metadata: { source: "unsupported" },
+      include: ["reasoning.encrypted_content"],
+      prompt: { id: "unsupported" },
+      truncation: "auto",
+      service_tier: "auto",
+      safety_identifier: "unsupported",
+      prompt_cache_key: "unsupported",
+      prompt_cache_retention: "24h",
+      prompt_cache_options: { mode: "explicit" },
+      context_management: [{ type: "compaction" }],
+      stream_options: { include_usage: true },
+      reasoning: { effort: "high", summary: "auto" },
+    },
+    context,
+    createModel({ id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" }),
+  );
+
+  assert.deepEqual(normalized.reasoning, { effort: "high" });
+  for (const unsupported of [
+    "previous_response_id",
+    "conversation",
+    "store",
+    "background",
+    "metadata",
+    "include",
+    "prompt",
+    "truncation",
+    "service_tier",
+    "safety_identifier",
+    "prompt_cache_key",
+    "prompt_cache_retention",
+    "prompt_cache_options",
+    "context_management",
+    "stream_options",
+  ]) {
+    assert.equal(unsupported in normalized, false, unsupported);
+  }
+  assert.deepEqual(normalized.input, [
+    generatedInput[0],
+    generatedInput[1],
+    ...firstOutput,
+    { ...generatedInput[5], call_id: "call_first" },
+    generatedInput[6],
+    ...secondOutput,
+    generatedInput[9],
+  ]);
+});
+
+test("DeepSeek replay state is provider-scoped and requires a web search call", () => {
+  const context = createContext({
+    systemPrompt: undefined,
+    messages: [
+      { role: "user", content: "hello", timestamp: 1 },
+      assistant({
+        provider: "openai",
+        api: "openai-responses",
+        content: [{ type: "text", text: "foreign" }],
+        state: [{ type: "web_search_call", id: "foreign" }],
+      }),
+      assistant({
+        content: [{ type: "text", text: "no search" }],
+        state: [{ type: "message", id: "plain" }],
+      }),
+    ],
+  });
+  const input = [
+    { role: "user", content: [{ type: "input_text", text: "hello" }] },
+    { type: "message", id: "foreign-generated" },
+    { type: "message", id: "plain-generated" },
+  ];
+
+  const normalized = payloadCompat.normalizeDeepSeekResponsesPayload(
+    { input },
+    context,
+    createModel(),
+  );
+  assert.deepEqual(normalized.input, input);
+});
+
+test("DeepSeek rejects image input before sending a request", async () => {
   let fetchCalled = false;
-  const { events, result } = await runStream({
-    context: createContext({
+  const stream = deepseek.streamDeepSeekResponses(
+    createModel(),
+    createContext({
       messages: [
         {
           role: "user",
@@ -332,302 +676,18 @@ test("DeepSeek native stream rejects images before fetch", async () => {
         },
       ],
     }),
-    fetch: async () => {
-      fetchCalled = true;
-      throw new Error("fetch must not run for image content");
+    {
+      apiKey: "sk-test",
+      fetch: async () => {
+        fetchCalled = true;
+        throw new Error("fetch should not run");
+      },
     },
-  });
+  );
+  const { events, result } = await consume(stream);
 
   assert.equal(fetchCalled, false);
   assert.equal(events.at(-1).type, "error");
   assert.equal(result.stopReason, "error");
-  assert.match(result.errorMessage, /does not support image content/);
-});
-
-test("DeepSeek native stream handles split UTF-8 SSE, tools, usage, hooks, and block order", async () => {
-  const body = [
-    sseData({
-      id: "response-1",
-      model: "deepseek-chat-202608",
-      choices: [{ delta: { reasoning_content: "思考" }, finish_reason: null }],
-    }),
-    sseData({ choices: [{ delta: { content: "答案" }, finish_reason: null }] }),
-    sseData({
-      choices: [
-        {
-          delta: {
-            tool_calls: [
-              {
-                index: 0,
-                id: "call-1",
-                function: { name: "lookup", arguments: '{"city":"深' },
-              },
-            ],
-          },
-          finish_reason: null,
-        },
-      ],
-    }),
-    sseData({
-      choices: [
-        {
-          delta: { tool_calls: [{ index: 0, function: { arguments: '圳"}' } }] },
-          finish_reason: "tool_calls",
-        },
-      ],
-      usage: {
-        prompt_tokens: 20,
-        completion_tokens: 9,
-        prompt_cache_hit_tokens: 7,
-        completion_tokens_details: { reasoning_tokens: 4 },
-      },
-    }),
-    sseData("[DONE]"),
-  ].join("");
-  const bytes = new TextEncoder().encode(body);
-  const splitAt = bytes.indexOf(new TextEncoder().encode("圳")[0]) + 1;
-  const calls = [];
-  const responses = [];
-
-  const { events, result } = await runStream({
-    model: createModel({
-      baseUrl: "https://api.deepseek.com/v1/chat/completions",
-      headers: { "X-Model-Header": "model", "X-Remove-Me": "model" },
-    }),
-    context: createContext({
-      tools: [{ name: "lookup", description: "Lookup", parameters: { type: "object" } }],
-    }),
-    reasoning: "high",
-    headers: {
-      "X-Model-Header": "request",
-      "X-Remove-Me": null,
-      "X-Request-Header": "present",
-    },
-    onPayload(payload) {
-      return { ...payload, temperature: 0.1, hook_marker: true };
-    },
-    onResponse(response) {
-      responses.push(response);
-    },
-    fetch: async (url, options) => {
-      calls.push({ url: String(url), options, payload: JSON.parse(options.body) });
-      return responseFromBytes([bytes.slice(0, splitAt), bytes.slice(splitAt)], {
-        headers: { "X-DeepSeek-Request-Id": "request-1" },
-      });
-    },
-  });
-
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].url, "https://api.deepseek.com/v1/chat/completions");
-  assert.equal(calls[0].options.method, "POST");
-  assert.equal(calls[0].options.headers.get("Authorization"), "Bearer sk-test");
-  assert.equal(calls[0].options.headers.get("X-Model-Header"), "request");
-  assert.equal(calls[0].options.headers.get("X-Request-Header"), "present");
-  assert.equal(calls[0].options.headers.has("X-Remove-Me"), false);
-  assert.equal(calls[0].payload.temperature, 0.1);
-  assert.equal(calls[0].payload.hook_marker, true);
-  assert.deepEqual(responses, [
-    {
-      status: 200,
-      headers: {
-        "content-type": "text/event-stream",
-        "x-deepseek-request-id": "request-1",
-      },
-    },
-  ]);
-
-  assert.deepEqual(
-    events.map((event) => event.type),
-    [
-      "start",
-      "thinking_start",
-      "thinking_delta",
-      "text_start",
-      "text_delta",
-      "toolcall_start",
-      "toolcall_delta",
-      "toolcall_delta",
-      "thinking_end",
-      "text_end",
-      "toolcall_end",
-      "done",
-    ],
-  );
-  assert.deepEqual(result.content, [
-    { type: "thinking", thinking: "思考" },
-    { type: "text", text: "答案" },
-    { type: "toolCall", id: "call-1", name: "lookup", arguments: { city: "深圳" } },
-  ]);
-  assert.equal(result.responseId, "response-1");
-  assert.equal(result.responseModel, "deepseek-chat-202608");
-  assert.equal(result.stopReason, "toolUse");
-  assert.equal(result.rawStopReason, "tool_calls");
-  assert.deepEqual(result.usage, {
-    input: 13,
-    output: 9,
-    cacheRead: 7,
-    cacheWrite: 0,
-    reasoning: 4,
-    totalTokens: 29,
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-  });
-});
-
-test("DeepSeek native stream maps length completion and cached-token detail usage", async () => {
-  const response = responseFromSse([
-    sseData({ choices: [{ delta: { content: "partial" }, finish_reason: "length" }] }),
-    sseData({
-      choices: [],
-      usage: {
-        prompt_tokens: 10,
-        completion_tokens: 3,
-        prompt_tokens_details: { cached_tokens: 4 },
-      },
-    }),
-    sseData("[DONE]"),
-  ]);
-
-  const { result } = await runStream({ fetch: async () => response });
-
-  assert.equal(result.stopReason, "length");
-  assert.deepEqual(result.usage, {
-    input: 6,
-    output: 3,
-    cacheRead: 4,
-    cacheWrite: 0,
-    reasoning: undefined,
-    totalTokens: 13,
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-  });
-});
-
-test("DeepSeek native stream reports JSON and plain-text HTTP error details", async () => {
-  for (const [response, expected] of [
-    [
-      new Response(JSON.stringify({ error: { message: "invalid key" } }), {
-        status: 401,
-        headers: { "Content-Type": "application/json" },
-      }),
-      /HTTP 401.*invalid key/,
-    ],
-    [new Response("upstream unavailable", { status: 502 }), /HTTP 502.*upstream unavailable/],
-  ]) {
-    const { events, result } = await runStream({ fetch: async () => response });
-    assert.equal(events.at(-1).type, "error");
-    assert.equal(result.stopReason, "error");
-    assert.match(result.errorMessage, expected);
-  }
-});
-
-test("DeepSeek native stream rejects malformed, truncated, empty, and unknown-finish responses", async () => {
-  const cases = [
-    {
-      name: "malformed",
-      response: () => responseFromSse([sseData("{not-json"), sseData("[DONE]")]),
-      expected: /Malformed DeepSeek SSE payload/,
-    },
-    {
-      name: "truncated",
-      response: () =>
-        responseFromSse([
-          sseData({ choices: [{ delta: { content: "partial" }, finish_reason: null }] }),
-        ]),
-      expected: /ended without \[DONE\]/,
-    },
-    {
-      name: "empty",
-      response: () =>
-        responseFromSse([
-          sseData({ choices: [{ delta: {}, finish_reason: "stop" }] }),
-          sseData("[DONE]"),
-        ]),
-      expected: /completed response with no content/,
-    },
-    {
-      name: "unknown finish",
-      response: () =>
-        responseFromSse([
-          sseData({ choices: [{ delta: { content: "blocked" }, finish_reason: "content_filter" }] }),
-          sseData("[DONE]"),
-        ]),
-      expected: /unsupported finish reason: content_filter/,
-    },
-    {
-      name: "missing body",
-      response: () => new Response(null, { status: 200 }),
-      expected: /no response body/,
-    },
-  ];
-
-  for (const current of cases) {
-    const { events, result } = await runStream({ fetch: async () => current.response() });
-    assert.equal(events.at(-1).type, "error", current.name);
-    assert.equal(result.stopReason, "error", current.name);
-    assert.match(result.errorMessage, current.expected, current.name);
-  }
-});
-
-test("DeepSeek base URL normalization appends /v1 only when no version or endpoint path exists", () => {
-  // one-api/new-api 系中转只在 /v1 下服务 API，裸域名路径被前置 SPA 兜底。
-  assert.equal(normalizeDeepSeekBaseUrl("https://relay.example.test"), "https://relay.example.test/v1");
-  assert.equal(normalizeDeepSeekBaseUrl("https://relay.example.test/"), "https://relay.example.test/v1");
-  assert.equal(normalizeDeepSeekBaseUrl("https://api.deepseek.com"), "https://api.deepseek.com/v1");
-  assert.equal(
-    normalizeDeepSeekBaseUrl("https://relay.example.test/deepseek"),
-    "https://relay.example.test/deepseek/v1",
-  );
-  // 已带版本段或完整端点路径的配置原样保留。
-  assert.equal(normalizeDeepSeekBaseUrl("https://relay.example.test/v1"), "https://relay.example.test/v1");
-  assert.equal(normalizeDeepSeekBaseUrl("https://relay.example.test/v1beta"), "https://relay.example.test/v1beta");
-  assert.equal(
-    normalizeDeepSeekBaseUrl("https://relay.example.test/v1/chat/completions/"),
-    "https://relay.example.test/v1/chat/completions",
-  );
-  assert.equal(
-    normalizeDeepSeekBaseUrl("https://relay.example.test/api/chat/completions"),
-    "https://relay.example.test/api/chat/completions",
-  );
-
-  const bareDomainModel = createModelFromConfig("deepseek", "deepseek-chat", "https://relay.example.test");
-  assert.equal(bareDomainModel.baseUrl, "https://relay.example.test/v1");
-});
-
-test("DeepSeek native stream fails fast on non-SSE 200 responses instead of reporting truncation", async () => {
-  // one-api 系中转的前置 SPA 会把未命中路径以 200 + HTML 兜底。
-  const { events, result } = await runStream({
-    fetch: async () =>
-      new Response("<!doctype html>\n<html lang=\"zh\"><head></head></html>", {
-        status: 200,
-        headers: { "Content-Type": "text/html; charset=utf-8" },
-      }),
-  });
-
-  assert.equal(events.at(-1).type, "error");
-  assert.equal(result.stopReason, "error");
-  assert.match(result.errorMessage, /returned "text\/html" instead of an SSE stream/);
-  assert.match(result.errorMessage, /check that the Base URL/);
-  assert.equal(result.errorMessage.includes("ended without"), false);
-});
-
-test("DeepSeek native stream maps caller cancellation without AbortSignal.any", async () => {
-  const controller = new AbortController();
-  controller.abort(new Error("cancelled by user"));
-  const originalAny = AbortSignal.any;
-
-  try {
-    AbortSignal.any = undefined;
-    const { events, result } = await runStream({
-      signal: controller.signal,
-      fetch: async (_url, options) => {
-        options.signal.throwIfAborted();
-        throw new Error("fetch should not continue");
-      },
-    });
-
-    assert.equal(events.at(-1).type, "error");
-    assert.equal(result.stopReason, "aborted");
-    assert.match(result.errorMessage, /cancelled by user/);
-  } finally {
-    AbortSignal.any = originalAny;
-  }
+  assert.match(result.errorMessage, /does not support image input/);
 });

--- a/crates/agent-gui/test/providers/hosted-search-events.test.mjs
+++ b/crates/agent-gui/test/providers/hosted-search-events.test.mjs
@@ -434,6 +434,215 @@ test("hosted search aggregation extracts OpenAI url_citation annotations and mar
   );
 });
 
+test("DeepSeek Responses search events recover query and citations without annotation.added", () => {
+  const deepseek = hostedSearchEvents.createHostedSearchEventAggregator({
+    providerId: "deepseek",
+  });
+
+  deepseek.accept({
+    event: "response.web_search_call.in_progress",
+    item_id: "deepseek-search-completed",
+  });
+  assert.equal(deepseek.getBlocks()[0].queries.length, 0);
+  assert.equal(deepseek.getBlocks()[0].sources.length, 0);
+
+  deepseek.accept({
+    event: "response.web_search_call.completed",
+    item_id: "deepseek-search-completed",
+    item: {
+      type: "web_search_call",
+      id: "deepseek-search-completed",
+      status: "completed",
+      action: { type: "search", query: "DeepSeek V4 release" },
+    },
+  });
+  deepseek.accept({
+    type: "response.completed",
+    response: {
+      output: [
+        {
+          type: "web_search_call",
+          id: "deepseek-search-completed",
+          status: "completed",
+          action: { type: "search", query: "DeepSeek V4 release" },
+        },
+        {
+          type: "message",
+          role: "assistant",
+          content: [
+            {
+              type: "output_text",
+              text: "V4 is generally available.",
+              annotations: [
+                {
+                  type: "url_citation",
+                  url: "https://api-docs.deepseek.com/news",
+                  title: "DeepSeek News",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  const block = deepseek.getBlocks()[0];
+  assert.equal(block.provider, "deepseek");
+  assert.equal(block.status, "completed");
+  assert.deepEqual(block.queries, ["DeepSeek V4 release"]);
+  assert.deepEqual(
+    block.sources.map((source) => ({
+      url: source.url,
+      title: source.title,
+      sourceType: source.sourceType,
+    })),
+    [
+      {
+        url: "https://api-docs.deepseek.com/news",
+        title: "DeepSeek News",
+        sourceType: "citation",
+      },
+    ],
+  );
+});
+
+test("Responses search parser extracts DeepSeek open_page urls as sources", () => {
+  const deepseek = hostedSearchEvents.createHostedSearchEventAggregator({
+    providerId: "deepseek",
+  });
+
+  deepseek.accept({
+    type: "response.output_item.done",
+    item: {
+      type: "web_search_call",
+      id: "deepseek-open-page",
+      status: "completed",
+      action: { type: "open_page", url: "https://api-docs.deepseek.com/guides/responses_api" },
+    },
+  });
+
+  const block = deepseek.getBlocks()[0];
+  assert.equal(block.status, "completed");
+  assert.deepEqual(
+    block.sources.map((source) => source.url),
+    ["https://api-docs.deepseek.com/guides/responses_api"],
+  );
+});
+
+test("hosted search fetch probe attaches SSE event names when data JSON omits type", async () => {
+  const originalFetch = globalThis.fetch;
+  const events = [];
+
+  globalThis.fetch = async () =>
+    new Response(
+      [
+        "event: response.output_item.done",
+        `data: ${JSON.stringify({
+          item: {
+            type: "web_search_call",
+            id: "deepseek-sse-event",
+            status: "completed",
+            action: { query: "DeepSeek SSE event field" },
+          },
+        })}`,
+        "",
+      ].join("\n"),
+      { headers: { "content-type": "text/event-stream; charset=utf-8" } },
+    );
+
+  const probe = hostedSearchEvents.startHostedSearchFetchProbe({
+    providerId: "deepseek",
+    sessionId: "session-sse-event",
+    requestId: "probe-sse-event",
+    enabled: true,
+    onRawEvent: (event) => events.push(event),
+  });
+
+  try {
+    await fetch("http://127.0.0.1:18080/proxy/deepseek/responses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        [hostedSearchEvents.HOSTED_SEARCH_PROBE_HEADER]: "probe-sse-event",
+      },
+      body: JSON.stringify({ model: "deepseek-v4-flash" }),
+    });
+    await probe.finish();
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "response.output_item.done");
+    assert.equal(events[0].item.id, "deepseek-sse-event");
+
+    const aggregator = hostedSearchEvents.createHostedSearchEventAggregator({
+      providerId: "deepseek",
+    });
+    aggregator.accept(events[0]);
+    assert.deepEqual(aggregator.getBlocks()[0].queries, ["DeepSeek SSE event field"]);
+  } finally {
+    await probe.finish();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("DeepSeek Responses search events retain DeepSeek provider attribution", () => {
+  const emitted = [];
+  const deepseek = hostedSearchEvents.createHostedSearchEventAggregator({
+    providerId: "deepseek",
+    onHostedSearch: (block) => emitted.push(block),
+  });
+
+  deepseek.accept({
+    type: "response.output_item.added",
+    item: {
+      type: "web_search_call",
+      id: "deepseek-search-1",
+      status: "in_progress",
+      action: {
+        query: "DeepSeek Responses API",
+        sources: [{ url: "https://example.com/deepseek-source", title: "DeepSeek Source" }],
+      },
+    },
+  });
+  deepseek.accept({
+    type: "response.web_search_call.completed",
+    item_id: "deepseek-search-1",
+  });
+  deepseek.accept({
+    type: "response.output_text.annotation.added",
+    annotation: {
+      type: "url_citation",
+      url: "https://example.com/deepseek-citation",
+      title: "DeepSeek Citation",
+    },
+  });
+
+  const block = deepseek.getBlocks()[0];
+  assert.equal(block.provider, "deepseek");
+  assert.equal(block.status, "completed");
+  assert.deepEqual(block.queries, ["DeepSeek Responses API"]);
+  assert.deepEqual(
+    block.sources.map((source) => ({
+      url: source.url,
+      title: source.title,
+      sourceType: source.sourceType,
+    })),
+    [
+      {
+        url: "https://example.com/deepseek-source",
+        title: "DeepSeek Source",
+        sourceType: "source",
+      },
+      {
+        url: "https://example.com/deepseek-citation",
+        title: "DeepSeek Citation",
+        sourceType: "citation",
+      },
+    ],
+  );
+  assert.ok(emitted.every((candidate) => candidate.provider === "deepseek"));
+});
+
 test("codex aggregator tracks xAI x_search_call items and extracts action sources", () => {
   const aggregator = hostedSearchEvents.createHostedSearchEventAggregator({
     providerId: "codex",

--- a/crates/agent-gui/test/providers/provider-cache-shape.test.mjs
+++ b/crates/agent-gui/test/providers/provider-cache-shape.test.mjs
@@ -12,7 +12,7 @@ test("DeepSeek cache diagnostics describe provider-managed prefix caching", () =
     describeProviderCacheShape({
       providerId: "deepseek",
       baseUrl: "https://api.deepseek.com",
-      modelApi: "deepseek-chat-completions",
+      modelApi: "deepseek-responses",
       sessionId: "conversation-1",
       cacheRetention: "long",
       headers: { "x-session-id": "ignored" },

--- a/crates/agent-gui/test/providers/request-options.test.mjs
+++ b/crates/agent-gui/test/providers/request-options.test.mjs
@@ -205,6 +205,14 @@ test("provider request helpers normalize auth, metadata, errors, and model value
     true,
   );
   assert.equal(
+    providers.providerSupportsNativeWebSearch("deepseek", "deepseek-responses"),
+    true,
+  );
+  assert.equal(
+    providers.providerSupportsNativeWebSearch("deepseek", "openai-completions"),
+    false,
+  );
+  assert.equal(
     providers.providerSupportsNativeWebSearch("codex", "openai-completions"),
     false,
   );
@@ -713,6 +721,108 @@ test("provider native web search injection is opt-in", async () => {
     id: "gemini-3-pro-preview",
   });
   assert.equal(geminiResult, geminiPayload);
+});
+
+test("DeepSeek Responses native web search is injected once and can be disabled", async () => {
+  const model = {
+    api: "deepseek-responses",
+    provider: "deepseek",
+    id: "deepseek-v4-flash",
+  };
+  const enabledOptions = providers.finalizeProviderStreamOptions({
+    providerId: "deepseek",
+    baseUrl: "https://api.deepseek.com",
+    nativeWebSearch: true,
+    model,
+    options: {},
+  });
+
+  const injected = await enabledOptions.onPayload({ input: "hello" }, model);
+  assert.deepEqual(injected.tools, [{ type: "web_search" }]);
+
+  const preserved = await enabledOptions.onPayload(
+    { input: "hello", tools: [{ type: "web_search_2025_08_26" }] },
+    model,
+  );
+  assert.deepEqual(preserved.tools, [{ type: "web_search_2025_08_26" }]);
+
+  const disabledOptions = providers.finalizeProviderStreamOptions({
+    providerId: "deepseek",
+    baseUrl: "https://api.deepseek.com",
+    nativeWebSearch: false,
+    model,
+    options: {},
+  });
+  const disabled = await disabledOptions.onPayload({ input: "hello" }, model);
+  assert.equal(disabled.tools, undefined);
+});
+
+test("DeepSeek full URL requests normalize legacy endpoints to /responses", async () => {
+  const localLoader = createTsModuleLoader({
+    mocks: {
+      "@liveagent/app/shims/tauriCore": {
+        async invoke(command) {
+          assert.equal(command, "proxy_get_server_info");
+          return { baseUrl: "http://127.0.0.1:18080", token: "proxy-token" };
+        },
+      },
+    },
+  });
+  const localProviders = localLoader.loadModule("src/lib/providers/llm.ts");
+  const prepared = await localProviders.prepareProviderRequest("deepseek", {
+    baseUrl: "https://relay.example.com/custom/chat/completions?region=cn",
+    isFullUrl: true,
+    apiKey: "secret",
+    requestFormat: "deepseek-responses",
+  });
+
+  assert.equal(prepared.baseUrl, "http://127.0.0.1:18080/proxy/deepseek");
+  assert.equal(
+    prepared.headers["x-liveagent-upstream-url"],
+    "https://relay.example.com/custom/v1/responses?region=cn",
+  );
+  assert.equal(prepared.headers["x-liveagent-upstream-origin"], "https://relay.example.com");
+});
+
+test("DeepSeek relay base URLs append /v1 while official DeepSeek stays at the root", async () => {
+  const localLoader = createTsModuleLoader({
+    mocks: {
+      "@liveagent/app/shims/tauriCore": {
+        async invoke(command) {
+          assert.equal(command, "proxy_get_server_info");
+          return { baseUrl: "http://127.0.0.1:18080", token: "proxy-token" };
+        },
+      },
+    },
+  });
+  const localProviders = localLoader.loadModule("src/lib/providers/llm.ts");
+
+  const official = await localProviders.prepareProviderRequest("deepseek", {
+    baseUrl: "https://api.deepseek.com",
+    apiKey: "secret",
+  });
+  assert.equal(official.baseUrl, "http://127.0.0.1:18080/proxy/deepseek");
+  assert.equal(official.headers["x-liveagent-upstream-origin"], "https://api.deepseek.com");
+  assert.equal(official.headers["x-liveagent-upstream-url"], undefined);
+
+  const officialWithVersion = await localProviders.prepareProviderRequest("deepseek", {
+    baseUrl: "https://api.deepseek.com/v1",
+    apiKey: "secret",
+  });
+  assert.equal(officialWithVersion.baseUrl, "http://127.0.0.1:18080/proxy/deepseek");
+
+  const relay = await localProviders.prepareProviderRequest("deepseek", {
+    baseUrl: "https://relay.example.com",
+    apiKey: "secret",
+  });
+  assert.equal(relay.baseUrl, "http://127.0.0.1:18080/proxy/deepseek/v1");
+  assert.equal(relay.headers["x-liveagent-upstream-origin"], "https://relay.example.com");
+
+  const relayWithVersion = await localProviders.prepareProviderRequest("deepseek", {
+    baseUrl: "https://relay.example.com/v1",
+    apiKey: "secret",
+  });
+  assert.equal(relayWithVersion.baseUrl, "http://127.0.0.1:18080/proxy/deepseek/v1");
 });
 
 test("provider payload finalization enables native web search for hosted search providers", async () => {

--- a/crates/agent-gui/test/settings/normalization.test.mjs
+++ b/crates/agent-gui/test/settings/normalization.test.mjs
@@ -277,7 +277,7 @@ test("gemini provider normalization keeps native routing and model limits", () =
   assert.equal(provider.models[0].maxOutputToken, 65_536);
 });
 
-test("DeepSeek is the fifth built-in provider with native-only defaults", () => {
+test("DeepSeek is the fifth built-in provider with Responses search enabled", () => {
   const providers = settings.getBuiltinCustomProviders();
   assert.deepEqual(
     providers.map((provider) => provider.type),
@@ -291,11 +291,11 @@ test("DeepSeek is the fifth built-in provider with native-only defaults", () => 
   assert.equal(provider.reasoning, "high");
   assert.equal(provider.promptCachingEnabled, false);
   assert.equal(provider.promptCacheHintMode, undefined);
-  assert.equal(provider.nativeWebSearchEnabled, false);
+  assert.equal(provider.nativeWebSearchEnabled, true);
   assert.equal(provider.requestFormat, undefined);
 });
 
-test("DeepSeek provider normalization keeps native routing and disables unsupported toggles", () => {
+test("DeepSeek provider normalization keeps native routing and native search", () => {
   const provider = settings.normalizeCustomProvider({
     id: "deepseek-1",
     name: " DeepSeek Relay ",
@@ -305,8 +305,8 @@ test("DeepSeek provider normalization keeps native routing and disables unsuppor
     promptCachingEnabled: true,
     promptCacheHintMode: "openai-key",
     nativeWebSearchEnabled: true,
-    models: ["deepseek-chat", "deepseek-reasoner"],
-    activeModels: ["deepseek-chat", "deepseek-reasoner"],
+    models: ["deepseek-v4-flash", "deepseek-v4-pro"],
+    activeModels: ["deepseek-v4-flash", "deepseek-v4-pro"],
   });
 
   assert.equal(provider.type, "deepseek");
@@ -314,7 +314,7 @@ test("DeepSeek provider normalization keeps native routing and disables unsuppor
   assert.equal(provider.requestFormat, undefined);
   assert.equal(provider.promptCachingEnabled, false);
   assert.equal(provider.promptCacheHintMode, undefined);
-  assert.equal(provider.nativeWebSearchEnabled, false);
+  assert.equal(provider.nativeWebSearchEnabled, true);
   assert.equal(provider.models[0].contextWindow, 1_000_000);
   assert.equal(provider.models[0].maxOutputToken, 384_000);
 });
@@ -650,29 +650,22 @@ test("chat runtime controls default and follow provider model reasoning support"
     }),
     ["high"],
   );
-  // DeepSeek 正式供应商直接读取自己的目录：chat 无思考，reasoner 恒开不可调，
-  // v4-pro 提供 high/max 两档。
+  // DeepSeek 正式供应商只暴露 Responses 模型：Flash 与 Pro 都遵循
+  // 官方 none/low/high/max 映射，并支持关闭思考。
   assert.deepEqual(
     settings.getChatRuntimeReasoningLevelsForProvider({
       providerId: "deepseek",
-      modelId: "deepseek-chat",
+      modelId: "deepseek-v4-flash",
     }),
-    [],
+    ["low", "high", "max"],
   );
-  assert.deepEqual(
-    settings.getChatRuntimeReasoningLevelsForProvider({
-      providerId: "deepseek",
-      modelId: "deepseek-reasoner",
-    }),
-    [],
-  );
-  assert.equal(settings.isThinkingAlwaysOnForModel("deepseek", "deepseek-reasoner"), true);
+  assert.equal(settings.isThinkingAlwaysOnForModel("deepseek", "deepseek-v4-flash"), false);
   assert.deepEqual(
     settings.getChatRuntimeReasoningLevelsForProvider({
       providerId: "deepseek",
       modelId: "deepseek-v4-pro",
     }),
-    ["high", "max"],
+    ["low", "high", "max"],
   );
 
   assert.deepEqual(
@@ -2656,9 +2649,12 @@ test("cross-provider models resolve real catalog limits instead of provider fall
     settings.getProviderModelDefaults("claude_code", "GROK-4.5@prod").contextWindow,
     500_000,
   );
-  // 国内厂商模型（deepseek/glm/qwen/kimi/MiniMax 等分区）没有自己的应用供应商
-  // 类型，配在任一类型下都经跨供应商回查取真实限额。
-  const deepseekUnderClaude = settings.getProviderModelDefaults("claude_code", "deepseek-chat");
+  // 国内厂商模型（deepseek/glm/qwen/kimi/MiniMax 等分区）配在任一类型下，
+  // 都经跨供应商回查取真实限额。
+  const deepseekUnderClaude = settings.getProviderModelDefaults(
+    "claude_code",
+    "deepseek-v4-flash",
+  );
   assert.equal(deepseekUnderClaude.contextWindow, 1_000_000);
   assert.equal(deepseekUnderClaude.maxOutputToken, 384_000);
   const glmUnderCodex = settings.getProviderModelDefaults("codex", "glm-4.7");

--- a/crates/agent-gui/test/settings/provider-deepseek.test.mjs
+++ b/crates/agent-gui/test/settings/provider-deepseek.test.mjs
@@ -30,7 +30,7 @@ test("desktop gateway bridge accepts DeepSeek and still rejects unknown provider
   assert.equal(gatewayTypes.normalizeGatewayProviderType("grok"), null);
 });
 
-test("CC Switch imports DeepSeek without Codex request fields or unsupported toggles", () => {
+test("CC Switch imports DeepSeek with native search enabled", () => {
   const provider = providerImports.providerFromCcs(
     {
       sourceId: "deepseek-official",
@@ -41,7 +41,7 @@ test("CC Switch imports DeepSeek without Codex request fields or unsupported tog
       isFullUrl: false,
       apiKey: "sk-test",
       requestFormat: "openai-completions",
-      models: ["deepseek-chat"],
+      models: ["deepseek-v4-flash"],
     },
     new Set(),
   );
@@ -49,11 +49,11 @@ test("CC Switch imports DeepSeek without Codex request fields or unsupported tog
   assert.equal(provider.type, "deepseek");
   assert.equal(provider.requestFormat, undefined);
   assert.equal(provider.promptCachingEnabled, false);
-  assert.equal(provider.nativeWebSearchEnabled, false);
-  assert.deepEqual(provider.activeModels, ["deepseek-chat"]);
+  assert.equal(provider.nativeWebSearchEnabled, true);
+  assert.deepEqual(provider.activeModels, ["deepseek-v4-flash"]);
 });
 
-test("Cherry DeepSeek imports override stale cache and native-search preferences", () => {
+test("Cherry DeepSeek imports disable cache but preserve explicit native-search preferences", () => {
   const item = {
     sourceId: "deepseek-source::deepseek-chat",
     sourceVersion: "2.x",
@@ -85,5 +85,5 @@ test("Cherry DeepSeek imports override stale cache and native-search preferences
   assert.equal(provider.type, "deepseek");
   assert.equal(provider.requestFormat, undefined);
   assert.equal(provider.promptCachingEnabled, false);
-  assert.equal(provider.nativeWebSearchEnabled, false);
+  assert.equal(provider.nativeWebSearchEnabled, true);
 });

--- a/crates/agent-ui/src/lib/models/catalog.generated.ts
+++ b/crates/agent-ui/src/lib/models/catalog.generated.ts
@@ -128,10 +128,8 @@ export const MODEL_CATALOG: Record<CatalogProviderId, readonly CatalogModelEntry
     { id: "grok-build-0.1", contextWindow: 256000, maxOutputToken: 32000, thinking: { levels: [], off: false } },
   ],
   deepseek: [
-    { id: "deepseek-chat", contextWindow: 1000000, maxOutputToken: 384000 },
-    { id: "deepseek-reasoner", contextWindow: 1000000, maxOutputToken: 384000, thinking: { levels: [], off: false } },
     { id: "deepseek-v4-flash", contextWindow: 1000000, maxOutputToken: 384000, thinking: { levels: ["low", "high", "max"], off: true } },
-    { id: "deepseek-v4-pro", contextWindow: 1000000, maxOutputToken: 384000, thinking: { levels: ["high", "max"], off: true } },
+    { id: "deepseek-v4-pro", contextWindow: 1000000, maxOutputToken: 384000, thinking: { levels: ["low", "high", "max"], off: true } },
   ],
   zhipuai: [
     { id: "glm-4.5", contextWindow: 131072, maxOutputToken: 98304, thinking: { levels: ["high"], off: true } },

--- a/crates/agent-ui/src/lib/settings/index.ts
+++ b/crates/agent-ui/src/lib/settings/index.ts
@@ -317,7 +317,7 @@ export function getBuiltinCustomProviders(): CustomProvider[] {
       activeModels: [],
       reasoning: "high",
       promptCachingEnabled: false,
-      nativeWebSearchEnabled: false,
+      nativeWebSearchEnabled: true,
       useSystemProxy: false,
       usageQuery: getDefaultUsageQueryConfig(),
     },
@@ -985,7 +985,7 @@ export function normalizeCustomProvider(input: unknown): CustomProvider {
     ...(type === "claude_code" && obj.promptCacheRetention === "long"
       ? { promptCacheRetention: "long" as const }
       : {}),
-    nativeWebSearchEnabled: type === "deepseek" ? false : obj.nativeWebSearchEnabled !== false,
+    nativeWebSearchEnabled: obj.nativeWebSearchEnabled !== false,
     useSystemProxy: obj.useSystemProxy === true,
     usageQuery: normalizeUsageQueryConfig(obj.usageQuery),
   };

--- a/crates/agent-ui/src/pages/settings/ProviderModal.tsx
+++ b/crates/agent-ui/src/pages/settings/ProviderModal.tsx
@@ -695,7 +695,7 @@ function useProviderModalController({ providerType, initialData, onSave, onClose
           ? "long"
           : undefined,
       nativeWebSearchEnabled:
-        providerType === "deepseek" ? false : (initialData?.nativeWebSearchEnabled ?? true),
+        initialData?.nativeWebSearchEnabled ?? true,
       useSystemProxy,
       usageQuery: serializeUsageQueryDraft(usageQuery, isGatewayWebui),
     });

--- a/scripts/generate-model-catalog.mjs
+++ b/scripts/generate-model-catalog.mjs
@@ -54,7 +54,7 @@ const SECTIONS = [
   { key: "google", sources: ["google"], min: 15 },
   { key: "openai", sources: ["openai"], min: 20 },
   { key: "xai", sources: ["xai"], min: 3 },
-  { key: "deepseek", sources: ["deepseek"], min: 3 },
+  { key: "deepseek", sources: ["deepseek"], min: 2 },
   // zai (Z.AI, international brand) is a superset of zhipuai with identical
   // ids and limits for the overlap; keep the domestic brand as the key.
   { key: "zhipuai", sources: ["zai", "zhipuai"], min: 10 },
@@ -75,7 +75,8 @@ const SENTINELS = [
   { section: "anthropic", id: "claude-sonnet-4-6", level: "high", off: true },
   { section: "openai", id: "gpt-5", level: "minimal" },
   { section: "openai", id: "gpt-5.6-sol", level: "max", contextWindow: 272_000 },
-  { section: "deepseek", id: "deepseek-chat" },
+  { section: "deepseek", id: "deepseek-v4-flash", level: "low", off: true },
+  { section: "deepseek", id: "deepseek-v4-pro", level: "high", off: true },
   { section: "zhipuai", id: "glm-4.6", off: true },
   { section: "alibaba", id: "qwen-max" },
 ];
@@ -86,6 +87,7 @@ const SENTINELS = [
 // input budget of any consumer that reserves the full output. Repair such
 // degenerate pairs with a uniform reservation cap.
 const MAX_OUTPUT_TOKEN_CAP = 32_000;
+const DEEPSEEK_RESPONSES_MODELS = new Set(["deepseek-v4-flash", "deepseek-v4-pro"]);
 function normalizeMaxOutputToken(contextWindow, maxOutputToken) {
   if (maxOutputToken < contextWindow) return maxOutputToken;
   return Math.min(MAX_OUTPUT_TOKEN_CAP, Math.max(1, Math.floor(contextWindow / 4)));
@@ -122,12 +124,18 @@ const TOGGLE_ONLY_LEVELS = ["high"];
 // models (empty options) are still honored as such.
 const CLIENT_SIDE_OFF_SECTIONS = new Set(["anthropic"]);
 
-// Facts the upstream schema cannot express, keyed "section/id". Kept tiny and
-// documented — anything expressible upstream must come from upstream.
+// Facts where the upstream aggregator is missing or lags the provider's
+// protocol documentation, keyed "section/id". Kept tiny and documented.
 // claude-fable-5: adaptive thinking cannot be disabled (the API requires the
 // thinking block; pi-ai's catalog marks off:null) — the client-side-off rule
 // above must not apply.
-const THINKING_OVERRIDES = new Map([["anthropic/claude-fable-5", { off: false }]]);
+// DeepSeek's Responses thinking guide documents the same none/low/high/max
+// ladder for both V4 models; models.dev currently omits low from V4 Pro.
+const THINKING_OVERRIDES = new Map([
+  ["anthropic/claude-fable-5", { off: false }],
+  ["deepseek/deepseek-v4-flash", { levels: ["low", "high", "max"], off: true }],
+  ["deepseek/deepseek-v4-pro", { levels: ["low", "high", "max"], off: true }],
+]);
 
 function normalizeThinking(model, id, label, sectionKey) {
   if (!model?.reasoning) return undefined;
@@ -323,6 +331,14 @@ function extractSection(section, upstream, claimedLower, codexModels) {
       fail(`section ${section.key}: source ${source} missing models map`);
     }
     for (const [id, model] of Object.entries(rawModels)) {
+      // The formal DeepSeek provider uses the native Responses API. Keep its
+      // catalog aligned with the models that DeepSeek documents for that API;
+      // retired Chat Completions aliases remain available through custom relay
+      // configurations, but must not reappear as official provider choices.
+      if (section.key === "deepseek" && !DEEPSEEK_RESPONSES_MODELS.has(id.toLowerCase())) {
+        console.error(`skip ${source}/${id} (not supported by DeepSeek Responses)`);
+        continue;
+      }
       // Aggregator-namespaced deployments (e.g. Bailian's "siliconflow/…",
       // "kimi/…") are not vendor model ids; relays never serve them verbatim.
       if (id.includes("/")) {


### PR DESCRIPTION
## Summary
- DeepSeek 正式供应商只保留官方 Responses 文档中的 V4 模型（`deepseek-v4-flash` / `deepseek-v4-pro`），实际请求走 `/responses`；官方根路径不带 `/v1`，中转补 `/v1`。
- 开启联网搜索时注入服务端 `web_search`，并回放 `web_search_call`，以支持无状态多轮原生搜索。
- 思考档位按官方 `none/low/high/max` 映射；关闭思考发送 `reasoning.effort: none`。存量 Codex 分组上的 DeepSeek 配置不自动迁移。

Closes #553

## Test plan
- [x] 用官方 `https://api.deepseek.com` + V4 Flash/Pro 发一轮普通对话，确认请求打到 `/responses`
- [x] 打开联网搜索，确认 payload 含 `tools: [{ type: "web_search" }]`，UI 能展示搜索来源
- [x] 搜索后再追问/调工具，确认后续请求回放了 `web_search_call`
- [x] 关闭思考，确认请求带 `reasoning: { effort: "none" }`，且不再默认 high
- [x] 中转 base URL（无 `/v1`）会补 `/v1/responses`；官方 URL 保持根路径
- [x] 存量挂在 Codex 分组的 DeepSeek 配置仍走原协议，不被改判
- [x] `crates/agent-gui` 下 DeepSeek / hosted-search / catalog 相关测试通过


Made with [Cursor](https://cursor.com)