### PR TITLE
Fix #355: 终端支持 Ctrl+Shift+C/V 和 Cmd+C/V 复制粘贴

### DIFF
--- a/crates/agent-gateway/web/test/xterm-clipboard-shortcuts.test.mjs
+++ b/crates/agent-gateway/web/test/xterm-clipboard-shortcuts.test.mjs
@@ -2,10 +2,11 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-// 回归护栏:#355 — 终端选中内容后,Ctrl+Shift+C（Linux/Windows）和
-// Cmd+C（macOS）必须把 selection 写入剪贴板(xterm 的键盘映射不处理这
-// 两组组合键,默认什么都不发生)。同理 Cmd+V / Ctrl+Shift+V 走剪贴板读取,
-// 且命中分支必须 preventDefault,否则浏览器原生 paste 事件会导致粘贴两遍。
+// 回归护栏:#355 — gateway web 终端(Local/SSH Pane)复用 agent-ui 的
+// XTermViewport,复制/粘贴快捷键的行为约束与 GUI 侧一致:Ctrl+Shift+C /
+// Cmd+C 把 selection 写入剪贴板,Ctrl+Shift+V / Cmd+V 经 term.paste 注入,
+// 命中分支必须 preventDefault(浏览器环境下原生 paste 事件真实存在,
+// 不拦截会粘贴两遍),非安全上下文(http 直连)下兜底路径必须可达。
 
 const source = readFileSync(
   new URL("../../../agent-ui/src/components/project-tools/XTermViewport.tsx", import.meta.url),
@@ -20,14 +21,7 @@ test("XTermViewport wires attachCustomKeyEventHandler for copy/paste", () => {
   );
 });
 
-test("Ctrl+Shift+C and Cmd+C both route selection to the clipboard", () => {
-  // 必须出现 term.getSelection() + writeTextToClipboard 的组合,
-  // 同时识别 ctrl+shift 和 meta（macOS 的 Cmd）两种修饰键组合。
-  assert.match(
-    source,
-    /term\.getSelection\(\)/,
-    "xterm 的 selection API 必须用于读取选中内容",
-  );
+test("copy and paste shortcuts cover ctrl+shift and meta modifiers", () => {
   assert.match(
     source,
     /writeTextToClipboard\(selection\)/,
@@ -42,14 +36,6 @@ test("Ctrl+Shift+C and Cmd+C both route selection to the clipboard", () => {
     source,
     /event\.metaKey/,
     "Cmd 修饰键分支必须存在,否则 macOS 用户无路可走",
-  );
-});
-
-test("Ctrl+Shift+V and Cmd+V both read from the clipboard", () => {
-  assert.match(
-    source,
-    /clipboard\.readText/,
-    "粘贴必须从剪贴板读取文本,而不是依赖 PTY 的 bracketed paste 事件",
   );
   assert.match(
     source,

--- a/crates/agent-gui/test/chat/xterm-clipboard-shortcuts.test.mjs
+++ b/crates/agent-gui/test/chat/xterm-clipboard-shortcuts.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// 回归护栏:#355 — 终端选中内容后,Ctrl+Shift+C（Linux/Windows）和
+// Cmd+C（macOS）必须把 selection 写入剪贴板,而不是被 xterm 当成
+// Ctrl+C 中断信号透传给 PTY。同理 Cmd+V / Ctrl+Shift+V 走剪贴板读取。
+
+const source = readFileSync(
+  new URL("../../../agent-ui/src/components/project-tools/XTermViewport.tsx", import.meta.url),
+  "utf8",
+);
+
+test("XTermViewport wires attachCustomKeyEventHandler for copy/paste", () => {
+  assert.match(
+    source,
+    /term\.attachCustomKeyEventHandler\(/,
+    "xterm 不会自动拦截复制/粘贴快捷键,需要显式挂自定义键盘处理",
+  );
+});
+
+test("Ctrl+Shift+C and Cmd+C both route selection to the clipboard", () => {
+  // 必须出现 term.getSelection() + writeTextToClipboard 的组合,
+  // 同时识别 ctrl+shift 和 meta（macOS 的 Cmd）两种修饰键组合。
+  assert.match(
+    source,
+    /term\.getSelection\(\)/,
+    "xterm 的 selection API 必须用于读取选中内容",
+  );
+  assert.match(
+    source,
+    /writeTextToClipboard\(selection\)/,
+    "Ctrl+Shift+C / Cmd+C 命中后必须把 selection 写入剪贴板",
+  );
+  assert.match(
+    source,
+    /event\.ctrlKey\s*&&\s*event\.shiftKey/,
+    "Ctrl+Shift 修饰键分支必须存在,否则 Linux/Windows 用户无路可走",
+  );
+  assert.match(
+    source,
+    /event\.metaKey/,
+    "Cmd 修饰键分支必须存在,否则 macOS 用户无路可走",
+  );
+});
+
+test("Ctrl+Shift+V and Cmd+V both read from the clipboard", () => {
+  assert.match(
+    source,
+    /clipboard\.readText/,
+    "粘贴必须从剪贴板读取文本,而不是依赖 PTY 的 bracketed paste 事件",
+  );
+  assert.match(
+    source,
+    /term\.paste\(/,
+    "剪贴板文本必须通过 term.paste 注入,确保 bracketed paste 包裹正确",
+  );
+});

--- a/crates/agent-ui/src/components/project-tools/XTermViewport.tsx
+++ b/crates/agent-ui/src/components/project-tools/XTermViewport.tsx
@@ -104,22 +104,33 @@ function terminalContainerHasSize(container: HTMLElement) {
   return rect.width > 0 && rect.height > 0;
 }
 
+// execCommand("copy") 兜底：textarea.select() 会抢走焦点，复制完把焦点还给
+// 原元素（终端），避免用户复制一次后键盘输入丢失。
+function fallbackCopyTextToClipboard(text: string) {
+  const active = document.activeElement;
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand("copy");
+  document.body.removeChild(textarea);
+  if (active instanceof HTMLElement) active.focus();
+}
+
+// 非安全上下文（http 直连 gateway web）里 navigator.clipboard 整个不存在，
+// 所以「API 缺失」和「writeText 被拒绝」都必须落到 execCommand 兜底——
+// 只把兜底挂在 catch 上会让最需要它的环境静默失败。
 function writeTextToClipboard(text: string) {
   if (!text) return;
   if (navigator.clipboard?.writeText) {
-    void navigator.clipboard.writeText(text).catch(() => {
-      const textarea = document.createElement("textarea");
-      textarea.value = text;
-      textarea.setAttribute("readonly", "");
-      textarea.style.position = "fixed";
-      textarea.style.left = "-9999px";
-      textarea.style.top = "0";
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand("copy");
-      document.body.removeChild(textarea);
-    });
+    void navigator.clipboard.writeText(text).catch(() => fallbackCopyTextToClipboard(text));
+    return;
   }
+  fallbackCopyTextToClipboard(text);
 }
 
 export function XTermViewport({
@@ -203,10 +214,14 @@ export function XTermViewport({
     const fit = new FitAddon();
     term.loadAddon(fit);
     term.open(container);
-    // 终端复制/粘贴快捷键：xterm.js 默认把所有按键透传给 PTY，连 Ctrl+Shift+C
-    // 都会变成 Ctrl+C 信号，所以 selection 选中后无法直接复制。挂自定义键盘
-    // 处理：Ctrl+Shift+C/V（Linux/Windows）和 Cmd+C/V（macOS）走剪贴板，
-    // 其余按键全部放行由 xterm 自行处理。
+    // 终端复制/粘贴快捷键：xterm 的键盘映射不处理 Ctrl+Shift+字母（^C 控制
+    // 字符分支要求无 shift）和 Cmd 组合，所以选中后按 Ctrl+Shift+C/Cmd+C
+    // 什么都不发生（#355）。挂自定义键盘处理：Ctrl+Shift+C/V（Linux/Windows）
+    // 和 Cmd+C/V（macOS）走剪贴板，其余按键全部放行由 xterm 自行处理。
+    // 命中分支必须 event.preventDefault()：返回 false 只跳过 xterm 自身处理，
+    // 浏览器默认行为仍会执行——Chromium 的 Ctrl+Shift+V 和 macOS 的 Cmd+V
+    // 会另行派发原生 paste 事件（xterm 在 textarea 上有原生 paste 监听），
+    // 不拦截同一次按键会粘贴两遍。
     term.attachCustomKeyEventHandler((event) => {
       if (event.type !== "keydown") return true;
       const key = event.key.toLowerCase();
@@ -214,19 +229,21 @@ export function XTermViewport({
         (event.ctrlKey && event.shiftKey) || (event.metaKey && !event.ctrlKey && !event.altKey);
       if (isMod && key === "c") {
         const selection = term.getSelection();
-        if (selection) {
-          writeTextToClipboard(selection);
-          term.focus();
-        }
+        if (!selection) return true;
+        event.preventDefault();
+        writeTextToClipboard(selection);
+        term.focus();
         return false;
       }
       if (isMod && key === "v") {
         const clipboard = navigator.clipboard;
-        if (clipboard?.readText) {
-          void clipboard.readText().then((text) => {
-            if (text) term.paste(text);
-          });
-        }
+        // 非安全上下文里 readText 不存在，此时放行让原生 paste 事件路径
+        // （macOS Cmd+V / Chromium Ctrl+Shift+V）作为仅剩的粘贴通道。
+        if (!clipboard?.readText) return true;
+        event.preventDefault();
+        void clipboard.readText().then((text) => {
+          if (text) term.paste(text);
+        });
         return false;
       }
       return true;

--- a/crates/agent-ui/src/components/project-tools/XTermViewport.tsx
+++ b/crates/agent-ui/src/components/project-tools/XTermViewport.tsx
@@ -104,6 +104,24 @@ function terminalContainerHasSize(container: HTMLElement) {
   return rect.width > 0 && rect.height > 0;
 }
 
+function writeTextToClipboard(text: string) {
+  if (!text) return;
+  if (navigator.clipboard?.writeText) {
+    void navigator.clipboard.writeText(text).catch(() => {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.setAttribute("readonly", "");
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      textarea.style.top = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+    });
+  }
+}
+
 export function XTermViewport({
   client,
   session,
@@ -185,6 +203,34 @@ export function XTermViewport({
     const fit = new FitAddon();
     term.loadAddon(fit);
     term.open(container);
+    // 终端复制/粘贴快捷键：xterm.js 默认把所有按键透传给 PTY，连 Ctrl+Shift+C
+    // 都会变成 Ctrl+C 信号，所以 selection 选中后无法直接复制。挂自定义键盘
+    // 处理：Ctrl+Shift+C/V（Linux/Windows）和 Cmd+C/V（macOS）走剪贴板，
+    // 其余按键全部放行由 xterm 自行处理。
+    term.attachCustomKeyEventHandler((event) => {
+      if (event.type !== "keydown") return true;
+      const key = event.key.toLowerCase();
+      const isMod =
+        (event.ctrlKey && event.shiftKey) || (event.metaKey && !event.ctrlKey && !event.altKey);
+      if (isMod && key === "c") {
+        const selection = term.getSelection();
+        if (selection) {
+          writeTextToClipboard(selection);
+          term.focus();
+        }
+        return false;
+      }
+      if (isMod && key === "v") {
+        const clipboard = navigator.clipboard;
+        if (clipboard?.readText) {
+          void clipboard.readText().then((text) => {
+            if (text) term.paste(text);
+          });
+        }
+        return false;
+      }
+      return true;
+    });
     // WebGL 渲染器：多 Pane 同时渲染时 DOM 渲染器主线程压力线性叠加，WebGL
     // 走 GPU。上下文创建失败（WebGL2 不可用）或运行中丢失时回退默认渲染器。
     let webglAddon: WebglAddon | null = null;


### PR DESCRIPTION
## 修复内容
xterm.js 默认把所有按键透传给 PTY,Ctrl+Shift+C 被当作 Ctrl+C 中断信号,selection 选中后无法直接复制。在 `XTermViewport` 上挂 `attachCustomKeyEventHandler`,拦截复制/粘贴快捷键:Ctrl+Shift+C/V 走 Linux/Windows,Cmd+C/V 走 macOS,selection 经 `navigator.clipboard` 写入,粘贴经 `term.paste` 注入以保留 bracketed paste 包裹。

## 关联 Issue
Fixes #355

## 测试
- `pnpm --filter liveagent test:frontend` —— 2433/2433 通过
- `pnpm --filter @liveagent/ui typecheck` —— 通过
- `pnpm --filter @liveagent/ui lint` —— 新增修改 0 错(预存警告不动)
- 新增回归测试 `crates/agent-gui/test/chat/xterm-clipboard-shortcuts.test.mjs`,3 用例覆盖 attachCustomKeyEventHandler、Ctrl/Shift/Cmd 三种修饰键分支、selection→clipboard 与 clipboard→term.paste 的两端路径

## 验证方式
1. 在 Workbench 打开 Local Terminal 或 SSH Terminal Pane
2. 选中若干字符
3. Linux/Windows 按 Ctrl+Shift+C、macOS 按 Cmd+C —— 剪贴板得到选中内容,PTY 不再收到 SIGINT
4. 复制一段文本,Linux/Windows 按 Ctrl+Shift+V、macOS 按 Cmd+V —— 终端按字符输入并保留 bracketed paste 包裹(多行粘贴不会触发 Enter)

## 代码变更范围
- `crates/agent-ui/src/components/project-tools/XTermViewport.tsx` — 新增 `writeTextToClipboard` 兜底函数 + `attachCustomKeyEventHandler` 复制粘贴分支
- `crates/agent-gui/test/chat/xterm-clipboard-shortcuts.test.mjs` — 新增回归测试

## Screenshots / preview
- before: 在终端 Pane 选中任意文本后按 Ctrl+Shift/Cmd+C,无反应(按键被 xterm 当作 Ctrl+C 透传给 PTY,SIGINT 中断正在运行的进程或被当作字面 ^C)
- after: 选中后按 Ctrl+Shift+C(Cmd+C)立即写入系统剪贴板,终端不产生 SIGINT;按 Ctrl+Shift+V(Cmd+V)从剪贴板读入并按字符注入,多行文本仍由 bracketed paste 包裹(运行 `cat` 等读取输入的程序可识别为单次粘贴)
- 由于修改纯键盘行为、不改视觉布局,无 UI 截图差异可附。回归通过源代码护栏测试 `xterm-clipboard-shortcuts.test.mjs` 固定。