### PR TITLE
fix(settings): 供应商卡片用量加载改为等高骨架占位，消除布局跳动

### DIFF
--- a/crates/agent-gui/test/settings/provider-usage-query.test.mjs
+++ b/crates/agent-gui/test/settings/provider-usage-query.test.mjs
@@ -259,4 +259,33 @@ test("provider card display exposes plans stale error and relative time", () => 
   assert.equal(display.plans[1].severity, "low");
   assert.deepEqual(display.updatedAt, { kind: "minutesAgo", value: 5 });
   assert.equal(display.refreshDisabled, true);
+  assert.equal(display.loading, false);
+});
+
+test("provider card display stays in loading until the first result lands", () => {
+  const now = 1_700_000_000_000;
+  const provider = { id: "p", usageQuery: { enabled: true } };
+
+  // 首个结果未回:无论请求是否已在途,都视为加载中(渲染等高骨架占位)。
+  assert.equal(usage.getProviderUsageCardDisplay(provider, undefined, false, now).loading, true);
+  assert.equal(usage.getProviderUsageCardDisplay(provider, undefined, true, now).loading, true);
+
+  // 结果落地(即使数据为空/失败形态)即退出加载态;手动刷新不回到骨架。
+  const empty = usage.getProviderUsageCardDisplay(
+    provider,
+    { data: [], queriedAt: now, error: null, isStale: false },
+    false,
+    now,
+  );
+  assert.equal(empty.loading, false);
+  assert.equal(empty.show, true);
+
+  const refreshing = usage.getProviderUsageCardDisplay(
+    provider,
+    { data: [{ planName: "Balance", remaining: 4.2, unit: "USD" }], queriedAt: now, error: null, isStale: false },
+    true,
+    now,
+  );
+  assert.equal(refreshing.loading, false);
+  assert.equal(refreshing.refreshDisabled, true);
 });

--- a/crates/agent-ui/src/i18n/translations/enUSSettings.ts
+++ b/crates/agent-ui/src/i18n/translations/enUSSettings.ts
@@ -555,6 +555,7 @@ export const EN_US_SETTINGS_TRANSLATIONS = {
   "settings.providerUsageStaleTitle": "Refresh failed; showing the last successful result",
   "settings.providerUsageRefresh": "Refresh usage",
   "settings.providerUsageInvalid": "Plan expired",
+  "settings.providerUsageNoData": "No usage data",
   "settings.providerUsageUpdated.justNow": "just now",
   "settings.providerUsageUpdated.minutesAgo": "{count} min ago",
   "settings.providerUsageUpdated.hoursAgo": "{count} h ago",

--- a/crates/agent-ui/src/i18n/translations/zhCNSettings.ts
+++ b/crates/agent-ui/src/i18n/translations/zhCNSettings.ts
@@ -534,6 +534,7 @@ export const ZH_CN_SETTINGS_TRANSLATIONS = {
   "settings.providerUsageStaleTitle": "刷新失败，展示上次成功结果",
   "settings.providerUsageRefresh": "刷新用量",
   "settings.providerUsageInvalid": "套餐已失效",
+  "settings.providerUsageNoData": "暂无用量数据",
   "settings.providerUsageUpdated.justNow": "刚刚",
   "settings.providerUsageUpdated.minutesAgo": "{count} 分钟前",
   "settings.providerUsageUpdated.hoursAgo": "{count} 小时前",

--- a/crates/agent-ui/src/lib/providers/usageQueryCore.ts
+++ b/crates/agent-ui/src/lib/providers/usageQueryCore.ts
@@ -191,6 +191,10 @@ export function getProviderUsageCardDisplay(
   const queriedAt = usage?.queriedAt ?? null;
   return {
     show: Boolean(provider.usageQuery?.enabled || usage),
+    // 首个结果落地前视为加载中(桌面端总会应答,成功或错误形态都会写入
+    // usage),卡片据此渲染等高骨架占位;已有结果的手动刷新不回到骨架,
+    // 保持旧值原位更新(stale-while-revalidate),避免高度反复变化。
+    loading: !usage,
     plans: (usage?.data ?? []).map(getUsagePlanDisplay),
     isStale: usage?.isStale === true,
     error: usage?.error ?? null,

--- a/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
@@ -614,10 +614,9 @@ function ProviderList(props: {
                   usageNow,
                 );
                 const usageExpanded = expandedUsageProviderIds.has(provider.id);
-                const visibleUsagePlans =
-                  usageDisplay.plans.length > 1 && !usageExpanded
-                    ? usageDisplay.plans.slice(0, 1)
-                    : usageDisplay.plans;
+                // 收起态只展示首个套餐,其余套餐放入可动画折叠容器;配合下方
+                // 等高骨架,卡片在"加载→出数"全程保持两行高度,不产生布局跳动。
+                const [firstUsagePlan, ...extraUsagePlans] = usageDisplay.plans;
                 return (
                   <div
                     key={provider.id}
@@ -648,42 +647,98 @@ function ProviderList(props: {
                         {provider.activeModels.length} {t("settings.activeModels")}
                       </div>
                       {usageDisplay.show ? (
-                        <div className="mt-1 flex min-w-0 flex-col gap-0.5 text-xs text-muted-foreground">
-                          {visibleUsagePlans.map((plan, index) => (
-                            <UsagePlanLine
-                              key={`${plan.title.kind === "text" ? plan.title.text : plan.title.kind}:${
-                                // biome-ignore lint/suspicious/noArrayIndexKey: 套餐无稳定 id,索引即位置语义
-                                index
-                              }`}
-                              plan={plan}
-                            />
-                          ))}
-                          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
-                            {usageDisplay.plans.length > 1 ? (
-                              <button
-                                type="button"
-                                className="text-primary hover:underline"
-                                onClick={() => toggleUsageExpanded(provider.id)}
-                              >
-                                {usageExpanded
-                                  ? t("settings.providerUsageCollapse")
-                                  : t("settings.providerUsageMorePlans").replace(
-                                      "{count}",
-                                      String(usageDisplay.plans.length - 1),
-                                    )}
-                              </button>
-                            ) : null}
-                            {usageDisplay.isStale ? (
-                              <span title={t("settings.providerUsageStaleTitle")}>
-                                {t("settings.providerUsageStale")}
+                        <div
+                          className="mt-1 min-w-0 text-xs text-muted-foreground"
+                          aria-busy={usageDisplay.loading}
+                        >
+                          {/* 主行与元信息行都固定 min-h-4(= text-xs 行高):加载时
+                              骨架等高占位,结果到达后原位替换,卡片高度全程稳定。 */}
+                          <div className="flex min-h-4 min-w-0 items-center">
+                            {firstUsagePlan ? (
+                              <span className="settings-usage-reveal flex min-w-0">
+                                <UsagePlanLine plan={firstUsagePlan} />
                               </span>
-                            ) : null}
-                            {usageDisplay.error ? (
-                              <span className="text-destructive">{usageDisplay.error}</span>
-                            ) : null}
-                            {usageDisplay.updatedAt ? (
-                              <time>{usageRelativeTimeText(t, usageDisplay.updatedAt)}</time>
-                            ) : null}
+                            ) : usageDisplay.loading ? (
+                              <span
+                                aria-hidden="true"
+                                className="h-2 w-32 max-w-full animate-pulse rounded-full bg-foreground/[0.08] motion-reduce:animate-none"
+                              />
+                            ) : (
+                              <span
+                                className={cn(
+                                  "settings-usage-reveal truncate",
+                                  usageDisplay.error && "text-destructive",
+                                )}
+                              >
+                                {usageDisplay.error ?? t("settings.providerUsageNoData")}
+                              </span>
+                            )}
+                          </div>
+                          {extraUsagePlans.length > 0 ? (
+                            <div
+                              className="grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none"
+                              style={{ gridTemplateRows: usageExpanded ? "1fr" : "0fr" }}
+                              aria-hidden={!usageExpanded}
+                            >
+                              <div className="min-h-0 overflow-hidden">
+                                {extraUsagePlans.map((plan, index) => (
+                                  <div
+                                    key={`${plan.title.kind === "text" ? plan.title.text : plan.title.kind}:${
+                                      // biome-ignore lint/suspicious/noArrayIndexKey: 套餐无稳定 id,索引即位置语义
+                                      index
+                                    }`}
+                                    className="flex min-h-4 min-w-0 items-center pt-0.5"
+                                  >
+                                    <UsagePlanLine plan={plan} />
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          ) : null}
+                          <div className="mt-0.5 flex min-h-4 min-w-0 items-center">
+                            {usageDisplay.loading ? (
+                              <span
+                                aria-hidden="true"
+                                className="h-2 w-16 animate-pulse rounded-full bg-foreground/[0.06] motion-reduce:animate-none"
+                              />
+                            ) : (
+                              <span className="settings-usage-reveal flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
+                                {extraUsagePlans.length > 0 ? (
+                                  <button
+                                    type="button"
+                                    className="inline-flex items-center gap-0.5 text-primary hover:underline"
+                                    aria-expanded={usageExpanded}
+                                    onClick={() => toggleUsageExpanded(provider.id)}
+                                  >
+                                    {usageExpanded
+                                      ? t("settings.providerUsageCollapse")
+                                      : t("settings.providerUsageMorePlans").replace(
+                                          "{count}",
+                                          String(extraUsagePlans.length),
+                                        )}
+                                    <ChevronDown
+                                      className={cn(
+                                        "h-3 w-3 transition-transform duration-200 motion-reduce:transition-none",
+                                        usageExpanded && "rotate-180",
+                                      )}
+                                    />
+                                  </button>
+                                ) : null}
+                                {usageDisplay.isStale ? (
+                                  <span title={t("settings.providerUsageStaleTitle")}>
+                                    {t("settings.providerUsageStale")}
+                                  </span>
+                                ) : null}
+                                {usageDisplay.error && firstUsagePlan ? (
+                                  <span className="min-w-0 truncate text-destructive">
+                                    {usageDisplay.error}
+                                  </span>
+                                ) : null}
+                                {usageDisplay.updatedAt ? (
+                                  <time>{usageRelativeTimeText(t, usageDisplay.updatedAt)}</time>
+                                ) : null}
+                              </span>
+                            )}
                           </div>
                         </div>
                       ) : null}

--- a/crates/agent-ui/src/styles/common-settings.css
+++ b/crates/agent-ui/src/styles/common-settings.css
@@ -429,3 +429,24 @@
     transition: none;
   }
 }
+
+/* 供应商卡片用量区:结果替换等高骨架占位时柔和浮现,只动透明度不动高度。 */
+.settings-usage-reveal {
+  animation: settings-usage-reveal 240ms ease-out;
+}
+
+@keyframes settings-usage-reveal {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-usage-reveal {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

- 供应商配置页(GUI 与 WebUI 共用 `agent-ui/ProvidersSection`)启用用量查询后,结果异步到达会把卡片从 66px 撑到 100px(Δ+34px),推移下方卡片造成布局跳动。
- 利用「收起态用量区高度确定为两行」的不变量,将用量区固定为两行等高结构(`min-h-4`):首个结果落地前渲染脉冲骨架占位(`getProviderUsageCardDisplay` 新增 `loading` 派生),数据到达后原位柔和浮现;成功/空数据/失败任意状态高度不变;已有数据的手动刷新走 stale-while-revalidate,不回退骨架。
- 多套餐展开/收起改为 `grid-template-rows 0fr↔1fr` 过渡动画并附旋转箭头指示;所有动画遵循 `prefers-reduced-motion`;新增「暂无用量数据」中英文案。

Fixes #566

## Test plan

- [x] `agent-gui` 用量查询 / 表单 / dialog 标准化 / i18n 测试 33/33 通过(含新增 loading 派生测试)
- [x] `agent-gui`、`agent-gateway/web` 两端 `tsc` 通过
- [x] biome 对改动文件检查通过(基于含 #564 的最新 main)
- [x] 浏览器实测:旧结构数据到达 Δ+34px;新结构加载中/加载后均 100px(Δ0),展开动画平滑

Made with [Cursor](https://cursor.com)