### PR TITLE
refactor(chat): 用量估算改为内容块感知口径，消除用量环读数跳变

### DIFF
--- a/crates/agent-gui/src/lib/chat/compaction/prune.ts
+++ b/crates/agent-gui/src/lib/chat/compaction/prune.ts
@@ -1,14 +1,12 @@
 import type { ToolResultMessage } from "@earendil-works/pi-ai";
-
+import { estimateContentTokenUnits } from "@liveagent/ui/lib/chat/contextUsage";
 import { sanitizeMessageForModelContext } from "../context/requestContextSanitizer";
 import {
   type ConversationViewState,
   getActiveSegment,
   replaceActiveSegmentMessages,
 } from "../conversation/conversationState";
-import { flattenContentBlocks, toPlainText } from "./payload";
 import type { PruneOptions } from "./policy";
-import { estimateTextTokens } from "./tokenLedger";
 
 const PRUNED_TOOL_OUTPUT_TEXT = "[output pruned to preserve context budget]";
 
@@ -52,9 +50,9 @@ export function pruneConversationState(
     if (userTurnsSeen < protectedRecentUserTurns) continue;
 
     const modelMessage = sanitizeMessageForModelContext(message) as ToolResultMessage;
-    const toolText = flattenContentBlocks(modelMessage.content);
-    const detailsText = modelMessage.details ? toPlainText(modelMessage.details) : "";
-    const estimated = estimateTextTokens(toolText) + estimateTextTokens(detailsText);
+    // 释放量与账本同口径：只按模型可见的 content 计（details 不发给模型）。
+    // 计入 details 会高报释放量而提前停手，实际上下文并未降到位。
+    const estimated = Math.ceil(estimateContentTokenUnits(modelMessage.content));
     if (estimated <= 0) continue;
     traversedToolTokens += estimated;
     if (traversedToolTokens <= protectedToolTokens) continue;

--- a/crates/agent-gui/src/lib/chat/compaction/tokenLedger.ts
+++ b/crates/agent-gui/src/lib/chat/compaction/tokenLedger.ts
@@ -1,6 +1,8 @@
 import type { Context, Message, Usage } from "@earendil-works/pi-ai";
 
 import {
+  estimateContentBlockTokenUnits,
+  estimateContentTokenUnits,
   estimateTextTokens,
   estimateTextTokenUnits,
   MESSAGE_ENVELOPE_TOKENS,
@@ -24,53 +26,28 @@ export { estimateTextTokens, estimateTextTokenUnits };
 const messageTokenCache = new WeakMap<object, number>();
 const toolsTokenCache = new WeakMap<object, number>();
 
+// 统一走共享层的内容块口径（文本 CJK 感知、二进制块按计价常量、小结构兜底
+// 序列化）。toolResult 的 details 是 UI/记账负载，provider 转换只发送 content，
+// 一律不计——shell 全量输出、文件读取元数据都挂在 details 上，计入即双算。
 function estimateMessageTokenUnits(message: Message): number {
-  let units = 0;
   if (message.role === "assistant") {
+    let units = 0;
     for (const block of message.content) {
       if (!block || typeof block !== "object") continue;
-      if (block.type === "text" || block.type === "thinking") {
-        const text =
-          (block as { text?: string; thinking?: string }).text ??
-          (block as { thinking?: string }).thinking;
-        if (typeof text === "string") units += estimateTextTokenUnits(text);
-        continue;
-      }
       if (block.type === "toolCall") {
         units += estimateTextTokenUnits(block.name) + stringifiedTokenUnits(block.arguments);
         continue;
       }
-      units += stringifiedTokenUnits(block);
+      units += estimateContentBlockTokenUnits(block);
     }
     return units;
   }
 
   if (message.role === "toolResult") {
-    for (const block of message.content) {
-      if (block && typeof block === "object" && block.type === "text") {
-        units += typeof block.text === "string" ? estimateTextTokenUnits(block.text) : 0;
-      } else {
-        units += stringifiedTokenUnits(block);
-      }
-    }
-    if (message.details != null) units += stringifiedTokenUnits(message.details);
-    return units;
+    return estimateContentTokenUnits(message.content);
   }
 
-  const content = (message as { content?: unknown }).content;
-  if (typeof content === "string") return estimateTextTokenUnits(content);
-  if (Array.isArray(content)) {
-    for (const block of content) {
-      if (block && typeof block === "object" && (block as { type?: string }).type === "text") {
-        const text = (block as { text?: string }).text;
-        units += typeof text === "string" ? estimateTextTokenUnits(text) : 0;
-      } else {
-        units += stringifiedTokenUnits(block);
-      }
-    }
-    return units;
-  }
-  return stringifiedTokenUnits(content);
+  return estimateContentTokenUnits((message as { content?: unknown }).content);
 }
 
 export function estimateMessageTokens(message: Message): number {
@@ -222,9 +199,9 @@ export class TokenLedger {
   }
 
   total(): number {
-    // 有 usage 锚点时恒信 observed + trailing：估算（尤其 base64 图片按序列化
-    // 字符数、CJK 按 0.7 tok/char）有意高估，与真实读数取 max 会让环读数与
-    // 自动压缩被估算劫持。估算只在完全没有 usage 锚点时兜底。
+    // 有 usage 锚点时恒信 observed + trailing：估算口径偏保守（CJK 0.7 tok/char、
+    // 二进制块按计价量级常量），与真实读数取 max 会让环读数与自动压缩被估算
+    // 劫持。估算只在完全没有 usage 锚点时兜底。
     if (!this.hasObservedUsage) return this.estimatedTotalTokens;
     return this.observedTokens + this.trailingTokens;
   }

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -510,9 +510,11 @@ export function ChatPage(props: ChatPageProps) {
     finishGatewayRunMirror,
   } = useGatewayRunMirrorCoordinator();
 
-  // 用量环读数：与 WebUI 同一把共享扫描器（deriveContextUsageTokens），
-  // 历史项 + 流式实时轮次（live store 每帧批量提交）联合倒扫。经订阅源
-  // 直达环组件，流式读数逐帧更新而不回流 ChatPage。
+  // 用量环读数：运行中直读 TokenLedger（消息落定即更新，不逐帧估算流式
+  // 文本，优先级与理由见 useContextUsageTokensSource 内注释）；账本无读数
+  // 或空闲时用与 WebUI 同源的 deriveContextUsageTokens 倒扫历史项（运行中
+  // 补上 live 尾部）。经订阅源直达环组件，读数变化只重渲染环本身而不回流
+  // ChatPage。
   const contextUsageRingRunning = isSending || compactionStatus.phase === "running";
   const contextUsageTokensSource = useContextUsageTokensSource({
     isRunning: contextUsageRingRunning,

--- a/crates/agent-gui/src/pages/chat/hooks/useContextUsageTokensSource.ts
+++ b/crates/agent-gui/src/pages/chat/hooks/useContextUsageTokensSource.ts
@@ -51,6 +51,13 @@ export function createContextUsageTokensSource(params: ContextUsageTokensSourceP
       ) {
         return cache.value;
       }
+      // 优先级（#426 引入时的原始设计，文件拆分时注释曾丢失）：运行中（发送/
+      // 压缩）转录尾部滞后于账本，账本读数优先；空闲时转录含权威锚点
+      //（edit-resend 截断历史后账本仍冻结在截断前读数），转录扫描才准。
+      // 惰性求值：命中账本优先项即跳过全量转录扫描（流式期每帧对大工具结果
+      // JSON.stringify 后丢弃的开销）。因此 GUI 环在流式期按消息落定跳变而
+      // 非逐帧估算；live 尾部联合倒扫仅在运行中而账本尚无读数时可达
+      //（如中继压缩落在本会话新建的控制器上）。
       let value: number | undefined;
       if (isRunning && runtimeValue !== undefined) {
         value = runtimeValue;

--- a/crates/agent-gui/test/chat/compaction-token-ledger.test.mjs
+++ b/crates/agent-gui/test/chat/compaction-token-ledger.test.mjs
@@ -4,6 +4,7 @@ import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 
 const loader = createTsModuleLoader();
 const ledgerModule = loader.loadModule("src/lib/chat/compaction/tokenLedger.ts");
+const { BINARY_BLOCK_TOKENS } = loader.loadModule("@liveagent/ui/lib/chat/contextUsage.ts");
 
 const {
   TokenLedger,
@@ -84,7 +85,7 @@ test("estimateTextTokenUnits is additive across arbitrary splits", () => {
   assert.ok(Math.abs(whole - split) < 1e-9, `whole=${whole} split=${split}`);
 });
 
-test("estimateMessageTokens covers text, tool calls, tool results and details", () => {
+test("estimateMessageTokens covers text, tool calls and model-visible tool result content", () => {
   assert.equal(estimateMessageTokens(user("a".repeat(400))), 100 + 8);
 
   const withToolCall = {
@@ -102,9 +103,40 @@ test("estimateMessageTokens covers text, tool calls, tool results and details", 
     Math.ceil((40 + "Read".length + argsChars) / 4) + 8,
   );
 
+  // details 是 UI/记账负载（shell 全量输出、文件元数据都挂在上面），provider
+  // 转换只发送 content——计入即双算，账本读数系统性虚高。
   const resultWithDetails = { ...toolResult("c".repeat(80)), details: { lines: 12 } };
-  const detailsChars = JSON.stringify({ lines: 12 }).length;
-  assert.equal(estimateMessageTokens(resultWithDetails), Math.ceil((80 + detailsChars) / 4) + 8);
+  assert.equal(estimateMessageTokens(resultWithDetails), Math.ceil(80 / 4) + 8);
+});
+
+test("estimateMessageTokens prices binary blocks at provider scale, not base64 length", () => {
+  // 400KB 图的 base64 按字符数会虚报 ~13 万 token，环随锚点在估算/真实 usage
+  // 间切换而剧烈跳变；按计价量级常量后读数与真实成本同量级。
+  const imageResult = {
+    role: "toolResult",
+    toolCallId: "tc-img",
+    toolName: "Read",
+    content: [
+      { type: "text", text: "a".repeat(40) },
+      { type: "image", data: "A".repeat(1_000_000), mimeType: "image/png" },
+    ],
+    isError: false,
+    timestamp: 3,
+  };
+  assert.equal(estimateMessageTokens(imageResult), Math.ceil(40 / 4) + BINARY_BLOCK_TOKENS + 8);
+
+  const imageUser = {
+    role: "user",
+    content: [
+      { type: "text", text: "看这张图" },
+      { type: "image", data: "B".repeat(500_000), mimeType: "image/jpeg" },
+    ],
+    timestamp: 1,
+  };
+  assert.equal(
+    estimateMessageTokens(imageUser),
+    Math.ceil(estimateTextTokenUnits("看这张图") + BINARY_BLOCK_TOKENS) + 8,
+  );
 });
 
 test("estimateMessageTokens memoizes by object identity", () => {

--- a/crates/agent-gui/test/chat/context-usage.test.mjs
+++ b/crates/agent-gui/test/chat/context-usage.test.mjs
@@ -21,6 +21,10 @@ const gatewayAppSource = readFileSync(
   ),
   "utf8",
 );
+const contextUsageRingSource = readFileSync(
+  new URL("../../../agent-ui/src/components/chat/ContextUsageRing.tsx", import.meta.url),
+  "utf8",
+);
 
 const {
   CONTEXT_USAGE_WARN_RATIO,
@@ -87,6 +91,26 @@ test("composer editor row reserves the right control rail so the scrollbar clear
   assert.match(chatComposerBarSource, /"relative flex flex-1 pl-4 pr-12"/);
   assert.doesNotMatch(chatComposerBarSource, /"relative flex flex-1 px-4"/);
   assert.doesNotMatch(chatComposerBarSource, /"px-0 py-0 pr-8"/);
+});
+
+test("context usage ring resets a stale confirm popover when compaction flips unavailable", () => {
+  // 可压缩分支翻回纯展示时（他端压缩/发消息置 disabled、压缩后占用掉回阈值
+  // 下），confirmOpen 必须渲染期归位：否则恢复可压缩后确认弹层会无操作自动
+  // 弹开，残留期间互斥守卫还会一直吞掉 tooltip 的打开请求。
+  assert.match(
+    contextUsageRingSource,
+    /if \(!compactAvailable && confirmOpen\) \{\s*setConfirmOpen\(false\);/,
+  );
+});
+
+test("context usage ring tracks pointer form-factor changes via matchMedia subscription", () => {
+  // iPad 插拔键鼠、可翻转本翻转等触屏形态热切换必须实时生效，
+  // 不能挂载时一次性求值定死交互模式。
+  assert.match(
+    contextUsageRingSource,
+    /useSyncExternalStore\(\s*subscribeCoarsePointer,\s*isCoarsePointerNow/,
+  );
+  assert.match(contextUsageRingSource, /addEventListener\("change", onChange\)/);
 });
 
 test("contextUsageRatio guards degenerate inputs", () => {
@@ -197,6 +221,49 @@ test("deriveContextUsageTokens prefers checkpoint fixed overhead and adds its tr
     { kind: "user", text: "x".repeat(4_000) },
   ];
   assert.equal(deriveContextUsageTokens(items), 41_008);
+});
+
+test("deriveContextUsageTokens counts user attachment metadata after the anchor", () => {
+  const attachment = {
+    relativePath: "uploads/diagram.png",
+    fileName: "diagram.png",
+    kind: "image",
+    sizeBytes: 123_456,
+  };
+  const anchor = { kind: "assistant", rounds: [{ meta: { usageTotalTokens: 50_000 } }] };
+  const text = "看看这张图";
+  const textOnly = deriveContextUsageTokens([anchor, { kind: "user", text }]);
+  const withAttachment = deriveContextUsageTokens([
+    anchor,
+    { kind: "user", text, attachments: [attachment] },
+  ]);
+  assert.ok(withAttachment > textOnly, "附件元数据必须计入尾部估算");
+  assert.equal(
+    withAttachment,
+    50_000 +
+      Math.ceil(
+        contextUsage.estimateTextTokenUnits(text) +
+          contextUsage.stringifiedTokenUnits(attachment),
+      ) +
+      8,
+  );
+});
+
+test("deriveContextUsageTokens counts attachment-only user messages", () => {
+  // 纯附件消息（正文为空）此前完全计零。
+  const attachment = {
+    relativePath: "uploads/error.log",
+    fileName: "error.log",
+    kind: "text",
+    sizeBytes: 2_048,
+  };
+  assert.equal(
+    deriveContextUsageTokens([
+      { kind: "checkpoint", content: "short summary", contextUsageTokens: 40_000 },
+      { kind: "user", text: "", attachments: [attachment] },
+    ]),
+    40_000 + Math.ceil(contextUsage.stringifiedTokenUnits(attachment)) + 8,
+  );
 });
 
 test("deriveContextUsageTokens returns undefined without any usage", () => {

--- a/crates/agent-gui/test/chat/context-usage.test.mjs
+++ b/crates/agent-gui/test/chat/context-usage.test.mjs
@@ -195,9 +195,37 @@ test("deriveContextUsageTokens adds messages and tool results after the newest u
     },
     { kind: "user", text: trailingUser },
   ];
-  const toolResultTokens =
-    Math.ceil(contextUsage.estimateTextTokenUnits(JSON.stringify(toolResultContent))) + 8;
+  // 工具结果只计模型可见文本（不再整块 JSON 序列化后按字符估）。
+  const toolResultTokens = Math.ceil(contextUsage.estimateTextTokenUnits("y".repeat(4_000))) + 8;
   assert.equal(deriveContextUsageTokens(items), 120_008 + toolResultTokens);
+});
+
+test("deriveContextUsageTokens prices binary tool payloads flat and ignores details", () => {
+  const items = [
+    {
+      kind: "assistant",
+      rounds: [
+        {
+          meta: { usageTotalTokens: 10_000 },
+          blocks: [
+            {
+              kind: "tool",
+              item: {
+                toolCall: { name: "Read", arguments: { path: "shot.png" } },
+                toolResult: {
+                  content: [{ type: "image", data: "A".repeat(1_000_000), mimeType: "image/png" }],
+                  details: { stdout: "C".repeat(400_000) },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ];
+  // 锚点轮次自身的工具结果补计：图按计价常量而非 base64/4（后者虚报 25 万
+  // token 令环跳变），details 不发给模型、不计。
+  assert.equal(deriveContextUsageTokens(items), 10_000 + contextUsage.BINARY_BLOCK_TOKENS + 8);
 });
 
 test("deriveContextUsageTokens falls back to checkpoint estimate after compaction", () => {

--- a/crates/agent-ui/src/components/chat/ContextUsageRing.tsx
+++ b/crates/agent-ui/src/components/chat/ContextUsageRing.tsx
@@ -1,6 +1,6 @@
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { cn } from "@liveagent/ui/lib/shared/utils";
-import { useMemo, useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import {
   canManualCompact,
   contextUsageLevel,
@@ -28,6 +28,27 @@ function getTokenFormatter(locale: string): Intl.NumberFormat {
   return formatter;
 }
 
+const COARSE_POINTER_QUERY = "(hover: none), (pointer: coarse)";
+
+// 触屏形态可热切换（iPad 插拔键鼠、可翻转本翻转），订阅 matchMedia change
+// 而非挂载时一次性求值，交互模式（两段点按 vs 悬停）随设备形态实时切换。
+function subscribeCoarsePointer(onChange: () => void): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+  const query = window.matchMedia(COARSE_POINTER_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+function isCoarsePointerNow(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia(COARSE_POINTER_QUERY).matches
+  );
+}
+
 /**
  * 上下文用量环：composer 内展示当前会话上下文占用百分比，占用 ≥ 50%（黄档）
  * 起可点击弹出确认后触发手动压缩。阈值与 WebUI 补算口径见 lib/chat/contextUsage.ts。
@@ -46,20 +67,27 @@ export function ContextUsageRing(props: {
 }) {
   const { totalTokens, contextWindow, disabled, onConfirm, className } = props;
   const { t, locale } = useLocale();
-  const isCoarsePointer = useMemo(
-    () =>
-      typeof window !== "undefined" &&
-      typeof window.matchMedia === "function" &&
-      window.matchMedia("(hover: none), (pointer: coarse)").matches,
-    [],
+  const isCoarsePointer = useSyncExternalStore(
+    subscribeCoarsePointer,
+    isCoarsePointerNow,
+    () => false,
   );
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const ratio = contextUsageRatio(totalTokens, contextWindow);
+  const compactAvailable = canManualCompact(ratio) && !disabled && Boolean(onConfirm);
+  // 确认弹层只在可压缩分支渲染，而可压缩状态可能在弹层打开期间翻回 false
+  //（他端开始压缩/发消息使 disabled 置位、他端压缩完成后占用掉回阈值下）。
+  // 此时弹层随分支切换直接卸载，confirmOpen 若残留 true：恢复可压缩后弹层
+  // 会无操作自动弹开，残留期间还会经 tooltip 互斥守卫一直吞掉 tooltip 的
+  // 打开请求。渲染期归位（adjust-state-during-render）在绘制前完成，不闪现。
+  if (!compactAvailable && confirmOpen) {
+    setConfirmOpen(false);
+  }
   if (typeof contextWindow !== "number" || !Number.isFinite(contextWindow) || contextWindow <= 0) {
     return null;
   }
 
-  const ratio = contextUsageRatio(totalTokens, contextWindow);
   // 只保留两个口径：展示值（取整、封顶 999）与画环/量度值（0-100 钳制，
   // 二者共用避免 a11y 量度与弧线漂移）。contextUsageRatio 不会返回负数。
   const displayedPercentage = Math.min(999, Math.round(ratio * 100));
@@ -78,7 +106,6 @@ export function ContextUsageRing(props: {
       <span className="text-muted-foreground">{windowLine}</span>
     </span>
   );
-  const compactAvailable = canManualCompact(ratio) && !disabled && Boolean(onConfirm);
 
   const handleTooltipOpenChange = (nextOpen: boolean) => {
     // 确认弹层展示期间抑制 tooltip 的打开请求（悬停/点按），保证不重叠。

--- a/crates/agent-ui/src/lib/chat/contextUsage.ts
+++ b/crates/agent-ui/src/lib/chat/contextUsage.ts
@@ -130,8 +130,9 @@ export function buildContextUsageScanItems(
 // 开销。两端（GUI TokenLedger 与 WebUI 倒扫）共用此口径，调参只改这里。
 export const MESSAGE_ENVELOPE_TOKENS = 8;
 
-// 非文本值的估算口径（字符串直估，其余 JSON 序列化后估）。GUI TokenLedger
-// 与 WebUI 倒扫共用，保证两端对同一负载的估算一致。
+// 结构化小负载的估算口径（字符串直估，其余 JSON 序列化后估）。只作为
+// estimateContentBlockTokenUnits 的兜底叶子使用；带 base64 的二进制块绝不能
+// 走到这里（见 BINARY_BLOCK_TOKENS）。
 export function stringifiedTokenUnits(value: unknown): number {
   if (typeof value === "string") return estimateTextTokenUnits(value);
   if (value == null) return 0;
@@ -143,20 +144,52 @@ export function stringifiedTokenUnits(value: unknown): number {
   }
 }
 
+// 模型对图片等二进制附件按图幅/文件计价（Anthropic ≈ 宽×高/750、OpenAI 按
+// tile），单块通常数百到 ~2k token，与 base64 长度无关。估算侧拿不到解码
+// 尺寸，取计价量级上限的常量。按序列化字符数估会差两个数量级——一张 400KB
+// 图的 base64 虚报 ~13 万 token，用量环随锚点在估算/真实 usage 间切换而剧烈
+// 跳变，自动压缩也会被幻影读数提前触发。
+export const BINARY_BLOCK_TOKENS = 1_600;
+
+// 内容块的统一估算：文本/思维链按 CJK 感知直估，携带 base64 负载的二进制块
+//（pi-ai ImageContent 等 {type, data, mimeType} 形态）按常量，其余小型结构
+// 块按序列化。GUI TokenLedger 与 WebUI 倒扫共用，两端口径一致。
+export function estimateContentBlockTokenUnits(block: unknown): number {
+  if (typeof block === "string") return estimateTextTokenUnits(block);
+  if (!block || typeof block !== "object") return 0;
+  const record = block as { text?: unknown; thinking?: unknown; data?: unknown };
+  if (typeof record.text === "string") return estimateTextTokenUnits(record.text);
+  if (typeof record.thinking === "string") return estimateTextTokenUnits(record.thinking);
+  if (typeof record.data === "string") return BINARY_BLOCK_TOKENS;
+  return stringifiedTokenUnits(block);
+}
+
+// 消息 content 的统一估算（string | 块数组 | 其他结构）。
+export function estimateContentTokenUnits(content: unknown): number {
+  if (typeof content === "string") return estimateTextTokenUnits(content);
+  if (Array.isArray(content)) {
+    let units = 0;
+    for (const block of content) units += estimateContentBlockTokenUnits(block);
+    return units;
+  }
+  return content == null ? 0 : stringifiedTokenUnits(content);
+}
+
 function messageTokensFromUnits(units: number): number {
   return Math.ceil(Math.max(0, units)) + MESSAGE_ENVELOPE_TOKENS;
 }
 
 // 两端 store 都按不可变更新替换工具结果对象，估算结果可按对象身份缓存；
-// 流式期间倒扫逐帧执行，没有这层缓存会对大工具结果每帧重复 JSON.stringify。
+// 流式期间倒扫逐帧执行，没有这层缓存会对大工具结果每帧重复估算。
 const toolResultTokenCache = new WeakMap<object, number>();
 
-function estimateToolResultTokens(result: { content?: unknown; details?: unknown }): number {
+function estimateToolResultTokens(result: { content?: unknown }): number {
   const cached = toolResultTokenCache.get(result);
   if (cached !== undefined) return cached;
-  const tokens = messageTokensFromUnits(
-    stringifiedTokenUnits(result.content) + stringifiedTokenUnits(result.details),
-  );
+  // 只计模型可见的 content：details 是 UI/记账负载，provider 转换从不发送
+  //（shell 的全量 stdout/stderr、文件读取元数据都挂在上面），计入会把 shell
+  // 输出双算、把纯元数据当上下文，读数系统性虚高。
+  const tokens = messageTokensFromUnits(estimateContentTokenUnits(result.content));
   toolResultTokenCache.set(result, tokens);
   return tokens;
 }
@@ -173,7 +206,7 @@ function estimateRoundTokens(
         block.item && typeof block.item === "object"
           ? (block.item as {
               toolCall?: { name?: string; arguments?: unknown };
-              toolResult?: { content?: unknown; details?: unknown };
+              toolResult?: { content?: unknown };
             })
           : undefined;
       const toolCall = item?.toolCall;
@@ -186,10 +219,7 @@ function estimateRoundTokens(
       continue;
     }
     if (!onlyToolResults) {
-      assistantUnits +=
-        typeof block.text === "string"
-          ? estimateTextTokenUnits(block.text)
-          : stringifiedTokenUnits(block);
+      assistantUnits += estimateContentBlockTokenUnits(block);
     }
   }
   if (onlyToolResults) return toolResultTokens;

--- a/crates/agent-ui/src/lib/chat/contextUsage.ts
+++ b/crates/agent-ui/src/lib/chat/contextUsage.ts
@@ -80,9 +80,11 @@ export function estimateTextTokens(text: string): number {
 
 // 两端 transcript 项的最小结构投影：GUI RenderTimelineItem（检查点 kind:"summary"）
 // 与 WebUI TranscriptRow（检查点 kind:"checkpoint"）经结构化类型直接传入。
+// attachments 两端同为 PendingUploadedFile 投影（GUI 时间线项 / WebUI user 行）。
 export type ContextUsageScanItem = {
   kind: string;
   text?: string;
+  attachments?: readonly unknown[];
   rounds?: readonly {
     meta?: {
       usageTotalTokens?: number;
@@ -204,8 +206,9 @@ export function positiveTokenCount(value: unknown): number | undefined {
 /**
  * 倒扫 transcript 求当前上下文占用：最近一个 assistant 轮次的真实 API usage
  * 是锚点（usage.totalTokens 已含该 assistant 输出及其之前的 system/tools/历史），
- * 再累加锚点之后的用户消息、后续 assistant 内容与工具结果。压缩检查点优先使用
- * 桌面端同步的权威 contextUsageTokens；旧历史没有该字段时才退回摘要正文估算。
+ * 再累加锚点之后的用户消息（正文 + 附件元数据）、后续 assistant 内容与工具
+ * 结果。压缩检查点优先使用桌面端同步的权威 contextUsageTokens；旧历史没有
+ * 该字段时才退回摘要正文估算。
  */
 export function deriveContextUsageTokens(
   items: readonly ContextUsageScanItem[],
@@ -220,8 +223,15 @@ export function deriveContextUsageTokens(
       return checkpointTokens === undefined ? undefined : checkpointTokens + trailingTokens;
     }
     if (item.kind === "user") {
-      if (typeof item.text === "string" && item.text.trim()) {
-        trailingTokens += estimateTextTokens(item.text) + MESSAGE_ENVELOPE_TOKENS;
+      let units = typeof item.text === "string" ? estimateTextTokenUnits(item.text.trim()) : 0;
+      // 附件按元数据序列化估算（路径/文件名/规模等即运行时注入的指令行量级；
+      // 原生 base64 附件路径下这是下界）。不计会让"检查点后发大批附件"的
+      // 空闲读数两端一致偏低，且纯附件消息此前完全计零。
+      for (const attachment of item.attachments ?? []) {
+        units += stringifiedTokenUnits(attachment);
+      }
+      if (units > 0) {
+        trailingTokens += messageTokensFromUnits(units);
       }
       continue;
     }


### PR DESCRIPTION
Closes #576

> 注意：本分支叠在 #573（`fix/context-usage-ring`）之上，请先合并 #573；合并后本 PR 的 diff 会自动收敛为最后一个提交（估算口径重构）。

## Summary

修复用量环读数在轮次间剧烈跳变（如 86% → 20%，无压缩发生）的根因：估算口径与真实 `usage` 锚点严重失配。估算通道整体重构为内容块感知的统一口径，GUI 账本与 WebUI 倒扫共用同一套函数，旧的整块 `JSON.stringify` 估算路径全部移除。

- **二进制块按计价量级估算**：共享层新增 `estimateContentBlockTokenUnits` / `estimateContentTokenUnits`，带 base64 负载的块（`{type, data, mimeType}` 形态）按新常量 `BINARY_BLOCK_TOKENS = 1600` 计。旧口径按 base64 字符数除 4，一张 400KB 图虚报 ~13 万 token，正是环冲高后跌回真实值的元凶
- **`toolResult.details` 一律不计**：provider 转换层只发送 `content`，`details`（shell 全量 stdout/stderr、文件元数据）从不进模型上下文；旧口径计入它导致 shell 输出双算、纯记账数据被当作上下文
- **`TokenLedger.estimateMessageTokenUnits` 重写**：三段各自为政的分支收敛为直接调用共享层函数，两端对同一负载估算完全一致
- **prune 释放量对齐**：剪枝收益只按模型可见的 `content` 计，不再因计入 `details` 高报释放量提前停手

## 跳变机制（详见 #576）

- 轮内锯齿：图片/大工具结果进入尾部估算 → 环瞬间冲高；真实 `usage` 到达 → 账本 rebase → 跌回
- 跨轮虚高驻留：某轮在真实 `usage` 到达前结束（中断/报错/中继不回报 usage），虚高估算盖进轮次元数据成为空闲期锚点（86%）；下一轮拿到真实 `usage` 后回落（20%）
- 附带影响：自动压缩阈值消费同一读数，幻影虚高会提前触发压缩

## Test plan

- [x] GUI chat 套件 1018 个测试全过（`node --test test/chat/*.test.mjs`）
- [x] WebUI 套件 627 个测试全过（`web/test` + `test/webui`）
- [x] 新增用例：二进制块按常量计价（账本 + 倒扫）、锚点轮次忽略 `details`、details 断言反转
- [x] `biome check` 与两个 crate 的 `tsc --noEmit` 均无错误

Made with [Cursor](https://cursor.com)