### PR TITLE
fix(chat): 修复图片查看器打开后视口测量时序回归导致的黑框

### DIFF
--- a/crates/agent-ui/src/components/chat/ImagePreview.tsx
+++ b/crates/agent-ui/src/components/chat/ImagePreview.tsx
@@ -421,6 +421,7 @@ export const ImagePreview = memo(function ImagePreview(props: ImagePreviewProps)
   const [activeIndex, setActiveIndex] = useState(clampedRequestedIndex);
   const [viewerState, setViewerState] = useState<ImageViewerState>(resetImageViewerState);
   const [viewportSize, setViewportSize] = useState<ImageViewerSize>({ width: 0, height: 0 });
+  const [viewportElement, setViewportElement] = useState<HTMLDivElement | null>(null);
   const [naturalSize, setNaturalSize] = useState<ImageViewerSize>({ width: 0, height: 0 });
   const [isDragging, setIsDragging] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
@@ -430,6 +431,10 @@ export const ImagePreview = memo(function ImagePreview(props: ImagePreviewProps)
   const [isCopying, setIsCopying] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const viewportRef = useRef<HTMLDivElement | null>(null);
+  const setViewportRef = useCallback((node: HTMLDivElement | null) => {
+    viewportRef.current = node;
+    setViewportElement(node);
+  }, []);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const resolvedDataRef = useRef(
     new WeakMap<ImagePreviewSlide, ReturnType<typeof resolveImagePreviewData>>(),
@@ -505,10 +510,9 @@ export const ImagePreview = memo(function ImagePreview(props: ImagePreviewProps)
   }, [open]);
 
   useEffect(() => {
-    const viewport = viewportRef.current;
-    if (!open || !viewport) return;
+    if (!open || !viewportElement) return;
     const updateViewportSize = () => {
-      setViewportSize({ width: viewport.clientWidth, height: viewport.clientHeight });
+      setViewportSize({ width: viewportElement.clientWidth, height: viewportElement.clientHeight });
     };
     updateViewportSize();
     if (typeof ResizeObserver === "undefined") {
@@ -516,9 +520,9 @@ export const ImagePreview = memo(function ImagePreview(props: ImagePreviewProps)
       return () => window.removeEventListener("resize", updateViewportSize);
     }
     const observer = new ResizeObserver(updateViewportSize);
-    observer.observe(viewport);
+    observer.observe(viewportElement);
     return () => observer.disconnect();
-  }, [open]);
+  }, [open, viewportElement]);
 
   const imageSize = useMemo(
     () => fitImageViewerSize(naturalSize, viewportSize, viewerState.rotation),
@@ -820,7 +824,7 @@ export const ImagePreview = memo(function ImagePreview(props: ImagePreviewProps)
           </div>
         </div>
         <div
-          ref={viewportRef}
+          ref={setViewportRef}
           role="application"
           aria-label={t("chat.imageViewer.viewer")}
           className={cn(


### PR DESCRIPTION
## Linked issue
Closes #602

## Summary

#448 将聊天图片查看器 `ImagePreview` 的模态实现迁移到了 `@base-ui/react` 的 `Dialog` 组件，`Dialog` 内容改为异步挂载。但视口测量逻辑仍然用 `useRef` 在 `open` 状态变化的同一个 effect 里同步读取视口 DOM 节点并测量尺寸——此时 `Dialog` 内容尚未真正挂载，`viewportRef.current` 为 `null`，`viewportSize` 因此从未被正确设置，图片无法计算出正确渲染尺寸，表现为查看器打开后出现黑框、图片内容不渲染。

修复方式：viewport 引用从纯 `useRef` 改为 callback ref (`setViewportRef`) + state (`viewportElement`)，测量 effect 依赖 `[open, viewportElement]`，在节点真正挂载后才会重新触发测量。`viewportRef` 本身保留，供拖拽/滚轮锚点计算等其他逻辑继续同步读取。`imagePreviewModel.ts` 纯函数层未改动。GUI 与 Gateway WebUI 共用同一份 `agent-ui` 组件，无需分别修复。

## Change scope
- Modules: agent-ui（GUI 与 Gateway WebUI 共享）
- Key paths: `crates/agent-ui/src/components/chat/ImagePreview.tsx`

## Screenshots / preview

修复后：图片查看器正常打开，无黑框，图片内容清晰渲染，工具栏（缩放、旋转、下载、信息面板、关闭等）完整可用。

![image viewer fixed](https://raw.githubusercontent.com/AlphaCatMeow/LiveAgent/assets-issue602/image-viewer-fixed.png)

## Verification

- `pnpm agent-gui build`: 通过
- `pnpm agent-gui test:frontend`: 通过
- `pnpm agent-gateway/web build`: 通过
- `pnpm agent-gateway/web test`: 通过
- 任务文件 lint: 零错误
- `check-ui-boundaries`: 通过（既有 3 个不合规文件与本次改动无关，未新增）
- `git diff --check`: 通过，无空白错误
- 人工 Tauri 验收（`start-tauri-dev.bat` 从本分支 HEAD 启动）：已发送消息附件图片点击预览 ✅、composer 待发附件预览 ✅、缩放 ✅、旋转 ✅、拖拽 ✅、重置 ✅、全屏 ✅、信息面板 ✅。多图切换：确认该应用当前未提供切换上下张图片的按钮/交互（滚轮用于缩放），这是既有产品形态限制，非本次改动范围，不涉及回归

## Pre-submit checklist
- [x] A requirement issue is linked (Closes #602)
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration. — N/A，纯 bugfix，无用户可见行为/配置变更需要文档更新

---
Depends-On: none
Stack-Root: #603