### PR TITLE
feat(providers): 引入 LLM seam 骨架——统一入口 llm.stream() 与协议适配器注册表

### DIFF
--- a/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
+++ b/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
@@ -29,12 +29,12 @@ import {
   createStreamingTextReconciler,
   describeProviderCacheShape,
   finalizeProviderStreamOptions,
+  llm,
   normalizeErrorMessage,
   type ProviderRuntimeConfig,
   prepareProviderRequest,
   resolveProviderCacheRetention,
   type StreamOptionsEx,
-  streamSimpleByApi,
   type ToolChoice,
   toSimpleStreamReasoning,
 } from "../../providers/llm";
@@ -1405,10 +1405,14 @@ export async function runAssistantWithTools(params: {
           }),
         );
 
-        return streamSimpleByApi(targetModel, effectiveContext, streamOptions);
+        return llm.stream({
+          model: targetModel,
+          context: effectiveContext,
+          options: streamOptions,
+        });
       };
 
-      const wrapWithGuard = (stream: ReturnType<typeof streamSimpleByApi>) =>
+      const wrapWithGuard = (stream: ReturnType<typeof llm.stream>) =>
         wrapStreamWithToolCallArgumentGuard(stream, (toolCall, reason) => {
           incompleteToolCallArguments.set(toolCall.id, reason);
         });

--- a/crates/agent-gui/src/lib/providers/llm.ts
+++ b/crates/agent-gui/src/lib/providers/llm.ts
@@ -48,3 +48,5 @@ export type {
   StreamOptionsEx,
   ToolChoice,
 } from "./runtime/types";
+export { llm, llmStream } from "./service/llmService";
+export type { LlmAdapter, LlmStreamRequest } from "./service/types";

--- a/crates/agent-gui/src/lib/providers/runtime/streamByApi.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/streamByApi.ts
@@ -1,165 +1,23 @@
 import type { Api, Context, Model } from "@earendil-works/pi-ai";
-import { stream as streamAnthropic } from "@earendil-works/pi-ai/api/anthropic-messages";
-import {
-  type GoogleOptions,
-  stream as streamGoogle,
-} from "@earendil-works/pi-ai/api/google-generative-ai";
-import {
-  type OpenAICompletionsOptions,
-  stream as streamOpenAICompletions,
-} from "@earendil-works/pi-ai/api/openai-completions";
-import {
-  type OpenAIResponsesOptions,
-  stream as streamOpenAIResponses,
-} from "@earendil-works/pi-ai/api/openai-responses";
-import { DEEPSEEK_RESPONSES_API, streamDeepSeekResponses } from "../deepSeekNative";
-import { resolveMaxTokens } from "./common";
-import { rejectEmptyOpenAICompletionsResponse } from "./openAICompletionsStream";
-import { withStreamRetry } from "./streamRetry";
-import {
-  clampOpenAIReasoningEffort,
-  resolveAnthropicThinkingRuntime,
-  resolveGeminiThinkingRuntime,
-} from "./thinkingLevels";
-import type { StreamOptionsEx, ToolChoice } from "./types";
+import { ensureDefaultLlmAdapters } from "../service/defaultAdapters";
+import { resolveAdapter } from "../service/registry";
+import type { StreamOptionsEx } from "./types";
 
-function mapToolChoiceToOpenAI(
-  toolChoice: ToolChoice | undefined,
-): OpenAICompletionsOptions["toolChoice"] | undefined {
-  if (!toolChoice) return undefined;
-  if (toolChoice === "any") return "required";
-  if (toolChoice === "auto" || toolChoice === "none") return toolChoice;
-  return {
-    type: "function",
-    function: {
-      name: toolChoice.name,
-    },
-  };
-}
+// 保证经本模块的任何调用（含被测试按路径 mock 后又还原的场景）注册表已就绪。
+ensureDefaultLlmAdapters();
 
-function mapToolChoiceToGoogle(
-  toolChoice: ToolChoice | undefined,
-): GoogleOptions["toolChoice"] | undefined {
-  if (!toolChoice) return undefined;
-  if (toolChoice === "auto" || toolChoice === "none" || toolChoice === "any") {
-    return toolChoice;
-  }
-  return "auto";
-}
-
-function buildOpenAIBaseOptions(model: Model<Api>, options: StreamOptionsEx) {
-  return {
-    temperature: options.temperature,
-    maxTokens: resolveMaxTokens(options.maxTokens, model.maxTokens),
-    signal: options.signal,
-    apiKey: options.apiKey,
-    cacheRetention: options.cacheRetention,
-    sessionId: options.sessionId,
-    headers: options.headers,
-    onPayload: options.onPayload,
-    maxRetryDelayMs: options.maxRetryDelayMs,
-    metadata: options.metadata,
-  };
-}
-
+/**
+ * 协议分发针孔（PR-1 seam 骨架）。
+ *
+ * 原五协议 switch 已搬移到 ../service/：pi-ai 四协议在 service/piAiAdapter.ts，
+ * DeepSeek 原生在 service/deepSeekAdapter.ts；本函数只剩注册表路由一行，
+ * 保留原签名、语义与 "Unsupported model API: ..." 错误文案。
+ *
+ * 统一入口 llm.stream()（service/llmService.ts）也经由本模块出站——传输
+ * golden 与 failover 测试按本模块路径 mock 即可截获全部出站流，这一
+ * 可观测点是 seam 的公开契约，后续 PR 不得绕开。
+ */
 export function streamSimpleByApi(model: Model<Api>, context: Context, options: StreamOptionsEx) {
-  switch (model.api) {
-    case "anthropic-messages": {
-      // Anthropic：需要我们自己调用 streamAnthropic()，以便显式传 toolChoice（以及启用/禁用 thinking）。
-      const anthropicThinking = resolveAnthropicThinkingRuntime(model, options);
-      // Anthropic 拒绝 extended thinking 与强制工具（"any"/{type:"tool"}）同请求
-      // （400）。降级为 auto：有界强制的调用方（plan mode 补提交轮）同时注入了
-      // 消息级提醒，语义仍然成立；直接 400 反而会进重试/failover 循环。
-      const requestedToolChoice = options.toolChoice ?? "none";
-      const anthropicToolChoice =
-        anthropicThinking.thinkingEnabled &&
-        requestedToolChoice !== "none" &&
-        requestedToolChoice !== "auto"
-          ? "auto"
-          : requestedToolChoice;
-      return withStreamRetry(
-        () => {
-          return streamAnthropic(model as Model<"anthropic-messages">, context, {
-            temperature: options.temperature,
-            maxTokens: anthropicThinking.maxTokens,
-            signal: options.signal,
-            apiKey: options.apiKey,
-            cacheRetention: options.cacheRetention,
-            sessionId: options.sessionId,
-            headers: options.headers,
-            onPayload: options.onPayload,
-            maxRetryDelayMs: options.maxRetryDelayMs,
-            metadata: options.metadata,
-            thinkingEnabled: anthropicThinking.thinkingEnabled,
-            ...(anthropicThinking.effort ? { effort: anthropicThinking.effort } : {}),
-            ...(anthropicThinking.thinkingBudgetTokens !== undefined
-              ? { thinkingBudgetTokens: anthropicThinking.thinkingBudgetTokens }
-              : {}),
-            toolChoice: anthropicToolChoice,
-          });
-        },
-        { signal: options.signal, ...options.streamRetry },
-      );
-    }
-    case "openai-completions": {
-      // 严格校验的 OpenAI 兼容端点（xAI/各类中转网关）对「带 tool_choice 但没带
-      // tools」的请求直接 400（"A tool_choice was set on the request but no tools
-      // were specified"）——compaction 摘要、标题生成等 text-only 请求没有工具，
-      // 会踩中。tool_choice 在无工具时本就无意义，只在请求真正携带 tools 时下发。
-      const openAIOptions: OpenAICompletionsOptions = {
-        ...buildOpenAIBaseOptions(model, options),
-        reasoningEffort: clampOpenAIReasoningEffort(model, options.reasoning),
-        toolChoice: context.tools?.length ? mapToolChoiceToOpenAI(options.toolChoice) : undefined,
-      };
-      return withStreamRetry(
-        () => {
-          return rejectEmptyOpenAICompletionsResponse(
-            streamOpenAICompletions(model as Model<"openai-completions">, context, openAIOptions),
-          );
-        },
-        { signal: options.signal, ...options.streamRetry },
-      );
-    }
-    case DEEPSEEK_RESPONSES_API:
-      return withStreamRetry(() => streamDeepSeekResponses(model, context, options), {
-        signal: options.signal,
-        ...options.streamRetry,
-      });
-    case "openai-responses": {
-      const openAIOptions: OpenAIResponsesOptions = {
-        ...buildOpenAIBaseOptions(model, options),
-        reasoningEffort: clampOpenAIReasoningEffort(model, options.reasoning),
-      };
-      return withStreamRetry(
-        () => streamOpenAIResponses(model as Model<"openai-responses">, context, openAIOptions),
-        {
-          signal: options.signal,
-          ...options.streamRetry,
-        },
-      );
-    }
-    case "google-generative-ai": {
-      const googleOptions: GoogleOptions = {
-        temperature: options.temperature,
-        maxTokens: resolveMaxTokens(options.maxTokens, model.maxTokens),
-        signal: options.signal,
-        apiKey: options.apiKey,
-        headers: options.headers,
-        onPayload: options.onPayload,
-        maxRetryDelayMs: options.maxRetryDelayMs,
-        metadata: options.metadata,
-        thinking: resolveGeminiThinkingRuntime(model, options.reasoning),
-        toolChoice: mapToolChoiceToGoogle(options.toolChoice) ?? "none",
-      };
-      return withStreamRetry(
-        () => streamGoogle(model as Model<"google-generative-ai">, context, googleOptions),
-        {
-          signal: options.signal,
-          ...options.streamRetry,
-        },
-      );
-    }
-    default:
-      throw new Error(`Unsupported model API: ${model.api}`);
-  }
+  ensureDefaultLlmAdapters();
+  return resolveAdapter(model.api).stream(model, context, options);
 }

--- a/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
@@ -15,6 +15,7 @@ import {
   withHostedSearchProbeHeader,
 } from "../hostedSearchEvents";
 import { providerSupportsNativeWebSearch } from "../nativeWebSearch";
+import { llm } from "../service/llmService";
 import { appendSystemPrompt, normalizeSessionId } from "./common";
 import { normalizeErrorMessage } from "./errors";
 import { createStreamingTextReconciler } from "./messageUtils";
@@ -32,7 +33,6 @@ import {
   resolveProviderCacheRetention,
   toSimpleStreamReasoning,
 } from "./requestOptions";
-import { streamSimpleByApi } from "./streamByApi";
 import { buildTextModeToolResultsForAssistant } from "./textModeToolRecovery";
 import type { ProviderRuntimeConfig, StreamOptionsEx } from "./types";
 
@@ -331,7 +331,7 @@ export async function streamAssistantMessage(params: {
 
   const startAttemptStream = (activeContext: Context) => {
     if (!failover || failover.fallbacks.length === 0) {
-      return streamSimpleByApi(m, activeContext, options);
+      return llm.stream({ model: m, context: activeContext, options });
     }
     // Candidate order: sticky active target first, then the rest in
     // primary→queue order. Breaker-open targets are skipped inside
@@ -360,7 +360,7 @@ export async function streamAssistantMessage(params: {
             : fallbackTargetIdentity(targetIndex),
         start: async () => {
           if (targetIndex === 0 || !fallback) {
-            return streamSimpleByApi(m, activeContext, options);
+            return llm.stream({ model: m, context: activeContext, options });
           }
           const prepared = await prepareFallbackTarget(targetIndex);
           params.debugLogger?.logRequest(
@@ -370,7 +370,11 @@ export async function streamAssistantMessage(params: {
               options: prepared.options,
             }),
           );
-          return streamSimpleByApi(prepared.model, activeContext, prepared.options);
+          return llm.stream({
+            model: prepared.model,
+            context: activeContext,
+            options: prepared.options,
+          });
         },
       } satisfies ProviderFailoverCandidate;
     });
@@ -575,7 +579,7 @@ export async function completeAssistantMessage(params: {
 
   return withPowerActivity("assistant-complete", `${params.providerId}:${modelId}`, async () => {
     try {
-      const s = streamSimpleByApi(m, callContext, options);
+      const s = llm.stream({ model: m, context: callContext, options });
       const final = await s.result();
 
       if (final.stopReason === "error" || final.stopReason === "aborted") {

--- a/crates/agent-gui/src/lib/providers/service/deepSeekAdapter.ts
+++ b/crates/agent-gui/src/lib/providers/service/deepSeekAdapter.ts
@@ -1,0 +1,19 @@
+import { DEEPSEEK_RESPONSES_API, streamDeepSeekResponses } from "../deepSeekNative";
+import { withStreamRetry } from "../runtime/streamRetry";
+import type { LlmAdapter } from "./types";
+
+/**
+ * DeepSeek 原生协议适配器。
+ *
+ * streamByApi.ts 中 DEEPSEEK_RESPONSES_API 分支的原样搬移（PR-1 行为等价
+ * 不变量）：withStreamRetry 包装位置与参数逐字保持。
+ */
+export const deepSeekAdapter: LlmAdapter = {
+  apis: [DEEPSEEK_RESPONSES_API] as const,
+  stream(model, context, options) {
+    return withStreamRetry(() => streamDeepSeekResponses(model, context, options), {
+      signal: options.signal,
+      ...options.streamRetry,
+    });
+  },
+};

--- a/crates/agent-gui/src/lib/providers/service/defaultAdapters.ts
+++ b/crates/agent-gui/src/lib/providers/service/defaultAdapters.ts
@@ -1,0 +1,18 @@
+import { deepSeekAdapter } from "./deepSeekAdapter";
+import { piAiAdapter } from "./piAiAdapter";
+import { registerAdapter } from "./registry";
+
+let installed = false;
+
+/**
+ * 安装默认适配器（幂等）。
+ *
+ * 由分发针孔（runtime/streamByApi.ts 兼容壳）与 llm.stream() 各自在模块加载
+ * 时调用：无论消费方从哪个入口进来，注册表都已就绪；重复调用零开销。
+ */
+export function ensureDefaultLlmAdapters(): void {
+  if (installed) return;
+  installed = true;
+  registerAdapter(piAiAdapter);
+  registerAdapter(deepSeekAdapter);
+}

--- a/crates/agent-gui/src/lib/providers/service/index.ts
+++ b/crates/agent-gui/src/lib/providers/service/index.ts
@@ -1,0 +1,6 @@
+export { deepSeekAdapter } from "./deepSeekAdapter";
+export { ensureDefaultLlmAdapters } from "./defaultAdapters";
+export { llm, llmStream, setLlmServiceDevModeForTest } from "./llmService";
+export { piAiAdapter } from "./piAiAdapter";
+export { registerAdapter, registeredApis, resolveAdapter } from "./registry";
+export type { LlmAdapter, LlmStreamRequest } from "./types";

--- a/crates/agent-gui/src/lib/providers/service/llmService.ts
+++ b/crates/agent-gui/src/lib/providers/service/llmService.ts
@@ -1,0 +1,62 @@
+import type { AssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { streamSimpleByApi } from "../runtime/streamByApi";
+import type { LlmStreamRequest } from "./types";
+
+/**
+ * dev 构建探测。
+ *
+ * Vite 下 import.meta.env.DEV 为真；生产构建被静态替换为 false。Node 测试
+ * 加载器（esbuild CJS 转译）中 import.meta 是空壳，可选链安全落到 false——
+ * 测试如需覆盖冻结路径用 setLlmServiceDevModeForTest。
+ */
+function detectDevBuild(): boolean {
+  try {
+    return Boolean((import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV);
+  } catch {
+    return false;
+  }
+}
+
+let devModeOverride: boolean | undefined;
+
+/** 测试专用：强制指定 dev 冻结开关（undefined 恢复自动探测）。 */
+export function setLlmServiceDevModeForTest(value: boolean | undefined): void {
+  devModeOverride = value;
+}
+
+function isDevBuild(): boolean {
+  return devModeOverride ?? detectDevBuild();
+}
+
+/** 已分发过的请求信封——一次性分发不变量的记账。 */
+const dispatchedRequests = new WeakSet<LlmStreamRequest>();
+
+/**
+ * LLM 统一流式入口。
+ *
+ * 职责被刻意压到最小（PR-1 行为等价不变量）：
+ * 1. 一次性分发——同一请求信封重复分发抛错，杜绝"复用上一轮请求信封"这类
+ *    隐性共享（重试/failover 的重放语义在适配器内部与调用方，不经此层）；
+ * 2. dev 冻结——仅 dev 构建把信封冻住，让越过 seam 之后的信封突变当场以
+ *    TypeError 暴露（ESM 严格模式）；生产构建零开销；
+ * 3. 经 runtime/streamByApi.ts 协议分发针孔路由到注册表适配器。针孔是 seam
+ *    的公开可观测点（传输 golden 与 failover 测试按该模块路径 mock 截获
+ *    全部出站流），不得绕开。
+ *
+ * 传输路由字段（headers 内 x-liveagent-* 等）不透明透传：不读取、不判断、
+ * 不缓存。
+ */
+export function llmStream(request: LlmStreamRequest): AssistantMessageEventStream {
+  if (dispatchedRequests.has(request)) {
+    throw new Error("LlmStreamRequest was already dispatched; build a fresh request per stream");
+  }
+  dispatchedRequests.add(request);
+  if (isDevBuild()) {
+    Object.freeze(request);
+  }
+  return streamSimpleByApi(request.model, request.context, request.options);
+}
+
+export const llm = {
+  stream: llmStream,
+};

--- a/crates/agent-gui/src/lib/providers/service/piAiAdapter.ts
+++ b/crates/agent-gui/src/lib/providers/service/piAiAdapter.ts
@@ -1,0 +1,189 @@
+import type { Api, Context, Model } from "@earendil-works/pi-ai";
+import { stream as streamAnthropic } from "@earendil-works/pi-ai/api/anthropic-messages";
+import {
+  type GoogleOptions,
+  stream as streamGoogle,
+} from "@earendil-works/pi-ai/api/google-generative-ai";
+import {
+  type OpenAICompletionsOptions,
+  stream as streamOpenAICompletions,
+} from "@earendil-works/pi-ai/api/openai-completions";
+import {
+  type OpenAIResponsesOptions,
+  stream as streamOpenAIResponses,
+} from "@earendil-works/pi-ai/api/openai-responses";
+import { resolveMaxTokens } from "../runtime/common";
+import { rejectEmptyOpenAICompletionsResponse } from "../runtime/openAICompletionsStream";
+import { withStreamRetry } from "../runtime/streamRetry";
+import {
+  clampOpenAIReasoningEffort,
+  resolveAnthropicThinkingRuntime,
+  resolveGeminiThinkingRuntime,
+} from "../runtime/thinkingLevels";
+import type { StreamOptionsEx, ToolChoice } from "../runtime/types";
+import type { LlmAdapter } from "./types";
+
+// ============================================================================
+// pi-ai 四协议适配器。
+//
+// 各分支为 streamByApi.ts 原实现的原样搬移（PR-1 行为等价不变量）：分支内的
+// withStreamRetry 包装位置、toolChoice 映射、thinking runtime 解析、注释
+// 一并保留，不做任何重写。判定基准是 PR-0 golden 快照零修改通过。
+// ============================================================================
+
+function mapToolChoiceToOpenAI(
+  toolChoice: ToolChoice | undefined,
+): OpenAICompletionsOptions["toolChoice"] | undefined {
+  if (!toolChoice) return undefined;
+  if (toolChoice === "any") return "required";
+  if (toolChoice === "auto" || toolChoice === "none") return toolChoice;
+  return {
+    type: "function",
+    function: {
+      name: toolChoice.name,
+    },
+  };
+}
+
+function mapToolChoiceToGoogle(
+  toolChoice: ToolChoice | undefined,
+): GoogleOptions["toolChoice"] | undefined {
+  if (!toolChoice) return undefined;
+  if (toolChoice === "auto" || toolChoice === "none" || toolChoice === "any") {
+    return toolChoice;
+  }
+  return "auto";
+}
+
+function buildOpenAIBaseOptions(model: Model<Api>, options: StreamOptionsEx) {
+  return {
+    temperature: options.temperature,
+    maxTokens: resolveMaxTokens(options.maxTokens, model.maxTokens),
+    signal: options.signal,
+    apiKey: options.apiKey,
+    cacheRetention: options.cacheRetention,
+    sessionId: options.sessionId,
+    headers: options.headers,
+    onPayload: options.onPayload,
+    maxRetryDelayMs: options.maxRetryDelayMs,
+    metadata: options.metadata,
+  };
+}
+
+function streamAnthropicMessages(model: Model<Api>, context: Context, options: StreamOptionsEx) {
+  // Anthropic：需要我们自己调用 streamAnthropic()，以便显式传 toolChoice（以及启用/禁用 thinking）。
+  const anthropicThinking = resolveAnthropicThinkingRuntime(model, options);
+  // Anthropic 拒绝 extended thinking 与强制工具（"any"/{type:"tool"}）同请求
+  // （400）。降级为 auto：有界强制的调用方（plan mode 补提交轮）同时注入了
+  // 消息级提醒，语义仍然成立；直接 400 反而会进重试/failover 循环。
+  const requestedToolChoice = options.toolChoice ?? "none";
+  const anthropicToolChoice =
+    anthropicThinking.thinkingEnabled &&
+    requestedToolChoice !== "none" &&
+    requestedToolChoice !== "auto"
+      ? "auto"
+      : requestedToolChoice;
+  return withStreamRetry(
+    () => {
+      return streamAnthropic(model as Model<"anthropic-messages">, context, {
+        temperature: options.temperature,
+        maxTokens: anthropicThinking.maxTokens,
+        signal: options.signal,
+        apiKey: options.apiKey,
+        cacheRetention: options.cacheRetention,
+        sessionId: options.sessionId,
+        headers: options.headers,
+        onPayload: options.onPayload,
+        maxRetryDelayMs: options.maxRetryDelayMs,
+        metadata: options.metadata,
+        thinkingEnabled: anthropicThinking.thinkingEnabled,
+        ...(anthropicThinking.effort ? { effort: anthropicThinking.effort } : {}),
+        ...(anthropicThinking.thinkingBudgetTokens !== undefined
+          ? { thinkingBudgetTokens: anthropicThinking.thinkingBudgetTokens }
+          : {}),
+        toolChoice: anthropicToolChoice,
+      });
+    },
+    { signal: options.signal, ...options.streamRetry },
+  );
+}
+
+function streamOpenAICompletionsApi(model: Model<Api>, context: Context, options: StreamOptionsEx) {
+  // 严格校验的 OpenAI 兼容端点（xAI/各类中转网关）对「带 tool_choice 但没带
+  // tools」的请求直接 400（"A tool_choice was set on the request but no tools
+  // were specified"）——compaction 摘要、标题生成等 text-only 请求没有工具，
+  // 会踩中。tool_choice 在无工具时本就无意义，只在请求真正携带 tools 时下发。
+  const openAIOptions: OpenAICompletionsOptions = {
+    ...buildOpenAIBaseOptions(model, options),
+    reasoningEffort: clampOpenAIReasoningEffort(model, options.reasoning),
+    toolChoice: context.tools?.length ? mapToolChoiceToOpenAI(options.toolChoice) : undefined,
+  };
+  return withStreamRetry(
+    () => {
+      return rejectEmptyOpenAICompletionsResponse(
+        streamOpenAICompletions(model as Model<"openai-completions">, context, openAIOptions),
+      );
+    },
+    { signal: options.signal, ...options.streamRetry },
+  );
+}
+
+function streamOpenAIResponsesApi(model: Model<Api>, context: Context, options: StreamOptionsEx) {
+  const openAIOptions: OpenAIResponsesOptions = {
+    ...buildOpenAIBaseOptions(model, options),
+    reasoningEffort: clampOpenAIReasoningEffort(model, options.reasoning),
+  };
+  return withStreamRetry(
+    () => streamOpenAIResponses(model as Model<"openai-responses">, context, openAIOptions),
+    {
+      signal: options.signal,
+      ...options.streamRetry,
+    },
+  );
+}
+
+function streamGoogleGenerativeAi(model: Model<Api>, context: Context, options: StreamOptionsEx) {
+  const googleOptions: GoogleOptions = {
+    temperature: options.temperature,
+    maxTokens: resolveMaxTokens(options.maxTokens, model.maxTokens),
+    signal: options.signal,
+    apiKey: options.apiKey,
+    headers: options.headers,
+    onPayload: options.onPayload,
+    maxRetryDelayMs: options.maxRetryDelayMs,
+    metadata: options.metadata,
+    thinking: resolveGeminiThinkingRuntime(model, options.reasoning),
+    toolChoice: mapToolChoiceToGoogle(options.toolChoice) ?? "none",
+  };
+  return withStreamRetry(
+    () => streamGoogle(model as Model<"google-generative-ai">, context, googleOptions),
+    {
+      signal: options.signal,
+      ...options.streamRetry,
+    },
+  );
+}
+
+export const piAiAdapter: LlmAdapter = {
+  apis: [
+    "anthropic-messages",
+    "openai-completions",
+    "openai-responses",
+    "google-generative-ai",
+  ] as const,
+  stream(model, context, options) {
+    switch (model.api) {
+      case "anthropic-messages":
+        return streamAnthropicMessages(model, context, options);
+      case "openai-completions":
+        return streamOpenAICompletionsApi(model, context, options);
+      case "openai-responses":
+        return streamOpenAIResponsesApi(model, context, options);
+      case "google-generative-ai":
+        return streamGoogleGenerativeAi(model, context, options);
+      default:
+        // 注册表按 apis 路由到这里，正常不可达；防御分支保持同一错误文案。
+        throw new Error(`Unsupported model API: ${model.api}`);
+    }
+  },
+};

--- a/crates/agent-gui/src/lib/providers/service/registry.ts
+++ b/crates/agent-gui/src/lib/providers/service/registry.ts
@@ -1,0 +1,38 @@
+import type { LlmAdapter } from "./types";
+
+/**
+ * api → adapter 注册表。
+ *
+ * PR-1 的注册表是模块内静态注册（registerAdapter 仅供本目录的默认装配与
+ * 测试使用），不提供运行期动态卸载——那是 PR-3 拦截器注册化的范畴。
+ */
+const adaptersByApi = new Map<string, LlmAdapter>();
+
+export function registerAdapter(adapter: LlmAdapter): void {
+  for (const api of adapter.apis) {
+    const existing = adaptersByApi.get(api);
+    if (existing && existing !== adapter) {
+      throw new Error(`Duplicate LLM adapter registration for API: ${api}`);
+    }
+    adaptersByApi.set(api, adapter);
+  }
+}
+
+/**
+ * 解析一个 wire 协议的适配器。
+ *
+ * 未注册协议的错误文案与重构前 streamByApi.ts 的 default 分支逐字保持一致
+ * （"Unsupported model API: ..."），错误路径也不漂移。
+ */
+export function resolveAdapter(api: string): LlmAdapter {
+  const adapter = adaptersByApi.get(api);
+  if (!adapter) {
+    throw new Error(`Unsupported model API: ${api}`);
+  }
+  return adapter;
+}
+
+/** 已注册协议列表（测试用，按注册顺序）。 */
+export function registeredApis(): string[] {
+  return [...adaptersByApi.keys()];
+}

--- a/crates/agent-gui/src/lib/providers/service/types.ts
+++ b/crates/agent-gui/src/lib/providers/service/types.ts
@@ -1,0 +1,38 @@
+import type { Api, AssistantMessageEventStream, Context, Model } from "@earendil-works/pi-ai";
+import type { StreamRetryConfig } from "../runtime/streamRetry";
+import type { StreamOptionsEx } from "../runtime/types";
+
+/**
+ * 一次 LLM 流式请求的完整信封。
+ *
+ * `model.api` 决定路由到哪个适配器；`context` 与 `options` 不做任何解释，
+ * 原样交给适配器——传输路由字段（headers 里的 x-liveagent-*、useSystemProxy
+ * 派生头）对 seam 不透明透传，seam 不读取、不判断、不缓存。
+ */
+export type LlmStreamRequest = {
+  model: Model<Api>;
+  context: Context;
+  options: StreamOptionsEx;
+};
+
+/**
+ * LLM 适配器：把一组 wire 协议接到统一分发入口 llm.stream() 上。
+ *
+ * PR-1 只要求 stream()（行为与被包装的原实现逐行等价）；resolveModel /
+ * retryPolicy 是 PR-2（策略归属权反转）预留的可选能力，当前没有实现者，
+ * 重试策略仍由调用方通过 options.streamRetry 携带。
+ */
+export type LlmAdapter = {
+  /** 本适配器承接的 wire 协议 id 集合（即 model.api 的取值）。 */
+  readonly apis: readonly string[];
+  /** 发起一次流式请求。必须保持被包装实现的语义，包括流内重试的包装位置。 */
+  stream(
+    model: Model<Api>,
+    context: Context,
+    options: StreamOptionsEx,
+  ): AssistantMessageEventStream;
+  /** PR-2 预留：路由时机的模型解析。 */
+  resolveModel?(model: Model<Api>): Model<Api>;
+  /** PR-2 预留：供应商级重试策略查询。 */
+  retryPolicy?(model: Model<Api>): StreamRetryConfig | undefined;
+};

--- a/crates/agent-gui/test/chat/agent-runner.test.mjs
+++ b/crates/agent-gui/test/chat/agent-runner.test.mjs
@@ -374,6 +374,13 @@ const llmMock = {
       },
     };
   },
+  // runner 经统一入口 llm.stream() 出站；mock 同构转发到上面的
+  // streamSimpleByApi，两个入口共享同一份请求记账。
+  llm: {
+    stream(request) {
+      return llmMock.streamSimpleByApi(request.model, request.context, request.options);
+    },
+  },
 };
 
 const loader = createTsModuleLoader({

--- a/crates/agent-gui/test/providers/llm-service-seam.test.mjs
+++ b/crates/agent-gui/test/providers/llm-service-seam.test.mjs
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+// ============================================================================
+// PR-1 seam 骨架单元测试：注册表分发、未知协议错误文案等价、一次性分发、
+// dev 冻结/生产不冻结、兼容壳与统一入口 llm.stream() 的 wire payload 等价。
+//
+// 行为等价的总判定基准是 PR-0 golden 两套件零修改通过（见
+// wire-payload-golden.test.mjs / transport-golden.test.mjs）；本文件补充
+// seam 自身的新契约。
+// ============================================================================
+
+const realAnthropic = await import(
+  new URL(
+    "../../node_modules/@earendil-works/pi-ai/dist/api/anthropic-messages.js",
+    import.meta.url,
+  ).href
+);
+const realCompletions = await import(
+  new URL(
+    "../../node_modules/@earendil-works/pi-ai/dist/api/openai-completions.js",
+    import.meta.url,
+  ).href
+);
+const realResponses = await import(
+  new URL(
+    "../../node_modules/@earendil-works/pi-ai/dist/api/openai-responses.js",
+    import.meta.url,
+  ).href
+);
+const realGoogle = await import(
+  new URL(
+    "../../node_modules/@earendil-works/pi-ai/dist/api/google-generative-ai.js",
+    import.meta.url,
+  ).href
+);
+
+const loader = createTsModuleLoader({
+  mocks: {
+    "@earendil-works/pi-ai/api/anthropic-messages": { stream: realAnthropic.stream },
+    "@earendil-works/pi-ai/api/openai-completions": { stream: realCompletions.stream },
+    "@earendil-works/pi-ai/api/openai-responses": { stream: realResponses.stream },
+    "@earendil-works/pi-ai/api/google-generative-ai": { stream: realGoogle.stream },
+  },
+});
+
+const { streamSimpleByApi } = loader.loadModule("src/lib/providers/runtime/streamByApi.ts");
+const { llm, llmStream, setLlmServiceDevModeForTest } = loader.loadModule(
+  "src/lib/providers/service/llmService.ts",
+);
+const { registeredApis, resolveAdapter, registerAdapter } = loader.loadModule(
+  "src/lib/providers/service/registry.ts",
+);
+const { piAiAdapter } = loader.loadModule("src/lib/providers/service/piAiAdapter.ts");
+const { deepSeekAdapter } = loader.loadModule("src/lib/providers/service/deepSeekAdapter.ts");
+const { DEEPSEEK_RESPONSES_API } = loader.loadModule("src/lib/providers/deepSeekNative.ts");
+
+function buildModel(api, overrides = {}) {
+  return {
+    id: "test-model",
+    provider: "openai",
+    api,
+    baseUrl: "https://example.com/v1",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 4096,
+    ...overrides,
+  };
+}
+
+function buildContext() {
+  return {
+    systemPrompt: "You are a precise assistant.",
+    messages: [{ role: "user", content: "hello world", timestamp: 1 }],
+  };
+}
+
+/** 在 onPayload 截获 wire payload 后中断请求（同 golden 的捕获通道）。 */
+async function captureViaEntry(entry, model, context, options = {}) {
+  let captured;
+  const stream = entry(model, context, {
+    apiKey: "sk-test",
+    ...options,
+    onPayload: async (payload) => {
+      captured = payload;
+      throw new Error("__capture_stop__");
+    },
+  });
+  try {
+    await stream.result();
+  } catch {
+    // onPayload 抛错中断请求属预期。
+  }
+  assert.ok(captured, "expected wire payload capture");
+  return JSON.parse(JSON.stringify(captured));
+}
+
+test.afterEach(() => {
+  setLlmServiceDevModeForTest(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// 注册表分发
+// ---------------------------------------------------------------------------
+
+test("seam/registry: 五协议各归其所（4×pi-ai + deepseek 原生）", () => {
+  // 触发默认装配（llmService 模块加载即注册，此处显式断言注册表内容）。
+  assert.deepEqual(registeredApis().sort(), [
+    "anthropic-messages",
+    DEEPSEEK_RESPONSES_API,
+    "google-generative-ai",
+    "openai-completions",
+    "openai-responses",
+  ].sort());
+
+  for (const api of [
+    "anthropic-messages",
+    "openai-completions",
+    "openai-responses",
+    "google-generative-ai",
+  ]) {
+    assert.equal(resolveAdapter(api), piAiAdapter, `${api} should route to piAiAdapter`);
+  }
+  assert.equal(resolveAdapter(DEEPSEEK_RESPONSES_API), deepSeekAdapter);
+});
+
+test("seam/registry: 未注册协议错误文案与重构前逐字一致", () => {
+  assert.throws(() => resolveAdapter("mock-api"), /^Error: Unsupported model API: mock-api$/);
+  // 经兼容壳走同一路径、同一文案。
+  assert.throws(
+    () => streamSimpleByApi(buildModel("mock-api"), buildContext(), { apiKey: "k" }),
+    /^Error: Unsupported model API: mock-api$/,
+  );
+});
+
+test("seam/registry: 同一协议重复注册不同适配器立即抛错", () => {
+  const rogue = { apis: ["anthropic-messages"], stream: () => {} };
+  assert.throws(
+    () => registerAdapter(rogue),
+    /Duplicate LLM adapter registration for API: anthropic-messages/,
+  );
+  // 同一适配器重复注册幂等（默认装配的 ensure 语义依赖它）。
+  registerAdapter(piAiAdapter);
+});
+
+// ---------------------------------------------------------------------------
+// llm.stream() 信封语义
+// ---------------------------------------------------------------------------
+
+test("seam/llm.stream: 同一请求信封二次分发抛错（一次性分发）", async () => {
+  const request = {
+    model: buildModel("openai-completions"),
+    context: buildContext(),
+    options: {
+      apiKey: "sk-test",
+      onPayload: async () => {
+        throw new Error("__capture_stop__");
+      },
+    },
+  };
+  const first = llm.stream(request);
+  try {
+    await first.result();
+  } catch {
+    // 中断属预期。
+  }
+  assert.throws(() => llm.stream(request), /already dispatched/);
+});
+
+test("seam/llm.stream: dev 构建冻结请求信封，生产构建不冻结", async () => {
+  setLlmServiceDevModeForTest(true);
+  const devRequest = {
+    model: buildModel("openai-completions"),
+    context: buildContext(),
+    options: {
+      apiKey: "sk-test",
+      onPayload: async () => {
+        throw new Error("__capture_stop__");
+      },
+    },
+  };
+  const devStream = llm.stream(devRequest);
+  try {
+    await devStream.result();
+  } catch {
+    // 中断属预期。
+  }
+  assert.ok(Object.isFrozen(devRequest), "dev build must freeze the request envelope");
+
+  setLlmServiceDevModeForTest(false);
+  const prodRequest = {
+    model: buildModel("openai-completions"),
+    context: buildContext(),
+    options: {
+      apiKey: "sk-test",
+      onPayload: async () => {
+        throw new Error("__capture_stop__");
+      },
+    },
+  };
+  const prodStream = llm.stream(prodRequest);
+  try {
+    await prodStream.result();
+  } catch {
+    // 中断属预期。
+  }
+  assert.equal(Object.isFrozen(prodRequest), false, "prod build must not freeze");
+});
+
+test("seam/llm.stream: 测试加载器环境自动探测落到不冻结（import.meta 空壳）", async () => {
+  // 不设 override：detectDevBuild 在 esbuild CJS 转译下 import.meta.env 不存在。
+  const request = {
+    model: buildModel("openai-completions"),
+    context: buildContext(),
+    options: {
+      apiKey: "sk-test",
+      onPayload: async () => {
+        throw new Error("__capture_stop__");
+      },
+    },
+  };
+  const stream = llmStream(request);
+  try {
+    await stream.result();
+  } catch {
+    // 中断属预期。
+  }
+  assert.equal(Object.isFrozen(request), false);
+});
+
+// ---------------------------------------------------------------------------
+// 兼容壳与统一入口等价
+// ---------------------------------------------------------------------------
+
+test("seam/equivalence: 兼容壳与 llm.stream() 产出同一 wire payload", async () => {
+  const context = buildContext();
+  const viaShim = await captureViaEntry(
+    streamSimpleByApi,
+    buildModel("openai-completions"),
+    context,
+  );
+  const viaService = await captureViaEntry(
+    (model, ctx, options) => llm.stream({ model, context: ctx, options }),
+    buildModel("openai-completions"),
+    context,
+  );
+  assert.deepEqual(viaService, viaShim);
+});
+
+test("seam/equivalence: deepseek 原生协议经两个入口同样等价", async () => {
+  const context = buildContext();
+  const model = buildModel(DEEPSEEK_RESPONSES_API, { provider: "deepseek" });
+  const viaShim = await captureViaEntry(streamSimpleByApi, model, context);
+  const viaService = await captureViaEntry(
+    (m, ctx, options) => llm.stream({ model: m, context: ctx, options }),
+    model,
+    context,
+  );
+  assert.deepEqual(viaService, viaShim);
+});

--- a/crates/agent-gui/test/providers/transport-golden.test.mjs
+++ b/crates/agent-gui/test/providers/transport-golden.test.mjs
@@ -1,0 +1,402 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+// ============================================================================
+// LLM seam 改造（golden 基线之二）：传输装配整体快照。
+//
+// custom-headers-propagation.test.mjs 断言"自定义头能抵达"；本文件把
+// prepareProviderRequest 的完整输出（反代 URL + 全量头集 + base64 覆盖包
+// 解码内容）逐字段锁死，并锁定 failover 场景下逐候选传输配置的独立性——
+// 供应商级 useSystemProxy 是"网络可达性属于每个目标"这一公理的载体，
+// seam 重构绝不允许把主选的传输事实泄漏给备选。
+// ============================================================================
+
+const rootDir = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const abs = (rel) => path.join(rootDir, rel);
+
+const piAiEventStream = await import(
+  new URL(
+    "../../node_modules/@earendil-works/pi-ai/dist/utils/event-stream.js",
+    import.meta.url,
+  ).href
+);
+
+const PROXY_SERVER_INFO = { baseUrl: "http://127.0.0.1:18080", token: "proxy-token" };
+const SESSION_ID = "00000000-0000-4000-8000-000000000001";
+
+function decodeOverrides(headers) {
+  const encoded = headers["x-liveagent-upstream-headers"];
+  if (encoded === undefined) return undefined;
+  return JSON.parse(Buffer.from(encoded, "base64").toString("utf8"));
+}
+
+/** 覆盖包单独解码断言，其余头逐字段断言。 */
+function splitPrepared(prepared) {
+  const { "x-liveagent-upstream-headers": _encoded, ...headers } = prepared.headers;
+  return { baseUrl: prepared.baseUrl, headers, overrides: decodeOverrides(prepared.headers) };
+}
+
+// ---------------------------------------------------------------------------
+// 第一部分：prepareProviderRequest 完整输出快照（真实实现，仅 mock tauri invoke）
+// ---------------------------------------------------------------------------
+
+const transportLoader = createTsModuleLoader({
+  mocks: {
+    "@tauri-apps/api/core": {
+      async invoke(command) {
+        if (command === "proxy_get_server_info") return PROXY_SERVER_INFO;
+        throw new Error(`unexpected tauri invoke: ${command}`);
+      },
+    },
+  },
+});
+const { prepareProviderRequest } = transportLoader.loadModule(
+  "src/lib/providers/runtime/requestOptions.ts",
+);
+const { ANTHROPIC_DEFAULT_REQUEST_HEADERS } = transportLoader.loadModule(
+  "@liveagent/ui/lib/providers/customHeaders.ts",
+);
+
+test("golden/transport: anthropic 全量头集（内置默认头 + 自定义头 + 覆盖包 + use-system-proxy）", async () => {
+  const prepared = await prepareProviderRequest(
+    "claude_code",
+    {
+      baseUrl: "https://api.anthropic.com/v1",
+      apiKey: "sk-ant-test",
+      customHeaders: [
+        { key: "X-Relay-Channel", value: "vip" },
+        // 浏览器禁止头名：常规通道会被 WebView 丢弃，只能靠覆盖包送达。
+        { key: "Cookie", value: "session=abc" },
+      ],
+      useSystemProxy: true,
+    },
+    { sessionId: SESSION_ID },
+  );
+  const { baseUrl, headers, overrides } = splitPrepared(prepared);
+
+  assert.equal(baseUrl, "http://127.0.0.1:18080/proxy/claude_code/v1");
+  assert.deepEqual(headers, {
+    "x-api-key": "sk-ant-test",
+    ...ANTHROPIC_DEFAULT_REQUEST_HEADERS,
+    "X-Relay-Channel": "vip",
+    Cookie: "session=abc",
+    "x-liveagent-upstream-origin": "https://api.anthropic.com",
+    "x-liveagent-proxy-token": "proxy-token",
+    "x-liveagent-use-system-proxy": "1",
+  });
+  // 覆盖包 = 内置默认头 + 自定义头；鉴权头（x-api-key）按排除集绝不进包。
+  assert.deepEqual(overrides, {
+    ...ANTHROPIC_DEFAULT_REQUEST_HEADERS,
+    "X-Relay-Channel": "vip",
+    Cookie: "session=abc",
+  });
+});
+
+test("golden/transport: codex Responses 链路带 session/conversation 头；直连时无 use-system-proxy", async () => {
+  const prepared = await prepareProviderRequest(
+    "codex",
+    { baseUrl: "https://chatgpt.com/backend-api/codex", apiKey: "sk-codex-test" },
+    { sessionId: SESSION_ID },
+  );
+  const { baseUrl, headers, overrides } = splitPrepared(prepared);
+
+  assert.equal(baseUrl, "http://127.0.0.1:18080/proxy/codex/backend-api/codex");
+  assert.deepEqual(headers, {
+    Authorization: "Bearer sk-codex-test",
+    session_id: SESSION_ID,
+    conversation_id: SESSION_ID,
+    "x-liveagent-upstream-origin": "https://chatgpt.com",
+    "x-liveagent-proxy-token": "proxy-token",
+  });
+  assert.deepEqual(overrides, {
+    session_id: SESSION_ID,
+    conversation_id: SESSION_ID,
+  });
+});
+
+test("golden/transport: codex Completions 格式绝不泄漏 session/conversation 头", async () => {
+  const prepared = await prepareProviderRequest(
+    "codex",
+    {
+      baseUrl: "https://relay.example.com/v1",
+      apiKey: "sk-relay-test",
+      requestFormat: "openai-completions",
+    },
+    { sessionId: SESSION_ID },
+  );
+  const { baseUrl, headers, overrides } = splitPrepared(prepared);
+
+  assert.equal(baseUrl, "http://127.0.0.1:18080/proxy/codex/v1");
+  // 无状态协议仅 Bearer；头集不含任何需要覆盖包的条目。
+  assert.deepEqual(headers, {
+    Authorization: "Bearer sk-relay-test",
+    "x-liveagent-upstream-origin": "https://relay.example.com",
+    "x-liveagent-proxy-token": "proxy-token",
+  });
+  assert.equal(overrides, undefined);
+});
+
+test("golden/transport: gemini 用 x-goog-api-key 单头鉴权", async () => {
+  const prepared = await prepareProviderRequest(
+    "gemini",
+    { baseUrl: "https://generativelanguage.googleapis.com", apiKey: "g-test-key" },
+    { sessionId: SESSION_ID },
+  );
+  const { baseUrl, headers, overrides } = splitPrepared(prepared);
+
+  assert.equal(baseUrl, "http://127.0.0.1:18080/proxy/gemini");
+  assert.deepEqual(headers, {
+    "x-goog-api-key": "g-test-key",
+    "x-liveagent-upstream-origin": "https://generativelanguage.googleapis.com",
+    "x-liveagent-proxy-token": "proxy-token",
+  });
+  assert.equal(overrides, undefined);
+});
+
+test("golden/transport: deepseek full URL 模式保留完整上游 URL（含查询参数）", async () => {
+  const prepared = await prepareProviderRequest(
+    "deepseek",
+    {
+      baseUrl: "https://relay.example.com/openai/v1/responses?alt=x",
+      apiKey: "sk-ds-test",
+      isFullUrl: true,
+    },
+    { sessionId: SESSION_ID },
+  );
+  const { baseUrl, headers, overrides } = splitPrepared(prepared);
+
+  assert.equal(baseUrl, "http://127.0.0.1:18080/proxy/deepseek");
+  assert.deepEqual(headers, {
+    Authorization: "Bearer sk-ds-test",
+    "x-liveagent-upstream-origin": "https://relay.example.com",
+    "x-liveagent-upstream-url": "https://relay.example.com/openai/v1/responses?alt=x",
+    "x-liveagent-proxy-token": "proxy-token",
+  });
+  assert.equal(overrides, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// 第二部分：failover 逐候选传输配置独立性。
+// 场景来自网络拓扑用户故事：主选是走应用代理的国外供应商，备选是直连的国内
+// 中转。断言两个目标各自独立装配（use-system-proxy 头互不泄漏），主选未提交
+// 失败后备选以自己的传输配置接管。
+// ---------------------------------------------------------------------------
+
+/** 捕获经 streamSimpleByApi 发出的每次调用（model + options.headers）。 */
+const streamCalls = [];
+let streamImpl = () => {
+  throw new Error("streamImpl was not configured");
+};
+
+const failoverLoader = createTsModuleLoader({
+  mocks: {
+    "@tauri-apps/api/core": {
+      async invoke(command) {
+        if (command === "proxy_get_server_info") return PROXY_SERVER_INFO;
+        throw new Error(`unexpected tauri invoke: ${command}`);
+      },
+    },
+    [abs("src/lib/providers/runtime/streamByApi.ts")]: {
+      streamSimpleByApi: (model, context, options) => {
+        streamCalls.push({ model, options });
+        return streamImpl(model, context, options);
+      },
+    },
+    [abs("src/lib/system/powerActivity.ts")]: {
+      withPowerActivity: (_scope, _reason, run) => run(),
+    },
+    [abs("src/lib/debug/agentDebug.ts")]: {
+      buildStreamRequestDebugPayload: () => ({}),
+    },
+    [abs("src/lib/providers/hostedSearchEvents.ts")]: {
+      createHostedSearchProbeId: () => undefined,
+      withHostedSearchProbeHeader: (headers) => headers ?? {},
+      startHostedSearchFetchProbe: () => ({ finish: async () => {} }),
+      createHostedSearchEventAggregator: () => ({
+        accept: () => {},
+        complete: () => [],
+        fail: () => {},
+        dispose: () => {},
+        getBlocks: () => [],
+      }),
+    },
+  },
+});
+
+const { streamAssistantMessage } = failoverLoader.loadModule(
+  "src/lib/providers/runtime/textOnlyRuntime.ts",
+);
+const { resetFailoverBreakers } = failoverLoader.loadModule(
+  "src/lib/providers/runtime/providerFailover.ts",
+);
+
+function makeAssistantMessage(overrides = {}) {
+  return {
+    role: "assistant",
+    content: [],
+    api: "anthropic-messages",
+    provider: "claude_code",
+    model: "claude-x",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 1,
+  };
+}
+
+function makeSourceStream(events) {
+  const stream = piAiEventStream.createAssistantMessageEventStream();
+  for (const event of events) stream.push(event);
+  return stream;
+}
+
+function successStream(text) {
+  const message = { ...makeAssistantMessage(), content: [{ type: "text", text }] };
+  return makeSourceStream([
+    { type: "start", partial: message },
+    { type: "text_delta", contentIndex: 0, delta: text, partial: message },
+    { type: "done", reason: "stop", message },
+  ]);
+}
+
+function uncommittedErrorStream(errorMessage) {
+  const message = { ...makeAssistantMessage(), stopReason: "error", errorMessage };
+  return makeSourceStream([
+    { type: "start", partial: message },
+    { type: "error", reason: "error", error: message },
+  ]);
+}
+
+test.beforeEach(() => {
+  resetFailoverBreakers();
+  streamCalls.length = 0;
+});
+
+test("golden/transport-failover: 主选走代理 + 备选直连，逐候选传输配置互不泄漏", async () => {
+  // 主选：国外供应商，勾选走应用代理。
+  const primaryRuntime = {
+    baseUrl: "https://api.anthropic.com/v1",
+    apiKey: "sk-primary",
+    promptCachingEnabled: false,
+    useSystemProxy: true,
+  };
+  // 备选：国内中转，直连（不带 useSystemProxy）。
+  const fallbackRuntime = {
+    baseUrl: "https://relay.cn.example/v1",
+    apiKey: "sk-fallback",
+    promptCachingEnabled: false,
+  };
+
+  streamImpl = (_model, _context, options) =>
+    options.headers["x-liveagent-use-system-proxy"] === "1"
+      ? uncommittedErrorStream("502 upstream proxy unavailable")
+      : successStream("fallback-answer");
+
+  const final = await streamAssistantMessage({
+    providerId: "claude_code",
+    model: "claude-x",
+    runtime: primaryRuntime,
+    context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+    sessionId: SESSION_ID,
+    onTextDelta: () => {},
+    failover: {
+      config: { maxSwitches: 3, failureThreshold: 3, cooldownSeconds: 60 },
+      primary: {
+        selectedModel: { customProviderId: "p-abroad", model: "claude-x" },
+        label: "国外官方 · claude-x",
+      },
+      fallbacks: [
+        {
+          selectedModel: { customProviderId: "p-cn-relay", model: "claude-x" },
+          providerId: "claude_code",
+          model: "claude-x",
+          label: "国内中转 · claude-x",
+          runtime: fallbackRuntime,
+        },
+      ],
+    },
+  });
+
+  assert.equal(final.content[0].text, "fallback-answer");
+  assert.equal(streamCalls.length, 2);
+
+  // 候选 1（主选）：真实 prepareProviderRequest 输出，带 use-system-proxy。
+  const primaryCall = streamCalls[0];
+  assert.equal(primaryCall.model.baseUrl, "http://127.0.0.1:18080/proxy/claude_code/v1");
+  assert.equal(primaryCall.options.headers["x-liveagent-use-system-proxy"], "1");
+  assert.equal(primaryCall.options.headers["x-api-key"], "sk-primary");
+  assert.equal(
+    primaryCall.options.headers["x-liveagent-upstream-origin"],
+    "https://api.anthropic.com",
+  );
+
+  // 候选 2（备选）：独立装配，绝不继承主选的 use-system-proxy 与凭据。
+  const fallbackCall = streamCalls[1];
+  assert.equal(fallbackCall.model.baseUrl, "http://127.0.0.1:18080/proxy/claude_code/v1");
+  assert.equal(fallbackCall.options.headers["x-liveagent-use-system-proxy"], undefined);
+  assert.equal(fallbackCall.options.headers["x-api-key"], "sk-fallback");
+  assert.equal(
+    fallbackCall.options.headers["x-liveagent-upstream-origin"],
+    "https://relay.cn.example",
+  );
+});
+
+test("golden/transport-failover: 反向拓扑（主选直连 + 备选走代理）同样逐候选独立", async () => {
+  const primaryRuntime = {
+    baseUrl: "https://relay.cn.example/v1",
+    apiKey: "sk-primary-direct",
+    promptCachingEnabled: false,
+  };
+  const fallbackRuntime = {
+    baseUrl: "https://api.anthropic.com/v1",
+    apiKey: "sk-fallback-proxied",
+    promptCachingEnabled: false,
+    useSystemProxy: true,
+  };
+
+  streamImpl = (_model, _context, options) =>
+    options.headers["x-liveagent-use-system-proxy"] === "1"
+      ? successStream("proxied-answer")
+      : uncommittedErrorStream("503 relay unavailable");
+
+  const final = await streamAssistantMessage({
+    providerId: "claude_code",
+    model: "claude-x",
+    runtime: primaryRuntime,
+    context: { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+    sessionId: SESSION_ID,
+    onTextDelta: () => {},
+    failover: {
+      config: { maxSwitches: 3, failureThreshold: 3, cooldownSeconds: 60 },
+      primary: {
+        selectedModel: { customProviderId: "p-cn-relay", model: "claude-x" },
+        label: "国内中转 · claude-x",
+      },
+      fallbacks: [
+        {
+          selectedModel: { customProviderId: "p-abroad", model: "claude-x" },
+          providerId: "claude_code",
+          model: "claude-x",
+          label: "国外官方 · claude-x",
+          runtime: fallbackRuntime,
+        },
+      ],
+    },
+  });
+
+  assert.equal(final.content[0].text, "proxied-answer");
+  assert.equal(streamCalls.length, 2);
+  assert.equal(streamCalls[0].options.headers["x-liveagent-use-system-proxy"], undefined);
+  assert.equal(streamCalls[0].options.headers["x-api-key"], "sk-primary-direct");
+  assert.equal(streamCalls[1].options.headers["x-liveagent-use-system-proxy"], "1");
+  assert.equal(streamCalls[1].options.headers["x-api-key"], "sk-fallback-proxied");
+});

--- a/crates/agent-gui/test/providers/wire-payload-golden.test.mjs
+++ b/crates/agent-gui/test/providers/wire-payload-golden.test.mjs
@@ -1,0 +1,348 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+// ============================================================================
+// LLM seam 改造（golden 基线之一）：五协议最终 wire payload 整体快照。
+//
+// 现有 provider 测试逐字段断言单个行为（tool_choice、缓存断点、thinking 档位…）；
+// 本文件的职责不同——把每条协议"固定输入 → 完整请求体"逐字段锁死，作为后续
+// seam 重构（PR-1 适配器包装 / PR-3 拦截器注册化）"行为等价"的判定基准。
+// 快照有意写成显式对象字面量而非 .snapshot 文件：diff 直接可读，且杜绝
+// 无意 re-record。
+//
+// 捕获通道：走真实 pi-ai stream()（连同 finalizeProviderStreamOptions 全部
+// payload 中间件），用 onPayload 截获最终线格式后抛错中断，网络零触碰。
+// ============================================================================
+
+const realAnthropic = await import(
+  new URL(
+    "../../node_modules/@earendil-works/pi-ai/dist/api/anthropic-messages.js",
+    import.meta.url,
+  ).href
+);
+const realCompletions = await import(
+  new URL(
+    "../../node_modules/@earendil-works/pi-ai/dist/api/openai-completions.js",
+    import.meta.url,
+  ).href
+);
+const realResponses = await import(
+  new URL(
+    "../../node_modules/@earendil-works/pi-ai/dist/api/openai-responses.js",
+    import.meta.url,
+  ).href
+);
+const realGoogle = await import(
+  new URL(
+    "../../node_modules/@earendil-works/pi-ai/dist/api/google-generative-ai.js",
+    import.meta.url,
+  ).href
+);
+
+const loader = createTsModuleLoader({
+  mocks: {
+    "@earendil-works/pi-ai/api/anthropic-messages": { stream: realAnthropic.stream },
+    "@earendil-works/pi-ai/api/openai-completions": { stream: realCompletions.stream },
+    "@earendil-works/pi-ai/api/openai-responses": { stream: realResponses.stream },
+    "@earendil-works/pi-ai/api/google-generative-ai": { stream: realGoogle.stream },
+  },
+});
+
+const { createModelFromConfig } = loader.loadModule("src/lib/providers/runtime/modelFactory.ts");
+const { streamSimpleByApi } = loader.loadModule("src/lib/providers/runtime/streamByApi.ts");
+const { finalizeProviderStreamOptions } = loader.loadModule(
+  "src/lib/providers/runtime/payloadPipeline.ts",
+);
+
+// 固定 session id：payload 中所有会话关联字段（prompt_cache_key/metadata.user_id）
+// 由它派生，保证快照确定性。
+const SESSION_ID = "00000000-0000-4000-8000-000000000001";
+
+const TOOLS = [
+  {
+    name: "read_file",
+    description: "Read a file",
+    parameters: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+  },
+];
+
+function buildContext({ withTools = true } = {}) {
+  return {
+    systemPrompt: "You are a precise assistant.",
+    messages: [{ role: "user", content: "hello world", timestamp: 1 }],
+    ...(withTools ? { tools: TOOLS } : {}),
+  };
+}
+
+/**
+ * 走真实装配链（finalizeProviderStreamOptions → streamSimpleByApi → 真实
+ * pi-ai stream），在 onPayload 链尾截获最终 wire payload 后中断请求。
+ */
+async function captureWirePayload(providerId, model, context, baseOptions) {
+  let captured;
+  const finalized = finalizeProviderStreamOptions({
+    providerId,
+    baseUrl: model.baseUrl,
+    options: baseOptions,
+    context,
+    model,
+  });
+  const prevOnPayload = finalized.onPayload;
+  const stream = streamSimpleByApi(model, context, {
+    ...finalized,
+    onPayload: async (payload, m) => {
+      captured = prevOnPayload ? ((await prevOnPayload(payload, m)) ?? payload) : payload;
+      throw new Error("__capture_stop__");
+    },
+  });
+  try {
+    await stream.result();
+  } catch {
+    // onPayload 抛错中断请求属预期。
+  }
+  assert.ok(captured, `expected wire payload capture for ${model.id}`);
+  // JSON 往返归一化：golden 锁定的是线上 JSON 形态；值为 undefined 的键
+  // （如 responses 链路的 prompt_cache_retention）序列化后不存在，不入快照。
+  return JSON.parse(JSON.stringify(captured));
+}
+
+const WIRE_TOOL_SCHEMA = {
+  type: "object",
+  properties: { path: { type: "string" } },
+  required: ["path"],
+};
+
+test("golden/anthropic-messages: 官方端点完整请求体（adaptive thinking + 缓存断点 + metadata）", async () => {
+  const baseUrl = "https://api.anthropic.com/v1";
+  const model = createModelFromConfig(
+    "claude_code",
+    "claude-sonnet-4-6",
+    baseUrl,
+    undefined,
+    undefined,
+    baseUrl,
+  );
+  const payload = await captureWirePayload("claude_code", model, buildContext(), {
+    apiKey: "sk-test",
+    reasoning: "high",
+    toolChoice: "auto",
+    sessionId: SESSION_ID,
+    cacheRetention: "short",
+    metadata: { user_id: SESSION_ID },
+  });
+
+  assert.deepEqual(payload, {
+    model: "claude-sonnet-4-6",
+    messages: [{ role: "user", content: [{ type: "text", text: "hello world" }] }],
+    max_tokens: 128000,
+    stream: true,
+    system: [{ type: "text", text: "You are a precise assistant." }],
+    tools: [
+      {
+        name: "read_file",
+        description: "Read a file",
+        eager_input_streaming: true,
+        input_schema: WIRE_TOOL_SCHEMA,
+      },
+    ],
+    thinking: { type: "adaptive", display: "summarized" },
+    output_config: { effort: "high" },
+    metadata: { user_id: SESSION_ID },
+    tool_choice: { type: "auto" },
+    cache_control: { type: "ephemeral" },
+  });
+});
+
+test("golden/openai-completions: 中转端点完整请求体（带工具 + reasoning_effort）", async () => {
+  const baseUrl = "https://relay.example.com/v1";
+  const model = createModelFromConfig(
+    "codex",
+    "gpt-5.2",
+    baseUrl,
+    "openai-completions",
+    undefined,
+    baseUrl,
+  );
+  const payload = await captureWirePayload("codex", model, buildContext(), {
+    apiKey: "sk-test",
+    reasoning: "high",
+    toolChoice: "auto",
+    sessionId: SESSION_ID,
+  });
+
+  assert.deepEqual(payload, {
+    model: "gpt-5.2",
+    messages: [
+      { role: "system", content: "You are a precise assistant." },
+      { role: "user", content: "hello world" },
+    ],
+    stream: true,
+    stream_options: { include_usage: true },
+    max_completion_tokens: 128000,
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "read_file",
+          description: "Read a file",
+          parameters: WIRE_TOOL_SCHEMA,
+          strict: false,
+        },
+      },
+    ],
+    tool_choice: "auto",
+    reasoning_effort: "high",
+  });
+});
+
+test("golden/openai-completions: text-only 请求既不带 tools 也不带 tool_choice（严格网关 400 回归）", async () => {
+  const baseUrl = "https://relay.example.com/v1";
+  const model = createModelFromConfig(
+    "codex",
+    "gpt-5.2",
+    baseUrl,
+    "openai-completions",
+    undefined,
+    baseUrl,
+  );
+  const payload = await captureWirePayload(
+    "codex",
+    model,
+    buildContext({ withTools: false }),
+    { apiKey: "sk-test", toolChoice: "auto", sessionId: SESSION_ID },
+  );
+
+  assert.deepEqual(payload, {
+    model: "gpt-5.2",
+    messages: [
+      { role: "system", content: "You are a precise assistant." },
+      { role: "user", content: "hello world" },
+    ],
+    stream: true,
+    stream_options: { include_usage: true },
+    max_completion_tokens: 128000,
+  });
+});
+
+test("golden/openai-responses: codex 官方端点完整请求体（store + prompt_cache_key + encrypted reasoning）", async () => {
+  const baseUrl = "https://chatgpt.com/backend-api/codex";
+  const model = createModelFromConfig(
+    "codex",
+    "gpt-5.2-codex",
+    baseUrl,
+    undefined,
+    undefined,
+    baseUrl,
+  );
+  const payload = await captureWirePayload("codex", model, buildContext(), {
+    apiKey: "sk-test",
+    reasoning: "high",
+    sessionId: SESSION_ID,
+    cacheRetention: "short",
+  });
+
+  assert.deepEqual(payload, {
+    model: "gpt-5.2-codex",
+    input: [
+      { role: "system", content: "You are a precise assistant." },
+      { role: "user", content: [{ type: "input_text", text: "hello world" }] },
+    ],
+    stream: true,
+    prompt_cache_key: SESSION_ID,
+    store: true,
+    max_output_tokens: 142000,
+    tools: [
+      {
+        type: "function",
+        name: "read_file",
+        description: "Read a file",
+        parameters: WIRE_TOOL_SCHEMA,
+      },
+    ],
+    reasoning: { effort: "high", summary: "auto" },
+    include: ["reasoning.encrypted_content"],
+  });
+});
+
+test("golden/google-generative-ai: 官方端点完整请求体（thinkingLevel + functionCallingConfig）", async () => {
+  const baseUrl = "https://generativelanguage.googleapis.com";
+  const model = createModelFromConfig(
+    "gemini",
+    "gemini-3-pro-preview",
+    baseUrl,
+    undefined,
+    undefined,
+    baseUrl,
+  );
+  const payload = await captureWirePayload("gemini", model, buildContext(), {
+    apiKey: "test-key",
+    reasoning: "high",
+    toolChoice: "auto",
+    sessionId: SESSION_ID,
+  });
+
+  assert.deepEqual(payload, {
+    model: "gemini-3-pro-preview",
+    contents: [{ role: "user", parts: [{ text: "hello world" }] }],
+    config: {
+      maxOutputTokens: 65536,
+      systemInstruction: "You are a precise assistant.",
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: "read_file",
+              description: "Read a file",
+              parametersJsonSchema: WIRE_TOOL_SCHEMA,
+            },
+          ],
+        },
+      ],
+      toolConfig: { functionCallingConfig: { mode: "AUTO" } },
+      thinkingConfig: { includeThoughts: true, thinkingLevel: "HIGH" },
+    },
+  });
+});
+
+test("golden/deepseek-responses: 原生适配器完整请求体（developer role + reasoning effort 直通）", async () => {
+  const baseUrl = "https://api.deepseek.com";
+  const model = createModelFromConfig(
+    "deepseek",
+    "deepseek-v4-flash",
+    baseUrl,
+    undefined,
+    undefined,
+    baseUrl,
+  );
+  const payload = await captureWirePayload("deepseek", model, buildContext(), {
+    apiKey: "sk-test",
+    reasoning: "high",
+    toolChoice: "auto",
+    sessionId: SESSION_ID,
+  });
+
+  assert.deepEqual(payload, {
+    model: "deepseek-v4-flash",
+    input: [
+      { role: "developer", content: "You are a precise assistant." },
+      { role: "user", content: [{ type: "input_text", text: "hello world" }] },
+    ],
+    stream: true,
+    max_output_tokens: 384000,
+    tools: [
+      {
+        type: "function",
+        name: "read_file",
+        description: "Read a file",
+        parameters: WIRE_TOOL_SCHEMA,
+      },
+    ],
+    tool_choice: "auto",
+    reasoning: { effort: "high" },
+  });
+});


### PR DESCRIPTION
﻿Closes #593

## 改动说明

在 PR-0 golden 基线（#590）保护下引入 LLM seam 骨架，行为严格等价：

- **新增 `crates/agent-gui/src/lib/providers/service/`**
  - `types.ts`：`LlmAdapter` 接口（必需 `stream()`；`resolveModel()`/`retryPolicy()` 为后续 PR 预留的可选签名）与 `LlmStreamRequest` 请求信封
  - `registry.ts`：api→adapter 注册表；未注册协议错误文案与重构前逐字一致（`Unsupported model API: ...`）
  - `piAiAdapter.ts`：原样搬移 streamByApi.ts 的 anthropic-messages / openai-completions / openai-responses / google-generative-ai 四分支（含各分支 withStreamRetry 包装位置、toolChoice 映射、thinking runtime 解析与注释）
  - `deepSeekAdapter.ts`：原样搬移 deepseek-responses 分支
  - `llmService.ts`：统一入口 `llm.stream(request)`——一次性分发（同一信封重复分发抛错）+ 仅 dev 构建生效的请求信封冻结（生产零开销）
- **`streamByApi.ts` 收缩为兼容壳**：保留 `streamSimpleByApi` 原签名，内部走注册表路由；该模块同时是 seam 的公开可观测针孔（传输 golden 与 failover 测试按此路径 mock 截获全部出站流）
- **消费方换统一入口**：agentRunner.ts（1 处）、textOnlyRuntime.ts（4 处）改调 `llm.stream()`，参数三元组不变；failover 逐候选传输独立与 buffer-until-commit 语义逐行保持
- **传输路由字段**（`x-liveagent-*` 头、useSystemProxy 派生头）对 seam 不透明透传：不读取、不判断、不缓存

零 Rust 改动（diff 不含 `src-tauri/**`）、零镜像文件改动、无依赖变更。

## 验证结果

- ✅ PR-0 golden 两套件 **零修改** 全部通过（wire-payload-golden 与 transport-golden 共 13 用例）——行为等价的判定基准
- ✅ 新增 `test/providers/llm-service-seam.test.mjs` 8 用例：注册表五协议分发、未知协议错误文案逐字等价、重复注册抛错、一次性分发、dev 冻结/生产不冻结/自动探测降级、兼容壳与 `llm.stream()` 双入口 wire payload 等价（openai-completions 与 deepseek 原生各一）
- ✅ `pnpm --dir crates/agent-gui build`
- ✅ `pnpm --dir crates/agent-gui test:frontend`（268 个测试文件，exit 0）
- ✅ 本 PR 全部改动文件 Biome lint 零错误（全仓既有 CRLF/格式基线错误与本改动无关，见下）
- ✅ `git diff --check`
- ⚠️ `node scripts/check-ui-boundaries.mjs` 报 3 个文件（agent-gui settings/index.ts、gateway web settings/index.ts、gateway web uiMessages.ts）——已核验三者内容与 upstream/main 完全一致且不在本 PR 改动集，属既有基线问题
- ⚠️ 全仓 `pnpm lint` 在 Windows checkout 上有 310+ 既有 CRLF/格式错误（基线问题，与本改动无关）

## 未运行项

- Rust/Go/WebUI 构建与测试：本 PR 不涉及对应目录

## 人工验收

已在 Windows Tauri 调试客户端（本分支 HEAD 构建）人工验证通过：带工具多轮对话、会话标题生成、手动压缩、断网重试提示、failover 切换。

## Screenshots / preview

<img width="2130" height="1471" alt="image" src="https://github.com/user-attachments/assets/b0c523d9-fda4-46fb-b6e1-49adadbcdc0c" />


## Stack

Depends-On: #590
Stack-Root: #590
