### PR TITLE
fix(build): disable custom codeSplitting that crashed the release bundle (black screen)

### DIFF
--- a/crates/agent-gui/vite.config.ts
+++ b/crates/agent-gui/vite.config.ts
@@ -30,22 +30,20 @@ export default defineConfig(async () => ({
   },
   build: {
     // Monaco language workers are emitted as indivisible lazy assets (largest
-    // is the TypeScript worker at ~6.6 MB). Application modules are still held
-    // to the 450 KB code-splitting group below.
+    // is the TypeScript worker at ~6.6 MB). Bump the warning limit so those
+    // known-large chunks don't drown out real regressions in the console.
     chunkSizeWarningLimit: 7_000,
+    // NOTE: a previous build config set `rolldownOptions.output.codeSplitting`
+    // with a `liveagent-app` group. That custom chunking split the
+    // `style-to-js → style-to-object → inline-style-parser` CommonJS interop
+    // chain across chunks, and rolldown's `__commonJSMin` thunks failed to
+    // initialize across the chunk boundary — the release bundle crashed at
+    // render time with "require_cjs$N is not a function" (black screen), while
+    // `tauri dev` (no chunk splitting) worked. Disabled here to fall back to
+    // rolldown's default automatic chunking, which keeps that CJS chain intact.
     rolldownOptions: {
       output: {
-        codeSplitting: {
-          minSize: 20_000,
-          maxSize: 450_000,
-          groups: [
-            {
-              name: "liveagent-app",
-              test: /\/crates\/(?:agent-gui|agent-ui)\/src\//,
-              entriesAware: true,
-            },
-          ],
-        },
+        codeSplitting: false,
       },
     },
   },


### PR DESCRIPTION
## Summary

The release (`tauri build`) bundle crashed on launch with a black screen and `AppErrorBoundary` showing `require_cjs$N is not a function`, while `tauri dev` worked fine. This fixes it by disabling the custom `codeSplitting` config that split a CommonJS interop chain across chunks.

Closes #612.

## Root cause

`crates/agent-gui/vite.config.ts` recently added `build.rolldownOptions.output.codeSplitting` with a `liveagent-app` group. That custom chunking split the `style-to-js → style-to-object → inline-style-parser` CommonJS chain across chunks. rolldown wraps CJS modules in `__commonJSMin` thunks, and across a chunk boundary those thunks weren't initialized before the call site ran — so `require_cjs$N` was `undefined` at render time → `require_cjs$N is not a function`.

`tauri dev` does no chunk splitting, so the chain stays in one module and works — which is why this slipped past `tsc`, tests, and dev.

In the broken bundle:
```js
// chunk A (style-to-object)
import { r as require_cjs$2 } from "./...-DLqXB6yr.js";  // from chunk B
...
var inline_style_parser_1 = __importDefault(require_cjs$2());  // 💥 not a function
```

## Fix

Set `codeSplitting: false` to fall back to rolldown's default automatic chunking, which keeps that CJS chain in one chunk. `chunkSizeWarningLimit` is kept so the known-large Monaco workers don't spam the console.

```ts
rolldownOptions: {
  output: {
    codeSplitting: false,
  },
},
```

## Verification

Built the release exe (`pnpm tauri build --no-bundle`) and confirmed:
- In the bundle: `style-to-js` / `style-to-object` / `inline-style-parser` now land in the **same** chunk; the cross-chunk `as require_cjs$N` named import is gone.
- The release exe (`target/release/liveagent.exe`) launches and renders correctly — no black screen, no `AppErrorBoundary`.

## Test plan

- [x] `pnpm tauri build --no-bundle` → run `target/release/liveagent.exe` → app renders (was: black screen).
- [x] `pnpm tauri dev` still works (unaffected — dev never split chunks).
- [x] No new chunk-size regressions beyond the existing Monaco-worker warning (covered by `chunkSizeWarningLimit`).

## Notes

- This is a build-config regression, not a code-logic change, so no runtime tests cover it; the verification above is the bundle-inspection + run-the-exe check.
- An alternative finer-grained fix (a high-priority group forcing the CJS chain into one chunk via `test: /[\/]\.pnpm[\/](?:style-to-js|style-to-object|inline-style-parser)@/`) was attempted first but didn't reliably capture `inline-style-parser`; default chunking is more robust.