### PR TITLE
fix(chat): hide leaked provider citation markers

### DIFF
--- a/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
+++ b/crates/agent-gui/src/lib/chat/runner/agentRunner.ts
@@ -46,6 +46,7 @@ import {
   isProviderNativeWebFetchToolName,
   isProviderNativeWebSearchToolName,
 } from "../../providers/nativeWebSearch";
+import { sanitizeAssistantMessage } from "../../providers/runtime/messageUtils";
 import {
   failoverBreakerKey,
   type ModelFailoverRuntimeConfig,
@@ -1721,7 +1722,7 @@ export async function runAssistantWithTools(params: {
                   : "completed";
             const hostedSearchBlocks = getHostedSearchBlocksForRound(currentRound);
             const assistantWithCanonicalToolNames = normalizeAssistantToolCallNamesForExecution(
-              event.message as AssistantMessage,
+              sanitizeAssistantMessage(event.message as AssistantMessage),
             );
             const assistantWithHostedSearch = applyHostedSearchBlocksToAssistant(
               assistantWithCanonicalToolNames,

--- a/crates/agent-gui/src/lib/providers/llm.ts
+++ b/crates/agent-gui/src/lib/providers/llm.ts
@@ -16,7 +16,11 @@ export {
   isOfficialGeminiApiBaseUrl,
   normalizeGeminiThoughtSignatures,
 } from "./runtime/geminiToolPayload";
-export { assistantMessageToText, createStreamingTextReconciler } from "./runtime/messageUtils";
+export {
+  assistantMessageToText,
+  createStreamingTextReconciler,
+  sanitizeAssistantMessage,
+} from "./runtime/messageUtils";
 export { createModelFromConfig } from "./runtime/modelFactory";
 export { parseModelValue, toModelValue } from "./runtime/modelValue";
 export { attachProviderNativeWebSearch } from "./runtime/nativeSearchPayload";

--- a/crates/agent-gui/src/lib/providers/runtime/messageUtils.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/messageUtils.ts
@@ -1,8 +1,77 @@
 export { assistantMessageToText } from "@liveagent/ui/lib/providers/errorMessage";
 
-const PROVIDER_CITATION_START = "\uE200cite";
-const PROVIDER_CITATION_END = "\uE201";
-const PROVIDER_CITATION_PATTERN = /\uE200cite(?:\uE202[^\uE201]*)+\uE201/g;
+/** OpenAI citation markers: `\uE200cite\uE202<source>[\uE202<locator>...]\uE201`. */
+const CITATION_START = "\uE200cite";
+const CITATION_DELIMITER = "\uE202";
+const CITATION_END = "\uE201";
+
+type CitationMatch = { kind: "complete"; end: number } | { kind: "incomplete" } | { kind: "none" };
+
+function matchCitationAt(text: string, from: number): CitationMatch {
+  const remaining = text.slice(from);
+  if (!remaining.startsWith(CITATION_START)) {
+    return CITATION_START.startsWith(remaining) ? { kind: "incomplete" } : { kind: "none" };
+  }
+
+  let index = from + CITATION_START.length;
+  if (index >= text.length) return { kind: "incomplete" };
+  if (text[index] !== CITATION_DELIMITER) return { kind: "none" };
+
+  while (index < text.length && text[index] === CITATION_DELIMITER) {
+    index += 1;
+    while (
+      index < text.length &&
+      text[index] !== CITATION_END &&
+      text[index] !== CITATION_DELIMITER
+    ) {
+      index += 1;
+    }
+    if (index >= text.length) return { kind: "incomplete" };
+  }
+
+  if (text[index] === CITATION_END) {
+    return { kind: "complete", end: index + CITATION_END.length };
+  }
+  return { kind: "none" };
+}
+
+function longestCitationStartPrefix(text: string) {
+  for (let length = Math.min(CITATION_START.length - 1, text.length); length > 0; length -= 1) {
+    const suffix = text.slice(-length);
+    if (CITATION_START.startsWith(suffix)) return suffix;
+  }
+  return "";
+}
+
+function sanitizeCitationText(text: string, holdIncomplete: boolean) {
+  let visible = "";
+  let index = 0;
+
+  while (index < text.length) {
+    const start = text.indexOf(CITATION_START, index);
+    if (start < 0) {
+      const rest = text.slice(index);
+      const prefix = longestCitationStartPrefix(rest);
+      visible += rest.slice(0, rest.length - prefix.length);
+      return { visible, pending: holdIncomplete ? prefix : "" };
+    }
+
+    visible += text.slice(index, start);
+    const match = matchCitationAt(text, start);
+    if (match.kind === "complete") {
+      index = match.end;
+      continue;
+    }
+    if (match.kind === "incomplete") {
+      return { visible, pending: holdIncomplete ? text.slice(start) : "" };
+    }
+
+    visible += CITATION_START;
+    index = start + CITATION_START.length;
+  }
+
+  return { visible, pending: "" };
+}
 
 /**
  * Provider-native web-search citations are sometimes returned as ChatGPT's
@@ -10,19 +79,7 @@ const PROVIDER_CITATION_PATTERN = /\uE200cite(?:\uE202[^\uE201]*)+\uE201/g;
  * are protocol metadata, not user-visible answer text.
  */
 export function stripProviderCitationMarkers(text: string) {
-  return text.replace(PROVIDER_CITATION_PATTERN, "");
-}
-
-function longestCitationPrefixSuffix(text: string) {
-  for (
-    let length = Math.min(PROVIDER_CITATION_START.length - 1, text.length);
-    length > 0;
-    length -= 1
-  ) {
-    const suffix = text.slice(-length);
-    if (PROVIDER_CITATION_START.startsWith(suffix)) return suffix;
-  }
-  return "";
+  return sanitizeCitationText(text, false).visible;
 }
 
 function createProviderCitationStreamSanitizer() {
@@ -30,29 +87,9 @@ function createProviderCitationStreamSanitizer() {
 
   return {
     append(text: string) {
-      let input = pending + text;
-      pending = "";
-      let output = "";
-
-      while (input) {
-        const start = input.indexOf(PROVIDER_CITATION_START);
-        if (start < 0) {
-          const suffix = longestCitationPrefixSuffix(input);
-          output += input.slice(0, input.length - suffix.length);
-          pending = suffix;
-          break;
-        }
-
-        output += input.slice(0, start);
-        const end = input.indexOf(PROVIDER_CITATION_END, start + PROVIDER_CITATION_START.length);
-        if (end < 0) {
-          pending = input.slice(start);
-          break;
-        }
-        input = input.slice(end + PROVIDER_CITATION_END.length);
-      }
-
-      return output;
+      const result = sanitizeCitationText(pending + text, true);
+      pending = result.pending;
+      return result.visible;
     },
     finish(text: string) {
       pending = "";

--- a/crates/agent-gui/src/lib/providers/runtime/messageUtils.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/messageUtils.ts
@@ -1,26 +1,116 @@
 export { assistantMessageToText } from "@liveagent/ui/lib/providers/errorMessage";
 
+const PROVIDER_CITATION_START = "\uE200cite";
+const PROVIDER_CITATION_END = "\uE201";
+const PROVIDER_CITATION_PATTERN = /\uE200cite(?:\uE202[^\uE201]*)+\uE201/g;
+
+/**
+ * Provider-native web-search citations are sometimes returned as ChatGPT's
+ * private-use text markup instead of structured citation annotations. They
+ * are protocol metadata, not user-visible answer text.
+ */
+export function stripProviderCitationMarkers(text: string) {
+  return text.replace(PROVIDER_CITATION_PATTERN, "");
+}
+
+function longestCitationPrefixSuffix(text: string) {
+  for (
+    let length = Math.min(PROVIDER_CITATION_START.length - 1, text.length);
+    length > 0;
+    length -= 1
+  ) {
+    const suffix = text.slice(-length);
+    if (PROVIDER_CITATION_START.startsWith(suffix)) return suffix;
+  }
+  return "";
+}
+
+function createProviderCitationStreamSanitizer() {
+  let pending = "";
+
+  return {
+    append(text: string) {
+      let input = pending + text;
+      pending = "";
+      let output = "";
+
+      while (input) {
+        const start = input.indexOf(PROVIDER_CITATION_START);
+        if (start < 0) {
+          const suffix = longestCitationPrefixSuffix(input);
+          output += input.slice(0, input.length - suffix.length);
+          pending = suffix;
+          break;
+        }
+
+        output += input.slice(0, start);
+        const end = input.indexOf(PROVIDER_CITATION_END, start + PROVIDER_CITATION_START.length);
+        if (end < 0) {
+          pending = input.slice(start);
+          break;
+        }
+        input = input.slice(end + PROVIDER_CITATION_END.length);
+      }
+
+      return output;
+    },
+    finish(text: string) {
+      pending = "";
+      return stripProviderCitationMarkers(text);
+    },
+  };
+}
+
+export function sanitizeAssistantMessage<T extends { content: unknown[] }>(message: T): T {
+  let changed = false;
+  const content = message.content.map((block) => {
+    if (!block || typeof block !== "object" || Array.isArray(block)) return block;
+    const candidate = block as { type?: unknown; text?: unknown };
+    if (candidate.type !== "text" || typeof candidate.text !== "string") return block;
+    const text = stripProviderCitationMarkers(candidate.text);
+    if (text === candidate.text) return block;
+    changed = true;
+    return { ...candidate, text };
+  });
+  return changed ? { ...message, content } : message;
+}
+
 export function createStreamingTextReconciler() {
   const emittedTextByKey = new Map<string, string>();
+  const citationSanitizersByKey = new Map<
+    string,
+    ReturnType<typeof createProviderCitationStreamSanitizer>
+  >();
+
+  const sanitizerFor = (key: string) => {
+    const existing = citationSanitizersByKey.get(key);
+    if (existing) return existing;
+    const sanitizer = createProviderCitationStreamSanitizer();
+    citationSanitizersByKey.set(key, sanitizer);
+    return sanitizer;
+  };
 
   return {
     appendDelta(key: string, delta: string) {
       if (!delta) return "";
+      const sanitizedDelta = sanitizerFor(key).append(delta);
+      if (!sanitizedDelta) return "";
       const previous = emittedTextByKey.get(key) ?? "";
-      emittedTextByKey.set(key, previous + delta);
-      return delta;
+      emittedTextByKey.set(key, previous + sanitizedDelta);
+      return sanitizedDelta;
     },
     reconcileFinalText(key: string, finalText: string) {
       if (!finalText) return "";
 
       const previous = emittedTextByKey.get(key) ?? "";
-      emittedTextByKey.set(key, finalText);
+      const sanitizedFinalText = sanitizerFor(key).finish(finalText);
+      emittedTextByKey.set(key, sanitizedFinalText);
 
       if (!previous) {
-        return finalText;
+        return sanitizedFinalText;
       }
-      if (finalText.startsWith(previous)) {
-        return finalText.slice(previous.length);
+      if (sanitizedFinalText.startsWith(previous)) {
+        return sanitizedFinalText.slice(previous.length);
       }
       return "";
     },

--- a/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
@@ -17,7 +17,7 @@ import {
 import { providerSupportsNativeWebSearch } from "../nativeWebSearch";
 import { appendSystemPrompt, normalizeSessionId } from "./common";
 import { normalizeErrorMessage } from "./errors";
-import { createStreamingTextReconciler } from "./messageUtils";
+import { createStreamingTextReconciler, sanitizeAssistantMessage } from "./messageUtils";
 import { createModelFromConfig } from "./modelFactory";
 import { finalizeProviderStreamOptions } from "./payloadPipeline";
 import {
@@ -469,7 +469,7 @@ export async function streamAssistantMessage(params: {
           }
         }
 
-        let final = await s.result();
+        let final = sanitizeAssistantMessage(await s.result());
         if (final.stopReason === "error" || final.stopReason === "aborted") {
           throw new Error(
             normalizeErrorMessage(

--- a/crates/agent-gui/test/providers/message-utils.test.mjs
+++ b/crates/agent-gui/test/providers/message-utils.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const { createStreamingTextReconciler, sanitizeAssistantMessage, stripProviderCitationMarkers } =
+  loader.loadModule("src/lib/providers/runtime/messageUtils.ts");
+
+const marker = "\uE200cite\uE202turn0search5\uE202turn0search15\uE201";
+
+test("provider citation markers are removed from complete text", () => {
+  assert.equal(
+    stripProviderCitationMarkers(`before ${marker} after`),
+    "before  after",
+  );
+});
+
+test("streaming reconciler removes citation markers split across deltas", () => {
+  const reconciler = createStreamingTextReconciler();
+  const first = `before ${marker.slice(0, 9)}`;
+  const second = `${marker.slice(9)} after`;
+
+  assert.equal(reconciler.appendDelta("0", first), "before ");
+  assert.equal(reconciler.appendDelta("0", second), " after");
+  assert.equal(reconciler.reconcileFinalText("0", `before ${marker} after`), "");
+});
+
+test("assistant message sanitization preserves non-text blocks", () => {
+  const toolCall = { type: "toolCall", id: "call-1", name: "Read", arguments: {} };
+  const message = {
+    role: "assistant",
+    content: [
+      { type: "text", text: `answer ${marker}` },
+      toolCall,
+    ],
+  };
+
+  const sanitized = sanitizeAssistantMessage(message);
+  assert.deepEqual(sanitized.content, [
+    { type: "text", text: "answer " },
+    toolCall,
+  ]);
+  assert.equal(sanitized.content[1], toolCall);
+});

--- a/crates/agent-gui/test/providers/message-utils.test.mjs
+++ b/crates/agent-gui/test/providers/message-utils.test.mjs
@@ -7,6 +7,7 @@ const { createStreamingTextReconciler, sanitizeAssistantMessage, stripProviderCi
   loader.loadModule("src/lib/providers/runtime/messageUtils.ts");
 
 const marker = "\uE200cite\uE202turn0search5\uE202turn0search15\uE201";
+const lookalike = "\uE200cite hello \uE201";
 
 test("provider citation markers are removed from complete text", () => {
   assert.equal(
@@ -15,14 +16,52 @@ test("provider citation markers are removed from complete text", () => {
   );
 });
 
+test("unterminated citation markers are dropped from complete text", () => {
+  assert.equal(
+    stripProviderCitationMarkers(`before \uE200cite\uE202turn0search5`),
+    "before ",
+  );
+  assert.equal(stripProviderCitationMarkers("before \uE200cit"), "before ");
+});
+
+test("lookalike text without a delimiter is kept", () => {
+  assert.equal(stripProviderCitationMarkers(`before ${lookalike} after`), `before ${lookalike} after`);
+});
+
 test("streaming reconciler removes citation markers split across deltas", () => {
   const reconciler = createStreamingTextReconciler();
-  const first = `before ${marker.slice(0, 9)}`;
-  const second = `${marker.slice(9)} after`;
+  const splitAt = marker.indexOf("\uE202") + 3;
+  const first = `before ${marker.slice(0, splitAt)}`;
+  const second = `${marker.slice(splitAt)} after`;
 
   assert.equal(reconciler.appendDelta("0", first), "before ");
   assert.equal(reconciler.appendDelta("0", second), " after");
   assert.equal(reconciler.reconcileFinalText("0", `before ${marker} after`), "");
+});
+
+test("stream and strip share the same citation matching rules", () => {
+  const reconciler = createStreamingTextReconciler();
+  assert.equal(reconciler.appendDelta("lookalike", `before ${lookalike} after`), `before ${lookalike} after`);
+  assert.equal(
+    reconciler.reconcileFinalText("lookalike", `before ${lookalike} after`),
+    "",
+  );
+
+  const split = createStreamingTextReconciler();
+  let streamed = "";
+  for (const chunk of `keep ${marker} going`) {
+    streamed += split.appendDelta("chars", chunk);
+  }
+  streamed += split.reconcileFinalText("chars", `keep ${marker} going`);
+  assert.equal(streamed, stripProviderCitationMarkers(`keep ${marker} going`));
+  assert.equal(streamed, "keep  going");
+});
+
+test("unterminated streamed citations are not flushed back on text_end", () => {
+  const reconciler = createStreamingTextReconciler();
+  const truncated = `answer \uE200cite\uE202turn0search5`;
+  assert.equal(reconciler.appendDelta("0", truncated), "answer ");
+  assert.equal(reconciler.reconcileFinalText("0", truncated), "");
 });
 
 test("assistant message sanitization preserves non-text blocks", () => {


### PR DESCRIPTION
## Linked issue

Closes #625

## Summary

部分模型或中转服务会将 ChatGPT 私有联网搜索引用标记直接混入普通文本，例如：

```text
citeturn0search5turn0search15
```

这些标记属于 provider 内部协议元数据，不应显示在用户回答中。流式响应中该标记还可能被拆分到多个 `text_delta`，导致仅按单个 chunk 过滤无法清理。

本 PR 在文本流和最终 assistant 消息两个阶段清理 provider citation markers，并增加跨 chunk 状态处理，避免这些标记出现在：

- 聊天界面；
- assistant 历史消息；
- 后续上下文请求；
- 持久化会话数据。

工具调用、图片等非文本内容不会被修改。

## Change scope

- Modules: `agent-gui`
- Key paths:
  - `crates/agent-gui/src/lib/providers/runtime/messageUtils.ts`
  - `crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts`
  - `crates/agent-gui/src/lib/chat/runner/agentRunner.ts`
  - `crates/agent-gui/src/lib/providers/llm.ts`
  - `crates/agent-gui/test/providers/message-utils.test.mjs`

## Screenshots / preview

这是一个聊天文本渲染行为修复，不涉及布局或视觉样式变化。

Runtime preview：

```text
Before:
Answer content citeturn0search5turn0search15 continues here.

After:
Answer content  continues here.
```

跨流式 chunk 的场景也会被处理：

```text
Chunk 1: Answer content cit
Chunk 2: eturn0search5turn0search15 continues here.

Rendered:
Answer content  continues here.
```

## Verification

- Targeted provider and agent tests: `108 tests passed`
  - citation marker 完整文本过滤；
  - 跨 delta 拆分的 citation marker 过滤；
  - assistant 非文本内容块保留；
  - agent runner；
  - hosted search；
  - native web search；
  - stream retry。
- GUI build:

  ```bash
  pnpm --filter liveagent build
  ```

  TypeScript 检查和 Vite 构建通过。
- 分支已同步最新 `upstream/main`，并确认无合并冲突。

## Pre-submit checklist

- [x] A requirement issue is linked with `Closes #N`.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.


![Runtime preview - citation marker filtered](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjAwIiBoZWlnaHQ9IjUyMCIgdmlld0JveD0iMCAwIDEyMDAgNTIwIj48cmVjdCB3aWR0aD0iMTIwMCIgaGVpZ2h0PSI1MjAiIHJ4PSIxOCIgZmlsbD0iIzBmMTcyYSIvPjx0ZXh0IHg9IjQ4IiB5PSI1OCIgZmlsbD0iI2UyZThmMCIgZm9udC1mYW1pbHk9IkFyaWFsLHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMjgiIGZvbnQtd2VpZ2h0PSI3MDAiPlByb3ZpZGVyIGNpdGF0aW9uIG1hcmtlciBmaWx0ZXJpbmcgLSBydW50aW1lIHByZXZpZXc8L3RleHQ+PHJlY3QgeD0iNDgiIHk9IjkyIiB3aWR0aD0iMTEwNCIgaGVpZ2h0PSIxNTAiIHJ4PSIxMiIgZmlsbD0iIzNmMWQyZSIvPjx0ZXh0IHg9Ijc2IiB5PSIxMzIiIGZpbGw9IiNmZGE0YWYiIGZvbnQtZmFtaWx5PSJBcmlhbCxzYW5zLXNlcmlmIiBmb250LXNpemU9IjIyIiBmb250LXdlaWdodD0iNzAwIj5CZWZvcmU8L3RleHQ+PHRleHQgeD0iNzYiIHk9IjE4MiIgZmlsbD0iI2ZlY2RkMyIgZm9udC1mYW1pbHk9Im1vbm9zcGFjZSIgZm9udC1zaXplPSIyMiI+QW5zd2VyIGNvbnRlbnQgW2NpdGU6dHVybjBzZWFyY2g1LHR1cm4wc2VhcmNoMTVdIGNvbnRpbnVlcyBoZXJlLjwvdGV4dD48cmVjdCB4PSI0OCIgeT0iMjc4IiB3aWR0aD0iMTEwNCIgaGVpZ2h0PSIxNTAiIHJ4PSIxMiIgZmlsbD0iIzEyMzUyNCIvPjx0ZXh0IHg9Ijc2IiB5PSIzMTgiIGZpbGw9IiM4NmVmYWMiIGZvbnQtZmFtaWx5PSJBcmlhbCxzYW5zLXNlcmlmIiBmb250LXNpemU9IjIyIiBmb250LXdlaWdodD0iNzAwIj5BZnRlcjwvdGV4dD48dGV4dCB4PSI3NiIgeT0iMzY4IiBmaWxsPSIjYmJmN2QwIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjIyIj5BbnN3ZXIgY29udGVudCAgY29udGludWVzIGhlcmUuPC90ZXh0Pjx0ZXh0IHg9IjQ4IiB5PSI0ODAiIGZpbGw9IiM5NGEzYjgiIGZvbnQtZmFtaWx5PSJBcmlhbCxzYW5zLXNlcmlmIiBmb250LXNpemU9IjE4Ij5UaGUgc2FtZSByZXN1bHQgaXMgcHJvZHVjZWQgd2hlbiB0aGUgbWFya2VyIGlzIHNwbGl0IGFjcm9zcyBzdHJlYW1pbmcgdGV4dF9kZWx0YSBjaHVua3MuPC90ZXh0Pjwvc3ZnPg==)