### PR TITLE
fix(chat): plan mode 改为有界升级,修复无限读文件循环

### DIFF
--- a/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
+++ b/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
@@ -35,6 +35,7 @@ import {
   resolveProviderCacheRetention,
   type StreamOptionsEx,
   streamSimpleByApi,
+  type ToolChoice,
   toSimpleStreamReasoning,
 } from "../../providers/llm";
 import {
@@ -488,6 +489,17 @@ export async function runAssistantWithTools(params: {
    * 提交用它跳过无意义的"收尾话"轮——批准事实由卡片展示,执行由续轮承接。
    */
   resolveToolTermination?: (toolCall: ToolCall) => boolean;
+  /**
+   * 每轮出站请求的 tool_choice 裁决钩子(编排层策略,runner 不感知具体模式)。
+   * 返回 undefined 走缺省(有工具则 "auto")。定向强制({type:"tool"})只应
+   * 由调用方在有界场景使用——无界强制会剥夺模型的文本收尾能力,导致失控循环。
+   */
+  resolveToolChoice?: (round: number) => ToolChoice | undefined;
+  /**
+   * 模型轮数上限(含):达到后当前工具批执行完即优雅终止本轮 run(不抛错,
+   * 结果保留在历史),由编排层决定后续(如 plan mode 的补提交/兜底)。缺省无上限。
+   */
+  maxRounds?: number;
 }) {
   const modelId = params.model.trim();
   if (!modelId) throw new Error("No model selected");
@@ -1305,7 +1317,10 @@ export async function runAssistantWithTools(params: {
               target.runtime.promptCacheRetention,
             ),
           metadata: buildProviderRequestMetadata(target.providerId, params.sessionId),
-          toolChoice: options?.toolChoice ?? (effectiveContext.tools?.length ? "auto" : undefined),
+          toolChoice:
+            params.resolveToolChoice?.(round) ??
+            options?.toolChoice ??
+            (effectiveContext.tools?.length ? "auto" : undefined),
           reasoning: normalizeStreamReasoning(options?.reasoning) ?? fallbackReasoning,
           workdir: params.workdir,
           streamRetry: {
@@ -1503,7 +1518,10 @@ export async function runAssistantWithTools(params: {
         // still executes and keeps its result in history, then the run ends —
         // otherwise one Read next to ExitPlanMode would silently void the
         // "submitting ends this turn" guarantee and run a wrap-up round.
+        // maxRounds is the run-level circuit breaker: once the cap is reached
+        // the current batch finishes normally, then the run ends gracefully.
         terminate:
+          (params.maxRounds !== undefined && currentRound >= params.maxRounds) ||
           (params.resolveToolTermination
             ? getAssistantToolCalls(assistantMessage).some((call) =>
                 params.resolveToolTermination?.(call),

--- a/crates/agent-gui/src/lib/chat/runner/toolExecutionPrompt.ts
+++ b/crates/agent-gui/src/lib/chat/runner/toolExecutionPrompt.ts
@@ -1,3 +1,4 @@
+import { EXIT_PLAN_MODE_TOOL_NAME } from "@liveagent/ui/lib/chat/planMode";
 import { buildMemoryToolsSuffixSection } from "../../memory/prompts/injection";
 import {
   inferRuntimePlatform,
@@ -21,6 +22,11 @@ export function buildToolsSuffix(
   const hasAny = (...names: string[]) => names.some(has);
   const hasDynamicMcp =
     allowAll || (availableToolNames ?? []).some((name) => name.startsWith("mcp_"));
+  // ExitPlanMode is injected only in plan mode. `allowAll` (tests / full dump)
+  // must not flip those rules on — that path describes every tool, not a live
+  // plan-mode registry.
+  const planModeActive = !allowAll && has(EXIT_PLAN_MODE_TOOL_NAME);
+  const present = (...names: string[]) => names.filter(has);
 
   const fileTools = ["Read", "Image", "Write", "Edit", "Delete", "List", "Grep", "Glob"].filter(
     has,
@@ -28,8 +34,13 @@ export function buildToolsSuffix(
   const hasFileTool = fileTools.length > 0;
   const hasReadFamily = hasAny("Read", "List", "Grep", "Glob");
   const canWrite = hasAny("Write", "Edit", "Delete");
+  const processWaitTools = present("ProcessWait", "ProcessStop");
+  const taskTools = present("TaskCreate", "TaskUpdate", "TaskList");
 
   const toolGroups: string[] = [];
+  if (planModeActive) {
+    toolGroups.push(`plan submission (${EXIT_PLAN_MODE_TOOL_NAME})`);
+  }
   if (fileTools.length > 0) toolGroups.push(`file tools (${fileTools.join(" / ")})`);
   if (has("SkillsManager")) toolGroups.push("skill tools (SkillsManager)");
   if (has("MemoryManager")) toolGroups.push("persistent memory (MemoryManager)");
@@ -37,26 +48,41 @@ export function buildToolsSuffix(
   if (has("CronTaskManager")) toolGroups.push("scheduled task management (CronTaskManager)");
   if (has("Agent")) toolGroups.push("subagent delegation (Agent)");
   if (has("SendMessage")) toolGroups.push("subagent message bus (SendMessage)");
+  if (has("AskUserQuestion")) toolGroups.push("user questions (AskUserQuestion)");
   if (has("Bash")) toolGroups.push("the command tool (Bash)");
-  if (has("ProcessWait")) {
-    toolGroups.push("resumable command waiting (ProcessWait / ProcessStop)");
+  if (processWaitTools.length > 0) {
+    toolGroups.push(`resumable command waiting (${processWaitTools.join(" / ")})`);
   }
   if (has("ManagedProcess")) toolGroups.push("managed local processes (ManagedProcess)");
-  if (hasAny("TaskCreate", "TaskUpdate", "TaskList")) {
-    toolGroups.push("durable task planning (TaskCreate / TaskUpdate / TaskList)");
+  if (taskTools.length > 0) {
+    toolGroups.push(`durable task planning (${taskTools.join(" / ")})`);
   }
   if (hasDynamicMcp) toolGroups.push("MCP business tools whose names are prefixed with mcp_");
 
   const sections: string[] = [];
 
+  // Plan mode 的行为规则由 system prompt 的 <plan-mode> 段唯一承载;这里只声明
+  // 工具面差异并指回该段,避免规则复述漂移。
+  sections.push(
+    planModeActive
+      ? [
+          "# Tool-Execution Mode",
+          "",
+          `Plan mode is ACTIVE. You have the read-only tools listed under **Available Tools**, plus ${EXIT_PLAN_MODE_TOOL_NAME}. Follow the <plan-mode> rules above: research, then submit the complete deliverable via ${EXIT_PLAN_MODE_TOOL_NAME} instead of plain assistant text.`,
+        ].join("\n")
+      : [
+          "# Tool-Execution Mode",
+          "",
+          "In this mode you have access to the tools listed under **Available Tools** at the end of this section. Invoke them when the task requires reading, searching, modifying, or coordinating state (files, commands, agents, MCP services). For pure Q&A, explanation, or analysis that does not depend on current state, answer directly without invoking tools.",
+        ].join("\n"),
+  );
+
   sections.push(
     [
-      "# Tool-Execution Mode",
-      "",
-      "In this mode you have access to the tools listed under **Available Tools** at the end of this section. Invoke them when the task requires reading, searching, modifying, or coordinating state (files, commands, agents, MCP services). For pure Q&A, explanation, or analysis that does not depend on current state, answer directly without invoking tools.",
-      "",
       "## Final Reply",
-      "- Your reply to the user is plain text plus Markdown.",
+      planModeActive
+        ? `- Do not put the complete deliverable in this reply. Call ${EXIT_PLAN_MODE_TOOL_NAME} instead; the plan card is what the user reviews.`
+        : "- Your reply to the user is plain text plus Markdown.",
       "- Never include raw tool-call JSON or raw tool arguments in your reply — describe what you did in plain words instead.",
     ].join("\n"),
   );
@@ -81,7 +107,9 @@ export function buildToolsSuffix(
         ...additionalRootLines,
         "- Files inside an enabled Skill: use `skill://<skill>/...` exactly as returned by SkillsManager or file tools.",
         "- Absolute paths, `~/...`, and `file://` URLs are also accepted and auto-normalized; never construct one when a returned path is available.",
-        "- Write, Edit, and Delete operate only inside the workspace, writable configured root:// project roots, or enabled writable Skills. Bash `cwd` may point outside the workspace under its existing policy, but additional project roots do not expand that policy.",
+        canWrite
+          ? "- Write, Edit, and Delete operate only inside the workspace, writable configured root:// project roots, or enabled writable Skills. Bash `cwd` may point outside the workspace under its existing policy, but additional project roots do not expand that policy."
+          : "- Structured file tools operate only inside the workspace, configured root:// project roots, or enabled Skills.",
         "- Use `/` as the separator everywhere, including Glob and Grep patterns; Windows `\\` is auto-normalized.",
         '- On a path error, follow its guidance: reuse a "Did you mean" candidate verbatim, or locate the file with Glob/Grep first, then retry with the returned path.',
       ].join("\n"),
@@ -214,7 +242,11 @@ export function buildToolsSuffix(
               "- ProcessWait defaults to 30000ms. For a quiet command that is expected to take several minutes, set ProcessWait.yield_time_ms up to 300000 instead of issuing repeated short waits.",
               "- Session responses use completed, failed, cancelled, or timed_out as terminal statuses. The reported session_duration_ms is cumulative from the original Bash start; never add values from multiple responses.",
               "- Omit Bash.timeout_ms when the command should run until completion. Set it only when a real hard runtime limit is desired; ProcessWait does not restart or extend that limit.",
-              "- Use ProcessStop with session_id to terminate the complete process tree when the command is no longer needed.",
+              ...(has("ProcessStop")
+                ? [
+                    "- Use ProcessStop with session_id to terminate the complete process tree when the command is no longer needed.",
+                  ]
+                : []),
               "- ProcessWait session_id values come from Bash/ProcessWait, not from ManagedProcess.process_id.",
             ]
           : []),
@@ -232,7 +264,9 @@ export function buildToolsSuffix(
         "## Agent Delegation",
         "- Use Agent for bounded, independent jobs that benefit from a fresh context: implementation, research, review, discussion, or verification. Do not delegate trivial work you can finish yourself.",
         "- To run multiple independent jobs in parallel, issue ONE Agent call whose `agents` array lists every job. Use sequential Agent calls only when a later job needs an earlier job's output.",
-        "- Default to mode=readonly for research, review, and discussion agents. Use mode=worktree (with apply_policy) only when the subagent is expected to produce file changes or the user explicitly asked for file output.",
+        planModeActive
+          ? "- PLAN MODE: every subagent is readonly this turn — mode=worktree is rejected. Delegate research/review only; file changes happen after the plan is approved."
+          : "- Default to mode=readonly for research, review, and discussion agents. Use mode=worktree (with apply_policy) only when the subagent is expected to produce file changes or the user explicitly asked for file output.",
         "- To continue with an existing delegated agent or a previously formed team, call Agent again with the same stable id(s) and only the new prompt — do not impersonate those agents from this transcript and do not restate their identity fields.",
         "- If an Agent call is rejected, no subagents were started; fix every listed issue and retry with one corrected call.",
       ].join("\n"),
@@ -265,16 +299,28 @@ export function buildToolsSuffix(
     );
   }
 
-  if (hasAny("TaskCreate", "TaskUpdate", "TaskList")) {
-    sections.push(
-      [
-        "## Task Planning",
+  if (taskTools.length > 0) {
+    const taskLines = ["## Task Planning"];
+    if (has("TaskCreate")) {
+      taskLines.push(
         "- Proactively use TaskCreate for multi-step work (3+ distinct steps) or multiple user requests; skip it for one trivial action.",
+      );
+    }
+    if (has("TaskUpdate")) {
+      taskLines.push(
         "- Task IDs are stable and executor-assigned. Use TaskUpdate with taskId; never replace or recreate the list after context compaction.",
         "- Exactly one task may be in_progress. Mark it in_progress before work and completed immediately after it is fully done.",
-        "- Use TaskList whenever the authoritative task state is unclear.",
-      ].join("\n"),
-    );
+      );
+    }
+    if (has("TaskList")) {
+      taskLines.push("- Use TaskList whenever the authoritative task state is unclear.");
+    }
+    if (planModeActive) {
+      taskLines.push(
+        `- Plan mode: do not start execution-side task work this turn. Submit the plan via ${EXIT_PLAN_MODE_TOOL_NAME}; TaskCreate happens after approval.`,
+      );
+    }
+    sections.push(taskLines.join("\n"));
   }
 
   if (has("MemoryManager")) {

--- a/crates/agent-gui/src/lib/chat/runner/toolExecutionPrompt.ts
+++ b/crates/agent-gui/src/lib/chat/runner/toolExecutionPrompt.ts
@@ -69,6 +69,11 @@ export function buildToolsSuffix(
           "# Tool-Execution Mode",
           "",
           `Plan mode is ACTIVE. You have the read-only tools listed under **Available Tools**, plus ${EXIT_PLAN_MODE_TOOL_NAME}. Follow the <plan-mode> rules above: research, then submit the complete deliverable via ${EXIT_PLAN_MODE_TOOL_NAME} instead of plain assistant text.`,
+          ...(has("AskUserQuestion")
+            ? [
+                "Detail decisions that belong to the user (scope, approach trade-offs, target behavior) go through AskUserQuestion during research — ask proactively instead of guessing.",
+              ]
+            : []),
         ].join("\n")
       : [
           "# Tool-Execution Mode",

--- a/crates/agent-gui/src/lib/providers/llm.ts
+++ b/crates/agent-gui/src/lib/providers/llm.ts
@@ -42,4 +42,9 @@ export {
 } from "./runtime/requestOptions";
 export { streamSimpleByApi } from "./runtime/streamByApi";
 export { completeAssistantMessage, streamAssistantMessage } from "./runtime/textOnlyRuntime";
-export type { ModelOption, ProviderRuntimeConfig, StreamOptionsEx } from "./runtime/types";
+export type {
+  ModelOption,
+  ProviderRuntimeConfig,
+  StreamOptionsEx,
+  ToolChoice,
+} from "./runtime/types";

--- a/crates/agent-gui/src/lib/providers/runtime/streamByApi.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/streamByApi.ts
@@ -67,6 +67,16 @@ export function streamSimpleByApi(model: Model<Api>, context: Context, options: 
     case "anthropic-messages": {
       // Anthropic：需要我们自己调用 streamAnthropic()，以便显式传 toolChoice（以及启用/禁用 thinking）。
       const anthropicThinking = resolveAnthropicThinkingRuntime(model, options);
+      // Anthropic 拒绝 extended thinking 与强制工具（"any"/{type:"tool"}）同请求
+      // （400）。降级为 auto：有界强制的调用方（plan mode 补提交轮）同时注入了
+      // 消息级提醒，语义仍然成立；直接 400 反而会进重试/failover 循环。
+      const requestedToolChoice = options.toolChoice ?? "none";
+      const anthropicToolChoice =
+        anthropicThinking.thinkingEnabled &&
+        requestedToolChoice !== "none" &&
+        requestedToolChoice !== "auto"
+          ? "auto"
+          : requestedToolChoice;
       return withStreamRetry(
         () => {
           return streamAnthropic(model as Model<"anthropic-messages">, context, {
@@ -85,7 +95,7 @@ export function streamSimpleByApi(model: Model<Api>, context: Context, options: 
             ...(anthropicThinking.thinkingBudgetTokens !== undefined
               ? { thinkingBudgetTokens: anthropicThinking.thinkingBudgetTokens }
               : {}),
-            toolChoice: options.toolChoice ?? "none",
+            toolChoice: anthropicToolChoice,
           });
         },
         { signal: options.signal, ...options.streamRetry },

--- a/crates/agent-gui/src/lib/tools/planModeTools.ts
+++ b/crates/agent-gui/src/lib/tools/planModeTools.ts
@@ -11,7 +11,7 @@
 // 远端(WebUI)按钮经 gateway chat_queue.plan_decision 转发到桌面后走同一入口
 // answerPlanDecision(approve → 宿主批准 handler;reject → 反馈作为消息发送)。
 
-import type { Tool, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
+import type { Message, Tool, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
 import {
   EXIT_PLAN_MODE_TOOL_NAME,
   type ExitPlanModeResultDetails,
@@ -19,6 +19,7 @@ import {
   sanitizePlanMarkdown,
 } from "@liveagent/ui/lib/chat/planMode";
 import { Type } from "typebox";
+import type { ToolChoice } from "../providers/runtime/types";
 import { AGENT_TOOL_NAME, SEND_MESSAGE_TOOL_NAME } from "../subagents/types";
 import {
   type BuiltinToolBundle,
@@ -252,34 +253,39 @@ export function isPlanModeAllowedTool(
   );
 }
 
-/** Plan mode 的 system prompt 段;run 内恒定文本,冻结注入以保护前缀缓存。 */
+/** Plan mode 的 system prompt 段;run 内恒定文本,冻结注入以保护前缀缓存。
+ *  plan mode 规则的唯一权威表述——toolsSuffix 与工具 description 只作指引,
+ *  不再复述,避免三处漂移与 token 浪费。措辞刻意不用"MUST before this turn
+ *  ends"式高压:那会抬高提交门槛、诱导模型为求"完整"而无限调研。 */
 export function buildPlanModeSystemPromptSection(): string {
   return [
     "<plan-mode>",
     "Plan mode is ACTIVE. This is a read-only planning phase:",
-    "- Research the task with the available read-only tools (and readonly subagents), then design an implementation plan.",
+    "- Research with the available read-only tools (and readonly subagents). Stop researching once you can produce the deliverable — do not re-read files you have already read; a re-read returns an unchanged stub, never new information.",
     "- Mutation is impossible this turn: write-capable tools are not in your tool list. Do not promise edits you cannot make here.",
-    `- When the plan is ready, call ${EXIT_PLAN_MODE_TOOL_NAME} with the complete plan (markdown). Submitting ends this turn immediately — the user replies with approval or feedback as a normal message.`,
-    "- If the user replies with feedback instead of approval, revise the plan accordingly and submit again.",
-    "- If the user asks to save the plan to a file, make writing that file the first step of the plan itself — the execution turn (full tools) will do it.",
-    "- On approval, execution starts automatically in the next turn with full tools — begin that turn by turning the plan into a task list (TaskCreate), then implement.",
-    "- Keep the plan concrete: files to touch, ordered steps, risks, and how to verify.",
+    `- Submit every complete answer through ${EXIT_PLAN_MODE_TOOL_NAME} — implementation plans, architecture summaries, research findings, Q&A, and recommendations alike — instead of plain assistant text. If no code changes are needed, the plan states that and carries the findings.`,
+    "- Submitting ends this turn immediately; the user replies with approval or feedback as a normal message. On feedback, revise the plan and submit again.",
+    "- If the user asks to save the plan to a file, make that write the first step of the plan itself — the execution turn (full tools) will do it.",
+    "- On approval, execution starts automatically in the next turn with full tools — begin that turn by turning the plan into a task list (TaskCreate), then implement. If the plan needs no file changes, confirm that briefly and stop.",
+    "- Keep implementation plans concrete: files to touch, ordered steps, risks, and how to verify.",
     "</plan-mode>",
   ].join("\n");
 }
 
-const EXIT_PLAN_MODE_TOOL_DESCRIPTION = `Present your implementation plan to the user. Only available in plan mode; call it once your research is complete and the plan is ready for review.
+// 只述工具自身的调用契约;plan mode 的行为规则统一由 <plan-mode> system 段承载。
+const EXIT_PLAN_MODE_TOOL_DESCRIPTION = `Present the complete user-facing deliverable for this turn (every finished answer, not only implementation plans). Only available in plan mode; call it once your research is complete.
 
-Submitting the plan ends this turn immediately. The user then replies as a normal message: approval starts execution automatically in the next turn (full tools); anything else is feedback — revise the plan and submit again.
+Submitting ends this turn immediately. The user replies as a normal message: approval starts execution automatically in the next turn (full tools); anything else is feedback — revise the plan and submit again.
 
 Rules:
-- \`plan\` must be the complete, self-contained plan in markdown — goals, files to change, ordered steps, risks, and verification. Do not reference earlier messages ("as discussed above").
+- \`plan\` must be the complete, self-contained markdown deliverable. Do not reference earlier messages ("as discussed above").
+- Implementation work: goals, files to change, ordered steps, risks, verification. Analysis/Q&A: the full findings, plus whether any follow-up code changes are needed.
 - If the user asked to save the plan to a file, include that write as the first step of the plan.`;
 
 const exitPlanModeParameters = Type.Object({
   plan: Type.String({
     description:
-      "The complete implementation plan in markdown: goals, files to change, ordered steps, risks, verification.",
+      "The complete user-facing deliverable in markdown. Implementation work: goals, files to change, ordered steps, risks, verification. Analysis/Q&A: the full findings, plus whether any follow-up code changes are needed.",
   }),
 });
 
@@ -310,7 +316,7 @@ export function createExitPlanModeTools(params: { conversationId: string }): Bui
     if (!plan) {
       return buildErrorResult(
         toolCall,
-        "plan is required: pass the complete implementation plan in markdown.",
+        "plan is required: pass the complete markdown deliverable.",
       );
     }
 
@@ -359,5 +365,162 @@ export function createExitPlanModeTools(params: { conversationId: string }): Bui
         },
       ],
     ]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plan mode 运行策略:有界升级状态机。
+//
+// 原则:绝不无界强制。常态 toolChoice=auto,模型可自由文本收尾;终止性由四道
+// **有界**防线保证:
+//   1. 终止谓词 —— ExitPlanMode 提交即结束本轮 run(runner resolveToolTermination);
+//   2. 轮数上限 —— 研究阶段 maxRounds 熔断,防失控循环(runner maxRounds);
+//   3. 补提交轮 —— run 以文本收尾且未提交时,追加一次 wire-only 提醒消息并定向
+//      强制 ExitPlanMode,只重试一次(nudging 态);
+//   4. 文本兜底 —— 补提交仍未产出时,把最后的助手文本注册为待决计划(合成
+//      ExitPlanMode 调用对),计划卡/审批/持久化零改动复用。
+// 任何模型行为都在有限步内收敛到计划卡。
+// ---------------------------------------------------------------------------
+
+/** 研究阶段的模型轮数熔断值(含);达到后当前批执行完即优雅终止,进入补提交。 */
+export const PLAN_MODE_MAX_RESEARCH_ROUNDS = 32;
+/** 补提交轮的轮数上限:定向强制下 1 轮即提交,留余量兜供应商降级为 auto 的情况。 */
+export const PLAN_MODE_MAX_NUDGE_ROUNDS = 4;
+/** 同一 (工具名, 参数) 的重复调用放行次数;超过即拦截,引导提交计划。 */
+export const PLAN_MODE_REPEAT_CALL_LIMIT = 2;
+
+/** 补提交轮注入的 wire-only 提醒(只进出站请求,不持久化、不进 UI)。 */
+export const PLAN_MODE_NUDGE_REMINDER = [
+  "[plan-mode reminder] Your previous turn ended without submitting the deliverable.",
+  `Call ${EXIT_PLAN_MODE_TOOL_NAME} now with the complete user-facing deliverable in markdown,`,
+  "based on the research you already completed. Do not run more research tools first.",
+].join(" ");
+
+export type PlanModeRunDecision =
+  | { kind: "submitted" }
+  | { kind: "nudge"; reminderText: string }
+  | { kind: "fallback" };
+
+export type PlanModeFallbackPlan = {
+  toolCall: ToolCall;
+  toolResult: ToolResultMessage;
+};
+
+export type PlanModeRunPolicy = {
+  /** ExitPlanMode 提交即终止本轮 run(交给 runner resolveToolTermination)。 */
+  resolveToolTermination: (toolCall: ToolCall) => boolean;
+  /** 当前 run 的 tool_choice:常态 undefined(缺省 auto);补提交轮定向强制。 */
+  resolveToolChoice: () => ToolChoice | undefined;
+  /** 当前 run 的轮数熔断值(交给 runner maxRounds)。 */
+  maxRounds: () => number;
+  /** 防空转守卫:同参重复的研究调用超过放行次数即拦截(接入 resolveToolGate)。 */
+  guardRepeatedToolCall: (toolCall: ToolCall) => { allow: true } | { allow: false; reason: string };
+  /** run 结束后的升级裁决:已提交 → done;首次未提交 → nudge;再次 → fallback。 */
+  decideAfterRun: (input: { emittedMessages: readonly Message[] }) => PlanModeRunDecision;
+  /** 文本兜底:把助手文本注册为待决计划并返回合成的 ExitPlanMode 调用对;
+   *  文本经 sanitize 后为空时返回 null(此时本轮无计划,turn 正常结束)。 */
+  registerFallbackPlan: (input: { planText: string }) => PlanModeFallbackPlan | null;
+};
+
+/** 递归键排序的稳定序列化:重复调用判定不受对象键序影响。模型参数来自 JSON,无环。 */
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function hasSuccessfulPlanSubmission(messages: readonly Message[]): boolean {
+  return messages.some(
+    (message) =>
+      message.role === "toolResult" &&
+      message.toolName === EXIT_PLAN_MODE_TOOL_NAME &&
+      !message.isError,
+  );
+}
+
+export function createPlanModeRunPolicy(params: { conversationId: string }): PlanModeRunPolicy {
+  let phase: "researching" | "nudging" = "researching";
+  const repeatCounts = new Map<string, number>();
+
+  return {
+    resolveToolTermination: (toolCall) => toolCall.name === EXIT_PLAN_MODE_TOOL_NAME,
+
+    resolveToolChoice: () =>
+      // 定向强制只出现在有界的补提交轮;供应商不支持时(如 Anthropic thinking、
+      // Google)由 provider 层降级为 auto,提醒消息仍然生效。
+      phase === "nudging" ? { type: "tool" as const, name: EXIT_PLAN_MODE_TOOL_NAME } : undefined,
+
+    maxRounds: () =>
+      phase === "nudging" ? PLAN_MODE_MAX_NUDGE_ROUNDS : PLAN_MODE_MAX_RESEARCH_ROUNDS,
+
+    guardRepeatedToolCall: (toolCall) => {
+      if (toolCall.name === EXIT_PLAN_MODE_TOOL_NAME) return { allow: true };
+      const key = `${toolCall.name}\u0000${stableStringify(toolCall.arguments ?? {})}`;
+      const count = (repeatCounts.get(key) ?? 0) + 1;
+      repeatCounts.set(key, count);
+      if (count <= PLAN_MODE_REPEAT_CALL_LIMIT) return { allow: true };
+      return {
+        allow: false,
+        reason:
+          `You already made this exact ${toolCall.name} call in this planning turn and its result has not changed. ` +
+          `Use the content you already gathered, or submit the deliverable via ${EXIT_PLAN_MODE_TOOL_NAME}.`,
+      };
+    },
+
+    decideAfterRun: ({ emittedMessages }) => {
+      if (hasSuccessfulPlanSubmission(emittedMessages)) {
+        return { kind: "submitted" };
+      }
+      if (phase === "researching") {
+        phase = "nudging";
+        return { kind: "nudge", reminderText: PLAN_MODE_NUDGE_REMINDER };
+      }
+      return { kind: "fallback" };
+    },
+
+    registerFallbackPlan: ({ planText }) => {
+      const plan = sanitizePlanMarkdown(planText);
+      if (!plan) return null;
+      const toolCallId = `call_plan_fallback_${crypto.randomUUID().replaceAll("-", "")}`;
+      const toolCall: ToolCall = {
+        type: "toolCall",
+        id: toolCallId,
+        name: EXIT_PLAN_MODE_TOOL_NAME,
+        arguments: { plan },
+      };
+      // 与真实 ExitPlanMode 执行完全同构:登记待决计划(覆盖旧登记)并通知订阅方,
+      // 计划卡按钮态、WebUI 预览、审批入口全部零改动复用。
+      pendingPlanByConversation.set(params.conversationId, {
+        conversationId: params.conversationId,
+        toolCallId,
+        plan,
+      });
+      emitChange();
+      const details: ExitPlanModeResultDetails = { kind: "exit_plan_mode", plan };
+      return {
+        toolCall,
+        toolResult: {
+          role: "toolResult",
+          toolCallId,
+          toolName: EXIT_PLAN_MODE_TOOL_NAME,
+          content: [
+            {
+              type: "text",
+              text: "Plan captured from the assistant's final text; the user will reply with approval or feedback.",
+            },
+          ],
+          details,
+          isError: false,
+          timestamp: Date.now(),
+        },
+      };
+    },
   };
 }

--- a/crates/agent-gui/src/lib/tools/planModeTools.ts
+++ b/crates/agent-gui/src/lib/tools/planModeTools.ts
@@ -12,6 +12,7 @@
 // answerPlanDecision(approve → 宿主批准 handler;reject → 反馈作为消息发送)。
 
 import type { Message, Tool, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
+import { ASK_USER_QUESTION_TOOL_NAME } from "@liveagent/ui/lib/chat/askUserQuestion";
 import {
   EXIT_PLAN_MODE_TOOL_NAME,
   type ExitPlanModeResultDetails,
@@ -262,6 +263,9 @@ export function buildPlanModeSystemPromptSection(): string {
     "<plan-mode>",
     "Plan mode is ACTIVE. This is a read-only planning phase:",
     "- Research with the available read-only tools (and readonly subagents). Stop researching once you can produce the deliverable — do not re-read files you have already read; a re-read returns an unchanged stub, never new information.",
+    // AskUserQuestion 在 plan mode 恒可用(isReadOnly 白名单),且是 run 内挂起
+    // 语义——作答后本轮继续,不影响提交终止与有界升级。
+    `- When a planning detail is genuinely the user's call — scope boundaries, mutually exclusive approaches, trade-offs, target behavior — proactively ask with ${ASK_USER_QUESTION_TOOL_NAME} during research instead of guessing or leaving open questions in the plan. Execution pauses for the answers and continues this turn. Resolve what the code itself can answer; batch the remaining decisions into one focused call.`,
     "- Mutation is impossible this turn: write-capable tools are not in your tool list. Do not promise edits you cannot make here.",
     `- Submit every complete answer through ${EXIT_PLAN_MODE_TOOL_NAME} — implementation plans, architecture summaries, research findings, Q&A, and recommendations alike — instead of plain assistant text. If no code changes are needed, the plan states that and carries the findings.`,
     "- Submitting ends this turn immediately; the user replies with approval or feedback as a normal message. On feedback, revise the plan and submit again.",

--- a/crates/agent-gui/src/pages/chat/runtime/chatPageRuntime.ts
+++ b/crates/agent-gui/src/pages/chat/runtime/chatPageRuntime.ts
@@ -105,7 +105,7 @@ export function createConversationRuntimeEntry(params: {
   };
 }
 
-function createEmptyAssistantUsage(): AssistantMessage["usage"] {
+export function createEmptyAssistantUsage(): AssistantMessage["usage"] {
   return {
     input: 0,
     output: 0,

--- a/crates/agent-gui/src/pages/chat/turns/runAgentConversationTurn.ts
+++ b/crates/agent-gui/src/pages/chat/turns/runAgentConversationTurn.ts
@@ -7,7 +7,6 @@ import type {
 } from "@earendil-works/pi-ai";
 import { ASK_USER_QUESTION_TOOL_NAME } from "@liveagent/ui/lib/chat/askUserQuestion";
 import type { HostedSearchBlock } from "@liveagent/ui/lib/chat/hostedSearch";
-import { EXIT_PLAN_MODE_TOOL_NAME } from "@liveagent/ui/lib/chat/planMode";
 import {
   composeTrajectorySystemPrompt,
   serializeToolCatalog,
@@ -85,6 +84,7 @@ import type { BuiltinToolExecutionContext } from "../../../lib/tools/builtinType
 import { createFileToolState } from "../../../lib/tools/fileToolState";
 import {
   buildPlanModeSystemPromptSection,
+  createPlanModeRunPolicy,
   isPlanModeAllowedTool,
 } from "../../../lib/tools/planModeTools";
 import { resolveShellSandboxSettings } from "../../../lib/tools/sandboxPolicy";
@@ -103,7 +103,11 @@ import {
   NOOP_TRAJECTORY_RECORDER,
   type TrajectoryRecorder,
 } from "../../../lib/trajectory/recorder";
-import { appendSystemPrompt, buildPartialAssistantMessage } from "../runtime/chatPageRuntime";
+import {
+  appendSystemPrompt,
+  buildPartialAssistantMessage,
+  createEmptyAssistantUsage,
+} from "../runtime/chatPageRuntime";
 import {
   buildGatewayToolCallPreviewArguments,
   summarizeToolCallForApproval,
@@ -569,6 +573,9 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
   // Plan mode 段:turn 级快照、run 内恒定文本,与 frozenTaskListContext 同列
   // 冻结注入——system 段任何变动都会作废整条前缀缓存,绝不能随状态中途改写。
   const planModeSection = planModeEnabled ? buildPlanModeSystemPromptSection() : "";
+  // Plan mode 运行策略(turn 级实例):有界升级状态机——终止谓词、轮数熔断、
+  // 重复调用守卫、run 后的补提交/兜底裁决全部收敛于此,runner 保持模式无关。
+  const planRunPolicy = planModeEnabled ? createPlanModeRunPolicy({ conversationId }) : null;
   const withAgentRuntimeContext = (context: Context): Context => {
     let systemPrompt = context.systemPrompt;
     if (planModeSection) {
@@ -733,6 +740,15 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
         allow: false,
         reason: `Plan mode is active: ${toolCall.name} is unavailable during planning. Research with read-only tools and submit the plan via ExitPlanMode.`,
       };
+    }
+    // 防空转守卫:plan mode 下同参重复的研究调用超过放行次数即拦截,拦截理由
+    // 作为 toolResult 引导模型停止刷读、提交计划(Read 的 unchanged 桩只省
+    // token,不打断循环;这里才是打断点)。
+    if (planRunPolicy) {
+      const repeatGate = planRunPolicy.guardRepeatedToolCall(toolCall);
+      if (!repeatGate.allow) {
+        return repeatGate;
+      }
     }
     const policy = resolveToolPolicy(toolCall.name, metadata, getToolPolicies?.());
     if (policy === "deny") {
@@ -973,6 +989,19 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
     }
   }
 
+  // Plan mode 文本兜底产出的合成消息对(assistant toolCall + toolResult),
+  // 随最终状态一次性落盘;卡片在 turn 落定后由持久化消息渲染。
+  let planFallbackMessages: Message[] = [];
+  const lastVisibleAssistantText = (messages: readonly Message[]): string => {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (message?.role !== "assistant") continue;
+      const text = assistantMessageToText(message).trim();
+      if (text) return text;
+    }
+    return "";
+  };
+
   let midStreamProtectionDisabled = false;
   while (!result) {
     let streamedAgentText = "";
@@ -1011,10 +1040,11 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
         resolveToolGate,
         requestToolFilter,
         // 计划提交即终止本轮(对话式范式,对齐 Codex):计划由卡片展示,用户以
-        // 消息或按钮回应;不存在挂起等待,也没有收尾模型轮。
-        resolveToolTermination: planModeEnabled
-          ? (toolCall) => toolCall.name === EXIT_PLAN_MODE_TOOL_NAME
-          : undefined,
+        // 消息或按钮回应;不存在挂起等待,也没有收尾模型轮。tool_choice 常态
+        // auto(策略只在补提交轮定向强制一次),maxRounds 为失控循环的熔断线。
+        resolveToolTermination: planRunPolicy?.resolveToolTermination,
+        resolveToolChoice: planRunPolicy ? () => planRunPolicy.resolveToolChoice() : undefined,
+        maxRounds: planRunPolicy?.maxRounds(),
         onRequestStart: ({ round, context, toolsSuffix }) => {
           const activeSources = new Set(
             currentTrajectoryRuntimeContext.entries.map((entry) => entry.source),
@@ -1355,6 +1385,66 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
           messageCount: result.messages.length,
         },
       );
+
+      // Plan mode 有界升级:run 正常结束但未经 ExitPlanMode 提交时,先补提交一
+      // 轮(nudge),仍未提交则把最后的助手文本兜底注册为待决计划。两步各至多
+      // 一次,turn 必然有限步收敛。
+      if (planRunPolicy) {
+        const decision = planRunPolicy.decideAfterRun({
+          emittedMessages: result.emittedMessages,
+        });
+        if (decision.kind === "nudge") {
+          // 对齐 mid-stream 压缩的循环重入范式:先把本 run 的消息提交进会话
+          // 状态并重置 live 轮(避免重入后 round key 冲突、消息双渲染),再带
+          // 一条 wire-only 提醒续跑。提醒只进出站请求——不追加进会话状态,
+          // 不持久化、不进 UI 与记忆抽取。
+          const interimState = appendMessagesToConversation(
+            getNextConversationState(),
+            result.emittedMessages,
+          );
+          latestAgentEmittedMessages = [];
+          applyConversationState(interimState);
+          clearPersistableAgentProgress();
+          resetLiveTranscript(transcriptStore);
+          const preparedContext = buildPreparedContext(interimState, combinedTools, {
+            includeUploadedFilesMetadata: true,
+          });
+          pendingAgentContext = {
+            ...preparedContext,
+            messages: [
+              ...preparedContext.messages,
+              {
+                role: "user",
+                content: [{ type: "text", text: decision.reminderText }],
+                timestamp: Date.now(),
+              },
+            ],
+          };
+          result = null;
+        } else if (decision.kind === "fallback") {
+          const fallback = planRunPolicy.registerFallbackPlan({
+            planText: lastVisibleAssistantText(result.messages),
+          });
+          if (fallback) {
+            // 合成 ExitPlanMode 调用对追加进最终历史:协议一致(assistant
+            // toolCall + toolResult),计划卡与审批链路零改动复用;usage 置零,
+            // 不污染用量统计。
+            planFallbackMessages = [
+              {
+                role: "assistant",
+                content: [fallback.toolCall],
+                api: runtimeModel.api,
+                provider: runtimeModel.provider,
+                model: runtimeModel.id,
+                usage: createEmptyAssistantUsage(),
+                stopReason: "toolUse",
+                timestamp: fallback.toolResult.timestamp,
+              } satisfies AssistantMessage,
+              fallback.toolResult,
+            ];
+          }
+        }
+      }
     } catch (error) {
       if (!midStreamCompactionRequested) {
         throw error;
@@ -1421,10 +1511,10 @@ export async function runAgentConversationTurn(params: RunAgentConversationTurnP
     throw new Error("Cancelled");
   }
 
-  const finalState = appendMessagesToConversation(
-    getNextConversationState(),
-    result.emittedMessages,
-  );
+  const finalState = appendMessagesToConversation(getNextConversationState(), [
+    ...result.emittedMessages,
+    ...planFallbackMessages,
+  ]);
   let completedState = finalState;
   const gatewayAssistantText = assistantMessageToText(result.assistant);
   if (!gatewayBridgeEvents.hasForwardedText() && gatewayAssistantText.length > 0) {

--- a/crates/agent-gui/test/chat/agent-runner.test.mjs
+++ b/crates/agent-gui/test/chat/agent-runner.test.mjs
@@ -12,6 +12,7 @@ const powerActivityModulePath = path.join(rootDir, "src/lib/system/powerActivity
 const streamQueue = [];
 const streamSideEffects = [];
 const observedStreamContexts = [];
+const observedStreamOptions = [];
 const HOSTED_SEARCH_PROBE_HEADER = "x-liveagent-hosted-search-probe";
 
 function createUsage() {
@@ -355,6 +356,7 @@ const llmMock = {
   },
   streamSimpleByApi(_model, context, options) {
     observedStreamContexts.push(context);
+    observedStreamOptions.push(options);
     const queued = streamQueue.shift();
     if (!queued) {
       throw new Error("No fake stream response queued");
@@ -398,6 +400,7 @@ function resetFakeStreams(...assistants) {
   streamQueue.push(...assistants);
   streamSideEffects.length = 0;
   observedStreamContexts.length = 0;
+  observedStreamOptions.length = 0;
 }
 
 function queueStreamSideEffect(sideEffect) {
@@ -2679,4 +2682,96 @@ test("resolveToolTermination spreads across a mixed parallel batch (still ends t
   assert.equal(observedStreamContexts.length, 1);
   assert.equal(textDeltas.join(""), "");
   assert.equal(result.assistant.stopReason, "toolUse");
+});
+
+test("ExitPlanMode in the tool list keeps toolChoice auto — plan rules live in the prompt, never in unbounded forcing", async () => {
+  resetFakeStreams(createTextAssistant("done"));
+  const tools = [
+    {
+      name: "Read",
+      description: "Read a file",
+      parameters: { type: "object", properties: {} },
+    },
+    {
+      name: "ExitPlanMode",
+      description: "Submit a plan",
+      parameters: { type: "object", properties: { plan: { type: "string" } } },
+    },
+  ];
+  const { params } = createBaseParams({
+    tools,
+    context: {
+      systemPrompt: "Base system prompt",
+      messages: [{ role: "user", content: "Start", timestamp: 1 }],
+      tools,
+    },
+  });
+
+  await runAssistantWithTools(params);
+
+  assert.equal(observedStreamOptions.length, 1);
+  assert.equal(observedStreamOptions[0].toolChoice, "auto");
+  assert.match(observedStreamContexts[0].systemPrompt, /Plan mode is ACTIVE/);
+  assert.doesNotMatch(
+    observedStreamContexts[0].systemPrompt,
+    /answer directly without invoking tools/,
+  );
+});
+
+test("resolveToolChoice drives per-round tool_choice on the outbound request", async () => {
+  const readCall = createToolCall("call-choice-1", "Read");
+  resetFakeStreams(createToolUseAssistant(readCall), createTextAssistant("done"));
+  const observedRounds = [];
+  const { params } = createBaseParams({
+    resolveToolChoice: (round) => {
+      observedRounds.push(round);
+      return round === 1 ? undefined : { type: "tool", name: "Read" };
+    },
+  });
+
+  await runAssistantWithTools(params);
+
+  assert.deepEqual(observedRounds, [1, 2]);
+  // undefined falls through to the default (auto with tools present).
+  assert.equal(observedStreamOptions[0].toolChoice, "auto");
+  assert.deepEqual(observedStreamOptions[1].toolChoice, { type: "tool", name: "Read" });
+});
+
+test("without resolveToolChoice the runner keeps toolChoice auto", async () => {
+  resetFakeStreams(createTextAssistant("done"));
+  const { params } = createBaseParams();
+
+  await runAssistantWithTools(params);
+
+  assert.equal(observedStreamOptions.length, 1);
+  assert.equal(observedStreamOptions[0].toolChoice, "auto");
+  assert.match(
+    observedStreamContexts[0].systemPrompt,
+    /answer directly without invoking tools/,
+  );
+});
+
+test("maxRounds ends the run gracefully after the capped round's tool batch", async () => {
+  const call1 = createToolCall("call-cap-1", "Read", { path: "a" });
+  const call2 = createToolCall("call-cap-2", "Read", { path: "b" });
+  const call3 = createToolCall("call-cap-3", "Read", { path: "c" });
+  resetFakeStreams(
+    createToolUseAssistant(call1),
+    createToolUseAssistant(call2),
+    createToolUseAssistant(call3),
+    createTextAssistant("never reached"),
+  );
+  const { params, executedToolCalls } = createBaseParams({ maxRounds: 2 });
+
+  const result = await runAssistantWithTools(params);
+
+  // Round 2 hits the cap: its tool batch still executes and lands in history,
+  // then the run ends without a further model round and without throwing.
+  assert.equal(observedStreamContexts.length, 2);
+  assert.deepEqual(
+    executedToolCalls.map((call) => call.id),
+    ["call-cap-1", "call-cap-2"],
+  );
+  assert.equal(result.assistant.stopReason, "toolUse");
+  assert.equal(result.messages.filter((message) => message.role === "toolResult").length, 2);
 });

--- a/crates/agent-gui/test/chat/markdown-image-policy.test.mjs
+++ b/crates/agent-gui/test/chat/markdown-image-policy.test.mjs
@@ -606,6 +606,8 @@ test("plan-mode tool rules require ExitPlanMode and do not allow a direct final 
   // 规则唯一权威在 <plan-mode> system 段;toolsSuffix 只声明工具面差异并指回。
   assert.match(suffix, /Follow the <plan-mode> rules above/);
   assert.match(suffix, /submit the complete deliverable via ExitPlanMode instead of plain assistant text/);
+  // 细节决策指引:AskUserQuestion 可用时提示积极提问。
+  assert.match(suffix, /go through AskUserQuestion during research — ask proactively instead of guessing/);
   assert.match(suffix, /Call ExitPlanMode instead; the plan card is what the user reviews/);
   assert.match(suffix, /plan submission \(ExitPlanMode\)/);
   assert.doesNotMatch(suffix, /answer directly without invoking tools/);
@@ -616,6 +618,14 @@ test("plan-mode tool rules require ExitPlanMode and do not allow a direct final 
   assert.match(suffix, /durable task planning \(TaskList\)/);
   assert.match(suffix, /resumable command waiting \(ProcessWait\)/);
   assert.match(suffix, /Submit the plan via ExitPlanMode; TaskCreate happens after approval/);
+
+  // AskUserQuestion 不在工具表时,plan 段不产生提问指引。
+  const suffixWithoutAsk = agentRunnerModule.buildToolsSuffix("/workspace", [
+    "Read",
+    "ExitPlanMode",
+  ]);
+  assert.match(suffixWithoutAsk, /Plan mode is ACTIVE/);
+  assert.doesNotMatch(suffixWithoutAsk, /AskUserQuestion/);
 });
 
 test("non-plan tool rules still allow answering analysis without tools", () => {

--- a/crates/agent-gui/test/chat/markdown-image-policy.test.mjs
+++ b/crates/agent-gui/test/chat/markdown-image-policy.test.mjs
@@ -588,6 +588,53 @@ test("agent Bash rules are Git Bash-first when runtime platform is Windows", () 
   assert.match(suffix, /require `nohup` and log redirection/);
 });
 
+test("plan-mode tool rules require ExitPlanMode and do not allow a direct final answer", () => {
+  const suffix = agentRunnerModule.buildToolsSuffix("/workspace", [
+    "Read",
+    "List",
+    "Grep",
+    "Glob",
+    "Image",
+    "ProcessWait",
+    "TaskList",
+    "Agent",
+    "SendMessage",
+    "AskUserQuestion",
+    "ExitPlanMode",
+  ]);
+  assert.match(suffix, /Plan mode is ACTIVE/);
+  // 规则唯一权威在 <plan-mode> system 段;toolsSuffix 只声明工具面差异并指回。
+  assert.match(suffix, /Follow the <plan-mode> rules above/);
+  assert.match(suffix, /submit the complete deliverable via ExitPlanMode instead of plain assistant text/);
+  assert.match(suffix, /Call ExitPlanMode instead; the plan card is what the user reviews/);
+  assert.match(suffix, /plan submission \(ExitPlanMode\)/);
+  assert.doesNotMatch(suffix, /answer directly without invoking tools/);
+  assert.doesNotMatch(suffix, /ProcessStop/);
+  assert.doesNotMatch(suffix, /Proactively use TaskCreate/);
+  assert.doesNotMatch(suffix, /mode=worktree \(with apply_policy\) only when/);
+  assert.match(suffix, /mode=worktree is rejected/);
+  assert.match(suffix, /durable task planning \(TaskList\)/);
+  assert.match(suffix, /resumable command waiting \(ProcessWait\)/);
+  assert.match(suffix, /Submit the plan via ExitPlanMode; TaskCreate happens after approval/);
+});
+
+test("non-plan tool rules still allow answering analysis without tools", () => {
+  const suffix = agentRunnerModule.buildToolsSuffix("/workspace", [
+    "Read",
+    "Write",
+    "Bash",
+    "TaskCreate",
+    "TaskUpdate",
+    "TaskList",
+    "ProcessWait",
+    "ProcessStop",
+  ]);
+  assert.match(suffix, /answer directly without invoking tools/);
+  assert.doesNotMatch(suffix, /Plan mode is ACTIVE/);
+  assert.match(suffix, /durable task planning \(TaskCreate \/ TaskUpdate \/ TaskList\)/);
+  assert.match(suffix, /resumable command waiting \(ProcessWait \/ ProcessStop\)/);
+});
+
 test("fs tool descriptions keep Image as the only display path for images", () => {
   const sourcePath = fileURLToPath(new URL("../../src/lib/tools/fsTools.ts", import.meta.url));
   const source = fs.readFileSync(sourcePath, "utf8");

--- a/crates/agent-gui/test/tools/plan-mode-tools.test.mjs
+++ b/crates/agent-gui/test/tools/plan-mode-tools.test.mjs
@@ -249,6 +249,11 @@ test("plan-mode prompt routes every complete answer through ExitPlanMode without
   // 反空转:引导"够用即停",并点明重复读取只会得到 unchanged 桩。
   assert.match(section, /Stop researching once you can produce the deliverable/);
   assert.match(section, /unchanged stub/);
+  // 细节决策积极提问:属于用户的决定用 AskUserQuestion 问清,而非猜测或把
+  // 开放问题遗留在计划里;作答后本轮继续。
+  assert.match(section, /proactively ask with AskUserQuestion during research/);
+  assert.match(section, /instead of guessing or leaving open questions in the plan/);
+  assert.match(section, /Execution pauses for the answers and continues this turn/);
   // 高压措辞已移除:它抬高提交门槛,诱导无限调研。
   assert.doesNotMatch(section, /You MUST call/);
   const bundle = tools.createExitPlanModeTools({ conversationId: "conv-prompt" });

--- a/crates/agent-gui/test/tools/plan-mode-tools.test.mjs
+++ b/crates/agent-gui/test/tools/plan-mode-tools.test.mjs
@@ -238,3 +238,153 @@ test("isPlanModeAllowedTool admits read-only, plan, and collaboration tools only
   assert.equal(tools.isPlanModeAllowedTool("Write", { isReadOnly: false }), false);
   assert.equal(tools.isPlanModeAllowedTool("mcp_srv_tool", undefined), false);
 });
+
+test("plan-mode prompt routes every complete answer through ExitPlanMode without unbounded pressure", () => {
+  const { tools } = loadModules();
+  const section = tools.buildPlanModeSystemPromptSection();
+  // 覆盖面:所有完整答案(不只实现计划)都经 ExitPlanMode 提交。
+  assert.match(section, /Submit every complete answer through ExitPlanMode/);
+  assert.match(section, /architecture summaries, research findings, Q&A/);
+  assert.match(section, /instead of plain assistant text/);
+  // 反空转:引导"够用即停",并点明重复读取只会得到 unchanged 桩。
+  assert.match(section, /Stop researching once you can produce the deliverable/);
+  assert.match(section, /unchanged stub/);
+  // 高压措辞已移除:它抬高提交门槛,诱导无限调研。
+  assert.doesNotMatch(section, /You MUST call/);
+  const bundle = tools.createExitPlanModeTools({ conversationId: "conv-prompt" });
+  const tool = bundle.tools.find((candidate) => candidate.name === "ExitPlanMode");
+  assert.match(tool.description, /every finished answer, not only implementation plans/);
+  assert.match(tool.description, /Submitting ends this turn immediately/);
+});
+
+// ---------------------------------------------------------------------------
+// 运行策略:有界升级状态机
+// ---------------------------------------------------------------------------
+
+function textAssistantMessage(text) {
+  return { role: "assistant", content: [{ type: "text", text }], timestamp: 1 };
+}
+
+function planToolResultMessage(toolCallId, isError = false) {
+  return {
+    role: "toolResult",
+    toolCallId,
+    toolName: "ExitPlanMode",
+    content: [{ type: "text", text: "ok" }],
+    isError,
+    timestamp: 1,
+  };
+}
+
+test("run policy: auto during research, one forced nudge, then text fallback registers the plan", () => {
+  const { tools } = loadModules();
+  const policy = tools.createPlanModeRunPolicy({ conversationId: "conv-policy" });
+
+  // 研究阶段:不强制 tool_choice,熔断线为研究上限。
+  assert.equal(policy.resolveToolChoice(), undefined);
+  assert.equal(policy.maxRounds(), tools.PLAN_MODE_MAX_RESEARCH_ROUNDS);
+  assert.equal(
+    policy.resolveToolTermination({ type: "toolCall", id: "c1", name: "ExitPlanMode" }),
+    true,
+  );
+  assert.equal(policy.resolveToolTermination({ type: "toolCall", id: "c2", name: "Read" }), false);
+
+  // 第一次 run 以文本收尾且未提交 → 补提交一轮(定向强制 + 提醒文案)。
+  const first = policy.decideAfterRun({ emittedMessages: [textAssistantMessage("plan text")] });
+  assert.equal(first.kind, "nudge");
+  assert.equal(first.reminderText, tools.PLAN_MODE_NUDGE_REMINDER);
+  assert.deepEqual(policy.resolveToolChoice(), { type: "tool", name: "ExitPlanMode" });
+  assert.equal(policy.maxRounds(), tools.PLAN_MODE_MAX_NUDGE_ROUNDS);
+
+  // 补提交仍未产出 → 文本兜底。
+  const second = policy.decideAfterRun({ emittedMessages: [textAssistantMessage("plan text")] });
+  assert.equal(second.kind, "fallback");
+
+  const fallback = policy.registerFallbackPlan({ planText: "## 兜底计划\n\n1. A\n" });
+  assert.ok(fallback);
+  assert.equal(fallback.toolCall.name, "ExitPlanMode");
+  assert.equal(fallback.toolResult.toolCallId, fallback.toolCall.id);
+  assert.equal(fallback.toolResult.isError, false);
+  assert.deepEqual(fallback.toolResult.details, {
+    kind: "exit_plan_mode",
+    plan: "## 兜底计划\n\n1. A",
+  });
+  // 与真实提交同构:登记待决计划,审批入口零改动复用。
+  assert.deepEqual(tools.getPendingPlanForConversation("conv-policy"), {
+    toolCallId: fallback.toolCall.id,
+    plan: "## 兜底计划\n\n1. A",
+  });
+  assert.equal(tools.isPlanDecisionPending(fallback.toolCall.id), true);
+  tools.cancelPendingPlanDecisionsForConversation("conv-policy");
+});
+
+test("run policy: a successful ExitPlanMode submission settles the run immediately", () => {
+  const { tools } = loadModules();
+  const policy = tools.createPlanModeRunPolicy({ conversationId: "conv-policy-ok" });
+  const decision = policy.decideAfterRun({
+    emittedMessages: [planToolResultMessage("call-ok-1")],
+  });
+  assert.equal(decision.kind, "submitted");
+  // 提交成功后不进入补提交态。
+  assert.equal(policy.resolveToolChoice(), undefined);
+});
+
+test("run policy: an errored ExitPlanMode result does not count as submission", () => {
+  const { tools } = loadModules();
+  const policy = tools.createPlanModeRunPolicy({ conversationId: "conv-policy-err" });
+  const decision = policy.decideAfterRun({
+    emittedMessages: [planToolResultMessage("call-err-1", true)],
+  });
+  assert.equal(decision.kind, "nudge");
+});
+
+test("run policy: fallback with empty text registers nothing and the turn just ends", () => {
+  const { tools } = loadModules();
+  const policy = tools.createPlanModeRunPolicy({ conversationId: "conv-policy-empty" });
+  policy.decideAfterRun({ emittedMessages: [] });
+  policy.decideAfterRun({ emittedMessages: [] });
+  assert.equal(policy.registerFallbackPlan({ planText: "   " }), null);
+  assert.equal(tools.getPendingPlanForConversation("conv-policy-empty"), null);
+});
+
+test("run policy: repeated identical research calls are blocked past the limit", () => {
+  const { tools } = loadModules();
+  const policy = tools.createPlanModeRunPolicy({ conversationId: "conv-policy-repeat" });
+  const read = (id) => ({
+    type: "toolCall",
+    id,
+    name: "Read",
+    // 键序不同也算同一调用(稳定序列化)。
+    arguments: id === "r2" ? { limit: 5, path: "a.ts" } : { path: "a.ts", limit: 5 },
+  });
+
+  assert.equal(policy.guardRepeatedToolCall(read("r1")).allow, true);
+  assert.equal(policy.guardRepeatedToolCall(read("r2")).allow, true);
+  const blocked = policy.guardRepeatedToolCall(read("r3"));
+  assert.equal(blocked.allow, false);
+  assert.match(blocked.reason, /already made this exact Read call/);
+  assert.match(blocked.reason, /ExitPlanMode/);
+
+  // 参数不同的调用不受影响。
+  assert.equal(
+    policy.guardRepeatedToolCall({
+      type: "toolCall",
+      id: "r4",
+      name: "Read",
+      arguments: { path: "b.ts" },
+    }).allow,
+    true,
+  );
+  // ExitPlanMode 永不被重复守卫拦截(修订后的重提不能被卡死)。
+  for (const id of ["p1", "p2", "p3", "p4"]) {
+    assert.equal(
+      policy.guardRepeatedToolCall({
+        type: "toolCall",
+        id,
+        name: "ExitPlanMode",
+        arguments: { plan: "same" },
+      }).allow,
+      true,
+    );
+  }
+});

--- a/crates/agent-ui/src/i18n/translations/enUSCommon.ts
+++ b/crates/agent-ui/src/i18n/translations/enUSCommon.ts
@@ -360,7 +360,7 @@ export const EN_US_COMMON_TRANSLATIONS = {
   "chat.upload.addSection": "Add",
   "chat.upload.filesAndFolders": "Files & folders",
   "chat.runtime.planModeTitle": "Plan mode",
-  "chat.runtime.planModeSlashOn":
+  "chat.runtime.planModeHint":
     "Research read-only and present a plan; execution starts after approval",
   "chat.runtime.planModeSlashOff": "Turn off plan mode",
   "chat.runtime.webSearch": "Web",

--- a/crates/agent-ui/src/i18n/translations/zhCNCommon.ts
+++ b/crates/agent-ui/src/i18n/translations/zhCNCommon.ts
@@ -329,7 +329,7 @@ export const ZH_CN_COMMON_TRANSLATIONS = {
   "chat.upload.addSection": "添加",
   "chat.upload.filesAndFolders": "文件和文件夹",
   "chat.runtime.planModeTitle": "计划模式",
-  "chat.runtime.planModeSlashOn": "开启计划模式",
+  "chat.runtime.planModeHint": "只读调研并产出计划,批准后自动开始执行",
   "chat.runtime.planModeSlashOff": "关闭计划模式",
   "chat.runtime.webSearch": "联网",
   "chat.runtime.thinking": "思考",

--- a/crates/agent-ui/src/pages/chat/ChatComposerBar.tsx
+++ b/crates/agent-ui/src/pages/chat/ChatComposerBar.tsx
@@ -1055,7 +1055,14 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: ChatComposer
                     </span>
                   </DropdownMenuItem>
                   {isAgentMode ? (
+                    // 计划模式开关行:整行即开关,右侧迷你 switch 呈现状态。
+                    // closeOnClick=false 让切换就地生效——开关动画可见,菜单
+                    // 不弹跳;行为说明降为 hover 提示,不再挤占行内小字。
                     <DropdownMenuItem
+                      closeOnClick={false}
+                      role="menuitemcheckbox"
+                      aria-checked={chatRuntimeControls.planModeEnabled}
+                      title={t("chat.runtime.planModeHint")}
                       onSelect={() =>
                         onChatRuntimeControlsChange({
                           planModeEnabled: !chatRuntimeControls.planModeEnabled,
@@ -1063,14 +1070,34 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: ChatComposer
                       }
                       className="composer-safety-item items-center gap-2 rounded-md py-1.5 text-xs"
                     >
-                      <Lightbulb className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      <Lightbulb
+                        className={cn(
+                          "h-3.5 w-3.5 shrink-0 transition-colors",
+                          chatRuntimeControls.planModeEnabled
+                            ? "text-sky-600 dark:text-sky-300"
+                            : "text-muted-foreground",
+                        )}
+                      />
                       <span className="min-w-0 flex-1 truncate font-medium leading-5">
                         {t("chat.runtime.planModeTitle")}
-                        <span className="ml-2 font-normal text-muted-foreground">
-                          {chatRuntimeControls.planModeEnabled
-                            ? t("chat.runtime.planModeSlashOff")
-                            : t("chat.runtime.planModeSlashOn")}
-                        </span>
+                      </span>
+                      {/* 视觉开关(aria 由行上的 menuitemcheckbox 承担):与计划
+                          pill 同用 sky 色系,状态一眼可辨。 */}
+                      <span
+                        aria-hidden
+                        className={cn(
+                          "ml-auto inline-flex h-[18px] w-8 shrink-0 items-center rounded-full transition-colors",
+                          chatRuntimeControls.planModeEnabled
+                            ? "bg-sky-500 dark:bg-sky-400"
+                            : "bg-muted-foreground/25",
+                        )}
+                      >
+                        <span
+                          className={cn(
+                            "block h-3.5 w-3.5 translate-x-[2px] rounded-full bg-white shadow-sm transition-transform dark:bg-slate-100",
+                            chatRuntimeControls.planModeEnabled && "translate-x-4",
+                          )}
+                        />
                       </span>
                     </DropdownMenuItem>
                   ) : null}


### PR DESCRIPTION
Fixes #588

## Summary

- **根因修复**:移除 plan mode 下每轮强制 `toolChoice: "any"` 的无界机制(`planModeForcesToolUse`)。它剥夺了模型的文本收尾能力——不提交计划时每轮必须调工具,导致无限 Read/Grep 循环。
- **有界升级架构**:新增 `createPlanModeRunPolicy` 状态机(`planModeTools.ts`),终止性由四道有界防线保证,任何模型行为都在有限步内收敛到计划卡:
  1. 终止谓词——`ExitPlanMode` 提交即结束本轮 run(原有);
  2. 轮数熔断——研究阶段上限 32 轮,达到后当前工具批执行完优雅终止,不抛错;
  3. 补提交轮——run 以文本收尾未提交时,注入一次 wire-only 提醒(不持久化、不进 UI)并定向强制 `{type:"tool", name:"ExitPlanMode"}`,仅升级一次(上限 4 轮);
  4. 文本兜底——仍未提交则把最后的助手文本注册为待决计划,合成 ExitPlanMode 调用对进历史,计划卡/审批短语/WebUI 链路零改动复用。
- **runner 恢复模式无关**:`agentRunner.ts` 删除 ExitPlanMode 硬编码,新增通用参数 `resolveToolChoice(round)` 与 `maxRounds`,plan 语义全部收敛到编排层策略。
- **协议守卫**:Anthropic extended thinking 与强制 tool_choice 互斥(400),`streamByApi.ts` 在该组合下自动降级为 `auto`,避免重试/failover 循环。
- **防空转守卫**:plan mode 下同参重复的研究调用(稳定序列化,键序无关)第 3 次起被拦截,拦截理由引导模型提交计划。
- **Prompt 收敛**:`<plan-mode>` system 段成为规则唯一权威,toolsSuffix 压缩为一行指引并删除重复的 "## Plan Mode" 段;移除 "You MUST call … before this turn ends" 高压措辞(抬高提交门槛、诱导无限调研),改为"够用即提交、勿重读已返回 unchanged 的文件"。

- **细节决策积极提问**:`<plan-mode>` 权威段新增准则——属于用户的决定(范围边界、互斥方案、取舍、目标行为)在调研阶段用 `AskUserQuestion` 主动问清,而非猜测或把开放问题遗留在计划里(代码能回答的自己查,剩余决策合并为一次聚焦提问);toolsSuffix plan 段按工具可用性追加一行指引。AskUserQuestion 本就在 plan mode 白名单内且为 run 内挂起语义,与提交终止/有界升级无冲突。
- **计划模式菜单项 UI 升级**(GUI 与 WebUI 共享的 `ChatComposerBar`):去掉"开启计划模式/关闭计划模式"行内小字,改为整行可点的开关行——右侧迷你 switch 呈现状态(与计划 pill 同用 sky 色系,开启时图标同步着色),`closeOnClick=false` 使切换就地生效、开关动画可见,行为说明降为 hover 提示,并补齐 `menuitemcheckbox` + `aria-checked` 语义。
## Test plan

- [x] 新增 9 个用例:策略状态机三态流转(auto → nudge → fallback)、提交成功即落定、错误结果不算提交、空文本兜底不注册、重复调用守卫(含键序无关与 ExitPlanMode 豁免)、`resolveToolChoice` 逐轮生效、`maxRounds` 优雅终止、ExitPlanMode 存在时 toolChoice 保持 auto
- [x] 同步三个既有测试文件的 prompt 文案断言
- [x] `tsc --noEmit` 与 `biome check` 通过
- [x] agent-gui 全量测试 2491 pass / 0 fail

Made with [Cursor](https://cursor.com)

