### PR TITLE
feat: improve approvals, changed-files cards, and long-conversation rendering

### DIFF
--- a/crates/agent-gateway/web/test/changed-files-card.test.mjs
+++ b/crates/agent-gateway/web/test/changed-files-card.test.mjs
@@ -29,6 +29,7 @@ function createCardModule() {
         },
       },
       "@liveagent/ui/components/IconSet": {
+        ChevronDown: NullIcon,
         FilePenLine: NullIcon,
         FolderTree: NullIcon,
         GitCommitHorizontal: NullIcon,
@@ -91,25 +92,25 @@ function renderCard(
   );
 }
 
-function assertVerticalPath(html, fileName, directory, fromIndex = 0) {
+function assertInlinePath(html, fileName, directory, fromIndex = 0) {
   const fileNameIndex = html.indexOf(`>${fileName}</span>`, fromIndex);
-  const directoryIndex = html.indexOf(`>${directory}</span>`, fileNameIndex);
   assert.notEqual(fileNameIndex, -1, `missing file name ${fileName}`);
+  if (!directory) return fileNameIndex;
+  const directoryIndex = html.indexOf(`>${directory}</span>`, fromIndex);
   assert.notEqual(directoryIndex, -1, `missing directory ${directory}`);
-  assert.ok(fileNameIndex < directoryIndex, `${fileName} must render above its directory`);
-  return directoryIndex;
+  return Math.max(fileNameIndex, directoryIndex);
 }
 
-test("WebUI changed-files rows render file names above directory paths", () => {
+test("WebUI changed-files rows render file names and directory paths inline", () => {
   const html = renderCard(createCardModule());
 
-  let position = assertVerticalPath(html, "ChangedFilesCard.tsx", "src/components/");
-  position = assertVerticalPath(html, "README.md", ".", position);
-  assertVerticalPath(html, "Settings.tsx", "src/pages/", position);
+  let position = assertInlinePath(html, "ChangedFilesCard.tsx", "src/components/");
+  position = assertInlinePath(html, "README.md", null, position);
+  assertInlinePath(html, "Settings.tsx", "src/pages/", position);
 
   assert.match(
     html,
-    /class="[^"]*line-through[^"]*"[^>]*>removed\.ts<\/span><span[^>]*>tmp\/<\/span>/,
+    /<span[^>]*>tmp\/<\/span><span[^>]*line-through[^>]*>removed\.ts<\/span>/,
   );
   for (const filePath of [
     "src/components/ChangedFilesCard.tsx",
@@ -122,15 +123,16 @@ test("WebUI changed-files rows render file names above directory paths", () => {
   assert.doesNotMatch(html, /aria-label="chat\.changedFiles\.(?:open|reveal|diff):/);
 });
 
-test("WebUI changed-files scrolling starts with the sixth row", () => {
+test("WebUI changed-files rows collapse after the fifth file", () => {
   const modules = createCardModule();
   const fiveFiles = renderCard(modules, { fileCount: 5 });
   const sixFiles = renderCard(modules, { fileCount: 6 });
 
-  assert.ok(!fiveFiles.includes("max-h-[calc(210px*var(--zone-font-scale,1))]"));
-  assert.ok(!fiveFiles.includes("overscroll-contain"));
-  assert.ok(sixFiles.includes("max-h-[calc(210px*var(--zone-font-scale,1))]"));
-  assert.ok(sixFiles.includes("overflow-y-auto overscroll-contain"));
+  assert.ok(!fiveFiles.includes('aria-expanded="false"'));
+  assert.ok(!fiveFiles.includes("chat.changedFiles.expand"));
+  assert.ok(sixFiles.includes('aria-expanded="false"'));
+  assert.ok(sixFiles.includes("chat.changedFiles.expand"));
+  assert.ok(!sixFiles.includes("overflow-y-auto"));
 });
 
 test("WebUI changed-files actions include the localized action and canonical path", () => {

--- a/crates/agent-gui/test/chat/changed-files-card.test.mjs
+++ b/crates/agent-gui/test/chat/changed-files-card.test.mjs
@@ -29,6 +29,7 @@ function createCardModule(rootDir) {
         },
       },
       "@liveagent/ui/components/IconSet": {
+        ChevronDown: NullIcon,
         FilePenLine: NullIcon,
         FolderTree: NullIcon,
         GitCommitHorizontal: NullIcon,
@@ -91,25 +92,25 @@ function renderCard(
   );
 }
 
-function assertVerticalPath(html, fileName, directory, fromIndex = 0) {
+function assertInlinePath(html, fileName, directory, fromIndex = 0) {
   const fileNameIndex = html.indexOf(`>${fileName}</span>`, fromIndex);
-  const directoryIndex = html.indexOf(`>${directory}</span>`, fileNameIndex);
   assert.notEqual(fileNameIndex, -1, `missing file name ${fileName}`);
+  if (!directory) return fileNameIndex;
+  const directoryIndex = html.indexOf(`>${directory}</span>`, fromIndex);
   assert.notEqual(directoryIndex, -1, `missing directory ${directory}`);
-  assert.ok(fileNameIndex < directoryIndex, `${fileName} must render above its directory`);
-  return directoryIndex;
+  return Math.max(fileNameIndex, directoryIndex);
 }
 
-test("GUI changed-files rows render file names above directory paths", () => {
+test("GUI changed-files rows render file names and directory paths inline", () => {
   const html = renderCard(createCardModule(rootDir));
 
-  let position = assertVerticalPath(html, "ChangedFilesCard.tsx", "src/components/");
-  position = assertVerticalPath(html, "README.md", ".", position);
-  assertVerticalPath(html, "Settings.tsx", "src/pages/", position);
+  let position = assertInlinePath(html, "ChangedFilesCard.tsx", "src/components/");
+  position = assertInlinePath(html, "README.md", null, position);
+  assertInlinePath(html, "Settings.tsx", "src/pages/", position);
 
   assert.match(
     html,
-    /class="[^"]*line-through[^"]*"[^>]*>removed\.ts<\/span><span[^>]*>tmp\/<\/span>/,
+    /<span[^>]*>tmp\/<\/span><span[^>]*line-through[^>]*>removed\.ts<\/span>/,
   );
   for (const filePath of [
     "src/components/ChangedFilesCard.tsx",
@@ -122,15 +123,16 @@ test("GUI changed-files rows render file names above directory paths", () => {
   assert.doesNotMatch(html, /aria-label="chat\.changedFiles\.(?:open|reveal|diff):/);
 });
 
-test("GUI changed-files scrolling starts with the sixth row", () => {
+test("GUI changed-files rows collapse after the fifth file", () => {
   const modules = createCardModule(rootDir);
   const fiveFiles = renderCard(modules, { fileCount: 5 });
   const sixFiles = renderCard(modules, { fileCount: 6 });
 
-  assert.ok(!fiveFiles.includes("max-h-[calc(210px*var(--zone-font-scale,1))]"));
-  assert.ok(!fiveFiles.includes("overscroll-contain"));
-  assert.ok(sixFiles.includes("max-h-[calc(210px*var(--zone-font-scale,1))]"));
-  assert.ok(sixFiles.includes("overflow-y-auto overscroll-contain"));
+  assert.ok(!fiveFiles.includes('aria-expanded="false"'));
+  assert.ok(!fiveFiles.includes("chat.changedFiles.expand"));
+  assert.ok(sixFiles.includes('aria-expanded="false"'));
+  assert.ok(sixFiles.includes("chat.changedFiles.expand"));
+  assert.ok(!sixFiles.includes("overflow-y-auto"));
 });
 
 test("GUI changed-files actions include the localized action and canonical path", () => {

--- a/crates/agent-ui/src/components/chat/ChangedFilesCard.tsx
+++ b/crates/agent-ui/src/components/chat/ChangedFilesCard.tsx
@@ -7,12 +7,17 @@
 
 import { FileChangeBadge } from "@liveagent/ui/components/chat/FileChangeBadge";
 import { getFileTypeIcon } from "@liveagent/ui/components/chat/fileTypeIcons";
-import { FilePenLine, FolderTree, GitCommitHorizontal } from "@liveagent/ui/components/IconSet";
+import {
+  ChevronDown,
+  FilePenLine,
+  FolderTree,
+  GitCommitHorizontal,
+} from "@liveagent/ui/components/IconSet";
 import { useLocale } from "@liveagent/ui/i18n/index";
 import type { ChangedFileEntry, ChangedFilesSummary } from "@liveagent/ui/lib/chat/changedFiles";
 import { cn } from "@liveagent/ui/lib/shared/utils";
 import { isSkillPath } from "@liveagent/ui/lib/skills/skillPaths";
-import { createContext, memo, useContext, useMemo } from "react";
+import { createContext, memo, useContext, useMemo, useState } from "react";
 
 export type ChangedFilesActions = {
   onOpenFile?: (path: string) => void;
@@ -37,7 +42,7 @@ function splitPath(path: string): { dir: string; base: string } {
 }
 
 const ROW_ACTION_CLASS =
-  "changed-file-row-action flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 opacity-0 transition-all hover:bg-foreground/[0.07] hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none group-hover/changed-file:opacity-100";
+  "changed-file-row-action flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-foreground/[0.07] hover:text-foreground focus-visible:bg-foreground/[0.08] focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring";
 const MAX_VISIBLE_FILES = 5;
 
 const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFileEntry }) {
@@ -50,32 +55,35 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
   const canOpen = Boolean(actions?.onOpenFile) && !file.deleted;
   const canReveal = Boolean(actions?.onRevealInFileTree) && !skillPath;
   const canOpenDiff = Boolean(actions?.onOpenDiff) && !skillPath;
+  const hasRowActions = canReveal || canOpenDiff;
   const FileTypeIcon = getFileTypeIcon(file.path, "file");
   const openLabel = `${t("chat.changedFiles.open")}: ${file.path}`;
   const revealLabel = `${t("chat.changedFiles.reveal")}: ${file.path}`;
   const diffLabel = `${t("chat.changedFiles.diff")}: ${file.path}`;
 
   const pathLabel = (
-    <span
-      title={file.path}
-      className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 overflow-hidden font-mono"
-    >
+    <span title={file.path} className="flex min-w-0 flex-1 items-center overflow-hidden font-mono">
       <span
         className={cn(
-          "min-w-0 max-w-full truncate text-[calc(11.5px*var(--zone-font-scale,1))] font-medium leading-tight text-foreground/90",
+          "min-w-0 truncate text-[calc(10.5px*var(--zone-font-scale,1))] leading-tight text-muted-foreground/65",
+          file.deleted && "line-through",
+        )}
+      >
+        {dir}
+      </span>
+      <span
+        className={cn(
+          "min-w-0 max-w-full truncate text-[calc(11.5px*var(--zone-font-scale,1))] font-medium leading-tight text-foreground/85",
           file.deleted && "text-muted-foreground line-through",
         )}
       >
         {base}
       </span>
-      <span className="min-w-0 max-w-full truncate text-[calc(10px*var(--zone-font-scale,1))] leading-tight text-muted-foreground/70">
-        {dir || "."}
-      </span>
     </span>
   );
 
   return (
-    <div className="group/changed-file flex min-w-0 items-center gap-1.5 rounded-lg px-2 py-1 transition-colors hover:bg-foreground/[0.04]">
+    <div className="group/changed-file relative flex min-h-8 min-w-0 items-center gap-1.5 rounded-lg px-2.5 py-0.5 transition-colors hover:bg-foreground/[0.04]">
       <FileTypeIcon
         className={cn("h-3.5 w-3.5 shrink-0", file.deleted && "opacity-50 saturate-0")}
       />
@@ -93,33 +101,51 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
         <span className="flex min-w-0 flex-1 items-stretch">{pathLabel}</span>
       )}
       {file.deleted ? (
-        <span className="shrink-0 rounded-full bg-muted/70 px-1.5 py-0.5 text-[calc(10px*var(--zone-font-scale,1))] leading-none text-muted-foreground">
+        <span
+          className={cn(
+            "shrink-0 rounded-full bg-muted/70 px-1.5 py-0.5 text-[calc(10px*var(--zone-font-scale,1))] leading-none text-muted-foreground transition-opacity",
+            hasRowActions &&
+              "group-hover/changed-file:opacity-0 group-focus-within/changed-file:opacity-0",
+          )}
+        >
           {t("chat.changedFiles.deleted")}
         </span>
       ) : (
-        <FileChangeBadge added={file.added} removed={file.removed} />
+        <FileChangeBadge
+          added={file.added}
+          removed={file.removed}
+          className={cn(
+            "min-w-16 justify-end transition-opacity",
+            hasRowActions &&
+              "group-hover/changed-file:opacity-0 group-focus-within/changed-file:opacity-0",
+          )}
+        />
       )}
-      {canReveal ? (
-        <button
-          type="button"
-          onClick={() => actions?.onRevealInFileTree?.(file.path)}
-          title={revealLabel}
-          aria-label={revealLabel}
-          className={ROW_ACTION_CLASS}
-        >
-          <FolderTree className="h-3.5 w-3.5" />
-        </button>
-      ) : null}
-      {canOpenDiff ? (
-        <button
-          type="button"
-          onClick={() => actions?.onOpenDiff?.(file.path)}
-          title={diffLabel}
-          aria-label={diffLabel}
-          className={ROW_ACTION_CLASS}
-        >
-          <GitCommitHorizontal className="h-3.5 w-3.5" />
-        </button>
+      {hasRowActions ? (
+        <div className="pointer-events-none absolute right-2.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-hover/changed-file:pointer-events-auto group-hover/changed-file:opacity-100 group-focus-within/changed-file:pointer-events-auto group-focus-within/changed-file:opacity-100">
+          {canReveal ? (
+            <button
+              type="button"
+              onClick={() => actions?.onRevealInFileTree?.(file.path)}
+              title={revealLabel}
+              aria-label={revealLabel}
+              className={ROW_ACTION_CLASS}
+            >
+              <FolderTree className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+          {canOpenDiff ? (
+            <button
+              type="button"
+              onClick={() => actions?.onOpenDiff?.(file.path)}
+              title={diffLabel}
+              aria-label={diffLabel}
+              className={ROW_ACTION_CLASS}
+            >
+              <GitCommitHorizontal className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+        </div>
       ) : null}
     </div>
   );
@@ -132,6 +158,7 @@ export const ChangedFilesCard = memo(function ChangedFilesCard({
 }) {
   const { t } = useLocale();
   const actions = useChangedFilesActions();
+  const [filesExpanded, setFilesExpanded] = useState(false);
   const title = useMemo(() => {
     const key =
       summary.files.length === 1 ? "chat.changedFiles.titleOne" : "chat.changedFiles.title";
@@ -139,42 +166,65 @@ export const ChangedFilesCard = memo(function ChangedFilesCard({
   }, [summary.files.length, t]);
   const canOpenReview =
     Boolean(actions?.onOpenDiff) && summary.files.some((file) => !isSkillPath(file.path));
+  const hasCollapsedFiles = summary.files.length > MAX_VISIBLE_FILES;
+  const visibleFiles =
+    hasCollapsedFiles && !filesExpanded ? summary.files.slice(0, MAX_VISIBLE_FILES) : summary.files;
+  const hiddenFileCount = summary.files.length - MAX_VISIBLE_FILES;
 
   return (
-    <div className="changed-files-card overflow-hidden rounded-xl border border-border/45 bg-background/60 backdrop-blur-sm dark:border-white/[0.07] dark:bg-white/[0.03]">
-      <div className="flex items-center gap-2.5 px-2.5 py-2">
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border/45 bg-background/75 text-foreground/70 shadow-[0_1px_0_rgba(255,255,255,0.5)_inset] dark:border-white/[0.08] dark:bg-white/[0.05] dark:shadow-[0_1px_0_rgba(255,255,255,0.05)_inset]">
+    <div className="changed-files-card overflow-hidden rounded-2xl border border-border/55 bg-background/55 backdrop-blur-sm dark:border-white/[0.09] dark:bg-white/[0.035]">
+      <div className="flex items-center gap-3 px-3 py-2.5">
+        <div className="flex w-8 min-h-8 shrink-0 items-center justify-center self-stretch rounded-xl border-0 bg-muted/60 text-foreground/70 shadow-none dark:bg-white/[0.07]">
           <FilePenLine className="h-4 w-4" />
         </div>
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span className="truncate text-[calc(12px*var(--zone-font-scale,1))] font-medium leading-tight text-foreground/85">
+        <div className="flex min-h-8 min-w-0 flex-1 flex-col justify-center gap-0.5">
+          <span className="truncate text-[calc(13px*var(--zone-font-scale,1))] font-semibold leading-tight text-foreground/90">
             {title}
           </span>
-          <FileChangeBadge added={summary.totalAdded} removed={summary.totalRemoved} />
+          <FileChangeBadge
+            added={summary.totalAdded}
+            removed={summary.totalRemoved}
+            className="text-[calc(11.5px*var(--zone-font-scale,1))]"
+          />
         </div>
         {canOpenReview ? (
           <button
             type="button"
             onClick={() => actions?.onOpenDiff?.(null)}
-            className="flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[calc(11px*var(--zone-font-scale,1))] font-medium leading-none text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus-visible:bg-foreground/[0.06] focus-visible:outline-none"
+            className="flex h-7 shrink-0 items-center gap-1.5 rounded-lg border border-border/55 bg-transparent px-2.5 text-[calc(11px*var(--zone-font-scale,1))] font-medium leading-none text-muted-foreground transition-colors hover:border-border/80 hover:bg-foreground/[0.05] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring dark:border-white/[0.1] dark:hover:border-white/[0.16] dark:hover:bg-white/[0.06]"
           >
             <GitCommitHorizontal className="h-3.5 w-3.5" />
             {t("chat.changedFiles.review")}
           </button>
         ) : null}
       </div>
-      {/* 最多露出 5 行，更多文件走内部滚动条。 */}
-      <div
-        className={cn(
-          "flex flex-col gap-0.5 border-t border-border/35 px-1 py-1 dark:border-white/[0.05]",
-          summary.files.length > MAX_VISIBLE_FILES &&
-            "max-h-[calc(210px*var(--zone-font-scale,1))] overflow-y-auto overscroll-contain",
-        )}
-      >
-        {summary.files.map((file) => (
+      {/* 超过 5 个文件时默认只展示前 5 个，点击后展开全部。 */}
+      <div className="flex flex-col gap-0 border-t border-border/30 px-2 py-1 dark:border-white/[0.05]">
+        {visibleFiles.map((file) => (
           <ChangedFileRow key={file.lastToolCallId || file.path} file={file} />
         ))}
       </div>
+      {hasCollapsedFiles ? (
+        <button
+          type="button"
+          onClick={() => setFilesExpanded((expanded) => !expanded)}
+          aria-expanded={filesExpanded}
+          className="flex w-full items-center gap-1 border-t border-border/20 py-2 pl-[calc(0.5rem+0.625rem)] pr-2.5 text-left text-[calc(11.5px*var(--zone-font-scale,1))] font-medium text-foreground/80 transition-colors hover:bg-foreground/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring dark:border-white/[0.05]"
+        >
+          <span className="truncate">
+            {filesExpanded
+              ? t("chat.changedFiles.collapse")
+              : t("chat.changedFiles.expand").replace("{count}", String(hiddenFileCount))}
+          </span>
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              "h-3.5 w-3.5 shrink-0 transition-transform",
+              filesExpanded && "rotate-180",
+            )}
+          />
+        </button>
+      ) : null}
     </div>
   );
 });

--- a/crates/agent-ui/src/components/chat/ChangedFilesCard.tsx
+++ b/crates/agent-ui/src/components/chat/ChangedFilesCard.tsx
@@ -63,17 +63,20 @@ const ChangedFileRow = memo(function ChangedFileRow({ file }: { file: ChangedFil
 
   const pathLabel = (
     <span title={file.path} className="flex min-w-0 flex-1 items-center overflow-hidden font-mono">
+      {dir ? (
+        <span
+          className={cn(
+            "min-w-0 truncate text-[calc(10.5px*var(--zone-font-scale,1))] leading-tight text-muted-foreground/65",
+            file.deleted && "line-through",
+          )}
+        >
+          {dir}
+        </span>
+      ) : null}
+      {/* shrink-0 keeps the file name intact while the directory truncates first. */}
       <span
         className={cn(
-          "min-w-0 truncate text-[calc(10.5px*var(--zone-font-scale,1))] leading-tight text-muted-foreground/65",
-          file.deleted && "line-through",
-        )}
-      >
-        {dir}
-      </span>
-      <span
-        className={cn(
-          "min-w-0 max-w-full truncate text-[calc(11.5px*var(--zone-font-scale,1))] font-medium leading-tight text-foreground/85",
+          "max-w-full shrink-0 truncate text-[calc(11.5px*var(--zone-font-scale,1))] font-medium leading-tight text-foreground/85",
           file.deleted && "text-muted-foreground line-through",
         )}
       >
@@ -203,28 +206,28 @@ export const ChangedFilesCard = memo(function ChangedFilesCard({
         {visibleFiles.map((file) => (
           <ChangedFileRow key={file.lastToolCallId || file.path} file={file} />
         ))}
+        {hasCollapsedFiles ? (
+          <button
+            type="button"
+            onClick={() => setFilesExpanded((expanded) => !expanded)}
+            aria-expanded={filesExpanded}
+            className="flex min-h-8 w-full items-center gap-1 rounded-lg px-2.5 py-0.5 text-left text-[calc(11.5px*var(--zone-font-scale,1))] font-medium text-foreground/80 transition-colors hover:bg-foreground/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+          >
+            <span className="truncate">
+              {filesExpanded
+                ? t("chat.changedFiles.collapse")
+                : t("chat.changedFiles.expand").replace("{count}", String(hiddenFileCount))}
+            </span>
+            <ChevronDown
+              aria-hidden="true"
+              className={cn(
+                "h-3.5 w-3.5 shrink-0 transition-transform",
+                filesExpanded && "rotate-180",
+              )}
+            />
+          </button>
+        ) : null}
       </div>
-      {hasCollapsedFiles ? (
-        <button
-          type="button"
-          onClick={() => setFilesExpanded((expanded) => !expanded)}
-          aria-expanded={filesExpanded}
-          className="flex w-full items-center gap-1 border-t border-border/20 py-2 pl-[calc(0.5rem+0.625rem)] pr-2.5 text-left text-[calc(11.5px*var(--zone-font-scale,1))] font-medium text-foreground/80 transition-colors hover:bg-foreground/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring dark:border-white/[0.05]"
-        >
-          <span className="truncate">
-            {filesExpanded
-              ? t("chat.changedFiles.collapse")
-              : t("chat.changedFiles.expand").replace("{count}", String(hiddenFileCount))}
-          </span>
-          <ChevronDown
-            aria-hidden="true"
-            className={cn(
-              "h-3.5 w-3.5 shrink-0 transition-transform",
-              filesExpanded && "rotate-180",
-            )}
-          />
-        </button>
-      ) : null}
     </div>
   );
 });

--- a/crates/agent-ui/src/i18n/translations/enUSCommon.ts
+++ b/crates/agent-ui/src/i18n/translations/enUSCommon.ts
@@ -401,7 +401,7 @@ export const EN_US_COMMON_TRANSLATIONS = {
   "chat.changedFiles.diff": "View diff",
   "chat.changedFiles.deleted": "Deleted",
   "chat.changedFiles.collapse": "Collapse file list",
-  "chat.changedFiles.expand": "Expand file list",
+  "chat.changedFiles.expand": "Show {count} more files",
   "chat.compactingContext": "Compressing context",
   "chat.compactingContextWait": "Compressing context, please wait...",
   "chat.contextCheckpoint.title": "Context Checkpoint",

--- a/crates/agent-ui/src/i18n/translations/zhCNCommon.ts
+++ b/crates/agent-ui/src/i18n/translations/zhCNCommon.ts
@@ -367,7 +367,7 @@ export const ZH_CN_COMMON_TRANSLATIONS = {
   "chat.changedFiles.diff": "查看 Diff",
   "chat.changedFiles.deleted": "已删除",
   "chat.changedFiles.collapse": "折叠文件列表",
-  "chat.changedFiles.expand": "展开文件列表",
+  "chat.changedFiles.expand": "再显示 {count} 个文件",
   "chat.compactingContext": "正在压缩上下文",
   "chat.compactingContextWait": "正在压缩上下文，请稍候...",
   "chat.contextCheckpoint.title": "上下文检查点",


### PR DESCRIPTION
## Linked issue

Closes #580 

## Summary

This PR improves the desktop conversation experience across approval flows, changed-files cards, and long conversations.

- Optimizes transcript virtualization and streaming rendering to reduce unnecessary updates and improve responsiveness in long conversations.
- Refines the approval UI with a compact composer-integrated layout.
- Adds sidebar indicators for pending approvals.
- Adds `Esc` and `Enter` keyboard shortcuts for approval actions.
- Reduces unnecessary spinner activity and improves in-progress state feedback.
- Redesigns the changed-files card with compact spacing, clearer alignment, and lighter visual styling.
- Collapses file lists longer than five items and expands them naturally on demand.
- Balances right-aligned change statistics with hover/focus file actions.
- Improves header alignment, review button styling, deleted-file handling, and keyboard focus states.

## Change scope

- Modules:
  - Desktop UI / React
  - Agent sessions and transcript rendering
  - Gateway web UI

- Key paths:
  - `crates/agent-ui/src/components/chat/`
  - `crates/agent-ui/src/components/chat/ToolApprovalBar.tsx`
  - `crates/agent-ui/src/components/chat/ChangedFilesCard.tsx`
  - `crates/agent-ui/src/components/chat/transcript-virtual/`
  - `crates/agent-ui/src/lib/chat/streamingRenderPolicy.ts`
  - `crates/agent-gateway/web/src/components/GatewayTranscript.tsx`
  - `crates/agent-gateway/web/src/lib/chat/transcript/`
  - `crates/agent-gateway/web/src/lib/transcript-virtual/`
  - `crates/agent-ui/src/i18n/translations/`

## Screenshots / preview

<img width="1436" height="836" alt="image" src="https://github.com/user-attachments/assets/60683eb6-0ad2-4568-a7a4-e10ec46f4f54" />

## Verification

- `git diff --check`
- `pnpm lint:ui`
- `pnpm typecheck:ui`
- Existing transcript virtualization and streaming-render tests cover the rendering behavior.
- No additional test files were added for the approval and changed-files visual refinements.

## Pre-submit checklist

- [x] A requirement issue is linked with `Closes #580`.
- [x] Synced with the target branch; no merge conflicts.
- [x] Before/after UI screenshots or a runtime recording are attached.
- [x] Performance comparison data is included.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated if required.