### PR TITLE
feat(settings): 供应商卡片增加一键复制 Base URL 和 API Key

### DIFF
--- a/crates/agent-gateway/web/src/agent-ui-adapters/providerSettings.tsx
+++ b/crates/agent-gateway/web/src/agent-ui-adapters/providerSettings.tsx
@@ -1,5 +1,12 @@
-import type { AppSettings, ProviderId } from "../lib/settings";
+import type { AppSettings, CustomProvider, ProviderId } from "../lib/settings";
 import type { SettingsSectionProps } from "../pages/settings/types";
+
+/** WebUI 会脱敏 API Key，复制配置按钮仅在桌面端提供。 */
+export function ProviderCopyConfigButton(_props: {
+  provider: Pick<CustomProvider, "baseUrl" | "apiKey">;
+}) {
+  return null;
+}
 
 export function ProviderSettingsExtension(_props: {
   activeTab: ProviderId;

--- a/crates/agent-gui/src/agent-ui-adapters/providerSettings.tsx
+++ b/crates/agent-gui/src/agent-ui-adapters/providerSettings.tsx
@@ -17,6 +17,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@liveagent/ui/components/ui/dialog";
+import { CopyButton } from "@liveagent/ui/components/ui/copy-button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -355,6 +356,29 @@ function CcsImportModal(props: {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/** 桌面端复制内容：Base URL 与 API Key 各占一行，空值省略。 */
+export function formatProviderCopyConfig(provider: Pick<CustomProvider, "baseUrl" | "apiKey">) {
+  return [provider.baseUrl.trim(), provider.apiKey.trim()].filter(Boolean).join("\n");
+}
+
+/**
+ * 供应商卡片上的一键复制按钮（仅桌面端）：把 Base URL 与 API Key 复制到
+ * 剪贴板。WebUI 会对 API Key 做脱敏，因此 gateway 端的同名适配器返回 null。
+ */
+export function ProviderCopyConfigButton(props: {
+  provider: Pick<CustomProvider, "baseUrl" | "apiKey">;
+}) {
+  const { provider } = props;
+  const { t } = useLocale();
+  return (
+    <CopyButton
+      value={formatProviderCopyConfig(provider)}
+      label={t("settings.providerCopyConfig")}
+      copiedLabel={t("settings.providerCopyConfigCopied")}
+    />
   );
 }
 

--- a/crates/agent-gui/src/agent-ui-adapters/providerSettings.tsx
+++ b/crates/agent-gui/src/agent-ui-adapters/providerSettings.tsx
@@ -7,6 +7,7 @@ import {
   RefreshCw,
 } from "@liveagent/ui/components/IconSet";
 import { Button } from "@liveagent/ui/components/ui/button";
+import { CopyButton } from "@liveagent/ui/components/ui/copy-button";
 import {
   Dialog,
   DialogActions,
@@ -17,7 +18,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@liveagent/ui/components/ui/dialog";
-import { CopyButton } from "@liveagent/ui/components/ui/copy-button";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/crates/agent-gui/test/settings/provider-copy-config.test.mjs
+++ b/crates/agent-gui/test/settings/provider-copy-config.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const importLoader = createTsModuleLoader({
+  mocks: {
+    "../../src-tauri/icons/custom/ccswitch.png": { default: "ccswitch.png" },
+    "../../src-tauri/icons/custom/cherrystudio.png": { default: "cherrystudio.png" },
+  },
+});
+const providerImports = importLoader.loadModule("src/agent-ui-adapters/providerSettings.tsx");
+
+const providersSectionSource = readFileSync(
+  new URL("../../../agent-ui/src/pages/settings/ProvidersSection.tsx", import.meta.url),
+  "utf8",
+);
+const guiAdapterSource = readFileSync(
+  new URL("../../src/agent-ui-adapters/providerSettings.tsx", import.meta.url),
+  "utf8",
+);
+const gatewayAdapterSource = readFileSync(
+  new URL("../../../agent-gateway/web/src/agent-ui-adapters/providerSettings.tsx", import.meta.url),
+  "utf8",
+);
+const zhSettingsSource = readFileSync(
+  new URL("../../../agent-ui/src/i18n/translations/zhCNSettings.ts", import.meta.url),
+  "utf8",
+);
+const enSettingsSource = readFileSync(
+  new URL("../../../agent-ui/src/i18n/translations/enUSSettings.ts", import.meta.url),
+  "utf8",
+);
+
+test("desktop copy payload puts Base URL and API Key on separate lines", () => {
+  assert.equal(
+    providerImports.formatProviderCopyConfig({
+      baseUrl: " https://api.example.com/v1 ",
+      apiKey: " sk-test ",
+    }),
+    "https://api.example.com/v1\nsk-test",
+  );
+});
+
+test("desktop copy payload omits blank Base URL or API Key", () => {
+  assert.equal(
+    providerImports.formatProviderCopyConfig({ baseUrl: "https://api.example.com", apiKey: "  " }),
+    "https://api.example.com",
+  );
+  assert.equal(
+    providerImports.formatProviderCopyConfig({ baseUrl: "", apiKey: "sk-only" }),
+    "sk-only",
+  );
+  assert.equal(providerImports.formatProviderCopyConfig({ baseUrl: "  ", apiKey: "" }), "");
+});
+
+test("the shared provider card places the copy button immediately before refresh usage", () => {
+  assert.match(
+    providersSectionSource,
+    /<ProviderCopyConfigButton provider=\{provider\} \/>\s*\{usageDisplay\.show \? \(/,
+  );
+  assert.match(providersSectionSource, /settings\.providerUsageRefresh/);
+});
+
+test("only the desktop adapter implements the copy button", () => {
+  assert.match(guiAdapterSource, /export function ProviderCopyConfigButton/);
+  assert.match(guiAdapterSource, /formatProviderCopyConfig\(provider\)/);
+  assert.match(guiAdapterSource, /settings\.providerCopyConfig/);
+  assert.match(guiAdapterSource, /settings\.providerCopyConfigCopied/);
+  assert.match(gatewayAdapterSource, /export function ProviderCopyConfigButton/);
+  assert.match(gatewayAdapterSource, /return null;/);
+  assert.doesNotMatch(gatewayAdapterSource, /CopyButton/);
+});
+
+test("copy-config labels exist in both settings locales", () => {
+  for (const source of [zhSettingsSource, enSettingsSource]) {
+    assert.match(source, /"settings\.providerCopyConfig":/);
+    assert.match(source, /"settings\.providerCopyConfigCopied":/);
+  }
+});

--- a/crates/agent-ui/src/i18n/translations/enUSSettings.ts
+++ b/crates/agent-ui/src/i18n/translations/enUSSettings.ts
@@ -572,6 +572,8 @@ export const EN_US_SETTINGS_TRANSLATIONS = {
   "settings.providerUsageStale": "Stale",
   "settings.providerUsageStaleTitle": "Refresh failed; showing the last successful result",
   "settings.providerUsageRefresh": "Refresh usage",
+  "settings.providerCopyConfig": "Copy Base URL and API Key",
+  "settings.providerCopyConfigCopied": "Copied to clipboard",
   "settings.providerUsageInvalid": "Plan expired",
   "settings.providerUsageNoData": "No usage data",
   "settings.providerUsageUpdated.justNow": "just now",

--- a/crates/agent-ui/src/i18n/translations/zhCNSettings.ts
+++ b/crates/agent-ui/src/i18n/translations/zhCNSettings.ts
@@ -548,6 +548,8 @@ export const ZH_CN_SETTINGS_TRANSLATIONS = {
   "settings.providerUsageStale": "旧数据",
   "settings.providerUsageStaleTitle": "刷新失败，展示上次成功结果",
   "settings.providerUsageRefresh": "刷新用量",
+  "settings.providerCopyConfig": "复制 Base URL 和 API Key",
+  "settings.providerCopyConfigCopied": "已复制到剪贴板",
   "settings.providerUsageInvalid": "套餐已失效",
   "settings.providerUsageNoData": "暂无用量数据",
   "settings.providerUsageUpdated.justNow": "刚刚",

--- a/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
@@ -1,4 +1,7 @@
-import { ProviderSettingsExtension } from "@liveagent/adapters/providerSettings";
+import {
+  ProviderCopyConfigButton,
+  ProviderSettingsExtension,
+} from "@liveagent/adapters/providerSettings";
 import {
   getProviderUsageCardDisplay,
   type ProviderUsageState,
@@ -746,6 +749,7 @@ function ProviderList(props: {
                       ) : null}
                     </div>
                     <div className="settings-card-actions settings-hover-actions flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                      <ProviderCopyConfigButton provider={provider} />
                       {usageDisplay.show ? (
                         <Button
                           variant="ghost"


### PR DESCRIPTION
## Linked issue

Closes #639

## Summary

配置供应商后，要把 Base URL 和 API Key 拷到别处，以前必须打开编辑弹窗再分别复制。本 PR 只在桌面 GUI 的供应商卡片上、刷新用量图标前增加复制按钮：点击后把 Base URL 与 API Key 按两行写入剪贴板，空字段省略。WebUI 会脱敏 API Key，同名适配器返回 `null`，不展示该按钮。

## Change scope

- Modules: agent-ui / agent-gui / agent-gateway (WebUI adapter stub only)
- Key paths:
  - `crates/agent-ui/src/pages/settings/ProvidersSection.tsx`
  - `crates/agent-gui/src/agent-ui-adapters/providerSettings.tsx`
  - `crates/agent-gateway/web/src/agent-ui-adapters/providerSettings.tsx`
  - `crates/agent-ui/src/i18n/translations/{zhCN,enUS}Settings.ts`
  - `crates/agent-gui/test/settings/provider-copy-config.test.mjs`

## Screenshots / preview

悬停供应商卡片后，复制按钮出现在刷新用量之前（本页 Anthropic 未开用量查询，因此刷新图标不显示）。点击后 tooltip 为「已复制到剪贴板」，卡片正文不展示 API Key。

![供应商卡片复制按钮](https://i.imgur.com/Q8wfC4S.png)

## Verification

- `pnpm lint`（agent-gui）：通过
- `node --test test/settings/provider-copy-config.test.mjs`（agent-gui）：5 项通过
- `node ../../scripts/run-node-tests.mjs --include-prefix translations test`：中英文 key 对齐
- 本地 GUI 供应商配置页：5 个供应商卡片均可点到复制按钮

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.