### PR TITLE
chore: upgrade workspace TypeScript to 7

### DIFF
--- a/crates/agent-gateway/test/helpers/load-web-module.mjs
+++ b/crates/agent-gateway/test/helpers/load-web-module.mjs
@@ -2,7 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import vm from "node:vm";
 import { createRequire } from "node:module";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { transpileTypeScriptModule } from "../../../../scripts/typescript-source-tools.mjs";
 
 const DEFAULT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json", ".css"];
 
@@ -134,7 +135,6 @@ export function createWebModuleLoader(options = {}) {
   const hostSourceDir = path.join(rootDir, "src");
   const sharedSourceDir = fileURLToPath(new URL("../../../agent-ui/src", import.meta.url));
   const requireFromRoot = createRequire(path.join(rootDir, "package.json"));
-  const ts = requireFromRoot("typescript");
   const cache = new Map();
   const mocks = new Map([
     ...Object.entries(createDefaultMocks()),
@@ -221,31 +221,7 @@ export function createWebModuleLoader(options = {}) {
     }
 
     const source = fs.readFileSync(filePath, "utf8");
-    const transpiled = ts.transpileModule(source, {
-      fileName: filePath,
-      compilerOptions: {
-        module: ts.ModuleKind.CommonJS,
-        target: ts.ScriptTarget.ES2022,
-        jsx: ts.JsxEmit.ReactJSX,
-        esModuleInterop: true,
-        allowSyntheticDefaultImports: true,
-        moduleResolution: ts.ModuleResolutionKind.Node10 ?? ts.ModuleResolutionKind.NodeJs,
-        resolveJsonModule: true,
-        ignoreDeprecations: "6.0",
-      },
-      reportDiagnostics: true,
-    });
-
-    const diagnostics = transpiled.diagnostics ?? [];
-    const fatalDiagnostics = diagnostics.filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
-    if (fatalDiagnostics.length > 0) {
-      const message = ts.formatDiagnosticsWithColorAndContext(fatalDiagnostics, {
-        getCanonicalFileName: (name) => name,
-        getCurrentDirectory: () => rootDir,
-        getNewLine: () => "\n",
-      });
-      throw new Error(message);
-    }
+    const outputText = transpileTypeScriptModule(source, filePath);
 
     const module = { exports: {} };
     cache.set(filePath, module);
@@ -262,10 +238,6 @@ export function createWebModuleLoader(options = {}) {
         ? resolveLocal(nextSpecifier, dirname)
         : requireFromRoot.resolve(nextSpecifier);
 
-    const outputText = transpiled.outputText.replaceAll(
-      "import.meta.url",
-      JSON.stringify(pathToFileURL(filePath).href),
-    );
     const wrapped = `(function (exports, require, module, __filename, __dirname) {\n${outputText}\n})`;
     const script = new vm.Script(wrapped, { filename: filePath });
     const compiled = script.runInThisContext();

--- a/crates/agent-gateway/web/package.json
+++ b/crates/agent-gateway/web/package.json
@@ -55,7 +55,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "postcss": "^8.5.8",
     "tailwindcss": "4.2.2",
-    "typescript": "6.0.2",
+    "typescript": "~7.0.2",
     "unplugin-icons": "^23.0.1",
     "vite": "^8.0.5"
   }

--- a/crates/agent-gateway/web/tsconfig.json
+++ b/crates/agent-gateway/web/tsconfig.json
@@ -7,12 +7,10 @@
     "allowJs": false,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
-    "ignoreDeprecations": "6.0",
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@liveagent/app/*": ["./src/*"],

--- a/crates/agent-gui/package.json
+++ b/crates/agent-gui/package.json
@@ -63,7 +63,6 @@
     "postcss": "^8.5.8",
     "tailwindcss": "4.2.2",
     "typescript": "~7.0.2",
-    "typescript-transpile": "npm:typescript@~6.0.3",
     "unplugin-icons": "^23.0.1",
     "vite": "^8.0.5"
   }

--- a/crates/agent-gui/test/helpers/load-ts-module.mjs
+++ b/crates/agent-gui/test/helpers/load-ts-module.mjs
@@ -3,10 +3,7 @@ import path from "node:path";
 import vm from "node:vm";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
-// typescript 7 (native tsc) no longer ships the JS compiler API the loader
-// needs (transpileModule/ModuleKind), so the transpile step stays on the
-// aliased typescript 6 package.
-import ts from "typescript-transpile";
+import { transpileTypeScriptModule } from "../../../../scripts/typescript-source-tools.mjs";
 
 const DEFAULT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json"];
 
@@ -307,31 +304,7 @@ export function createTsModuleLoader(options = {}) {
     }
 
     const source = fs.readFileSync(filePath, "utf8");
-    const transpiled = ts.transpileModule(source, {
-      fileName: filePath,
-      compilerOptions: {
-        module: ts.ModuleKind.CommonJS,
-        target: ts.ScriptTarget.ES2022,
-        jsx: ts.JsxEmit.ReactJSX,
-        esModuleInterop: true,
-        allowSyntheticDefaultImports: true,
-        moduleResolution: ts.ModuleResolutionKind.Node10 ?? ts.ModuleResolutionKind.NodeJs,
-        resolveJsonModule: true,
-        ignoreDeprecations: "6.0",
-      },
-      reportDiagnostics: true,
-    });
-
-    const diagnostics = transpiled.diagnostics ?? [];
-    const fatalDiagnostics = diagnostics.filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
-    if (fatalDiagnostics.length > 0) {
-      const message = ts.formatDiagnosticsWithColorAndContext(fatalDiagnostics, {
-        getCanonicalFileName: (name) => name,
-        getCurrentDirectory: () => rootDir,
-        getNewLine: () => "\n",
-      });
-      throw new Error(message);
-    }
+    const outputText = transpileTypeScriptModule(source, filePath);
 
     const module = { exports: {} };
     cache.set(filePath, module);
@@ -347,7 +320,7 @@ export function createTsModuleLoader(options = {}) {
         ? resolveLocal(nextSpecifier, dirname)
         : requireFromRoot.resolve(nextSpecifier);
 
-    const wrapped = `(function (exports, require, module, __filename, __dirname) {\n${transpiled.outputText}\n})`;
+    const wrapped = `(function (exports, require, module, __filename, __dirname) {\n${outputText}\n})`;
     const script = new vm.Script(wrapped, { filename: filePath });
     const previousWindow = globalThis.window;
     if (typeof globalThis.window === "undefined") {

--- a/crates/agent-gui/test/i18n/shared-translations.test.mjs
+++ b/crates/agent-gui/test/i18n/shared-translations.test.mjs
@@ -3,7 +3,11 @@ import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
-import ts from "typescript-transpile";
+import {
+  parseTypeScriptSource,
+  staticStringValue,
+  walkSyntaxTree,
+} from "../../../../scripts/typescript-source-tools.mjs";
 import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 
 const repositoryRoot = fileURLToPath(new URL("../../../../", import.meta.url));
@@ -44,19 +48,19 @@ function sourceFilesUnder(directory) {
   return files;
 }
 
-function sourceReference(sourceFile, node) {
-  const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-  return `${path.relative(repositoryRoot, sourceFile.fileName)}:${position.line + 1}`;
+function sourceReference(file, node) {
+  return `${path.relative(repositoryRoot, file)}:${node.loc?.start.line ?? 1}`;
 }
 
 function collectLiteralTranslationArguments(node, literals = []) {
-  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-    literals.push(node);
-  } else if (ts.isParenthesizedExpression(node)) {
+  const value = staticStringValue(node);
+  if (value !== undefined) {
+    literals.push({ node, value });
+  } else if (node?.type === "ParenthesizedExpression") {
     collectLiteralTranslationArguments(node.expression, literals);
-  } else if (ts.isConditionalExpression(node)) {
-    collectLiteralTranslationArguments(node.whenTrue, literals);
-    collectLiteralTranslationArguments(node.whenFalse, literals);
+  } else if (node?.type === "ConditionalExpression") {
+    collectLiteralTranslationArguments(node.consequent, literals);
+    collectLiteralTranslationArguments(node.alternate, literals);
   }
   return literals;
 }
@@ -79,17 +83,12 @@ function collectTranslationKeys(sourceRoot, collectTranslationLikeLiterals = fal
   );
 
   for (const file of sourceFilesUnder(sourceRoot)) {
-    const sourceFile = ts.createSourceFile(
-      file,
-      readFileSync(file, "utf8"),
-      ts.ScriptTarget.Latest,
-      true,
-      file.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-    );
+    const syntaxTree = parseTypeScriptSource(readFileSync(file, "utf8"), file);
 
-    function visit(node) {
-      if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-        const key = node.text;
+    walkSyntaxTree(syntaxTree, (node) => {
+      const literalValue = staticStringValue(node);
+      if (literalValue !== undefined) {
+        const key = literalValue;
         const root = key.split(".")[0];
         if (
           collectTranslationLikeLiterals &&
@@ -97,25 +96,21 @@ function collectTranslationKeys(sourceRoot, collectTranslationLikeLiterals = fal
           knownRoots.has(root) &&
           !nonTranslationLiterals.has(key)
         ) {
-          addReference(translationLikeLiterals, key, sourceReference(sourceFile, node));
+          addReference(translationLikeLiterals, key, sourceReference(file, node));
         }
       }
 
       if (
-        ts.isCallExpression(node) &&
-        ts.isIdentifier(node.expression) &&
-        (node.expression.text === "t" || node.expression.text === "translate") &&
+        node.type === "CallExpression" &&
+        node.callee.type === "Identifier" &&
+        (node.callee.name === "t" || node.callee.name === "translate") &&
         node.arguments.length > 0
       ) {
         for (const literal of collectLiteralTranslationArguments(node.arguments[0])) {
-          addReference(directKeys, literal.text, sourceReference(sourceFile, literal));
+          addReference(directKeys, literal.value, sourceReference(file, literal.node));
         }
       }
-
-      ts.forEachChild(node, visit);
-    }
-
-    visit(sourceFile);
+    });
   }
 
   return { directKeys, translationLikeLiterals };

--- a/crates/agent-ui/package.json
+++ b/crates/agent-ui/package.json
@@ -41,6 +41,6 @@
     "@types/react-dom": "^19.2.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "typescript": "6.0.2"
+    "typescript": "~7.0.2"
   }
 }

--- a/crates/agent-ui/tsconfig.json
+++ b/crates/agent-ui/tsconfig.json
@@ -5,8 +5,6 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "paths": {
       "@liveagent/app/*": ["../agent-gui/src/*"],
       "@liveagent/adapters/*": ["../agent-gui/src/agent-ui-adapters/*"],

--- a/package.json
+++ b/package.json
@@ -44,5 +44,9 @@
       "unplugin-icons": "23.0.1",
       "vite": "8.0.5"
     }
+  },
+  "devDependencies": {
+    "@babel/parser": "7.29.8",
+    "esbuild": "0.28.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,14 @@ overrides:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@babel/parser':
+        specifier: 7.29.8
+        version: 7.29.8
+      esbuild:
+        specifier: 0.28.2
+        version: 0.28.2
 
   crates/agent-gateway/web:
     dependencies:
@@ -127,10 +134,10 @@ importers:
         version: 1.2.67
       '@svgr/core':
         specifier: ^8.1.0
-        version: 8.1.0(typescript@6.0.2)
+        version: 8.1.0(typescript@7.0.2)
       '@svgr/plugin-jsx':
         specifier: ^8.1.0
-        version: 8.1.0(@svgr/core@8.1.0(typescript@6.0.2))
+        version: 8.1.0(@svgr/core@8.1.0(typescript@7.0.2))
       '@tailwindcss/postcss':
         specifier: 4.2.2
         version: 4.2.2
@@ -145,7 +152,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 6.0.1(vite@8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       postcss:
         specifier: 8.5.8
         version: 8.5.8
@@ -153,14 +160,14 @@ importers:
         specifier: 4.2.2
         version: 4.2.2
       typescript:
-        specifier: 6.0.2
-        version: 6.0.2
+        specifier: ~7.0.2
+        version: 7.0.2
       unplugin-icons:
         specifier: 23.0.1
-        version: 23.0.1(@svgr/core@8.1.0(typescript@6.0.2))
+        version: 23.0.1(@svgr/core@8.1.0(typescript@7.0.2))
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0)
+        version: 8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
 
   crates/agent-gui:
     dependencies:
@@ -281,7 +288,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 6.0.1(vite@8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       jsdom:
         specifier: ^30.0.1
         version: 30.0.1
@@ -294,15 +301,12 @@ importers:
       typescript:
         specifier: ~7.0.2
         version: 7.0.2
-      typescript-transpile:
-        specifier: npm:typescript@~6.0.3
-        version: typescript@6.0.3
       unplugin-icons:
         specifier: 23.0.1
         version: 23.0.1(@svgr/core@8.1.0(typescript@7.0.2))
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0)
+        version: 8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
 
   crates/agent-ui:
     dependencies:
@@ -380,8 +384,8 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
       typescript:
-        specifier: 6.0.2
-        version: 6.0.2
+        specifier: ~7.0.2
+        version: 7.0.2
 
 packages:
 
@@ -744,6 +748,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.3':
     resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@exodus/bytes@1.15.1':
     resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
@@ -1994,6 +2154,11 @@ packages:
   es-toolkit@1.50.0:
     resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
 
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3020,16 +3185,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
@@ -3745,6 +3900,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
   '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.8.0':
@@ -4104,17 +4337,6 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7)
 
-  '@svgr/core@8.1.0(typescript@6.0.2)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
-      camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@6.0.2)
-      snake-case: 3.0.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@svgr/core@8.1.0(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.29.7
@@ -4130,16 +4352,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
       entities: 4.5.0
-
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.2))':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
-      '@svgr/core': 8.1.0(typescript@6.0.2)
-      '@svgr/hast-util-to-babel-ast': 8.0.0
-      svg-parser: 2.0.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@7.0.2))':
     dependencies:
@@ -4527,10 +4739,10 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
 
   '@vue/reactivity@3.5.41':
     dependencies:
@@ -4626,15 +4838,6 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
-
-  cosmiconfig@8.3.6(typescript@6.0.2):
-    dependencies:
-      import-fresh: 3.3.1
-      js-yaml: 4.3.1
-      parse-json: 5.2.0
-      path-type: 4.0.0
-    optionalDependencies:
-      typescript: 6.0.2
 
   cosmiconfig@8.3.6(typescript@7.0.2):
     dependencies:
@@ -4914,6 +5117,35 @@ snapshots:
       is-arrayish: 0.2.1
 
   es-toolkit@1.50.0: {}
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -6305,10 +6537,6 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  typescript@6.0.2: {}
-
-  typescript@6.0.3: {}
-
   typescript@7.0.2:
     optionalDependencies:
       '@typescript/typescript-aix-ppc64': 7.0.2
@@ -6381,16 +6609,6 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  unplugin-icons@23.0.1(@svgr/core@8.1.0(typescript@6.0.2)):
-    dependencies:
-      '@antfu/install-pkg': 1.1.0
-      '@iconify/utils': 3.1.4
-      local-pkg: 1.2.1
-      obug: 2.1.4
-      unplugin: 2.3.11
-    optionalDependencies:
-      '@svgr/core': 8.1.0(typescript@6.0.2)
-
   unplugin-icons@23.0.1(@svgr/core@8.1.0(typescript@7.0.2)):
     dependencies:
       '@antfu/install-pkg': 1.1.0
@@ -6437,7 +6655,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0):
+  vite@8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -6446,6 +6664,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.2.0
+      esbuild: 0.28.2
       fsevents: 2.3.3
       jiti: 2.7.0
       yaml: 2.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,5 @@ packages:
 
 allowBuilds:
   "@google/genai": true
+  esbuild: true
   protobufjs: true

--- a/scripts/typescript-source-tools.mjs
+++ b/scripts/typescript-source-tools.mjs
@@ -3,7 +3,7 @@ import { parse } from "@babel/parser";
 import { transformSync } from "esbuild";
 
 export function parseTypeScriptSource(source, fileName) {
-  const supportsJsx = /\.[cm]?[jt]sx$/i.test(fileName) && fileName.toLowerCase().endsWith("x");
+  const supportsJsx = /\.[cm]?[jt]sx$/i.test(fileName);
   return parse(source, {
     sourceFilename: fileName,
     sourceType: "module",
@@ -11,6 +11,17 @@ export function parseTypeScriptSource(source, fileName) {
     plugins: supportsJsx ? ["typescript", "jsx"] : ["typescript"],
   });
 }
+
+const NON_CHILD_KEYS = new Set([
+  "comments",
+  "errors",
+  "extra",
+  "innerComments",
+  "leadingComments",
+  "loc",
+  "tokens",
+  "trailingComments",
+]);
 
 export function walkSyntaxTree(node, visitor) {
   if (!node || typeof node !== "object") return;
@@ -22,13 +33,15 @@ export function walkSyntaxTree(node, visitor) {
 
   visitor(node);
   for (const [key, child] of Object.entries(node)) {
-    if (["comments", "errors", "extra", "loc", "tokens"].includes(key)) continue;
+    if (NON_CHILD_KEYS.has(key)) continue;
     walkSyntaxTree(child, visitor);
   }
 }
 
 export function staticStringValue(node) {
-  if (node?.type === "StringLiteral") return node.value;
+  // DirectiveLiteral: Babel lifts prologue strings ("use strict"-style
+  // statements) out of ExpressionStatement, unlike the TypeScript AST.
+  if (node?.type === "StringLiteral" || node?.type === "DirectiveLiteral") return node.value;
   if (node?.type !== "TemplateLiteral" || node.expressions.length > 0) return undefined;
   return node.quasis[0]?.value.cooked ?? node.quasis[0]?.value.raw;
 }

--- a/scripts/typescript-source-tools.mjs
+++ b/scripts/typescript-source-tools.mjs
@@ -1,0 +1,62 @@
+import { pathToFileURL } from "node:url";
+import { parse } from "@babel/parser";
+import { transformSync } from "esbuild";
+
+export function parseTypeScriptSource(source, fileName) {
+  const supportsJsx = /\.[cm]?[jt]sx$/i.test(fileName) && fileName.toLowerCase().endsWith("x");
+  return parse(source, {
+    sourceFilename: fileName,
+    sourceType: "module",
+    createParenthesizedExpressions: true,
+    plugins: supportsJsx ? ["typescript", "jsx"] : ["typescript"],
+  });
+}
+
+export function walkSyntaxTree(node, visitor) {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const child of node) walkSyntaxTree(child, visitor);
+    return;
+  }
+  if (typeof node.type !== "string") return;
+
+  visitor(node);
+  for (const [key, child] of Object.entries(node)) {
+    if (["comments", "errors", "extra", "loc", "tokens"].includes(key)) continue;
+    walkSyntaxTree(child, visitor);
+  }
+}
+
+export function staticStringValue(node) {
+  if (node?.type === "StringLiteral") return node.value;
+  if (node?.type !== "TemplateLiteral" || node.expressions.length > 0) return undefined;
+  return node.quasis[0]?.value.cooked ?? node.quasis[0]?.value.raw;
+}
+
+function loaderFor(filePath) {
+  const extension = filePath.toLowerCase().match(/\.[^.]+$/)?.[0];
+  if (extension === ".tsx") return "tsx";
+  if (extension === ".jsx") return "jsx";
+  if ([".js", ".mjs", ".cjs"].includes(extension)) return "js";
+  return "ts";
+}
+
+export function transpileTypeScriptModule(source, filePath) {
+  const sourceWithImportMeta = source.replaceAll(
+    "import.meta.url",
+    JSON.stringify(pathToFileURL(filePath).href),
+  );
+  try {
+    return transformSync(sourceWithImportMeta, {
+      format: "cjs",
+      jsx: "automatic",
+      loader: loaderFor(filePath),
+      platform: "node",
+      sourcefile: filePath,
+      target: "es2022",
+    }).code;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to transpile ${filePath}: ${detail}`, { cause: error });
+  }
+}

--- a/scripts/ui-boundary-declarations.mjs
+++ b/scripts/ui-boundary-declarations.mjs
@@ -1,81 +1,58 @@
-import { createRequire } from "node:module";
+import { parseTypeScriptSource, walkSyntaxTree } from "./typescript-source-tools.mjs";
 
-const requireFromAgentUi = createRequire(
-  new URL("../crates/agent-ui/package.json", import.meta.url),
-);
-const ts = requireFromAgentUi("typescript");
-
-function parseSourceFile(source, fileName) {
-  return ts.createSourceFile(
-    fileName,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    fileName.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-  );
-}
-
-function staticPropertyName(name) {
-  if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) return name.text;
-  if (!ts.isComputedPropertyName(name)) return null;
-  return ts.isStringLiteralLike(name.expression) ? name.expression.text : null;
+function staticPropertyName(name, computed = false) {
+  if (!computed && name?.type === "Identifier") return name.name;
+  if (name?.type === "StringLiteral") return name.value;
+  return null;
 }
 
 function assignmentTargetName(node) {
-  if (ts.isIdentifier(node)) return node.text;
-  if (ts.isPropertyAccessExpression(node)) return node.name.text;
-  if (!ts.isElementAccessExpression(node)) return null;
-  return node.argumentExpression && ts.isStringLiteralLike(node.argumentExpression)
-    ? node.argumentExpression.text
-    : null;
+  if (node?.type === "Identifier") return node.name;
+  if (node?.type !== "MemberExpression" && node?.type !== "OptionalMemberExpression") {
+    return null;
+  }
+  return staticPropertyName(node.property, node.computed);
 }
 
 function isFunctionImplementation(node) {
-  return ts.isArrowFunction(node) || ts.isFunctionExpression(node);
+  return node?.type === "ArrowFunctionExpression" || node?.type === "FunctionExpression";
 }
 
 export function findRetiredSharedDeclarations(source, fileName, retiredNames) {
   const retired = retiredNames instanceof Set ? retiredNames : new Set(retiredNames);
-  const sourceFile = parseSourceFile(source, fileName);
+  const syntaxTree = parseTypeScriptSource(source, fileName);
   const declarations = [];
 
   function add(name, node, kind) {
     if (!name || !retired.has(name)) return;
-    const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
     declarations.push({
       name,
       kind,
-      line: position.line + 1,
-      column: position.character + 1,
+      line: node.loc?.start.line ?? 1,
+      column: (node.loc?.start.column ?? 0) + 1,
     });
   }
 
-  function visit(node) {
-    if (ts.isFunctionDeclaration(node)) {
-      add(node.name?.text, node, "function");
-    } else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
-      add(node.name.text, node, "variable");
+  walkSyntaxTree(syntaxTree, (node) => {
+    if (node.type === "FunctionDeclaration") {
+      add(node.id?.name, node, "function");
+    } else if (node.type === "VariableDeclarator" && node.id.type === "Identifier") {
+      add(node.id.name, node, "variable");
+    } else if (node.type === "ObjectMethod" || node.type === "ClassMethod") {
+      add(staticPropertyName(node.key, node.computed), node, "method");
     } else if (
-      ts.isMethodDeclaration(node) ||
-      ts.isGetAccessorDeclaration(node) ||
-      ts.isSetAccessorDeclaration(node)
+      node.type === "ClassProperty" ||
+      node.type === "ClassAccessorProperty" ||
+      node.type === "ClassPrivateProperty"
     ) {
-      add(staticPropertyName(node.name), node, "method");
-    } else if (ts.isPropertyDeclaration(node)) {
-      add(staticPropertyName(node.name), node, "property");
-    } else if (ts.isPropertyAssignment(node) && isFunctionImplementation(node.initializer)) {
-      add(staticPropertyName(node.name), node, "property");
-    } else if (
-      ts.isBinaryExpression(node) &&
-      node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
-      node.operatorToken.kind <= ts.SyntaxKind.LastAssignment
-    ) {
+      add(staticPropertyName(node.key, node.computed), node, "property");
+    } else if (node.type === "ObjectProperty" && isFunctionImplementation(node.value)) {
+      add(staticPropertyName(node.key, node.computed), node, "property");
+    } else if (node.type === "AssignmentExpression") {
       add(assignmentTargetName(node.left), node, "assignment");
     }
-    ts.forEachChild(node, visit);
-  }
+  });
 
-  visit(sourceFile);
   return declarations;
 }
 
@@ -85,41 +62,39 @@ export function rendersImportedComponent(
   moduleSpecifier,
   importedComponentName,
 ) {
-  const sourceFile = parseSourceFile(source, fileName);
+  const syntaxTree = parseTypeScriptSource(source, fileName);
   const localComponentNames = new Set();
 
-  for (const statement of sourceFile.statements) {
+  for (const statement of syntaxTree.program.body) {
     if (
-      !ts.isImportDeclaration(statement) ||
-      !ts.isStringLiteralLike(statement.moduleSpecifier) ||
-      statement.moduleSpecifier.text !== moduleSpecifier
+      statement.type !== "ImportDeclaration" ||
+      statement.source.value !== moduleSpecifier ||
+      statement.importKind === "type"
     ) {
       continue;
     }
-    const importClause = statement.importClause;
-    if (!importClause || importClause.isTypeOnly || !importClause.namedBindings) continue;
-    if (!ts.isNamedImports(importClause.namedBindings)) continue;
-    for (const specifier of importClause.namedBindings.elements) {
-      const importedName = specifier.propertyName?.text ?? specifier.name.text;
-      if (specifier.isTypeOnly || importedName !== importedComponentName) continue;
-      localComponentNames.add(specifier.name.text);
+    for (const specifier of statement.specifiers) {
+      if (specifier.type !== "ImportSpecifier" || specifier.importKind === "type") continue;
+      const importedName =
+        specifier.imported.type === "Identifier"
+          ? specifier.imported.name
+          : specifier.imported.value;
+      if (importedName === importedComponentName) {
+        localComponentNames.add(specifier.local.name);
+      }
     }
   }
 
   if (localComponentNames.size === 0) return false;
   let rendersComponent = false;
-  function visit(node) {
-    if (rendersComponent) return;
+  walkSyntaxTree(syntaxTree, (node) => {
     if (
-      (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
-      ts.isIdentifier(node.tagName) &&
-      localComponentNames.has(node.tagName.text)
+      node.type === "JSXOpeningElement" &&
+      node.name.type === "JSXIdentifier" &&
+      localComponentNames.has(node.name.name)
     ) {
       rendersComponent = true;
-      return;
     }
-    ts.forEachChild(node, visit);
-  }
-  visit(sourceFile);
+  });
   return rendersComponent;
 }

--- a/scripts/ui-boundary-declarations.mjs
+++ b/scripts/ui-boundary-declarations.mjs
@@ -1,9 +1,12 @@
-import { parseTypeScriptSource, walkSyntaxTree } from "./typescript-source-tools.mjs";
+import {
+  parseTypeScriptSource,
+  staticStringValue,
+  walkSyntaxTree,
+} from "./typescript-source-tools.mjs";
 
 function staticPropertyName(name, computed = false) {
   if (!computed && name?.type === "Identifier") return name.name;
-  if (name?.type === "StringLiteral") return name.value;
-  return null;
+  return staticStringValue(name) ?? null;
 }
 
 function assignmentTargetName(node) {


### PR DESCRIPTION
Closes #574 

## Summary

Upgrade all direct workspace TypeScript dependencies to 7.0.2 and remove the legacy TypeScript JavaScript Compiler API usage from test and scanning tools.

## Change scope

- Modules: agent-gui, agent-gateway WebUI, shared UI, repository scripts
- Key changes:
  - Upgrade workspace TypeScript to `~7.0.2`
  - Remove `typescript-transpile` / TypeScript 6 alias
  - Remove obsolete TypeScript compiler options
  - Replace legacy compiler API usage in tests and scanners
  - Add `@babel/parser` and `esbuild` as development-only tooling
  - Keep Buf's transitive TypeScript 5.4.5 dependency unchanged

## Screenshots / preview

N/A — no user-facing UI behavior or layout changes.

## Verification

- GUI frontend tests: 2437/2437
- Gateway WebUI tests: 627/627
- Script tests: 12/12
- GUI build passed
- WebUI build passed
- UI boundary checks passed
- GUI, WebUI, and shared UI lint passed
- All direct workspace TypeScript versions are 7.0.2
- `git diff --check` passed

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused.
- [x] No secrets, tokens, or personal data included.
- [x] No generated code was hand-edited.