### PR TITLE
fix(chat): 修复上下文用量环确认弹层状态泄漏并补齐附件估算与触屏形态热切换

### DIFF
--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -510,9 +510,11 @@ export function ChatPage(props: ChatPageProps) {
     finishGatewayRunMirror,
   } = useGatewayRunMirrorCoordinator();
 
-  // 用量环读数：与 WebUI 同一把共享扫描器（deriveContextUsageTokens），
-  // 历史项 + 流式实时轮次（live store 每帧批量提交）联合倒扫。经订阅源
-  // 直达环组件，流式读数逐帧更新而不回流 ChatPage。
+  // 用量环读数：运行中直读 TokenLedger（消息落定即更新，不逐帧估算流式
+  // 文本，优先级与理由见 useContextUsageTokensSource 内注释）；账本无读数
+  // 或空闲时用与 WebUI 同源的 deriveContextUsageTokens 倒扫历史项（运行中
+  // 补上 live 尾部）。经订阅源直达环组件，读数变化只重渲染环本身而不回流
+  // ChatPage。
   const contextUsageRingRunning = isSending || compactionStatus.phase === "running";
   const contextUsageTokensSource = useContextUsageTokensSource({
     isRunning: contextUsageRingRunning,

--- a/crates/agent-gui/src/pages/chat/hooks/useContextUsageTokensSource.ts
+++ b/crates/agent-gui/src/pages/chat/hooks/useContextUsageTokensSource.ts
@@ -51,6 +51,13 @@ export function createContextUsageTokensSource(params: ContextUsageTokensSourceP
       ) {
         return cache.value;
       }
+      // 优先级（#426 引入时的原始设计，文件拆分时注释曾丢失）：运行中（发送/
+      // 压缩）转录尾部滞后于账本，账本读数优先；空闲时转录含权威锚点
+      //（edit-resend 截断历史后账本仍冻结在截断前读数），转录扫描才准。
+      // 惰性求值：命中账本优先项即跳过全量转录扫描（流式期每帧对大工具结果
+      // JSON.stringify 后丢弃的开销）。因此 GUI 环在流式期按消息落定跳变而
+      // 非逐帧估算；live 尾部联合倒扫仅在运行中而账本尚无读数时可达
+      //（如中继压缩落在本会话新建的控制器上）。
       let value: number | undefined;
       if (isRunning && runtimeValue !== undefined) {
         value = runtimeValue;

--- a/crates/agent-gui/test/chat/context-usage.test.mjs
+++ b/crates/agent-gui/test/chat/context-usage.test.mjs
@@ -21,6 +21,10 @@ const gatewayAppSource = readFileSync(
   ),
   "utf8",
 );
+const contextUsageRingSource = readFileSync(
+  new URL("../../../agent-ui/src/components/chat/ContextUsageRing.tsx", import.meta.url),
+  "utf8",
+);
 
 const {
   CONTEXT_USAGE_WARN_RATIO,
@@ -87,6 +91,26 @@ test("composer editor row reserves the right control rail so the scrollbar clear
   assert.match(chatComposerBarSource, /"relative flex flex-1 pl-4 pr-12"/);
   assert.doesNotMatch(chatComposerBarSource, /"relative flex flex-1 px-4"/);
   assert.doesNotMatch(chatComposerBarSource, /"px-0 py-0 pr-8"/);
+});
+
+test("context usage ring resets a stale confirm popover when compaction flips unavailable", () => {
+  // 可压缩分支翻回纯展示时（他端压缩/发消息置 disabled、压缩后占用掉回阈值
+  // 下），confirmOpen 必须渲染期归位：否则恢复可压缩后确认弹层会无操作自动
+  // 弹开，残留期间互斥守卫还会一直吞掉 tooltip 的打开请求。
+  assert.match(
+    contextUsageRingSource,
+    /if \(!compactAvailable && confirmOpen\) \{\s*setConfirmOpen\(false\);/,
+  );
+});
+
+test("context usage ring tracks pointer form-factor changes via matchMedia subscription", () => {
+  // iPad 插拔键鼠、可翻转本翻转等触屏形态热切换必须实时生效，
+  // 不能挂载时一次性求值定死交互模式。
+  assert.match(
+    contextUsageRingSource,
+    /useSyncExternalStore\(\s*subscribeCoarsePointer,\s*isCoarsePointerNow/,
+  );
+  assert.match(contextUsageRingSource, /addEventListener\("change", onChange\)/);
 });
 
 test("contextUsageRatio guards degenerate inputs", () => {
@@ -197,6 +221,49 @@ test("deriveContextUsageTokens prefers checkpoint fixed overhead and adds its tr
     { kind: "user", text: "x".repeat(4_000) },
   ];
   assert.equal(deriveContextUsageTokens(items), 41_008);
+});
+
+test("deriveContextUsageTokens counts user attachment metadata after the anchor", () => {
+  const attachment = {
+    relativePath: "uploads/diagram.png",
+    fileName: "diagram.png",
+    kind: "image",
+    sizeBytes: 123_456,
+  };
+  const anchor = { kind: "assistant", rounds: [{ meta: { usageTotalTokens: 50_000 } }] };
+  const text = "看看这张图";
+  const textOnly = deriveContextUsageTokens([anchor, { kind: "user", text }]);
+  const withAttachment = deriveContextUsageTokens([
+    anchor,
+    { kind: "user", text, attachments: [attachment] },
+  ]);
+  assert.ok(withAttachment > textOnly, "附件元数据必须计入尾部估算");
+  assert.equal(
+    withAttachment,
+    50_000 +
+      Math.ceil(
+        contextUsage.estimateTextTokenUnits(text) +
+          contextUsage.stringifiedTokenUnits(attachment),
+      ) +
+      8,
+  );
+});
+
+test("deriveContextUsageTokens counts attachment-only user messages", () => {
+  // 纯附件消息（正文为空）此前完全计零。
+  const attachment = {
+    relativePath: "uploads/error.log",
+    fileName: "error.log",
+    kind: "text",
+    sizeBytes: 2_048,
+  };
+  assert.equal(
+    deriveContextUsageTokens([
+      { kind: "checkpoint", content: "short summary", contextUsageTokens: 40_000 },
+      { kind: "user", text: "", attachments: [attachment] },
+    ]),
+    40_000 + Math.ceil(contextUsage.stringifiedTokenUnits(attachment)) + 8,
+  );
 });
 
 test("deriveContextUsageTokens returns undefined without any usage", () => {

--- a/crates/agent-ui/src/components/chat/ContextUsageRing.tsx
+++ b/crates/agent-ui/src/components/chat/ContextUsageRing.tsx
@@ -1,6 +1,6 @@
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { cn } from "@liveagent/ui/lib/shared/utils";
-import { useMemo, useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import {
   canManualCompact,
   contextUsageLevel,
@@ -28,6 +28,27 @@ function getTokenFormatter(locale: string): Intl.NumberFormat {
   return formatter;
 }
 
+const COARSE_POINTER_QUERY = "(hover: none), (pointer: coarse)";
+
+// 触屏形态可热切换（iPad 插拔键鼠、可翻转本翻转），订阅 matchMedia change
+// 而非挂载时一次性求值，交互模式（两段点按 vs 悬停）随设备形态实时切换。
+function subscribeCoarsePointer(onChange: () => void): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+  const query = window.matchMedia(COARSE_POINTER_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+function isCoarsePointerNow(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia(COARSE_POINTER_QUERY).matches
+  );
+}
+
 /**
  * 上下文用量环：composer 内展示当前会话上下文占用百分比，占用 ≥ 50%（黄档）
  * 起可点击弹出确认后触发手动压缩。阈值与 WebUI 补算口径见 lib/chat/contextUsage.ts。
@@ -46,20 +67,27 @@ export function ContextUsageRing(props: {
 }) {
   const { totalTokens, contextWindow, disabled, onConfirm, className } = props;
   const { t, locale } = useLocale();
-  const isCoarsePointer = useMemo(
-    () =>
-      typeof window !== "undefined" &&
-      typeof window.matchMedia === "function" &&
-      window.matchMedia("(hover: none), (pointer: coarse)").matches,
-    [],
+  const isCoarsePointer = useSyncExternalStore(
+    subscribeCoarsePointer,
+    isCoarsePointerNow,
+    () => false,
   );
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const ratio = contextUsageRatio(totalTokens, contextWindow);
+  const compactAvailable = canManualCompact(ratio) && !disabled && Boolean(onConfirm);
+  // 确认弹层只在可压缩分支渲染，而可压缩状态可能在弹层打开期间翻回 false
+  //（他端开始压缩/发消息使 disabled 置位、他端压缩完成后占用掉回阈值下）。
+  // 此时弹层随分支切换直接卸载，confirmOpen 若残留 true：恢复可压缩后弹层
+  // 会无操作自动弹开，残留期间还会经 tooltip 互斥守卫一直吞掉 tooltip 的
+  // 打开请求。渲染期归位（adjust-state-during-render）在绘制前完成，不闪现。
+  if (!compactAvailable && confirmOpen) {
+    setConfirmOpen(false);
+  }
   if (typeof contextWindow !== "number" || !Number.isFinite(contextWindow) || contextWindow <= 0) {
     return null;
   }
 
-  const ratio = contextUsageRatio(totalTokens, contextWindow);
   // 只保留两个口径：展示值（取整、封顶 999）与画环/量度值（0-100 钳制，
   // 二者共用避免 a11y 量度与弧线漂移）。contextUsageRatio 不会返回负数。
   const displayedPercentage = Math.min(999, Math.round(ratio * 100));
@@ -78,7 +106,6 @@ export function ContextUsageRing(props: {
       <span className="text-muted-foreground">{windowLine}</span>
     </span>
   );
-  const compactAvailable = canManualCompact(ratio) && !disabled && Boolean(onConfirm);
 
   const handleTooltipOpenChange = (nextOpen: boolean) => {
     // 确认弹层展示期间抑制 tooltip 的打开请求（悬停/点按），保证不重叠。

--- a/crates/agent-ui/src/lib/chat/contextUsage.ts
+++ b/crates/agent-ui/src/lib/chat/contextUsage.ts
@@ -80,9 +80,11 @@ export function estimateTextTokens(text: string): number {
 
 // 两端 transcript 项的最小结构投影：GUI RenderTimelineItem（检查点 kind:"summary"）
 // 与 WebUI TranscriptRow（检查点 kind:"checkpoint"）经结构化类型直接传入。
+// attachments 两端同为 PendingUploadedFile 投影（GUI 时间线项 / WebUI user 行）。
 export type ContextUsageScanItem = {
   kind: string;
   text?: string;
+  attachments?: readonly unknown[];
   rounds?: readonly {
     meta?: {
       usageTotalTokens?: number;
@@ -204,8 +206,9 @@ export function positiveTokenCount(value: unknown): number | undefined {
 /**
  * 倒扫 transcript 求当前上下文占用：最近一个 assistant 轮次的真实 API usage
  * 是锚点（usage.totalTokens 已含该 assistant 输出及其之前的 system/tools/历史），
- * 再累加锚点之后的用户消息、后续 assistant 内容与工具结果。压缩检查点优先使用
- * 桌面端同步的权威 contextUsageTokens；旧历史没有该字段时才退回摘要正文估算。
+ * 再累加锚点之后的用户消息（正文 + 附件元数据）、后续 assistant 内容与工具
+ * 结果。压缩检查点优先使用桌面端同步的权威 contextUsageTokens；旧历史没有
+ * 该字段时才退回摘要正文估算。
  */
 export function deriveContextUsageTokens(
   items: readonly ContextUsageScanItem[],
@@ -220,8 +223,15 @@ export function deriveContextUsageTokens(
       return checkpointTokens === undefined ? undefined : checkpointTokens + trailingTokens;
     }
     if (item.kind === "user") {
-      if (typeof item.text === "string" && item.text.trim()) {
-        trailingTokens += estimateTextTokens(item.text) + MESSAGE_ENVELOPE_TOKENS;
+      let units = typeof item.text === "string" ? estimateTextTokenUnits(item.text.trim()) : 0;
+      // 附件按元数据序列化估算（路径/文件名/规模等即运行时注入的指令行量级；
+      // 原生 base64 附件路径下这是下界）。不计会让"检查点后发大批附件"的
+      // 空闲读数两端一致偏低，且纯附件消息此前完全计零。
+      for (const attachment of item.attachments ?? []) {
+        units += stringifiedTokenUnits(attachment);
+      }
+      if (units > 0) {
+        trailingTokens += messageTokensFromUnits(units);
       }
       continue;
     }


### PR DESCRIPTION
Closes #572

## Summary

- **确认弹层状态泄漏**：`ContextUsageRing` 的可压缩状态在确认弹层打开期间翻回 false 时（他端压缩/发消息置 disabled、压缩完成后占用掉回 50% 阈值下），`confirmOpen` 残留 true——恢复可压缩后弹层会无操作自动弹开，残留期间互斥守卫一直吞掉 tooltip 的打开请求。改为渲染期归位（adjust-state-during-render），绘制前完成、不闪现。
- **触屏形态热切换**：`isCoarsePointer` 由挂载时一次性 `matchMedia` 求值改为 `useSyncExternalStore` 订阅 change 事件，iPad 插拔键鼠、可翻转本翻转后交互模式（两段点按 vs 悬停）实时切换。
- **倒扫计入用户附件**：共享扫描器 `deriveContextUsageTokens` 的 user 分支此前只估算正文、纯附件消息计零。现按元数据序列化口径计入 `attachments`（GUI `RenderUserMessage` 与 WebUI user 行同为顶层 `PendingUploadedFile[]`，结构化类型直接生效，两端口径一致、无需改调用方）。
- **注释还原/修正**：还原 `useContextUsageTokensSource` 中"运行中账本优先、空闲时转录倒扫"的原始设计注释（#426 引入、文件拆分时丢失），并修正 `ChatPage.tsx` 处与实现不符的"流式逐帧联合倒扫"注释。

## Test plan

- [x] `crates/agent-gui` chat 套件：1016 项全部通过（含新增 4 项：确认弹层归位与 matchMedia 订阅的源码断言、附件计入锚点尾部、纯附件消息不计零）
- [x] `crates/agent-gateway/web` WebUI 套件：627 项全部通过
- [x] biome check 改动文件无告警

Made with [Cursor](https://cursor.com)