### PR TITLE
fix(webui): drop custom codeSplitting that crashed page load

### DIFF
--- a/crates/agent-gateway/web/vite.config.ts
+++ b/crates/agent-gateway/web/vite.config.ts
@@ -37,24 +37,16 @@ export default defineConfig(() => ({
     outDir: "dist",
     emptyOutDir: true,
     // Monaco language workers are emitted as indivisible lazy assets (largest
-    // is the TypeScript worker at ~6.6 MB). Application modules are still held
-    // to the 450 KB code-splitting group below.
+    // is the TypeScript worker at ~6.6 MB). Bump the warning limit so those
+    // known-large chunks don't drown out real regressions in the console.
     chunkSizeWarningLimit: 7_000,
-    rolldownOptions: {
-      output: {
-        codeSplitting: {
-          minSize: 20_000,
-          maxSize: 450_000,
-          groups: [
-            {
-              name: "liveagent-webui",
-              test: /\/crates\/(?:agent-ui|agent-gateway\/web)\/src\//,
-              entriesAware: true,
-            },
-          ],
-        },
-      },
-    },
+    // Do not restore `rolldownOptions.output.codeSplitting` with a
+    // `liveagent-webui` group / `maxSize: 450_000`. That size-based split cut
+    // `GatewayTerminalStreamHandle extends TerminalStreamBuffer` across chunks
+    // and created a circular ESM cycle, crashing load with
+    // "Class extends value undefined is not a constructor or null".
+    // `codeSplitting: false` (used by the GUI in #613) inlines every overlay
+    // into a ~23 MB main bundle, which is fine for Tauri but not for WebUI.
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Summary

- WebUI 生产构建一打开就崩：`Class extends value undefined is not a constructor or null`（chunk `liveagent-webui~index~WorkspaceFilePreviewOverlay~WorkspaceCodeEditorOverlay-DRjxHQ_D.js`）。
- 去掉 WebUI 的自定义 `codeSplitting` 分组，回退到 rolldown 默认按动态 import 切块，让 `GatewayTerminalStreamHandle extends TerminalStreamBuffer` 留在同一 chunk。
- 不套 GUI #613 的 `codeSplitting: false`：那会把 overlay 全部内联进约 23 MB 主包，浏览器不可接受。

Closes #618.

## Root cause

`crates/agent-gateway/web/vite.config.ts` 的 `liveagent-webui` 组 + `maxSize: 450_000` 把类继承拆到互相 import 的两个 chunk。子类求值时父类绑定仍是 `undefined`。桌面端同类问题已在 #613 修掉，WebUI 当时漏了同一套配置。

## Test plan

- [x] `pnpm --filter @liveagent/gateway-webui exec vite build`：产物不再出现 `liveagent-webui~index~WorkspaceFilePreviewOverlay~WorkspaceCodeEditorOverlay-*.js`。
- [x] 父类 `TerminalStreamBuffer` 与子类 `GatewayTerminalStreamHandle` 落在同一 `index-*.js` chunk。
- [x] `vite preview` 打开登录页正常渲染，无该 TypeError。
- [ ] 部署后用浏览器再确认 Gateway 登录页可打开。


Made with [Cursor](https://cursor.com)