### PR TITLE
fix(chat): update missing model selection hint

### DIFF
--- a/crates/agent-gui/src/pages/chat/runtime/modelSelection.ts
+++ b/crates/agent-gui/src/pages/chat/runtime/modelSelection.ts
@@ -34,7 +34,7 @@ export function resolveEffectiveChatModelSelection(params: {
   const resolveLocalSelection = (): EffectiveChatModelSelection => {
     const activeSelectedModel = resolveActiveModelSelection(settings, conversationSelectedModel);
     if (!activeSelectedModel) {
-      throw new Error("请先在左上角选择一个模型（或先去设置添加模型）。");
+      throw new Error("请先在输入框左下角选择一个模型（或先去设置添加模型）。");
     }
 
     const { customProviderId, model } = activeSelectedModel;

--- a/crates/agent-gui/test/chat/model-selection.test.mjs
+++ b/crates/agent-gui/test/chat/model-selection.test.mjs
@@ -47,6 +47,19 @@ test("local chat model selection resolves only an enabled selected model", () =>
   });
 });
 
+test("missing local model selection points to the composer control", () => {
+  const app = appSettings([provider({ id: "openai-main", models: ["gpt-5"] })]);
+
+  assert.throws(
+    () => modelSelection.resolveEffectiveChatModelSelection({ settings: app }),
+    (error) => {
+      assert.match(error.message, /输入框左下角选择一个模型/);
+      assert.doesNotMatch(error.message, /左上角/);
+      return true;
+    },
+  );
+});
+
 test("remote chat model selection does not fall back to another provider with the same type", () => {
   const app = appSettings(
     [


### PR DESCRIPTION
## Linked issue

Closes #652

## Summary

Updates the missing-model validation message to point to the model picker in the lower-left area of the composer. The previous message referred to the obsolete upper-left location.

Adds a regression test for the case where at least one model is available but neither the current conversation nor the global settings has a valid selected model.

## Change scope

- Modules: agent-gui
- Key paths:
  - `crates/agent-gui/src/pages/chat/runtime/modelSelection.ts`
  - `crates/agent-gui/test/chat/model-selection.test.mjs`

## Screenshots / preview

<img width="1400" height="800" alt="image" src="https://github.com/user-attachments/assets/c6012635-d1bf-425d-bee3-deb1d96de379" />

## Verification

- `cd crates/agent-gui && node --test test/chat/model-selection.test.mjs`
  - Passed: 12/12 tests.
- `cd crates/agent-gui && pnpm exec biome lint src/pages/chat/runtime/modelSelection.ts test/chat/model-selection.test.mjs --max-diagnostics=none`
- `git diff --check`

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are not required; this corrects an existing UI validation message.