### PR TITLE
feat(gui): enforce a single desktop instance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3429,6 +3429,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-mcp-bridge",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tempfile",
@@ -6705,6 +6706,22 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows 0.61.3",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/crates/agent-gui/src-tauri/Cargo.toml
+++ b/crates/agent-gui/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ prost-build = "0.14.4"
 
 [dependencies]
 tauri = { version = "2.11.5", features = ["tray-icon", "image-png"] }
+tauri-plugin-single-instance = "2.4.3"
 tauri-plugin-opener = "2.5.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"

--- a/crates/agent-gui/src-tauri/src/commands/app/update.rs
+++ b/crates/agent-gui/src-tauri/src/commands/app/update.rs
@@ -587,6 +587,11 @@ pub fn app_restart(app: AppHandle) -> Result<(), String> {
     if let Err(error) = app.save_window_state(crate::WINDOW_STATE_FLAGS) {
         eprintln!("failed to save window state before restart: {error}");
     }
+    // restart() spawns the replacement before this process exits; if the new
+    // process reaches single-instance init while we still hold the lock, it
+    // forwards to a dying process and exits, so release the lock first.
+    #[cfg(not(debug_assertions))]
+    tauri_plugin_single_instance::destroy(&app);
     app.restart();
 }
 

--- a/crates/agent-gui/src-tauri/src/lib.rs
+++ b/crates/agent-gui/src-tauri/src/lib.rs
@@ -734,12 +734,17 @@ pub fn run() {
     ));
     let stt_manager = Arc::new(services::stt::SttManager::default());
 
-    let app = tauri::Builder::default()
-        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-            if let Err(error) = show_main_window(app) {
-                eprintln!("failed to focus existing LiveAgent instance: {error}");
-            }
-        }))
+    let builder = tauri::Builder::default();
+    // dev 构建与已安装正式版共享 identifier；若 dev 也注册单实例，
+    // `tauri dev` 会把启动转发给正在运行的正式版然后自我退出。
+    #[cfg(not(debug_assertions))]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+        if let Err(error) = show_main_window(app) {
+            eprintln!("failed to focus existing LiveAgent instance: {error}");
+        }
+    }));
+
+    let app = builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_mcp_bridge::init())

--- a/crates/agent-gui/src-tauri/src/lib.rs
+++ b/crates/agent-gui/src-tauri/src/lib.rs
@@ -735,6 +735,11 @@ pub fn run() {
     let stt_manager = Arc::new(services::stt::SttManager::default());
 
     let app = tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            if let Err(error) = show_main_window(app) {
+                eprintln!("failed to focus existing LiveAgent instance: {error}");
+            }
+        }))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_mcp_bridge::init())


### PR DESCRIPTION
<!--
Read .github/CONTRIBUTING.md before submitting.
A PR failing any of the following is automatically converted to draft:
  1. The body references an issue via Closes/Fixes/Resolves #123;
  2. UI / feature / backend behavior changes include screenshots or a runtime preview;
  3. No merge conflicts with the target branch.
-->

## Linked issue

Closes #584

## Summary

Add `tauri-plugin-single-instance` to prevent LiveAgent from launching multiple desktop instances.

The plugin is registered first in the Tauri builder. When a second instance is launched, it forwards the launch event to the existing instance, exits the newly launched process, and brings the existing main window to the foreground. Hidden or minimized windows are shown, restored, and focused.

The plugin supports the desktop platforms handled by Tauri, including Windows, macOS, and Linux.

## Change scope

- Modules: `agent-gui / src-tauri`
- Key paths:
  - `crates/agent-gui/src-tauri/Cargo.toml`
  - `crates/agent-gui/src-tauri/src/lib.rs`
  - `Cargo.lock`

## Screenshots / preview

<img width="1393" height="821" alt="image" src="https://github.com/user-attachments/assets/cb5bfef6-39b3-4c20-9471-510737ec9c59" />

Runtime preview required for this desktop startup behavior.

Expected preview flow:

1. Launch the LiveAgent desktop application.
2. Launch LiveAgent again from the application shortcut or Start menu.
3. Confirm that the second process exits.
4. Confirm that the existing LiveAgent window is shown, restored if minimized, and focused.

A screenshot or recording showing the second launch being redirected to the existing instance should be attached here.

## Verification

- `cargo check -p liveagent --locked` passed.
- `cargo fmt --all -- --check` passed.
- `git diff --check` passed.
- `cargo test -p liveagent --lib` compiled and ran:
  - 904 tests passed.
  - 21 tests failed.
  - 2 tests were ignored.
- The failing tests are unrelated Windows environment-sensitive tests involving temporary worktrees, Linux path simulation, and shell/session timing. No failure was related to `tauri-plugin-single-instance`.
- No new unit tests were added because the behavior is provided by the platform-specific Tauri plugin and requires a multi-process runtime verification.

## Pre-submit checklist

- [x] A requirement issue is linked: #584.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] No documentation changes are required because the behavior is automatic and introduces no new configuration or deployment steps.