### PR TITLE
refactor(settings): 重构「备份与同步」页面 UI——状态横幅 + 两栏布局,精简描述文字

### DIFF
--- a/crates/agent-gui/src/i18n/config.ts
+++ b/crates/agent-gui/src/i18n/config.ts
@@ -109,16 +109,15 @@ export const GUI_TRANSLATION_OVERRIDES: Record<Locale, Record<string, string>> =
     "settings.navShortcuts": "快捷键",
     "settings.navBackup": "备份与同步",
     "settings.backupLocalTitle": "本地备份",
-    "settings.backupLocalDesc":
-      "把服务商、MCP、系统设置和技能启用状态导出为单个 JSON 文件；导入会整域覆盖对应配置。",
     "settings.backupExport": "导出配置",
+    "settings.backupExportHint": "保存为单个 JSON 文件",
     "settings.backupImport": "导入配置",
+    "settings.backupImportHint": "从备份文件整域恢复",
     "settings.backupExportDone": "已导出到：",
     "settings.backupExportFailed": "导出失败",
     "settings.backupImportDone": "导入完成：",
     "settings.backupImportFailed": "导入失败",
-    "settings.backupAutoBackupHint":
-      "导入前会自动把当前配置备份到 ~/.liveagent/backups/，保留最近 10 份。",
+    "settings.backupAutoBackupHint": "导入前自动备份当前配置，保留最近 10 份。",
     "settings.backupImportConfirmTitle": "确认导入配置",
     "settings.backupImportConfirmSubtitle": "备份文件中包含的配置域会被整域覆盖，此操作不可撤销。",
     "settings.backupImportConfirmAction": "覆盖导入",
@@ -131,11 +130,21 @@ export const GUI_TRANSLATION_OVERRIDES: Record<Locale, Record<string, string>> =
     "settings.backupDomainSystem": "系统设置",
     "settings.backupDomainSkills": "技能",
     "settings.backupScopeTitle": "备份范围",
-    "settings.backupScopeDesc":
-      "仅覆盖服务商、MCP、系统设置和技能启用状态。对话历史、记忆库、上传文件和 SSH 私钥不在备份范围内。",
+    "settings.backupScopeIncluded": "包含",
+    "settings.backupScopeExcluded": "不包含",
+    "settings.backupScopeChat": "对话历史",
+    "settings.backupScopeMemory": "记忆库",
+    "settings.backupScopeUploads": "上传文件",
+    "settings.backupScopeSshKeys": "SSH 私钥",
     "settings.backupSyncTitle": "WebDAV 同步",
-    "settings.backupSyncDesc":
-      "把同一份配置同步到你自己的 WebDAV 网盘，在多台设备之间共用。WebDAV 账号密码只保存在本机，不会随配置同步出去。",
+    "settings.backupSyncCredentialNote": "账号密码仅保存在本机",
+    "settings.backupSyncLoading": "正在读取同步配置…",
+    "settings.backupSyncStatusReady": "云同步已就绪",
+    "settings.backupSyncStatusNeverSynced": "尚未同步，点击「上传」推送本机配置",
+    "settings.backupSyncStatusNotConfigured": "未配置云同步",
+    "settings.backupSyncStatusNotConfiguredHint": "填写 WebDAV 信息，在多台设备间同步配置",
+    "settings.backupSyncAutoOn": "自动同步已开启",
+    "settings.backupSyncAutoOff": "手动同步",
     "settings.backupSyncPreset": "服务商预设",
     "settings.backupSyncPreset_jianguoyun": "坚果云",
     "settings.backupSyncPreset_nextcloud": "Nextcloud",
@@ -150,8 +159,7 @@ export const GUI_TRANSLATION_OVERRIDES: Record<Locale, Record<string, string>> =
     "settings.backupSyncProfileHint":
       "同一账号下可用不同配置档名隔离多套配置，留空则使用 liveagent / default。",
     "settings.backupSyncAuto": "自动同步",
-    "settings.backupSyncAutoHint":
-      "配置变更后自动上传到远端。自动同步只上传，不会自动覆盖本机配置。",
+    "settings.backupSyncAutoHint": "配置变更后自动上传，不会覆盖本机",
     "settings.backupSyncAutoDone": "已自动同步到远端",
     "settings.backupSyncAutoConfirmTitle": "开启自动同步？",
     "settings.backupSyncAutoConfirmSubtitle": "此后每次配置变更都会自动上传到远端，不再逐次询问。",
@@ -359,16 +367,16 @@ export const GUI_TRANSLATION_OVERRIDES: Record<Locale, Record<string, string>> =
     "settings.navShortcuts": "Shortcuts",
     "settings.navBackup": "Backup & Sync",
     "settings.backupLocalTitle": "Local backup",
-    "settings.backupLocalDesc":
-      "Export providers, MCP, system settings and skill activation to a single JSON file. Importing replaces each included domain wholesale.",
     "settings.backupExport": "Export config",
+    "settings.backupExportHint": "Save as a single JSON file",
     "settings.backupImport": "Import config",
+    "settings.backupImportHint": "Restore from a backup file",
     "settings.backupExportDone": "Exported to: ",
     "settings.backupExportFailed": "Export failed",
     "settings.backupImportDone": "Import complete: ",
     "settings.backupImportFailed": "Import failed",
     "settings.backupAutoBackupHint":
-      "Before importing, the current config is backed up to ~/.liveagent/backups/ (last 10 kept).",
+      "The current config is auto-backed up before import (last 10 kept).",
     "settings.backupImportConfirmTitle": "Confirm config import",
     "settings.backupImportConfirmSubtitle":
       "Every domain present in the backup file will be replaced wholesale. This cannot be undone.",
@@ -382,11 +390,23 @@ export const GUI_TRANSLATION_OVERRIDES: Record<Locale, Record<string, string>> =
     "settings.backupDomainSystem": "System",
     "settings.backupDomainSkills": "Skills",
     "settings.backupScopeTitle": "Backup scope",
-    "settings.backupScopeDesc":
-      "Only providers, MCP, system settings and skill activation are covered. Chat history, memory, uploads and SSH private keys are not included.",
+    "settings.backupScopeIncluded": "Included",
+    "settings.backupScopeExcluded": "Not included",
+    "settings.backupScopeChat": "Chat history",
+    "settings.backupScopeMemory": "Memory",
+    "settings.backupScopeUploads": "Uploads",
+    "settings.backupScopeSshKeys": "SSH keys",
     "settings.backupSyncTitle": "WebDAV Sync",
-    "settings.backupSyncDesc":
-      "Sync one configuration across devices through your own WebDAV storage. The WebDAV account and password stay on this machine and are never included in synced snapshots.",
+    "settings.backupSyncCredentialNote": "Credentials never leave this device",
+    "settings.backupSyncLoading": "Loading sync settings…",
+    "settings.backupSyncStatusReady": "Cloud sync ready",
+    "settings.backupSyncStatusNeverSynced":
+      "Not synced yet — use Upload to push this machine's config",
+    "settings.backupSyncStatusNotConfigured": "Cloud sync not set up",
+    "settings.backupSyncStatusNotConfiguredHint":
+      "Fill in the WebDAV details to sync your config across devices",
+    "settings.backupSyncAutoOn": "Auto sync on",
+    "settings.backupSyncAutoOff": "Manual sync",
     "settings.backupSyncPreset": "Provider Preset",
     "settings.backupSyncPreset_jianguoyun": "Jianguoyun",
     "settings.backupSyncPreset_nextcloud": "Nextcloud",
@@ -401,8 +421,7 @@ export const GUI_TRANSLATION_OVERRIDES: Record<Locale, Record<string, string>> =
     "settings.backupSyncProfileHint":
       "Use different profiles to keep separate configuration sets under one account. Defaults to liveagent / default when left blank.",
     "settings.backupSyncAuto": "Auto Sync",
-    "settings.backupSyncAutoHint":
-      "Upload automatically after configuration changes. Auto sync only uploads and never overwrites this machine.",
+    "settings.backupSyncAutoHint": "Upload after changes; never overwrites this machine",
     "settings.backupSyncAutoDone": "Auto-synced to remote",
     "settings.backupSyncAutoConfirmTitle": "Enable auto sync?",
     "settings.backupSyncAutoConfirmSubtitle":

--- a/crates/agent-gui/src/pages/settings/BackupSyncSection.tsx
+++ b/crates/agent-gui/src/pages/settings/BackupSyncSection.tsx
@@ -1,31 +1,38 @@
 import {
   AlertTriangle,
-  Archive,
   ArchiveRestore,
+  Brain,
+  CheckCircle2,
+  CircleHelp,
   Cloud,
   CloudDownload,
   Download,
+  FileText,
+  HardDrive,
+  Key,
   Loader2,
+  Lock,
+  McpLogo,
+  MessageSquare,
   Plug,
   Save,
+  Server,
+  Settings2,
   Shield,
+  SkillIcon,
   Upload,
+  XCircle,
+  Zap,
 } from "@liveagent/ui/components/IconSet";
 import { Button } from "@liveagent/ui/components/ui/button";
 import { useConfirmDialog } from "@liveagent/ui/components/ui/confirm-dialog";
 import { Input } from "@liveagent/ui/components/ui/input";
 import { Label } from "@liveagent/ui/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@liveagent/ui/components/ui/select";
+import { LabelTooltip } from "@liveagent/ui/components/ui/label-tooltip";
 import { Switch } from "@liveagent/ui/components/ui/switch";
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { listen } from "@tauri-apps/api/event";
-import { useCallback, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import {
   applyBackupImport,
   BACKUP_SYNC_STATUS_EVENT,
@@ -103,6 +110,180 @@ function describeSource(manifest: BackupManifest, t: (key: string) => string) {
         </div>
       ))}
       <div className="pt-1">{summarizeDomains(manifest.domains, t)}</div>
+    </div>
+  );
+}
+
+/** 即时反馈条：成功绿 / 失败红，替代裸文本。 */
+function FeedbackStrip({ status }: { status: Status }) {
+  if (!status) return null;
+  const ok = status.kind === "ok";
+  return (
+    <div
+      className={`flex items-start gap-2 rounded-xl border px-3 py-2.5 text-xs leading-relaxed ${
+        ok
+          ? "border-emerald-600/25 bg-emerald-500/10 text-emerald-700 dark:border-emerald-400/25 dark:text-emerald-300"
+          : "border-destructive/30 bg-destructive/10 text-destructive"
+      }`}
+    >
+      {ok ? (
+        <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      ) : (
+        <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      )}
+      <span className="min-w-0 break-all font-medium">{status.text}</span>
+    </div>
+  );
+}
+
+function FieldLabel({ children, hint }: { children: ReactNode; hint?: string }) {
+  return (
+    <Label className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+      {children}
+      {hint ? (
+        <LabelTooltip label={<span className="max-w-64 text-xs leading-relaxed">{hint}</span>}>
+          <CircleHelp className="h-3.5 w-3.5 cursor-help text-muted-foreground/60" />
+        </LabelTooltip>
+      ) : null}
+    </Label>
+  );
+}
+
+/** 顶部状态横幅：未配置 / 已就绪 / 自动同步失败，聚合上次同步时间与自动同步开关态。 */
+function SyncStatusBanner({
+  view,
+  loading,
+  t,
+}: {
+  view: BackupSyncConfigView | null;
+  loading: boolean;
+  t: (key: string) => string;
+}) {
+  if (loading && !view) {
+    return (
+      <div className="flex items-center gap-3 rounded-2xl border border-border/60 bg-card px-5 py-4">
+        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        <span className="text-sm text-muted-foreground">{t("settings.backupSyncLoading")}</span>
+      </div>
+    );
+  }
+
+  // 加载失败时 view 为 null：按「未配置」展示，具体错误由表单区的反馈条给出。
+  const configured = view ? canTestSyncConnection(view) : false;
+  const failed = Boolean(view?.lastError);
+
+  const iconWrap = failed
+    ? "bg-destructive/10 text-destructive"
+    : configured
+      ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+      : "bg-muted text-muted-foreground";
+
+  return (
+    <div className="rounded-2xl border border-border/60 bg-card px-5 py-4">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-3">
+        <div
+          className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ${iconWrap}`}
+        >
+          {failed ? <AlertTriangle className="h-5 w-5" /> : <Cloud className="h-5 w-5" />}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold text-foreground">
+            {failed
+              ? t("settings.backupSyncAutoErrorTitle")
+              : configured
+                ? t("settings.backupSyncStatusReady")
+                : t("settings.backupSyncStatusNotConfigured")}
+          </div>
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            {configured
+              ? view?.lastSyncAt
+                ? `${t("settings.backupSyncLastAt")}${formatTimestamp(view.lastSyncAt)}`
+                : t("settings.backupSyncStatusNeverSynced")
+              : t("settings.backupSyncStatusNotConfiguredHint")}
+          </p>
+        </div>
+        {configured ? (
+          <span
+            className={`inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium leading-none ${
+              view?.autoSync
+                ? "border-emerald-600/25 bg-emerald-500/10 text-emerald-700 dark:border-emerald-400/25 dark:text-emerald-300"
+                : "border-border/70 bg-muted/45 text-muted-foreground"
+            }`}
+          >
+            <Zap className="h-3 w-3" />
+            {view?.autoSync ? t("settings.backupSyncAutoOn") : t("settings.backupSyncAutoOff")}
+          </span>
+        ) : null}
+      </div>
+      {failed && view?.lastError ? (
+        <p className="mt-3 break-all rounded-xl bg-destructive/10 px-3 py-2 text-xs leading-relaxed text-destructive/90">
+          {view.lastError}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/** 本地备份的大号操作磁贴。 */
+function ActionTile({
+  icon,
+  busy,
+  title,
+  hint,
+  disabled,
+  onClick,
+}: {
+  icon: ReactNode;
+  busy: boolean;
+  title: string;
+  hint: string;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="group flex w-full items-center gap-3 rounded-xl border border-border/60 bg-background/60 px-3.5 py-3 text-left transition-colors hover:border-border hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-55"
+    >
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+        {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : icon}
+      </span>
+      <span className="min-w-0">
+        <span className="block text-sm font-medium text-foreground">{title}</span>
+        <span className="mt-0.5 block truncate text-xs text-muted-foreground">{hint}</span>
+      </span>
+    </button>
+  );
+}
+
+/** 备份范围条目：包含项常色，排除项弱化。 */
+function ScopeItem({
+  icon,
+  label,
+  excluded = false,
+}: {
+  icon: ReactNode;
+  label: string;
+  excluded?: boolean;
+}) {
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-lg px-2.5 py-2 text-xs ${
+        excluded ? "bg-muted/30 text-muted-foreground/70" : "bg-muted/45 text-foreground/85"
+      }`}
+    >
+      <span
+        className={`flex h-4 w-4 shrink-0 items-center justify-center ${excluded ? "opacity-60" : ""}`}
+      >
+        {icon}
+      </span>
+      <span
+        className={`truncate font-medium ${excluded ? "line-through decoration-muted-foreground/40" : ""}`}
+      >
+        {label}
+      </span>
     </div>
   );
 }
@@ -191,10 +372,9 @@ export function BackupSyncSection(props: SettingsSectionProps) {
   }, []);
 
   const handlePresetChange = useCallback(
-    (value: string) => {
-      const next = value as PresetId;
-      setPreset(next);
-      const matched = SYNC_PRESETS.find((item) => item.id === next);
+    (value: PresetId) => {
+      setPreset(value);
+      const matched = SYNC_PRESETS.find((item) => item.id === value);
       // 选「自定义」时保留当前 URL，只有选到具体预设才覆写。
       if (matched) patchForm({ url: matched.url });
     },
@@ -403,282 +583,322 @@ export function BackupSyncSection(props: SettingsSectionProps) {
     }
   }, [confirm, syncStateAfterRestore, t]);
 
+  const presetOptions: { id: PresetId }[] = [...SYNC_PRESETS, { id: "custom" as const }];
+
   return (
-    <div className="space-y-6">
-      <section className="space-y-3 rounded-2xl border border-border/60 bg-card p-4">
-        <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-          <Archive className="h-4 w-4 text-muted-foreground" />
-          {t("settings.backupLocalTitle")}
-        </div>
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          {t("settings.backupLocalDesc")}
-        </p>
+    <div className="mx-auto w-full max-w-[980px] space-y-5">
+      <SyncStatusBanner view={syncView} loading={syncBusy === "load"} t={t} />
 
-        <div className="flex flex-wrap gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={busy !== null}
-            onClick={() => void handleExport()}
-          >
-            {busy === "export" ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Download className="h-3.5 w-3.5" />
-            )}
-            {t("settings.backupExport")}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={busy !== null}
-            onClick={() => void handleImport()}
-          >
-            {busy === "import" ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Upload className="h-3.5 w-3.5" />
-            )}
-            {t("settings.backupImport")}
-          </Button>
-        </div>
-
-        <div className="flex items-start gap-2 text-xs leading-relaxed text-muted-foreground">
-          <ArchiveRestore className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-          <span>{t("settings.backupAutoBackupHint")}</span>
-        </div>
-
-        {status ? (
-          <div
-            className={`break-all text-xs font-medium ${
-              status.kind === "ok" ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"
-            }`}
-          >
-            {status.text}
-          </div>
-        ) : null}
-      </section>
-
-      <section className="space-y-3 rounded-2xl border border-border/60 bg-card p-4">
-        <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-          <Cloud className="h-4 w-4 text-muted-foreground" />
-          {t("settings.backupSyncTitle")}
-        </div>
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          {t("settings.backupSyncDesc")}
-        </p>
-
-        <div className="space-y-3">
-          <div className="space-y-1.5">
-            <Label className="text-xs">{t("settings.backupSyncPreset")}</Label>
-            <Select value={preset} onValueChange={handlePresetChange} disabled={syncLocked}>
-              <SelectTrigger className="h-9">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {SYNC_PRESETS.map((item) => (
-                  <SelectItem key={item.id} value={item.id}>
-                    {t(`settings.backupSyncPreset_${item.id}`)}
-                  </SelectItem>
-                ))}
-                <SelectItem value="custom">{t("settings.backupSyncPreset_custom")}</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-1.5">
-            <Label className="text-xs">{t("settings.backupSyncUrl")}</Label>
-            <Input
-              value={form.url}
-              disabled={syncLocked}
-              placeholder="https://dav.example.com/dav/"
-              onChange={(event) => patchForm({ url: event.target.value })}
-            />
-          </div>
-
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="space-y-1.5">
-              <Label className="text-xs">{t("settings.backupSyncUsername")}</Label>
-              <Input
-                value={form.username}
-                disabled={syncLocked}
-                autoComplete="off"
-                onChange={(event) => patchForm({ username: event.target.value })}
-              />
+      {/* 两栏等高拉伸（默认 stretch），保证左右卡片底边始终对齐。 */}
+      <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
+        {/* 左栏：WebDAV 同步配置。弹性布局把底部操作区钉在底边，撑高时中间留白。 */}
+        <section className="flex flex-col rounded-2xl border border-border/60 bg-card">
+          <header className="flex flex-wrap items-center justify-between gap-2 border-b border-border/60 px-5 py-4">
+            <div className="flex items-center gap-2.5">
+              <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <Cloud className="h-4 w-4" />
+              </span>
+              <h3 className="text-sm font-semibold text-foreground">
+                {t("settings.backupSyncTitle")}
+              </h3>
             </div>
-            <div className="space-y-1.5">
-              <Label className="text-xs">{t("settings.backupSyncPassword")}</Label>
-              <Input
-                type="password"
-                value={form.password}
-                disabled={syncLocked}
-                autoComplete="new-password"
-                placeholder={
-                  syncView?.hasPassword && !form.passwordTouched
-                    ? t("settings.backupSyncPasswordSaved")
-                    : ""
-                }
-                onChange={(event) => {
-                  const password = event.target.value;
-                  // 清空密码框视为「没动过」，而不是「把密码改成空」。
-                  // 后端只在 passwordTouched 时采用新值，若这里对空串也置 true，
-                  // 用户输入几个字符再全删掉就会静默抹掉已存的密码 —— 与本框
-                  // 自己的「留空则不修改」占位提示直接矛盾，且此后自动同步因
-                  // 凭据不全而永久静默跳过（auto_upload 的 credentials 分支）。
-                  // 真要清空密码就关掉同步或改用户名，不该由删字符触发。
-                  patchForm({ password, passwordTouched: password.length > 0 });
-                }}
-              />
-            </div>
-          </div>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-muted/45 px-2.5 py-1 text-[11px] font-medium leading-none text-muted-foreground">
+              <Lock className="h-3 w-3" />
+              {t("settings.backupSyncCredentialNote")}
+            </span>
+          </header>
 
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="flex-1 space-y-4 px-5 py-4">
             <div className="space-y-1.5">
-              <Label className="text-xs">{t("settings.backupSyncRemoteDir")}</Label>
-              <Input
-                value={form.remoteDir}
-                disabled={syncLocked}
-                placeholder="liveagent"
-                onChange={(event) => patchForm({ remoteDir: event.target.value })}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label className="text-xs">{t("settings.backupSyncProfile")}</Label>
-              <Input
-                value={form.profile}
-                disabled={syncLocked}
-                placeholder="default"
-                onChange={(event) => patchForm({ profile: event.target.value })}
-              />
-            </div>
-          </div>
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            {t("settings.backupSyncProfileHint")}
-          </p>
-
-          <div className="flex items-start justify-between gap-3 rounded-xl border border-border/60 px-3.5 py-3">
-            <div className="min-w-0 space-y-1">
-              <div className="text-xs font-medium text-foreground">
-                {t("settings.backupSyncAuto")}
+              <FieldLabel>{t("settings.backupSyncPreset")}</FieldLabel>
+              <div className="flex flex-wrap gap-1.5">
+                {presetOptions.map((item) => {
+                  const active = preset === item.id;
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      disabled={syncLocked}
+                      aria-pressed={active}
+                      onClick={() => handlePresetChange(item.id)}
+                      className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-55 ${
+                        active
+                          ? "border-primary/40 bg-primary/10 text-primary"
+                          : "border-border/70 bg-background/60 text-muted-foreground hover:border-border hover:text-foreground"
+                      }`}
+                    >
+                      {t(`settings.backupSyncPreset_${item.id}`)}
+                    </button>
+                  );
+                })}
               </div>
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                {t("settings.backupSyncAutoHint")}
-              </p>
             </div>
-            <Switch
-              checked={form.autoSync}
-              disabled={syncLocked}
-              title={t("settings.backupSyncAuto")}
-              aria-label={t("settings.backupSyncAuto")}
-              onCheckedChange={(checked) => void handleAutoSyncChange(checked)}
-            />
-          </div>
-        </div>
 
-        <div className="flex flex-wrap gap-2">
-          <Button size="sm" disabled={syncLocked} onClick={() => void handleSaveSync()}>
-            {syncBusy === "save" ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Save className="h-3.5 w-3.5" />
-            )}
-            {t("settings.backupSyncSave")}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={syncLocked || dirty}
-            onClick={() => void handleTestSync()}
-          >
-            {syncBusy === "test" ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Plug className="h-3.5 w-3.5" />
-            )}
-            {t("settings.backupSyncTest")}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={syncLocked || dirty}
-            onClick={() => void handleUpload()}
-          >
-            {syncBusy === "upload" ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Cloud className="h-3.5 w-3.5" />
-            )}
-            {t("settings.backupSyncUpload")}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={syncLocked || dirty}
-            onClick={() => void handleDownload()}
-          >
-            {syncBusy === "download" ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <CloudDownload className="h-3.5 w-3.5" />
-            )}
-            {t("settings.backupSyncDownload")}
-          </Button>
-        </div>
-
-        {dirty && !syncLocked ? (
-          <p className="text-xs font-medium text-amber-700 dark:text-amber-300">
-            {t("settings.backupSyncDirtyHint")}
-          </p>
-        ) : null}
-
-        {syncView?.lastSyncAt ? (
-          <p className="text-xs text-muted-foreground">
-            {t("settings.backupSyncLastAt")}
-            {formatTimestamp(syncView.lastSyncAt)}
-          </p>
-        ) : null}
-
-        {/*
-          自动同步失败的常驻横幅。区别于下面那条 syncStatus —— 后者是本次交互的
-          即时反馈，切走页面就没了；这条来自库里的 last_error，只要故障没修好，
-          每次进设置页都还在。用户不会在后台同步失败时正好盯着这个页面。
-        */}
-        {syncView?.lastError ? (
-          <div className="flex items-start gap-2.5 rounded-xl border border-destructive/30 bg-destructive/10 px-3.5 py-3">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
-            <div className="min-w-0 space-y-1">
-              <div className="text-xs font-medium text-destructive">
-                {t("settings.backupSyncAutoErrorTitle")}
+            <div className="space-y-1.5">
+              <FieldLabel>{t("settings.backupSyncUrl")}</FieldLabel>
+              <div className="relative">
+                <Server className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/60" />
+                <Input
+                  value={form.url}
+                  disabled={syncLocked}
+                  placeholder="https://dav.example.com/dav/"
+                  className="pl-9"
+                  onChange={(event) => patchForm({ url: event.target.value })}
+                />
               </div>
-              <p className="break-all text-xs leading-relaxed text-destructive/90">
-                {syncView.lastError}
-              </p>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <FieldLabel>{t("settings.backupSyncUsername")}</FieldLabel>
+                <Input
+                  value={form.username}
+                  disabled={syncLocked}
+                  autoComplete="off"
+                  onChange={(event) => patchForm({ username: event.target.value })}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <FieldLabel>{t("settings.backupSyncPassword")}</FieldLabel>
+                <div className="relative">
+                  <Key className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/60" />
+                  <Input
+                    type="password"
+                    value={form.password}
+                    disabled={syncLocked}
+                    autoComplete="new-password"
+                    className="pl-9"
+                    placeholder={
+                      syncView?.hasPassword && !form.passwordTouched
+                        ? t("settings.backupSyncPasswordSaved")
+                        : ""
+                    }
+                    onChange={(event) => {
+                      const password = event.target.value;
+                      // 清空密码框视为「没动过」，而不是「把密码改成空」。
+                      // 后端只在 passwordTouched 时采用新值，若这里对空串也置 true，
+                      // 用户输入几个字符再全删掉就会静默抹掉已存的密码 —— 与本框
+                      // 自己的「留空则不修改」占位提示直接矛盾，且此后自动同步因
+                      // 凭据不全而永久静默跳过（auto_upload 的 credentials 分支）。
+                      // 真要清空密码就关掉同步或改用户名，不该由删字符触发。
+                      patchForm({ password, passwordTouched: password.length > 0 });
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <FieldLabel>{t("settings.backupSyncRemoteDir")}</FieldLabel>
+                <Input
+                  value={form.remoteDir}
+                  disabled={syncLocked}
+                  placeholder="liveagent"
+                  onChange={(event) => patchForm({ remoteDir: event.target.value })}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <FieldLabel hint={t("settings.backupSyncProfileHint")}>
+                  {t("settings.backupSyncProfile")}
+                </FieldLabel>
+                <Input
+                  value={form.profile}
+                  disabled={syncLocked}
+                  placeholder="default"
+                  onChange={(event) => patchForm({ profile: event.target.value })}
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-background/60 px-3.5 py-3">
+              <div className="flex min-w-0 items-center gap-2.5">
+                <Zap className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <div className="min-w-0">
+                  <div className="text-xs font-medium text-foreground">
+                    {t("settings.backupSyncAuto")}
+                  </div>
+                  <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                    {t("settings.backupSyncAutoHint")}
+                  </p>
+                </div>
+              </div>
+              <Switch
+                checked={form.autoSync}
+                disabled={syncLocked}
+                title={t("settings.backupSyncAuto")}
+                aria-label={t("settings.backupSyncAuto")}
+                onCheckedChange={(checked) => void handleAutoSyncChange(checked)}
+              />
             </div>
           </div>
-        ) : null}
 
-        {syncStatus ? (
-          <div
-            className={`break-all text-xs font-medium ${
-              syncStatus.kind === "ok"
-                ? "text-emerald-600 dark:text-emerald-400"
-                : "text-destructive"
-            }`}
-          >
-            {syncStatus.text}
-          </div>
-        ) : null}
-      </section>
+          <footer className="space-y-3 border-t border-border/60 px-5 py-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <Button size="sm" disabled={syncLocked} onClick={() => void handleSaveSync()}>
+                {syncBusy === "save" ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Save className="h-3.5 w-3.5" />
+                )}
+                {t("settings.backupSyncSave")}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={syncLocked || dirty}
+                onClick={() => void handleTestSync()}
+              >
+                {syncBusy === "test" ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Plug className="h-3.5 w-3.5" />
+                )}
+                {t("settings.backupSyncTest")}
+              </Button>
+              <div className="mx-1 h-4 w-px bg-border/70" />
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={syncLocked || dirty}
+                onClick={() => void handleUpload()}
+              >
+                {syncBusy === "upload" ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Upload className="h-3.5 w-3.5" />
+                )}
+                {t("settings.backupSyncUpload")}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={syncLocked || dirty}
+                onClick={() => void handleDownload()}
+              >
+                {syncBusy === "download" ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <CloudDownload className="h-3.5 w-3.5" />
+                )}
+                {t("settings.backupSyncDownload")}
+              </Button>
+            </div>
 
-      <section className="space-y-2 rounded-2xl border border-border/60 bg-card p-4">
-        <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-          <Shield className="h-4 w-4 text-muted-foreground" />
-          {t("settings.backupScopeTitle")}
-        </div>
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          {t("settings.backupScopeDesc")}
-        </p>
-      </section>
+            {dirty && !syncLocked ? (
+              <div className="flex items-center gap-1.5 text-xs font-medium text-amber-700 dark:text-amber-300">
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                {t("settings.backupSyncDirtyHint")}
+              </div>
+            ) : null}
+
+            <FeedbackStrip status={syncStatus} />
+          </footer>
+        </section>
+
+        {/* 右栏：本地备份 + 备份范围。范围卡弹性补足高度，与左栏底边对齐。 */}
+        <aside className="flex flex-col gap-5">
+          <section className="space-y-3 rounded-2xl border border-border/60 bg-card p-4">
+            <div className="flex items-center gap-2.5">
+              <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <HardDrive className="h-4 w-4" />
+              </span>
+              <h3 className="text-sm font-semibold text-foreground">
+                {t("settings.backupLocalTitle")}
+              </h3>
+            </div>
+
+            <div className="space-y-2">
+              <ActionTile
+                icon={<Download className="h-4 w-4" />}
+                busy={busy === "export"}
+                title={t("settings.backupExport")}
+                hint={t("settings.backupExportHint")}
+                disabled={busy !== null}
+                onClick={() => void handleExport()}
+              />
+              <ActionTile
+                icon={<Upload className="h-4 w-4" />}
+                busy={busy === "import"}
+                title={t("settings.backupImport")}
+                hint={t("settings.backupImportHint")}
+                disabled={busy !== null}
+                onClick={() => void handleImport()}
+              />
+            </div>
+
+            <div className="flex items-start gap-2 text-[11px] leading-relaxed text-muted-foreground">
+              <ArchiveRestore className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{t("settings.backupAutoBackupHint")}</span>
+            </div>
+
+            <FeedbackStrip status={status} />
+          </section>
+
+          <section className="flex-1 space-y-3 rounded-2xl border border-border/60 bg-card p-4">
+            <div className="flex items-center gap-2.5">
+              <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <Shield className="h-4 w-4" />
+              </span>
+              <h3 className="text-sm font-semibold text-foreground">
+                {t("settings.backupScopeTitle")}
+              </h3>
+            </div>
+
+            <div className="space-y-1.5">
+              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">
+                {t("settings.backupScopeIncluded")}
+              </div>
+              <div className="grid grid-cols-2 gap-1.5">
+                <ScopeItem
+                  icon={<Server className="h-3.5 w-3.5" />}
+                  label={t("settings.backupDomainProviders")}
+                />
+                <ScopeItem
+                  icon={<McpLogo className="h-3.5 w-3.5" />}
+                  label={t("settings.backupDomainMcp")}
+                />
+                <ScopeItem
+                  icon={<Settings2 className="h-3.5 w-3.5" />}
+                  label={t("settings.backupDomainSystem")}
+                />
+                <ScopeItem
+                  icon={<SkillIcon className="h-3.5 w-3.5" />}
+                  label={t("settings.backupDomainSkills")}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">
+                {t("settings.backupScopeExcluded")}
+              </div>
+              <div className="grid grid-cols-2 gap-1.5">
+                <ScopeItem
+                  excluded
+                  icon={<MessageSquare className="h-3.5 w-3.5" />}
+                  label={t("settings.backupScopeChat")}
+                />
+                <ScopeItem
+                  excluded
+                  icon={<Brain className="h-3.5 w-3.5" />}
+                  label={t("settings.backupScopeMemory")}
+                />
+                <ScopeItem
+                  excluded
+                  icon={<FileText className="h-3.5 w-3.5" />}
+                  label={t("settings.backupScopeUploads")}
+                />
+                <ScopeItem
+                  excluded
+                  icon={<Key className="h-3.5 w-3.5" />}
+                  label={t("settings.backupScopeSshKeys")}
+                />
+              </div>
+            </div>
+          </section>
+        </aside>
+      </div>
 
       {dialog}
     </div>


### PR DESCRIPTION
Closes #623

## Summary

对设置中的「备份与同步」页面进行彻底的 UI 重构,仅调整展示层,备份/同步逻辑(表单脏检测、密码 touched 语义、确认弹窗、自动同步事件监听等)保持不变:

- **顶部状态横幅**:一眼看到云同步状态(未配置 / 已就绪 / 上次自动同步失败),聚合上次同步时间与自动同步开/关徽标;持久性 last_error 直接展示在横幅内,取代原先散落在卡片尾部的小字状态。
- **两栏布局**(等高拉伸,底边对齐):
  - 左栏 WebDAV 配置卡:服务商预设由下拉框改为胶囊按钮组;服务器地址/密码输入框内嵌图标;「配置档名」长说明移入悬停 tooltip;保存/测试/上传/下载统一到卡片底部操作栏,操作区随卡片拉伸钉在底边。
  - 右栏:本地备份改为「导出/导入」大号操作磁贴;「备份范围」由两段描述文字改为「包含 / 不包含」的可视化图标清单。
- **精简文案**:删除本地备份、WebDAV 同步、备份范围三段长描述,中英文文案同步更新;成功/失败反馈由裸彩色文本改为带图标的着色反馈条。
- 修复一个边界情况:同步配置加载失败时,状态横幅按「未配置」展示而非永久停留在加载态。

## Screenshots / preview
<img width="1401" height="801" alt="image" src="https://github.com/user-attachments/assets/56a8d5db-0c4f-4fe1-bd84-6ad2f150b0bd" />


## Test plan

- [x] `biome check` 通过,`tsc --noEmit` 全仓零错误
- [x] `test/settings` 全部 329 项测试通过(备份同步表单逻辑测试 backup-auto-sync-dirty 等不受影响)
- [x] 浏览器实测浅色/深色模式渲染,两栏底边对齐
- [x] 在 Tauri 应用内验证保存/测试连接/上传/下载与确认弹窗流程