### PR TITLE
ci: 优化 Tauri Rust Check——修复缓存路径、消除重复编译、跳过无关 PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,53 +168,72 @@ jobs:
         working-directory: crates/agent-gui
         run: pnpm test:release
 
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'crates/agent-gui/src-tauri/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              # build.rs 编译 gateway protos 并从 package.json 读取应用版本。
+              - 'crates/agent-gateway/proto/**'
+              - 'crates/agent-gui/package.json'
+              - '.github/workflows/ci.yml'
+
   tauri-rust:
     name: Tauri Rust Check
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: changes
+    # push 到 main 时始终运行以持续更新共享缓存;PR 仅在 Rust 相关路径变更时运行。
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true') }}
+    env:
+      # 行号级 debuginfo:显著降低 codegen 与链接开销,同时保留可读的失败回溯。
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@v6
 
       - name: Install Tauri Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            protobuf-compiler \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: protobuf-compiler libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+          version: 1.0
+          # 缓存恢复时执行安装脚本(如 ldconfig 触发器),保证测试运行期动态链接可用。
+          execute_install_scripts: true
+
+      - name: Install mold linker
+        uses: rui314/setup-mold@v1
 
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: crates/agent-gui/src-tauri
+          # Cargo workspace 根在仓库根目录(Cargo.lock 与 target/ 均在此),
+          # 指向子目录会导致依赖产物完全不被缓存。
+          workspaces: .
 
-      - name: Check Tauri backend tests
+      - name: Build Tauri backend tests
         env:
           CARGO_TERM_COLOR: always
-        run: cargo check --manifest-path crates/agent-gui/src-tauri/Cargo.toml --tests
+        run: cargo test --manifest-path crates/agent-gui/src-tauri/Cargo.toml --lib --no-run
 
-      - name: Test Tauri history migrations
+      - name: Test Tauri backend
         env:
           CARGO_TERM_COLOR: always
-        run: cargo test --manifest-path crates/agent-gui/src-tauri/Cargo.toml chat_history --lib
-
-      - name: Test SSH local forwarding
-        env:
-          CARGO_TERM_COLOR: always
-        run: cargo test --manifest-path crates/agent-gui/src-tauri/Cargo.toml ssh_local_forward --lib
-
-      - name: Test Tauri shell-runner cancellation
-        env:
-          CARGO_TERM_COLOR: always
-        run: cargo test --manifest-path crates/agent-gui/src-tauri/Cargo.toml shell_runner --lib
-
-      - name: Test Tauri MCP integration
-        env:
-          CARGO_TERM_COLOR: always
-        run: cargo test --manifest-path crates/agent-gui/src-tauri/Cargo.toml integration_commands::mcp --lib
+        # libtest 支持多个过滤器(取并集),单次调用可让各组测试并行执行。
+        run: >
+          cargo test --manifest-path crates/agent-gui/src-tauri/Cargo.toml --lib --
+          chat_history ssh_local_forward shell_runner integration_commands::mcp
 
   ui-boundaries:
     name: Shared UI Boundaries


### PR DESCRIPTION
## Summary

Tauri Rust Check 此前热缓存约 9 分钟、冷缓存约 22 分钟。根因分析(基于 #561 的运行数据与完整日志):

- **rust-cache 路径配置错误(最大问题)**:`workspaces: crates/agent-gui/src-tauri` 指向子目录,而 Cargo workspace 根在仓库根目录(`Cargo.lock` 与 `target/` 均在根)。日志显示即使缓存 "full match: true",每次仍从头重编 880+ 个依赖 crate——缓存里只有 registry 下载内容,编译产物从未被缓存。已改为 `workspaces: .`
- **同一 crate 全量编译两遍**:`cargo check --tests` 只产出 rmeta,`cargo test` 需要完整 codegen,产物互不复用。改为 `cargo test --lib --no-run` 编译一次,四组测试合并为单次多过滤器调用(libtest 取并集并行执行,原先 4 次串行调用中 46s 的 ssh 测试无法与其他测试并行)
- **编译/链接加速**:`CARGO_PROFILE_DEV_DEBUG=line-tables-only`(保留行号回溯)+ mold 链接器
- **apt 依赖缓存**:cache-apt-pkgs-action 替代每次约 54s 的 apt-get install
- **路径过滤**:新增 paths-filter 前置 job,纯前端 PR 直接跳过该 job(仓库无 required status checks,跳过不阻塞合并);push main 始终运行以持续更新共享缓存

权衡说明:不再 type-check `main.rs` bin 目标(仅 6 行,desktop-release workflow 仍会完整构建)。

## Test plan

- [x] YAML 语法校验通过
- [ ] 本 PR 首次 CI 运行为冷缓存(cache key 因配置变更而更新),验证 job 正常通过
- [ ] 二次运行验证热缓存耗时(预期约 3-5 分钟)

Made with [Cursor](https://cursor.com)