### PR TITLE
refactor(chat): 工作空间菜单分类整理 + 项目配置弹窗三面板 UI 重构

### DIFF
--- a/crates/agent-gui/test/settings/workspace-resource-settings.test.mjs
+++ b/crates/agent-gui/test/settings/workspace-resource-settings.test.mjs
@@ -185,9 +185,8 @@ test("workspace configuration uses one entry and one shared two-column modal", (
   assert.match(sharedDirectoryPanel, /maxLength=\{32\}/);
   assert.match(sharedDirectoryPanel, /pattern="\[a-z\]\[a-z0-9_-\]\{0,31\}"/);
   assert.match(sharedDirectoryPanel, /<Input/);
-  assert.match(sharedDirectoryPanel, /<Select\b/);
-  assert.match(sharedDirectoryPanel, /<SelectItem value="read"/);
-  assert.match(sharedDirectoryPanel, /<SelectItem value="write"/);
+  assert.match(sharedDirectoryPanel, /\["read", "write"\] as const/);
+  assert.match(sharedDirectoryPanel, /aria-pressed=\{value === option\}/);
   assert.doesNotMatch(sharedDirectoryPanel, /<(?:input|select|option)\b/);
   assert.doesNotMatch(sharedResourcePanel, /McpImportView|McpRegistryBrowser|SkillsStoreView/);
 });

--- a/crates/agent-ui/src/components/chat/ChatHistorySidebarRows.tsx
+++ b/crates/agent-ui/src/components/chat/ChatHistorySidebarRows.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -1416,51 +1417,22 @@ export const ProjectRow = memo(function ProjectRow(props: {
                   sideOffset={6}
                   className="sidebar-context-menu"
                 >
+                  {/* 第一组：管理 —— 配置、分组归属、归档状态。 */}
                   <DropdownMenuItem
                     disabled={isInteractionDisabled}
                     onSelect={() => onConfigureProject(project)}
                     className="gap-2"
                   >
-                    <Settings className="h-3.5 w-3.5" />
+                    <Settings className="h-3.5 w-3.5 text-muted-foreground" />
                     {t("chat.workspaceConfigure")}
                   </DropdownMenuItem>
-                  {!isDefaultProject ? (
-                    <>
-                      <DropdownMenuItem
-                        disabled={isInteractionDisabled}
-                        onSelect={handleRequestRemove}
-                        className="gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive"
-                      >
-                        <X className="h-3.5 w-3.5" />
-                        {t("chat.workspaceRemoveOnly")}
-                      </DropdownMenuItem>
-                      {project.worktree ? (
-                        <DropdownMenuItem
-                          disabled={isInteractionDisabled}
-                          onSelect={handleRequestDeleteWorktree}
-                          className="gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive"
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                          {t("chat.workspaceDeleteWorktree")}
-                        </DropdownMenuItem>
-                      ) : null}
-                    </>
-                  ) : null}
-                  {!isArchived && canArchive ? (
-                    <DropdownMenuItem
-                      disabled={isInteractionDisabled}
-                      onSelect={handleArchive}
-                      className="gap-2"
-                    >
-                      <Archive className="h-3.5 w-3.5" />
-                      {t("chat.workspaceArchive")}
-                    </DropdownMenuItem>
-                  ) : null}
-                  {onMoveProjectToGroup ? (
+                  {/* 无任何分组时隐藏“移动到分组”，避免展开空的子菜单。 */}
+                  {onMoveProjectToGroup && workspaceProjectGroups.length > 0 ? (
                     <DropdownMenuSub>
-                      <DropdownMenuSubTrigger className="gap-2">
-                        <Folder className="h-3.5 w-3.5" />
-                        <span>{t("chat.workspaceGroupMove")}</span>
+                      <DropdownMenuSubTrigger disabled={isInteractionDisabled} className="gap-2">
+                        <Folder className="h-3.5 w-3.5 text-muted-foreground" />
+                        <span className="min-w-0 flex-1">{t("chat.workspaceGroupMove")}</span>
+                        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
                       </DropdownMenuSubTrigger>
                       <DropdownMenuSubContent
                         side="right"
@@ -1484,16 +1456,29 @@ export const ProjectRow = memo(function ProjectRow(props: {
                           </DropdownMenuItem>
                         ))}
                         {currentGroupId ? (
-                          <DropdownMenuItem
-                            onSelect={() => onMoveProjectToGroup(project.path, null)}
-                            className="gap-2 text-xs"
-                          >
-                            <X className="h-3.5 w-3.5" />
-                            <span>{t("chat.workspaceGroupUngroup")}</span>
-                          </DropdownMenuItem>
+                          <>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              onSelect={() => onMoveProjectToGroup(project.path, null)}
+                              className="gap-2 text-xs"
+                            >
+                              <X className="h-3.5 w-3.5 text-muted-foreground" />
+                              <span>{t("chat.workspaceGroupUngroup")}</span>
+                            </DropdownMenuItem>
+                          </>
                         ) : null}
                       </DropdownMenuSubContent>
                     </DropdownMenuSub>
+                  ) : null}
+                  {!isArchived && canArchive ? (
+                    <DropdownMenuItem
+                      disabled={isInteractionDisabled}
+                      onSelect={handleArchive}
+                      className="gap-2"
+                    >
+                      <Archive className="h-3.5 w-3.5 text-muted-foreground" />
+                      {t("chat.workspaceArchive")}
+                    </DropdownMenuItem>
                   ) : null}
                   {isArchived ? (
                     <DropdownMenuItem
@@ -1501,9 +1486,13 @@ export const ProjectRow = memo(function ProjectRow(props: {
                       onSelect={handleUnarchive}
                       className="gap-2"
                     >
-                      <ArchiveRestore className="h-3.5 w-3.5" />
+                      <ArchiveRestore className="h-3.5 w-3.5 text-muted-foreground" />
                       {t("chat.workspaceUnarchive")}
                     </DropdownMenuItem>
+                  ) : null}
+                  {/* 第二组：浏览定位 —— 在文件树 / 系统资源管理器中打开。 */}
+                  {onBrowseProjectInFileTree || onBrowseProjectInSystemFileManager ? (
+                    <DropdownMenuSeparator />
                   ) : null}
                   {onBrowseProjectInFileTree ? (
                     <DropdownMenuItem
@@ -1511,7 +1500,7 @@ export const ProjectRow = memo(function ProjectRow(props: {
                       onSelect={handleBrowseInFileTree}
                       className="gap-2"
                     >
-                      <FolderTree className="h-3.5 w-3.5" />
+                      <FolderTree className="h-3.5 w-3.5 text-muted-foreground" />
                       {t("chat.workspaceBrowseInFileTree")}
                     </DropdownMenuItem>
                   ) : null}
@@ -1521,9 +1510,33 @@ export const ProjectRow = memo(function ProjectRow(props: {
                       onSelect={handleBrowseInSystemFileManager}
                       className="gap-2"
                     >
-                      <FolderOpen className="h-3.5 w-3.5" />
+                      <FolderOpen className="h-3.5 w-3.5 text-muted-foreground" />
                       {t("chat.workspaceBrowseInSystemFileManager")}
                     </DropdownMenuItem>
+                  ) : null}
+                  {/* 第三组：危险操作 —— 固定在菜单底部并以分隔线隔开。 */}
+                  {!isDefaultProject ? (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        disabled={isInteractionDisabled}
+                        onSelect={handleRequestRemove}
+                        className="gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                        {t("chat.workspaceRemoveOnly")}
+                      </DropdownMenuItem>
+                      {project.worktree ? (
+                        <DropdownMenuItem
+                          disabled={isInteractionDisabled}
+                          onSelect={handleRequestDeleteWorktree}
+                          className="gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                          {t("chat.workspaceDeleteWorktree")}
+                        </DropdownMenuItem>
+                      ) : null}
+                    </>
                   ) : null}
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/crates/agent-ui/src/components/chat/ProjectPromptEditorModal.tsx
+++ b/crates/agent-ui/src/components/chat/ProjectPromptEditorModal.tsx
@@ -4,7 +4,7 @@ import {
   type WorkspaceProject,
   workspaceProjectPathKey,
 } from "@liveagent/app/lib/settings";
-import { BookOpen, Check, FileText, Layers, Loader2 } from "@liveagent/ui/components/IconSet";
+import { BookOpen, Check, Loader2 } from "@liveagent/ui/components/IconSet";
 import { Button } from "@liveagent/ui/components/ui/button";
 import {
   Dialog,
@@ -30,88 +30,57 @@ export function ProjectPromptSettingsPanel(props: {
   strategy: ProjectPromptStrategy;
   onProjectPromptChange: (value: string) => void;
   onStrategyChange: (value: ProjectPromptStrategy) => void;
+  className?: string;
 }) {
-  const { projectPrompt, strategy, onProjectPromptChange, onStrategyChange } = props;
+  const { projectPrompt, strategy, onProjectPromptChange, onStrategyChange, className } = props;
   const { t } = useLocale();
 
   return (
-    <>
-      <section>
-        <div className="mb-3 flex items-start gap-3">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/60 text-muted-foreground">
-            <Layers className="h-4 w-4" />
-          </div>
-          <div>
-            <h3 className="text-sm font-semibold">{t("chat.projectPromptStrategy")}</h3>
-            <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
-              {t("chat.projectPromptStrategyHint")}
-            </p>
-          </div>
-        </div>
-        <div className="grid gap-2 sm:grid-cols-2">
+    <section className={cn("flex min-h-full flex-col p-6 max-[720px]:p-4", className)}>
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+        <h3 className="text-base font-semibold">{t("chat.projectPromptTitle")}</h3>
+        <fieldset className="flex h-8 shrink-0 items-center gap-0.5 rounded-lg border border-border/60 bg-muted/40 p-0.5">
+          <legend className="sr-only">{t("chat.projectPromptStrategy")}</legend>
           {(["append", "replace"] as const).map((value) => (
             <button
               key={value}
               type="button"
               aria-pressed={strategy === value}
               className={cn(
-                "min-h-20 rounded-xl border px-4 py-3 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
-                strategy === value
-                  ? "border-violet-500/40 bg-violet-500/[0.07]"
-                  : "border-border/60 bg-card hover:border-border",
+                "rounded-md px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground",
+                strategy === value && "bg-background text-foreground shadow-sm",
               )}
               onClick={() => onStrategyChange(value)}
             >
-              <span className="flex items-center justify-between gap-3 text-sm font-medium">
-                {t(value === "append" ? "chat.projectPromptAppend" : "chat.projectPromptReplace")}
-                <span
-                  className={cn(
-                    "flex h-4 w-4 items-center justify-center rounded-full border",
-                    strategy === value
-                      ? "border-violet-500 bg-violet-500 text-white"
-                      : "border-border",
-                  )}
-                >
-                  {strategy === value ? <Check className="h-3 w-3" /> : null}
-                </span>
-              </span>
-              <span className="mt-1.5 block text-xs leading-5 text-muted-foreground">
-                {t(
-                  value === "append"
-                    ? "chat.projectPromptAppendHint"
-                    : "chat.projectPromptReplaceHint",
-                )}
-              </span>
+              {t(value === "append" ? "chat.projectPromptAppend" : "chat.projectPromptReplace")}
             </button>
           ))}
-        </div>
-      </section>
+        </fieldset>
+      </div>
+      {/* 只解释当前选中的组合策略，随切换实时更新。 */}
+      <p className="mt-1.5 text-xs leading-5 text-muted-foreground">
+        {t(
+          strategy === "append" ? "chat.projectPromptAppendHint" : "chat.projectPromptReplaceHint",
+        )}
+      </p>
 
-      <section className="rounded-2xl border border-border/60 bg-card p-4 shadow-xs">
-        <div className="mb-3 flex items-start justify-between gap-4">
-          <div className="flex items-start gap-3">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/60 text-muted-foreground">
-              <FileText className="h-4 w-4" />
-            </div>
-            <div>
-              <h3 className="text-sm font-semibold">{t("chat.projectPromptContent")}</h3>
-              <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
-                {t("chat.projectPromptContentHint")}
-              </p>
-            </div>
-          </div>
-          <span className="shrink-0 rounded-full border border-border/60 bg-muted/40 px-2.5 py-1 text-xs tabular-nums text-muted-foreground">
-            {projectPrompt.length.toLocaleString()} {t("settings.agentsCharacters")}
-          </span>
-        </div>
-        <Textarea
-          value={projectPrompt}
-          placeholder={t("chat.projectPromptPlaceholder")}
-          className="h-64 min-h-64 resize-none overflow-y-auto p-4 font-mono text-[13px] leading-6"
-          onChange={(event) => onProjectPromptChange(event.currentTarget.value)}
-        />
-      </section>
-    </>
+      <Textarea
+        value={projectPrompt}
+        placeholder={t("chat.projectPromptPlaceholder")}
+        aria-label={t("chat.projectPromptTitle")}
+        className="mt-3 min-h-52 flex-1 resize-none overflow-y-auto rounded-xl p-4 font-mono text-[13px] leading-6"
+        onChange={(event) => onProjectPromptChange(event.currentTarget.value)}
+      />
+
+      <div className="mt-2 flex items-baseline justify-between gap-3 px-1 text-[11px] text-muted-foreground">
+        <span className="min-w-0 truncate">
+          {projectPrompt ? null : t("chat.projectPromptContentHint")}
+        </span>
+        <span className="shrink-0 tabular-nums">
+          {projectPrompt.length.toLocaleString()} {t("settings.agentsCharacters")}
+        </span>
+      </div>
+    </section>
   );
 }
 
@@ -169,15 +138,16 @@ export function ProjectPromptEditorModal(props: {
           </div>
         </DialogHeader>
 
-        <DialogBody className="space-y-5 overflow-y-auto px-6 py-5">
+        <DialogBody className="flex flex-col p-0">
           <ProjectPromptSettingsPanel
             projectPrompt={projectPrompt}
             strategy={strategy}
             onProjectPromptChange={setProjectPrompt}
             onStrategyChange={setStrategy}
+            className="px-6 py-5"
           />
 
-          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          {error ? <p className="px-6 pb-4 text-xs text-destructive">{error}</p> : null}
         </DialogBody>
 
         <DialogFooter className="px-6">

--- a/crates/agent-ui/src/components/chat/WorkspaceProjectSettingsModal.tsx
+++ b/crates/agent-ui/src/components/chat/WorkspaceProjectSettingsModal.tsx
@@ -454,14 +454,12 @@ export function WorkspaceProjectSettingsModal(props: {
             ) : null}
 
             {activePanel === "prompt" ? (
-              <div className="space-y-5 p-6">
-                <ProjectPromptSettingsPanel
-                  projectPrompt={projectPrompt}
-                  strategy={projectPromptStrategy}
-                  onProjectPromptChange={setProjectPrompt}
-                  onStrategyChange={setProjectPromptStrategy}
-                />
-              </div>
+              <ProjectPromptSettingsPanel
+                projectPrompt={projectPrompt}
+                strategy={projectPromptStrategy}
+                onProjectPromptChange={setProjectPrompt}
+                onStrategyChange={setProjectPromptStrategy}
+              />
             ) : null}
           </main>
         </DialogBody>
@@ -491,9 +489,10 @@ export function WorkspaceProjectSettingsModal(props: {
             <Button
               onClick={() => void handleSave()}
               disabled={saving || !dialogOpen || projectNameInvalid}
-              className="min-w-20 max-[520px]:flex-1"
+              className="max-[520px]:flex-1"
             >
-              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : t("workspaceEditor.save")}
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {t("workspaceEditor.save")}
             </Button>
           </DialogActions>
         </DialogFooter>

--- a/crates/agent-ui/src/components/chat/workspace-project-settings/WorkspaceDirectorySettingsPanel.tsx
+++ b/crates/agent-ui/src/components/chat/workspace-project-settings/WorkspaceDirectorySettingsPanel.tsx
@@ -6,11 +6,43 @@ import type {
 } from "@liveagent/ui/contracts/workspaceProjectRoots";
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { cn } from "@liveagent/ui/lib/shared/utils";
-import { AlertCircle, Folder, FolderTree, Loader2, Plus, Trash2 } from "../../IconSet";
+import { AlertCircle, Folder, FolderTree, Info, Lock, Plus, Trash2 } from "../../IconSet";
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../ui/select";
 import { rootStateTone } from "./workspaceProjectSettingsUtils";
+
+const ROOT_ACCESS_OPTIONS = ["read", "write"] as const;
+
+function RootAccessToggle(props: {
+  value: WorkspaceProjectRootAccess;
+  disabled: boolean;
+  ariaLabel: string;
+  readLabel: string;
+  writeLabel: string;
+  onChange: (access: WorkspaceProjectRootAccess) => void;
+}) {
+  const { value, disabled, ariaLabel, readLabel, writeLabel, onChange } = props;
+  return (
+    <fieldset className="flex h-7 shrink-0 items-center gap-0.5 rounded-lg border border-border/60 bg-muted/40 p-0.5">
+      <legend className="sr-only">{ariaLabel}</legend>
+      {ROOT_ACCESS_OPTIONS.map((option) => (
+        <button
+          key={option}
+          type="button"
+          aria-pressed={value === option}
+          disabled={disabled}
+          className={cn(
+            "rounded-md px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-50",
+            value === option && "bg-background text-foreground shadow-sm",
+          )}
+          onClick={() => onChange(option)}
+        >
+          {option === "read" ? readLabel : writeLabel}
+        </button>
+      ))}
+    </fieldset>
+  );
+}
 
 export function WorkspaceDirectorySettingsPanel(props: {
   project: WorkspaceProject;
@@ -42,48 +74,124 @@ export function WorkspaceDirectorySettingsPanel(props: {
 
   return (
     <section className="mx-auto max-w-[720px] space-y-4 p-6 max-[720px]:p-4">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h3 className="text-base font-semibold">{t("chat.workspaceSettingsDirectories")}</h3>
-          <p className="mt-1 max-w-[560px] text-xs leading-5 text-muted-foreground">
-            {t("chat.workspaceSettingsDirectoriesDescription")}
-          </p>
-        </div>
-        {rootClient ? (
-          <Button
-            size="sm"
-            className="shrink-0 gap-1.5"
-            onClick={onAdd}
-            disabled={!loaded || loading}
-          >
-            <Plus className="h-3.5 w-3.5" />
-            {t("chat.workspaceSettingsAddDirectory")}
-          </Button>
-        ) : null}
-      </div>
+      <h3 className="text-base font-semibold">{t("chat.workspaceSettingsDirectories")}</h3>
 
-      <div className="rounded-xl border border-primary/20 bg-primary/[0.035] px-3 py-2.5">
-        <div className="flex items-center gap-2.5">
+      {/* 主目录与附加目录合并为同一张列表卡片，形成统一的目录清单。 */}
+      <div className="overflow-hidden rounded-xl border border-border/60">
+        <div className="flex items-center gap-3 px-4 py-3">
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-            <Folder className="h-3.5 w-3.5" />
+            <FolderTree className="h-3.5 w-3.5" />
           </div>
           <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="text-sm font-medium">
-                {t("chat.workspaceSettingsPrimaryDirectory")}
-              </span>
-              <span className="rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
-                {t("chat.workspaceSettingsPrimaryBadge")}
-              </span>
-            </div>
+            <div className="text-sm font-medium">{t("chat.workspaceSettingsPrimaryDirectory")}</div>
             <div
-              className="mt-0.5 truncate font-mono text-[11px] leading-5 text-muted-foreground"
+              className="truncate font-mono text-[11px] leading-4 text-muted-foreground"
               title={project.path}
             >
               {project.path}
             </div>
           </div>
+          <div className="flex shrink-0 items-center gap-1.5 text-[11px] text-muted-foreground">
+            <Lock className="h-3 w-3" />
+            {t("chat.workspaceSettingsDirectoryWrite")}
+          </div>
         </div>
+
+        {loading ? (
+          <div className="space-y-2 border-t border-border/50 px-4 py-3">
+            <span className="sr-only" role="status">
+              {t("chat.workspaceSettingsDirectoriesLoading")}
+            </span>
+            {[0, 1].map((row) => (
+              <div key={row} className="flex animate-pulse items-center gap-3 py-1">
+                <div className="h-8 w-8 shrink-0 rounded-lg bg-muted/70" />
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <div className="h-3 w-24 rounded bg-muted/70" />
+                  <div className="h-2.5 w-48 max-w-full rounded bg-muted/50" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          roots.map((root) => (
+            <div
+              key={root.id}
+              className="flex items-center gap-3 border-t border-border/50 px-4 py-2.5 transition-colors hover:bg-muted/25 max-[560px]:flex-wrap"
+            >
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/60 text-muted-foreground">
+                <Folder className="h-3.5 w-3.5" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <Input
+                    value={root.alias}
+                    onChange={(event) => onAliasChange(root.id, event.currentTarget.value)}
+                    aria-label={t("chat.workspaceSettingsDirectoryAlias")}
+                    maxLength={32}
+                    pattern="[a-z][a-z0-9_-]{0,31}"
+                    disabled={!loaded}
+                    className="h-6 min-w-0 max-w-[180px] border-transparent bg-transparent px-1 text-sm font-medium shadow-none hover:border-border/60 focus-visible:border-border/60 focus-visible:ring-2 focus-visible:ring-foreground/10"
+                  />
+                  {/* 正常状态不显示徽标，只有异常/待批准时提醒。 */}
+                  {root.state !== "active" ? (
+                    <span
+                      className={cn(
+                        "shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
+                        rootStateTone(root.state),
+                      )}
+                    >
+                      {t(
+                        `chat.workspaceSettingsDirectoryState${root.state
+                          .split("-")
+                          .map((part) => part[0].toUpperCase() + part.slice(1))
+                          .join("")}`,
+                      )}
+                    </span>
+                  ) : null}
+                </div>
+                <div
+                  className="truncate font-mono text-[11px] leading-4 text-muted-foreground"
+                  title={root.displayPath}
+                >
+                  {root.displayPath}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-1 max-[560px]:w-full max-[560px]:justify-end">
+                <RootAccessToggle
+                  value={root.access}
+                  disabled={!loaded}
+                  ariaLabel={t("chat.workspaceSettingsDirectoryAccess")}
+                  readLabel={t("chat.workspaceSettingsDirectoryRead")}
+                  writeLabel={t("chat.workspaceSettingsDirectoryWrite")}
+                  onChange={(access) => onAccessChange(root.id, access)}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+                  title={t("chat.workspaceSettingsRemoveDirectory")}
+                  disabled={!loaded}
+                  onClick={() => onRemove(root.id)}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+
+        {rootClient ? (
+          <button
+            type="button"
+            onClick={onAdd}
+            disabled={!loaded || loading}
+            className="flex w-full items-center justify-center gap-1.5 border-t border-dashed border-border/60 px-4 py-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t("chat.workspaceSettingsAddDirectory")}
+          </button>
+        ) : null}
       </div>
 
       {!rootClient ? (
@@ -98,100 +206,7 @@ export function WorkspaceDirectorySettingsPanel(props: {
             </p>
           </div>
         </div>
-      ) : loading ? (
-        <div className="flex min-h-28 items-center justify-center gap-2 text-xs text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          {t("chat.workspaceSettingsDirectoriesLoading")}
-        </div>
-      ) : roots.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-border/70 px-6 py-9 text-center">
-          <FolderTree className="mx-auto h-6 w-6 text-muted-foreground/70" />
-          <div className="mt-3 text-sm font-medium">
-            {t("chat.workspaceSettingsDirectoriesEmpty")}
-          </div>
-          <p className="mx-auto mt-1 max-w-[420px] text-xs leading-5 text-muted-foreground">
-            {t("chat.workspaceSettingsDirectoriesEmptyDescription")}
-          </p>
-        </div>
-      ) : (
-        <div className="divide-y divide-border/40 overflow-hidden rounded-xl border border-border/50 bg-background/60">
-          {roots.map((root) => (
-            <div
-              key={root.id}
-              className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-2 px-3 py-2.5 transition-colors hover:bg-muted/30 max-[560px]:grid-cols-1"
-            >
-              <div className="min-w-0">
-                <div className="flex min-w-0 items-center gap-2">
-                  <Input
-                    value={root.alias}
-                    onChange={(event) => onAliasChange(root.id, event.currentTarget.value)}
-                    aria-label={t("chat.workspaceSettingsDirectoryAlias")}
-                    maxLength={32}
-                    pattern="[a-z][a-z0-9_-]{0,31}"
-                    disabled={!loaded}
-                    className="h-7 min-w-0 max-w-[180px] border-transparent bg-transparent px-1.5 text-sm font-medium shadow-none hover:border-border/60 focus-visible:border-border/60 focus-visible:ring-2 focus-visible:ring-foreground/10"
-                  />
-                  <span
-                    className={cn(
-                      "shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
-                      rootStateTone(root.state),
-                    )}
-                  >
-                    {t(
-                      `chat.workspaceSettingsDirectoryState${root.state
-                        .split("-")
-                        .map((part) => part[0].toUpperCase() + part.slice(1))
-                        .join("")}`,
-                    )}
-                  </span>
-                </div>
-                <div
-                  className="mt-0.5 truncate font-mono text-[11px] leading-4 text-muted-foreground"
-                  title={root.displayPath}
-                >
-                  {root.displayPath}
-                </div>
-              </div>
-              <div className="flex shrink-0 items-center justify-end gap-1 max-[560px]:justify-between">
-                <label className="sr-only" htmlFor={`workspace-root-access-${root.id}`}>
-                  {t("chat.workspaceSettingsDirectoryAccess")}
-                </label>
-                <Select
-                  value={root.access}
-                  disabled={!loaded}
-                  onValueChange={(value) =>
-                    onAccessChange(root.id, value as WorkspaceProjectRootAccess)
-                  }
-                >
-                  <SelectTrigger
-                    id={`workspace-root-access-${root.id}`}
-                    className="h-8 w-auto min-w-24 border-border/60 px-2.5 text-xs"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent align="end">
-                    <SelectItem value="read">{t("chat.workspaceSettingsDirectoryRead")}</SelectItem>
-                    <SelectItem value="write">
-                      {t("chat.workspaceSettingsDirectoryWrite")}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-9 w-9 shrink-0 text-muted-foreground hover:text-destructive"
-                  title={t("chat.workspaceSettingsRemoveDirectory")}
-                  disabled={!loaded}
-                  onClick={() => onRemove(root.id)}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+      ) : null}
 
       {error ? (
         <div className="flex gap-2 rounded-lg border border-destructive/25 bg-destructive/5 px-3 py-2.5 text-xs text-destructive">
@@ -199,6 +214,11 @@ export function WorkspaceDirectorySettingsPanel(props: {
           <span>{error}</span>
         </div>
       ) : null}
+
+      <p className="flex items-start gap-2 px-1 text-xs leading-5 text-muted-foreground">
+        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        {t("chat.workspaceSettingsDirectoriesDescription")}
+      </p>
     </section>
   );
 }

--- a/crates/agent-ui/src/components/chat/workspace-project-settings/WorkspaceGeneralSettingsPanel.tsx
+++ b/crates/agent-ui/src/components/chat/workspace-project-settings/WorkspaceGeneralSettingsPanel.tsx
@@ -1,4 +1,6 @@
 import type { WorkspaceProject } from "@liveagent/app/lib/settings";
+import { Badge } from "@liveagent/ui/components/ui/badge";
+import { CopyButton } from "@liveagent/ui/components/ui/copy-button";
 import { Input } from "@liveagent/ui/components/ui/input";
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { cn } from "@liveagent/ui/lib/shared/utils";
@@ -25,64 +27,77 @@ export function WorkspaceGeneralSettingsPanel(props: {
   const { t } = useLocale();
 
   return (
-    <section className="mx-auto max-w-[680px] space-y-6 p-6 max-[720px]:p-4">
-      <div>
-        <h3 className="text-base font-semibold">{t("chat.workspaceSettingsGeneral")}</h3>
-        <p className="mt-1 text-xs leading-5 text-muted-foreground">
-          {t("chat.workspaceSettingsGeneralDescription")}
-        </p>
-      </div>
+    <section className="mx-auto max-w-[640px] space-y-4 p-6 max-[720px]:p-4">
+      <h3 className="text-base font-semibold">{t("chat.workspaceSettingsGeneral")}</h3>
+
       <div className="overflow-hidden rounded-xl border border-border/60">
-        <div className="grid grid-cols-[140px_minmax(0,1fr)] items-start gap-4 border-b border-border/50 px-4 py-3.5 max-[520px]:grid-cols-1 max-[520px]:gap-2">
-          <div className="pt-2 text-xs font-medium text-muted-foreground max-[520px]:pt-0">
+        <div className="flex items-center justify-between gap-6 px-4 py-3 max-[560px]:flex-col max-[560px]:items-stretch max-[560px]:gap-2">
+          <label htmlFor="workspace-project-name" className="shrink-0 text-[13px] font-medium">
             {t("chat.workspaceSettingsProjectName")}
-          </div>
-          <div className="min-w-0">
+          </label>
+          <div className="w-[300px] max-w-full max-[560px]:w-full">
             <Input
+              id="workspace-project-name"
               value={projectName}
               onChange={(event) => onProjectNameChange(event.currentTarget.value)}
               disabled={!canRenameProject || saving}
               aria-invalid={projectNameInvalid || undefined}
-              aria-describedby="workspace-project-name-description"
+              aria-describedby={
+                projectNameInvalid || !canRenameProject
+                  ? "workspace-project-name-description"
+                  : undefined
+              }
               className={cn(
-                "h-9 text-sm font-medium",
+                "h-9 text-sm",
                 projectNameInvalid && "border-destructive focus-visible:ring-destructive/20",
               )}
             />
-            <p
-              id="workspace-project-name-description"
-              className={cn(
-                "mt-1.5 text-[11px] leading-4 text-muted-foreground",
-                projectNameInvalid && "text-destructive",
-              )}
-            >
-              {projectNameInvalid
-                ? t("chat.workspaceSettingsProjectNameRequired")
-                : canRenameProject
-                  ? t("chat.workspaceSettingsProjectNameDescription")
+            {/* 仅在出错或只读时展示辅助文字，正常状态保持安静。 */}
+            {projectNameInvalid || !canRenameProject ? (
+              <p
+                id="workspace-project-name-description"
+                className={cn(
+                  "mt-1.5 text-[11px] leading-4 text-muted-foreground",
+                  projectNameInvalid && "text-destructive",
+                )}
+              >
+                {projectNameInvalid
+                  ? t("chat.workspaceSettingsProjectNameRequired")
                   : t("chat.workspaceSettingsProjectNameReadonly")}
-            </p>
+              </p>
+            ) : null}
           </div>
         </div>
-        <div className="grid grid-cols-[140px_minmax(0,1fr)] items-center gap-4 border-b border-border/50 px-4 py-3.5 max-[520px]:grid-cols-1 max-[520px]:gap-1">
-          <div className="text-xs font-medium text-muted-foreground">
-            {t("chat.workspaceSettingsProjectType")}
-          </div>
-          <div className="text-sm">{projectKindLabel}</div>
+
+        <div className="flex items-center justify-between gap-6 border-t border-border/50 px-4 py-3">
+          <span className="text-[13px] font-medium">{t("chat.workspaceSettingsProjectType")}</span>
+          <Badge variant="muted">{projectKindLabel}</Badge>
         </div>
-        <div className="grid grid-cols-[140px_minmax(0,1fr)] items-start gap-4 px-4 py-3.5 max-[520px]:grid-cols-1 max-[520px]:gap-1">
-          <div className="text-xs font-medium text-muted-foreground">
+
+        <div className="flex items-center justify-between gap-6 border-t border-border/50 px-4 py-3 max-[560px]:flex-col max-[560px]:items-stretch max-[560px]:gap-1.5">
+          <span className="shrink-0 text-[13px] font-medium">
             {t("chat.workspaceSettingsPrimaryDirectory")}
+          </span>
+          <div className="flex min-w-0 items-center gap-0.5">
+            <span
+              className="min-w-0 truncate font-mono text-xs text-muted-foreground"
+              title={project.path}
+            >
+              {project.path}
+            </span>
+            <CopyButton
+              value={project.path}
+              label={t("chat.copy")}
+              copiedLabel={t("chat.markdown.copied")}
+            />
           </div>
-          <div className="break-all font-mono text-xs leading-5">{project.path}</div>
         </div>
       </div>
-      <div className="flex gap-3 rounded-xl border border-border/60 bg-muted/20 p-4">
-        <Shield className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-        <p className="text-xs leading-5 text-muted-foreground">
-          {t("chat.workspaceSettingsPrimaryHint")}
-        </p>
-      </div>
+
+      <p className="flex items-start gap-2 px-1 text-xs leading-5 text-muted-foreground">
+        <Shield className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        {t("chat.workspaceSettingsPrimaryHint")}
+      </p>
     </section>
   );
 }

--- a/crates/agent-ui/src/i18n/translations/enUSCommon.ts
+++ b/crates/agent-ui/src/i18n/translations/enUSCommon.ts
@@ -202,7 +202,6 @@ export const EN_US_COMMON_TRANSLATIONS = {
   "chat.projectPromptReplace": "Replace",
   "chat.projectPromptReplaceHint":
     "Use only the project prompt here and leave out the global prompt.",
-  "chat.projectPromptContent": "Prompt content",
   "chat.projectPromptContentHint": "Leave empty to use global prompts only for this project.",
   "chat.projectPromptPlaceholder":
     "Describe the context, constraints, and working style specific to this project...",
@@ -211,11 +210,7 @@ export const EN_US_COMMON_TRANSLATIONS = {
   "chat.workspaceSettingsGeneral": "General",
   "chat.workspaceSettingsDirectories": "Directories & permissions",
   "chat.workspaceSettingsResources": "Resources",
-  "chat.workspaceSettingsGeneralDescription":
-    "Manage the project name and review its type and default working directory.",
   "chat.workspaceSettingsProjectName": "Project name",
-  "chat.workspaceSettingsProjectNameDescription":
-    "This name appears in the sidebar and project selectors.",
   "chat.workspaceSettingsProjectNameRequired": "Project name is required.",
   "chat.workspaceSettingsProjectNameReadonly": "The default workspace name cannot be changed.",
   "chat.workspaceSettingsProjectType": "Project type",
@@ -224,20 +219,16 @@ export const EN_US_COMMON_TRANSLATIONS = {
   "chat.workspaceSettingsKindHistory": "History workspace",
   "chat.workspaceSettingsPrimaryDirectory": "Primary directory",
   "chat.workspaceSettingsPrimaryHint":
-    "The primary directory remains the default location for conversations, Git, terminals, and the file tree. Additional directories do not change project ownership.",
+    "The primary directory is the default location for conversations, Git, terminals, and the file tree.",
   "chat.workspaceSettingsDirectoriesDescription":
-    "Add out-of-project roots for structured file tools and control read or write access. This setting does not sandbox Bash or process tools; command access still follows existing tool policy.",
+    "Additional directory grants only apply to structured file tools; command and process tools still follow existing tool policy.",
   "chat.workspaceSettingsAddDirectory": "Add directory",
-  "chat.workspaceSettingsPrimaryBadge": "Default workspace",
   "chat.workspaceSettingsDirectoriesUnavailable": "Directory grant service unavailable",
   "chat.workspaceSettingsDirectoriesDesktopOnly":
     "This environment is not connected to local directory permissions. Configure them in the desktop app.",
   "chat.workspaceSettingsDirectoriesGatewayDescription":
     "WebUI is not connected to the target desktop Agent. Directory grants can be managed remotely after the connection recovers.",
   "chat.workspaceSettingsDirectoriesLoading": "Loading directory permissions…",
-  "chat.workspaceSettingsDirectoriesEmpty": "No additional directories",
-  "chat.workspaceSettingsDirectoriesEmptyDescription":
-    "Add shared code, API schemas, or documentation so the Agent can access them with the permission you choose.",
   "chat.workspaceSettingsDirectoryAlias": "Directory alias",
   "chat.workspaceSettingsDirectoryStateActive": "Available",
   "chat.workspaceSettingsDirectoryStateMissing": "Missing",
@@ -245,8 +236,8 @@ export const EN_US_COMMON_TRANSLATIONS = {
   "chat.workspaceSettingsDirectoryStatePendingApproval": "Pending approval",
   "chat.workspaceSettingsRemoveDirectory": "Remove directory",
   "chat.workspaceSettingsDirectoryAccess": "Access",
-  "chat.workspaceSettingsDirectoryRead": "Read-only reference",
-  "chat.workspaceSettingsDirectoryWrite": "Allow edits",
+  "chat.workspaceSettingsDirectoryRead": "Read-only",
+  "chat.workspaceSettingsDirectoryWrite": "Read & write",
   "chat.workspaceSettingsDirectoryDuplicate":
     "This directory has already been added to the project.",
   "chat.workspaceSettingsResourcesDescription":

--- a/crates/agent-ui/src/i18n/translations/zhCNCommon.ts
+++ b/crates/agent-ui/src/i18n/translations/zhCNCommon.ts
@@ -185,7 +185,6 @@ export const ZH_CN_COMMON_TRANSLATIONS = {
   "chat.projectPromptAppendHint": "先应用当前全局提示词，再追加这个项目的专属要求。",
   "chat.projectPromptReplace": "覆盖",
   "chat.projectPromptReplaceHint": "这个项目只使用项目提示词，不加载全局提示词。",
-  "chat.projectPromptContent": "提示词内容",
   "chat.projectPromptContentHint": "留空表示该项目仅使用全局提示词。",
   "chat.projectPromptPlaceholder": "输入这个项目专属的背景、约束和工作方式...",
   "chat.workspaceSettingsTitle": "项目配置",
@@ -193,9 +192,7 @@ export const ZH_CN_COMMON_TRANSLATIONS = {
   "chat.workspaceSettingsGeneral": "通用配置",
   "chat.workspaceSettingsDirectories": "目录与权限",
   "chat.workspaceSettingsResources": "资源配置",
-  "chat.workspaceSettingsGeneralDescription": "管理项目名称，并查看项目类型和默认工作目录。",
   "chat.workspaceSettingsProjectName": "项目名称",
-  "chat.workspaceSettingsProjectNameDescription": "名称会显示在侧边栏和项目选择位置。",
   "chat.workspaceSettingsProjectNameRequired": "项目名称不能为空。",
   "chat.workspaceSettingsProjectNameReadonly": "默认工作区名称不可修改。",
   "chat.workspaceSettingsProjectType": "项目类型",
@@ -203,21 +200,16 @@ export const ZH_CN_COMMON_TRANSLATIONS = {
   "chat.workspaceSettingsKindFolder": "本地文件夹",
   "chat.workspaceSettingsKindHistory": "历史工作区",
   "chat.workspaceSettingsPrimaryDirectory": "主目录",
-  "chat.workspaceSettingsPrimaryHint":
-    "主目录是会话、Git、终端和文件树的默认工作位置。附加目录不会改变项目归属。",
+  "chat.workspaceSettingsPrimaryHint": "主目录是会话、Git、终端和文件树的默认工作位置。",
   "chat.workspaceSettingsDirectoriesDescription":
-    "为结构化文件工具添加项目外目录，并分别控制读取或写入权限。该设置不限制 Bash 或进程工具；命令访问仍遵循现有工具策略。",
+    "附加目录授权仅作用于结构化文件工具，命令与进程工具仍遵循现有策略。",
   "chat.workspaceSettingsAddDirectory": "添加目录",
-  "chat.workspaceSettingsPrimaryBadge": "默认工作区",
   "chat.workspaceSettingsDirectoriesUnavailable": "目录授权服务不可用",
   "chat.workspaceSettingsDirectoriesDesktopOnly":
     "当前环境尚未连接本机目录授权服务，请在桌面端完成配置。",
   "chat.workspaceSettingsDirectoriesGatewayDescription":
     "当前 WebUI 尚未连接目标桌面 Agent，连接恢复后即可远程管理目录授权。",
   "chat.workspaceSettingsDirectoriesLoading": "正在读取目录权限…",
-  "chat.workspaceSettingsDirectoriesEmpty": "尚未添加附加目录",
-  "chat.workspaceSettingsDirectoriesEmptyDescription":
-    "添加共享代码、接口定义或文档目录后，Agent 可以按授予的权限访问它们。",
   "chat.workspaceSettingsDirectoryAlias": "目录别名",
   "chat.workspaceSettingsDirectoryStateActive": "正常",
   "chat.workspaceSettingsDirectoryStateMissing": "目录缺失",
@@ -225,8 +217,8 @@ export const ZH_CN_COMMON_TRANSLATIONS = {
   "chat.workspaceSettingsDirectoryStatePendingApproval": "等待批准",
   "chat.workspaceSettingsRemoveDirectory": "移除目录",
   "chat.workspaceSettingsDirectoryAccess": "访问权限",
-  "chat.workspaceSettingsDirectoryRead": "只读参考",
-  "chat.workspaceSettingsDirectoryWrite": "允许编辑",
+  "chat.workspaceSettingsDirectoryRead": "只读",
+  "chat.workspaceSettingsDirectoryWrite": "读写",
   "chat.workspaceSettingsDirectoryDuplicate": "该目录已经添加到当前项目。",
   "chat.workspaceSettingsResourcesDescription":
     "控制此项目会向 Agent 提供哪些 Skills 与 MCP 服务。",


### PR DESCRIPTION
Closes #637

## Summary

- **侧边栏工作空间菜单**:按"管理 / 浏览定位 / 危险操作"三组分隔,危险操作沉底;无任何分组时隐藏"移动到分组",避免展开空子菜单;子菜单触发器补充右箭头指示
- **通用配置**:改为设置卡片行布局(名称 / 类型 / 主目录),主目录新增复制按钮,辅助文字仅在出错或只读时出现,删除页面描述与常驻说明
- **目录与权限**:主目录与附加目录合并为统一目录清单卡片;读写权限从下拉框改为"只读 | 读写"分段开关;"添加目录"改为列表底部虚线添加行(兼作空态);加载改骨架屏;状态徽标仅异常/待批准时显示;长描述压缩为底部一行脚注
- **项目提示词**:编辑器 flex 撑满面板高度成为主角;拼接/覆盖策略改为头部分段开关 + 动态单行提示(原五段静态文字);字数统计移至底部状态行,空内容时上下文提示"留空表示仅使用全局提示词"
- **弹窗底栏**:保存按钮与取消按钮等宽,保存中显示"图标+文字"避免宽度跳变
- 中英文案同步精简,删除弃用 key;结构断言测试同步更新(Select → aria-pressed 分段开关)

## Test plan

- [x] `agent-ui` tsc 类型检查通过
- [x] biome lint/format 通过(含 a11y 规则)
- [x] `workspace-resource-settings.test.mjs` 7 项结构断言通过
- [x] i18n 一致性测试 10 项通过(两语言键位对齐)
- [ ] 桌面端手动验证:无分组/有分组菜单、目录增删改权限、提示词编辑与保存

Made with [Cursor](https://cursor.com)