### PR TITLE
fix(chat): 修复 @ 文件/skill 候选列表文件名居中

### DIFF
--- a/crates/agent-ui/src/components/chat/MentionComposerOverlays.tsx
+++ b/crates/agent-ui/src/components/chat/MentionComposerOverlays.tsx
@@ -124,7 +124,7 @@ export function Popup({
                 // visual 34px row keeps the 4px gap while clicks in the gap
                 // still land on a row instead of a dead strip. shrink-0 stops
                 // the max-h flex column from compressing rows before it scrolls.
-                "mention-popup-item group flex h-[38px] shrink-0 cursor-pointer items-center gap-3 rounded-lg border-y-2 border-transparent bg-clip-padding px-3 text-xs leading-5 transition-colors",
+                "mention-popup-item group flex h-[38px] shrink-0 cursor-pointer items-center justify-start gap-3 rounded-lg border-y-2 border-transparent bg-clip-padding px-3 text-left text-xs leading-5 transition-colors",
                 i === highlightIndex
                   ? "bg-foreground/[0.07] text-foreground"
                   : "text-foreground/85 hover:bg-foreground/[0.05] dark:text-foreground/90",

--- a/crates/agent-ui/src/styles/common-settings.css
+++ b/crates/agent-ui/src/styles/common-settings.css
@@ -116,6 +116,7 @@
 
   .mention-popup-item {
     animation: mentionItemIn 0.2s cubic-bezier(0.16, 1, 0.3, 1) both;
+    text-align: left;
   }
 
   .mention-popup-item:nth-child(1) {


### PR DESCRIPTION
## 问题

#641：输入框里 `@` 文件引用和 skill 候选列表的名字变成居中，看起来没对齐。

原因是候选行是原生 `<button>`，浏览器默认 `text-align: center`，文件名又包在 `flex-1` 里，短名字会漂在图标右边的中间。

## 改动

给 mention popup 行补上左对齐（`text-left` / `justify-start`，以及 CSS `text-align: left`）。

Fixes #641
<img width="1269" height="651" alt="ScreenShot_2026-08-28_010111_653" src="https://github.com/user-attachments/assets/c9b38a7e-014d-45b2-9d72-83d5605632a8" />
