### PR TITLE
fix(providers): 拆分 OpenAI 兼容端点内联的 <think> 标签并接通 chat 模式思考渲染

### DIFF
--- a/crates/agent-gui/src/lib/providers/runtime/inlineThinkTagStream.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/inlineThinkTagStream.ts
@@ -1,0 +1,361 @@
+import {
+  type AssistantMessage,
+  type AssistantMessageEventStream,
+  createAssistantMessageEventStream,
+} from "@earendil-works/pi-ai";
+
+const OPEN_TAG = "<think>";
+const CLOSE_TAG = "</think>";
+/** 正文恰好以 `<` 开头时不能无限等下去——超过这个长度就判定不是思考标签。 */
+const MAX_PROBE_CHARS = 64;
+
+type Mode = "probing" | "thinking" | "answer" | "passthrough";
+
+function splitInlineThinkText(text: string) {
+  const trimmed = text.trimStart();
+  if (!trimmed.startsWith(OPEN_TAG)) {
+    return { thinking: "", answer: text, matched: false };
+  }
+  const rest = trimmed.slice(OPEN_TAG.length);
+  const closeAt = rest.indexOf(CLOSE_TAG);
+  if (closeAt < 0) return { thinking: rest, answer: "", matched: true };
+  return {
+    thinking: rest.slice(0, closeAt),
+    answer: rest.slice(closeAt + CLOSE_TAG.length).trimStart(),
+    matched: true,
+  };
+}
+
+function rewriteContent(content: AssistantMessage["content"]): AssistantMessage["content"] {
+  const head = content[0];
+  if (head?.type !== "text") return content;
+  const split = splitInlineThinkText(head.text);
+  if (!split.matched) return content;
+  // 思考块无条件保留（哪怕为空），否则事件流里的 contentIndex 位移会和最终消息
+  // 的数组下标对不上，后续工具调用会被错位读取。
+  const rewritten: AssistantMessage["content"] = [{ type: "thinking", thinking: split.thinking }];
+  if (split.answer.length > 0) rewritten.push({ ...head, text: split.answer });
+  return [...rewritten, ...content.slice(1)];
+}
+
+function rewriteMessage(message: AssistantMessage): AssistantMessage {
+  const content = rewriteContent(message.content);
+  return content === message.content ? message : { ...message, content };
+}
+
+/** 末尾最长的、构成 `tag` 前缀的子串长度——用于跨 chunk 切分的闭合标签。 */
+function partialTagSuffixLength(buffer: string, tag: string) {
+  const max = Math.min(buffer.length, tag.length - 1);
+  for (let length = max; length > 0; length -= 1) {
+    if (buffer.endsWith(tag.slice(0, length))) return length;
+  }
+  return 0;
+}
+
+/**
+ * Ollama 的 OpenAI 兼容端点会把推理模型的思考过程以字面量 `<think>...</think>`
+ * 内联在 `content` 里，而不是走 `reasoning_content` 字段。这里在事件流层把它拆成
+ * 独立的 thinking 块，让上层拿到和原生推理供应商一致的事件序列。
+ *
+ * 只有源 contentIndex 0 的文本块开头（允许前导空白）才参与识别；原生推理供应商的
+ * 0 号块是 thinking，天然不会命中。
+ */
+export function wrapInlineThinkTagStream(
+  source: AssistantMessageEventStream,
+): AssistantMessageEventStream {
+  const output = createAssistantMessageEventStream();
+
+  let mode: Mode = "probing";
+  let headBuffer = "";
+  let carry = "";
+  let thinkingText = "";
+  let answerText = "";
+  let answerBlockCreated = false;
+  let thinkingEnded = false;
+  let headSettled = false;
+  let headTextStartSeen = false;
+
+  const shiftIndex = (index: number) => (index >= 1 && answerBlockCreated ? index + 1 : index);
+
+  const pushThinkingDelta = (delta: string, partial: AssistantMessage) => {
+    if (!delta) return;
+    thinkingText += delta;
+    output.push({
+      type: "thinking_delta",
+      contentIndex: 0,
+      delta,
+      partial: rewriteMessage(partial),
+    });
+  };
+
+  const endThinking = (partial: AssistantMessage) => {
+    if (thinkingEnded) return;
+    thinkingEnded = true;
+    output.push({
+      type: "thinking_end",
+      contentIndex: 0,
+      content: thinkingText,
+      partial: rewriteMessage(partial),
+    });
+  };
+
+  const pushAnswer = (chunk: string, partial: AssistantMessage) => {
+    let text = chunk;
+    if (!answerBlockCreated) {
+      // `</think>` 与正文之间的换行不属于回答内容。
+      text = text.replace(/^\s+/, "");
+      if (!text) return;
+      answerBlockCreated = true;
+      output.push({ type: "text_start", contentIndex: 1, partial: rewriteMessage(partial) });
+    }
+    if (!text) return;
+    answerText += text;
+    output.push({
+      type: "text_delta",
+      contentIndex: 1,
+      delta: text,
+      partial: rewriteMessage(partial),
+    });
+  };
+
+  const feedThinking = (chunk: string, partial: AssistantMessage) => {
+    const buffer = carry + chunk;
+    carry = "";
+    const closeAt = buffer.indexOf(CLOSE_TAG);
+    if (closeAt >= 0) {
+      pushThinkingDelta(buffer.slice(0, closeAt), partial);
+      endThinking(partial);
+      mode = "answer";
+      pushAnswer(buffer.slice(closeAt + CLOSE_TAG.length), partial);
+      return;
+    }
+    const hold = partialTagSuffixLength(buffer, CLOSE_TAG);
+    carry = hold > 0 ? buffer.slice(buffer.length - hold) : "";
+    pushThinkingDelta(buffer.slice(0, buffer.length - hold), partial);
+  };
+
+  const rejectProbe = (partial: AssistantMessage) => {
+    mode = "passthrough";
+    // 只补发源真的发过的 text_start，否则透传就不再是恒等的了。
+    if (headTextStartSeen) {
+      output.push({ type: "text_start", contentIndex: 0, partial: rewriteMessage(partial) });
+    }
+    if (headBuffer) {
+      output.push({
+        type: "text_delta",
+        contentIndex: 0,
+        delta: headBuffer,
+        partial: rewriteMessage(partial),
+      });
+    }
+    headBuffer = "";
+  };
+
+  const feedProbe = (chunk: string, partial: AssistantMessage) => {
+    headBuffer += chunk;
+    const trimmed = headBuffer.trimStart();
+    if (trimmed.startsWith(OPEN_TAG)) {
+      mode = "thinking";
+      headBuffer = "";
+      output.push({ type: "thinking_start", contentIndex: 0, partial: rewriteMessage(partial) });
+      feedThinking(trimmed.slice(OPEN_TAG.length), partial);
+      return;
+    }
+    if (OPEN_TAG.startsWith(trimmed) && headBuffer.length <= MAX_PROBE_CHARS) return;
+    rejectProbe(partial);
+  };
+
+  /** 用完整文本做权威对账，补齐流式期间因缓冲而未发出的尾巴。 */
+  const settleHead = (content: string, partial: AssistantMessage) => {
+    if (headSettled || mode === "passthrough") return;
+    headSettled = true;
+    const split = splitInlineThinkText(content);
+
+    if (!split.matched) {
+      headBuffer = content;
+      rejectProbe(partial);
+      output.push({
+        type: "text_end",
+        contentIndex: 0,
+        content,
+        partial: rewriteMessage(partial),
+      });
+      return;
+    }
+
+    if (mode === "probing") {
+      mode = "thinking";
+      headBuffer = "";
+      output.push({ type: "thinking_start", contentIndex: 0, partial: rewriteMessage(partial) });
+    }
+    carry = "";
+    if (split.thinking.length > thinkingText.length) {
+      pushThinkingDelta(split.thinking.slice(thinkingText.length), partial);
+    }
+    endThinking(partial);
+    mode = "answer";
+    if (split.answer.length > answerText.length) {
+      pushAnswer(split.answer.slice(answerText.length), partial);
+    }
+    if (answerBlockCreated) {
+      output.push({
+        type: "text_end",
+        contentIndex: 1,
+        content: answerText,
+        partial: rewriteMessage(partial),
+      });
+    }
+  };
+
+  const flushResidue = (message: AssistantMessage) => {
+    if (headSettled || mode === "passthrough") return;
+    const head = message.content[0];
+    if (head?.type === "text") {
+      settleHead(head.text, message);
+      return;
+    }
+    // 中断得太早，最终消息里连 0 号文本块都没有。
+    headSettled = true;
+    if (mode === "probing") {
+      if (headBuffer) rejectProbe(message);
+      return;
+    }
+    pushThinkingDelta(carry, message);
+    carry = "";
+    endThinking(message);
+  };
+
+  void (async () => {
+    for await (const event of source) {
+      if (mode === "passthrough") {
+        output.push(event);
+        if (event.type === "done" || event.type === "error") return;
+        continue;
+      }
+
+      switch (event.type) {
+        case "start":
+          output.push(event);
+          break;
+        case "text_start":
+          // 0 号块暂扣：还不知道它会变成 thinking_start 还是普通正文。
+          if (event.contentIndex === 0) {
+            headTextStartSeen = true;
+            break;
+          }
+          output.push({
+            type: "text_start",
+            contentIndex: shiftIndex(event.contentIndex),
+            partial: rewriteMessage(event.partial),
+          });
+          break;
+        case "text_delta":
+          if (event.contentIndex === 0) {
+            if (mode === "probing") feedProbe(event.delta, event.partial);
+            else if (mode === "thinking") feedThinking(event.delta, event.partial);
+            else pushAnswer(event.delta, event.partial);
+            break;
+          }
+          output.push({
+            type: "text_delta",
+            contentIndex: shiftIndex(event.contentIndex),
+            delta: event.delta,
+            partial: rewriteMessage(event.partial),
+          });
+          break;
+        case "text_end":
+          if (event.contentIndex === 0) {
+            settleHead(event.content, event.partial);
+            break;
+          }
+          output.push({
+            type: "text_end",
+            contentIndex: shiftIndex(event.contentIndex),
+            content: event.content,
+            partial: rewriteMessage(event.partial),
+          });
+          break;
+        // 0 号块已经是原生思考块，说明供应商走的是 reasoning_content，直接放行。
+        case "thinking_start":
+          if (mode === "probing" && event.contentIndex === 0) {
+            mode = "passthrough";
+            output.push(event);
+            break;
+          }
+          output.push({
+            type: "thinking_start",
+            contentIndex: shiftIndex(event.contentIndex),
+            partial: rewriteMessage(event.partial),
+          });
+          break;
+        case "thinking_delta":
+          if (mode === "probing" && event.contentIndex === 0) {
+            mode = "passthrough";
+            output.push(event);
+            break;
+          }
+          output.push({
+            type: "thinking_delta",
+            contentIndex: shiftIndex(event.contentIndex),
+            delta: event.delta,
+            partial: rewriteMessage(event.partial),
+          });
+          break;
+        case "thinking_end":
+          if (mode === "probing" && event.contentIndex === 0) {
+            mode = "passthrough";
+            output.push(event);
+            break;
+          }
+          output.push({
+            type: "thinking_end",
+            contentIndex: shiftIndex(event.contentIndex),
+            content: event.content,
+            partial: rewriteMessage(event.partial),
+          });
+          break;
+        case "toolcall_start":
+          output.push({
+            type: "toolcall_start",
+            contentIndex: shiftIndex(event.contentIndex),
+            partial: rewriteMessage(event.partial),
+          });
+          break;
+        case "toolcall_delta":
+          output.push({
+            type: "toolcall_delta",
+            contentIndex: shiftIndex(event.contentIndex),
+            delta: event.delta,
+            partial: rewriteMessage(event.partial),
+          });
+          break;
+        case "toolcall_end":
+          output.push({
+            type: "toolcall_end",
+            contentIndex: shiftIndex(event.contentIndex),
+            toolCall: event.toolCall,
+            partial: rewriteMessage(event.partial),
+          });
+          break;
+        case "done":
+          flushResidue(event.message);
+          output.push({
+            type: "done",
+            reason: event.reason,
+            message: rewriteMessage(event.message),
+          });
+          return;
+        case "error":
+          flushResidue(event.error);
+          output.push({ type: "error", reason: event.reason, error: rewriteMessage(event.error) });
+          return;
+      }
+    }
+
+    const settled = await source.result();
+    flushResidue(settled);
+    output.end(rewriteMessage(settled));
+  })();
+
+  return output;
+}

--- a/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts
@@ -187,6 +187,7 @@ export async function streamAssistantMessage(params: {
   context: Context;
   workdir?: string;
   onTextDelta: (delta: string) => void;
+  onThinkingDelta?: (delta: string) => void;
   sessionId?: string;
   cacheRetention?: CacheRetention;
   signal?: AbortSignal;
@@ -526,6 +527,9 @@ export async function streamAssistantMessage(params: {
               appendOrderedText(delta);
               params.onTextDelta(delta);
             }
+          } else if (event.type === "thinking_delta") {
+            // 思考内容不进 orderedBlocks——那套排序只服务于正文与 hosted search 的交织。
+            params.onThinkingDelta?.(event.delta);
           }
         }
 

--- a/crates/agent-gui/src/lib/providers/service/piAiAdapter.ts
+++ b/crates/agent-gui/src/lib/providers/service/piAiAdapter.ts
@@ -137,7 +137,10 @@ function streamOpenAIResponsesApi(model: Model<Api>, context: Context, options: 
     reasoningEffort: clampOpenAIReasoningEffort(model, options.reasoning),
   };
   return withStreamRetry(
-    () => streamOpenAIResponses(model as Model<"openai-responses">, context, openAIOptions),
+    () =>
+      wrapInlineThinkTagStream(
+        streamOpenAIResponses(model as Model<"openai-responses">, context, openAIOptions),
+      ),
     {
       signal: options.signal,
       ...options.streamRetry,

--- a/crates/agent-gui/src/lib/providers/service/piAiAdapter.ts
+++ b/crates/agent-gui/src/lib/providers/service/piAiAdapter.ts
@@ -13,6 +13,7 @@ import {
   stream as streamOpenAIResponses,
 } from "@earendil-works/pi-ai/api/openai-responses";
 import { resolveMaxTokens } from "../runtime/common";
+import { wrapInlineThinkTagStream } from "../runtime/inlineThinkTagStream";
 import { rejectEmptyOpenAICompletionsResponse } from "../runtime/openAICompletionsStream";
 import { withStreamRetry } from "../runtime/streamRetry";
 import {
@@ -120,8 +121,10 @@ function streamOpenAICompletionsApi(model: Model<Api>, context: Context, options
   };
   return withStreamRetry(
     () => {
-      return rejectEmptyOpenAICompletionsResponse(
-        streamOpenAICompletions(model as Model<"openai-completions">, context, openAIOptions),
+      return wrapInlineThinkTagStream(
+        rejectEmptyOpenAICompletionsResponse(
+          streamOpenAICompletions(model as Model<"openai-completions">, context, openAIOptions),
+        ),
       );
     },
     { signal: options.signal, ...options.streamRetry },

--- a/crates/agent-gui/src/pages/chat/turns/runTextConversationTurn.ts
+++ b/crates/agent-gui/src/pages/chat/turns/runTextConversationTurn.ts
@@ -31,6 +31,7 @@ import type {
 } from "../../../lib/chat/memory/extractionEngine";
 import {
   appendTextDeltaToRound,
+  appendThinkingDeltaToRound,
   collapseThinking,
   type LiveRound,
   updateLiveRound,
@@ -449,6 +450,37 @@ export async function runTextConversationTurn(params: RunTextConversationTurnPar
             if (!compaction.shouldProtectMidStream(streamedAssistantTokenUnits)) return;
             compactionRequested = true;
             scope.controller.abort();
+          },
+          onThinkingDelta: (delta) => {
+            if (failoverStatusVisible) {
+              failoverStatusVisible = false;
+              updateGatewayBridgeToolStatus(null);
+            }
+            nativeWebSearchStatusController.noteVisibleActivity();
+            gatewayBridgeEvents.queueEvent({
+              type: "thinking",
+              text: delta,
+              round: textRound,
+              conversation_id: conversationId,
+            });
+            // 思考只能挂在 live round 上，草稿通道没有思考块；切过去前先把已有草稿
+            // 正文喂进这一轮，否则渲染层改用 live round 后那段文字会消失。
+            const shouldSeedExistingText =
+              !textModeUsesLiveRounds && streamedAssistantText.length > 0;
+            ensureTextLiveRound(textRound);
+            batchLiveRoundsUpdate(
+              (prev) =>
+                updateLiveRound(prev, textRound, (target) => ({
+                  ...appendThinkingDeltaToRound(
+                    shouldSeedExistingText
+                      ? appendTextDeltaToRound(target, streamedAssistantText)
+                      : target,
+                    delta,
+                  ),
+                  thinkingOpen: true,
+                })),
+              transcriptStore,
+            );
           },
           onHostedSearch: (hostedSearch) => {
             trajectory.firstToken(textRound);

--- a/crates/agent-gui/test/providers/inline-think-tag-stream.test.mjs
+++ b/crates/agent-gui/test/providers/inline-think-tag-stream.test.mjs
@@ -319,52 +319,56 @@ test("inline think: aborting mid-thought flushes the reasoning and rewrites the 
   assert.equal(error.error.stopReason, "aborted");
 });
 
-test("inline think: streamSimpleByApi mounts the wrapper on openai-completions", async () => {
-  const message = createAssistant([{ type: "text", text: "<think>hmm</think>hi" }]);
-  const scopedLoader = createTsModuleLoader({
-    mocks: {
-      "@earendil-works/pi-ai/api/openai-completions": {
-        stream() {
-          return {
-            async *[Symbol.asyncIterator]() {
-              yield {
-                type: "text_delta",
-                contentIndex: 0,
-                delta: "<think>hmm</think>hi",
-                partial: message,
-              };
-              yield { type: "done", reason: "stop", message };
-            },
-            async result() {
-              return message;
-            },
-          };
+// 两个 OpenAI 兼容协议都要挂上：本地 llama.cpp 既可以走 /v1/chat/completions，
+// 也可以经 codex 预设走 /v1/responses，两条路都会内联 <think>。
+for (const api of ["openai-completions", "openai-responses"]) {
+  test(`inline think: streamSimpleByApi mounts the wrapper on ${api}`, async () => {
+    const message = createAssistant([{ type: "text", text: "<think>hmm</think>hi" }]);
+    const scopedLoader = createTsModuleLoader({
+      mocks: {
+        [`@earendil-works/pi-ai/api/${api}`]: {
+          stream() {
+            return {
+              async *[Symbol.asyncIterator]() {
+                yield {
+                  type: "text_delta",
+                  contentIndex: 0,
+                  delta: "<think>hmm</think>hi",
+                  partial: message,
+                };
+                yield { type: "done", reason: "stop", message };
+              },
+              async result() {
+                return message;
+              },
+            };
+          },
         },
       },
-    },
+    });
+    const { streamSimpleByApi } = scopedLoader.loadModule(
+      "src/lib/providers/runtime/streamByApi.ts",
+    );
+
+    const stream = streamSimpleByApi(
+      {
+        id: "qwen3",
+        api,
+        provider: "openai",
+        baseUrl: "http://127.0.0.1:11434/v1",
+        maxTokens: 1024,
+      },
+      { messages: [] },
+      { streamRetry: { disabled: true } },
+    );
+    const events = await collect(stream);
+    const result = await stream.result();
+
+    assert.equal(concatDeltas(events, "thinking_delta", 0), "hmm");
+    assert.equal(concatDeltas(events, "text_delta", 1), "hi");
+    assert.deepEqual(result.content, [
+      { type: "thinking", thinking: "hmm" },
+      { type: "text", text: "hi" },
+    ]);
   });
-  const { streamSimpleByApi } = scopedLoader.loadModule(
-    "src/lib/providers/runtime/streamByApi.ts",
-  );
-
-  const stream = streamSimpleByApi(
-    {
-      id: "qwen3",
-      api: "openai-completions",
-      provider: "openai",
-      baseUrl: "http://127.0.0.1:11434/v1",
-      maxTokens: 1024,
-    },
-    { messages: [] },
-    { streamRetry: { disabled: true } },
-  );
-  const events = await collect(stream);
-  const result = await stream.result();
-
-  assert.equal(concatDeltas(events, "thinking_delta", 0), "hmm");
-  assert.equal(concatDeltas(events, "text_delta", 1), "hi");
-  assert.deepEqual(result.content, [
-    { type: "thinking", thinking: "hmm" },
-    { type: "text", text: "hi" },
-  ]);
-});
+}

--- a/crates/agent-gui/test/providers/inline-think-tag-stream.test.mjs
+++ b/crates/agent-gui/test/providers/inline-think-tag-stream.test.mjs
@@ -1,0 +1,370 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const { wrapInlineThinkTagStream } = loader.loadModule(
+  "src/lib/providers/runtime/inlineThinkTagStream.ts",
+);
+
+function createUsage() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function createAssistant(content, overrides = {}) {
+  return {
+    role: "assistant",
+    content,
+    api: "openai-completions",
+    provider: "openai",
+    model: "qwen3",
+    usage: createUsage(),
+    stopReason: "stop",
+    timestamp: 1,
+    ...overrides,
+  };
+}
+
+/**
+ * Replays a text block the way pi-ai's openai-completions adapter does: a
+ * text_start, one text_delta per chunk with a partial that reflects everything
+ * accumulated so far, then a text_end carrying the authoritative full text.
+ */
+function createTextSource(chunks, options = {}) {
+  const { trailing = [], terminal = "done", extraContent = [] } = options;
+  const full = chunks.join("");
+  const finalMessage = createAssistant(
+    [{ type: "text", text: full }, ...extraContent],
+    terminal === "error" ? { stopReason: "aborted", errorMessage: "Cancelled" } : {},
+  );
+  const partialAt = (soFar) => createAssistant([{ type: "text", text: soFar }, ...extraContent]);
+
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "start", partial: createAssistant([]) };
+      yield { type: "text_start", contentIndex: 0, partial: partialAt("") };
+      let soFar = "";
+      for (const chunk of chunks) {
+        soFar += chunk;
+        yield { type: "text_delta", contentIndex: 0, delta: chunk, partial: partialAt(soFar) };
+      }
+      if (options.omitTextEnd !== true) {
+        yield { type: "text_end", contentIndex: 0, content: full, partial: partialAt(full) };
+      }
+      for (const event of trailing) yield event;
+      if (terminal === "done") {
+        yield { type: "done", reason: "stop", message: finalMessage };
+      } else if (terminal === "error") {
+        yield { type: "error", reason: "aborted", error: finalMessage };
+      }
+    },
+    async result() {
+      return finalMessage;
+    },
+  };
+}
+
+async function collect(stream) {
+  const events = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+function concatDeltas(events, type, contentIndex) {
+  return events
+    .filter((event) => event.type === type && event.contentIndex === contentIndex)
+    .map((event) => event.delta)
+    .join("");
+}
+
+test("inline think: tag split across chunks becomes a separate thinking block", async () => {
+  const events = await collect(
+    wrapInlineThinkTagStream(
+      createTextSource(["<th", "ink>rea", "son", "</thi", "nk> Ans", "wer"]),
+    ),
+  );
+
+  assert.deepEqual(
+    events.map((event) => event.type),
+    [
+      "start",
+      "thinking_start",
+      "thinking_delta",
+      "thinking_delta",
+      "thinking_end",
+      "text_start",
+      "text_delta",
+      "text_delta",
+      "text_end",
+      "done",
+    ],
+  );
+  assert.equal(concatDeltas(events, "thinking_delta", 0), "reason");
+  assert.equal(concatDeltas(events, "text_delta", 1), "Answer");
+  assert.equal(events.find((event) => event.type === "thinking_end").content, "reason");
+
+  const done = events.at(-1);
+  assert.deepEqual(done.message.content, [
+    { type: "thinking", thinking: "reason" },
+    { type: "text", text: "Answer" },
+  ]);
+});
+
+test("inline think: plain answers pass through with identical event objects", async () => {
+  const source = createTextSource(["Hello ", "world"]);
+  const sourceEvents = [];
+  const tapped = {
+    async *[Symbol.asyncIterator]() {
+      for await (const event of source) {
+        sourceEvents.push(event);
+        yield event;
+      }
+    },
+    result: () => source.result(),
+  };
+
+  const events = await collect(wrapInlineThinkTagStream(tapped));
+
+  assert.deepEqual(
+    events.map((event) => event.type),
+    ["start", "text_start", "text_delta", "text_delta", "text_end", "done"],
+  );
+  // The probe withholds text_start and replays a copy once it rejects the tag,
+  // so identity only has to hold from the next source event onward.
+  for (const event of events.slice(3)) {
+    assert.ok(sourceEvents.includes(event), `expected identity passthrough for ${event.type}`);
+  }
+  assert.equal(events.at(-1).message.content[0].text, "Hello world");
+});
+
+test("inline think: an ambiguous head that is later rejected emits the buffered text once", async () => {
+  const events = await collect(wrapInlineThinkTagStream(createTextSource(["<th", "anks!"])));
+
+  assert.deepEqual(
+    events.map((event) => event.type),
+    ["start", "text_start", "text_delta", "text_end", "done"],
+  );
+  assert.equal(concatDeltas(events, "text_delta", 0), "<thanks!");
+  assert.equal(events.at(-1).message.content.length, 1);
+  assert.equal(events.at(-1).message.content[0].text, "<thanks!");
+});
+
+test("inline think: an unclosed tag never creates an answer block", async () => {
+  const events = await collect(
+    wrapInlineThinkTagStream(createTextSource(["<think>still ", "reasoning"])),
+  );
+
+  assert.equal(
+    events.some((event) => event.type === "text_start" || event.type === "text_end"),
+    false,
+  );
+  assert.equal(concatDeltas(events, "thinking_delta", 0), "still reasoning");
+  assert.deepEqual(events.at(-1).message.content, [
+    { type: "thinking", thinking: "still reasoning" },
+  ]);
+});
+
+test("inline think: whitespace after the close tag is dropped and text_end matches the deltas", async () => {
+  const events = await collect(
+    wrapInlineThinkTagStream(createTextSource(["<think>why</think>", "\n\n", "  Final answer"])),
+  );
+
+  const textDeltas = events.filter((event) => event.type === "text_delta");
+  assert.equal(textDeltas[0].delta, "Final answer");
+  const textEnd = events.find((event) => event.type === "text_end");
+  assert.equal(textEnd.contentIndex, 1);
+  // The downstream reconciler diffs text_end against the deltas it already saw;
+  // any mismatch re-injects raw tag text into the transcript.
+  assert.equal(textEnd.content, concatDeltas(events, "text_delta", 1));
+  assert.equal(textEnd.content, "Final answer");
+});
+
+test("inline think: tool calls after an answer shift up by one index", async () => {
+  const toolCall = { type: "toolCall", id: "call_1", name: "read_file", arguments: { path: "/" } };
+  const source = createTextSource(["<think>plan</think>Doing it"], {
+    extraContent: [toolCall],
+    trailing: [
+      {
+        type: "toolcall_start",
+        contentIndex: 1,
+        partial: createAssistant([
+          { type: "text", text: "<think>plan</think>Doing it" },
+          toolCall,
+        ]),
+      },
+      {
+        type: "toolcall_end",
+        contentIndex: 1,
+        toolCall,
+        partial: createAssistant([
+          { type: "text", text: "<think>plan</think>Doing it" },
+          toolCall,
+        ]),
+      },
+    ],
+  });
+
+  const events = await collect(wrapInlineThinkTagStream(source));
+  const start = events.find((event) => event.type === "toolcall_start");
+  const end = events.find((event) => event.type === "toolcall_end");
+
+  assert.equal(start.contentIndex, 2);
+  assert.equal(end.contentIndex, 2);
+  // agentRunner normalizes tool calls via partial.content[contentIndex]; a stale
+  // index there makes the call silently vanish.
+  assert.equal(end.partial.content[2], toolCall);
+  assert.deepEqual(events.at(-1).message.content, [
+    { type: "thinking", thinking: "plan" },
+    { type: "text", text: "Doing it" },
+    toolCall,
+  ]);
+});
+
+test("inline think: a truncated think block keeps following indices unshifted", async () => {
+  const toolCall = { type: "toolCall", id: "call_2", name: "ls", arguments: {} };
+  const partial = createAssistant([{ type: "text", text: "<think>cut off" }, toolCall]);
+  const source = createTextSource(["<think>cut off"], {
+    extraContent: [toolCall],
+    trailing: [{ type: "toolcall_end", contentIndex: 1, toolCall, partial }],
+  });
+
+  const events = await collect(wrapInlineThinkTagStream(source));
+  const end = events.find((event) => event.type === "toolcall_end");
+
+  assert.equal(end.contentIndex, 1);
+  assert.equal(end.partial.content[1], toolCall);
+});
+
+test("inline think: a tag in the middle of an answer is left alone", async () => {
+  const events = await collect(
+    wrapInlineThinkTagStream(createTextSource(["Use ", "<think> to reason"])),
+  );
+
+  assert.equal(concatDeltas(events, "text_delta", 0), "Use <think> to reason");
+  assert.equal(
+    events.some((event) => event.type === "thinking_start"),
+    false,
+  );
+});
+
+test("inline think: native thinking blocks at index 0 stay untouched", async () => {
+  const partial = createAssistant([
+    { type: "thinking", thinking: "native" },
+    { type: "text", text: "answer" },
+  ]);
+  const source = {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "thinking_start", contentIndex: 0, partial };
+      yield { type: "thinking_delta", contentIndex: 0, delta: "native", partial };
+      yield { type: "thinking_end", contentIndex: 0, content: "native", partial };
+      yield { type: "text_start", contentIndex: 1, partial };
+      yield { type: "text_delta", contentIndex: 1, delta: "answer", partial };
+      yield { type: "text_end", contentIndex: 1, content: "answer", partial };
+      yield { type: "done", reason: "stop", message: partial };
+    },
+    async result() {
+      return partial;
+    },
+  };
+
+  const events = await collect(wrapInlineThinkTagStream(source));
+
+  assert.deepEqual(
+    events.map((event) => [event.type, event.contentIndex]),
+    [
+      ["thinking_start", 0],
+      ["thinking_delta", 0],
+      ["thinking_end", 0],
+      ["text_start", 1],
+      ["text_delta", 1],
+      ["text_end", 1],
+      ["done", undefined],
+    ],
+  );
+  assert.equal(events.at(-1).message, partial);
+});
+
+test("inline think: a stream that ends without a terminal event still rewrites result()", async () => {
+  const stream = wrapInlineThinkTagStream(
+    createTextSource(["<think>r</think>a"], { terminal: "none" }),
+  );
+  const events = await collect(stream);
+  const result = await stream.result();
+
+  assert.deepEqual(result.content, [
+    { type: "thinking", thinking: "r" },
+    { type: "text", text: "a" },
+  ]);
+  assert.equal(events.at(-1).type, "text_end");
+});
+
+test("inline think: aborting mid-thought flushes the reasoning and rewrites the error message", async () => {
+  const stream = wrapInlineThinkTagStream(
+    createTextSource(["<think>half way"], { terminal: "error", omitTextEnd: true }),
+  );
+  const events = await collect(stream);
+  const error = events.at(-1);
+
+  assert.equal(error.type, "error");
+  assert.equal(concatDeltas(events, "thinking_delta", 0), "half way");
+  assert.equal(events.some((event) => event.type === "thinking_end"), true);
+  assert.deepEqual(error.error.content, [{ type: "thinking", thinking: "half way" }]);
+  assert.equal(error.error.stopReason, "aborted");
+});
+
+test("inline think: streamSimpleByApi mounts the wrapper on openai-completions", async () => {
+  const message = createAssistant([{ type: "text", text: "<think>hmm</think>hi" }]);
+  const scopedLoader = createTsModuleLoader({
+    mocks: {
+      "@earendil-works/pi-ai/api/openai-completions": {
+        stream() {
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield {
+                type: "text_delta",
+                contentIndex: 0,
+                delta: "<think>hmm</think>hi",
+                partial: message,
+              };
+              yield { type: "done", reason: "stop", message };
+            },
+            async result() {
+              return message;
+            },
+          };
+        },
+      },
+    },
+  });
+  const { streamSimpleByApi } = scopedLoader.loadModule(
+    "src/lib/providers/runtime/streamByApi.ts",
+  );
+
+  const stream = streamSimpleByApi(
+    {
+      id: "qwen3",
+      api: "openai-completions",
+      provider: "openai",
+      baseUrl: "http://127.0.0.1:11434/v1",
+      maxTokens: 1024,
+    },
+    { messages: [] },
+    { streamRetry: { disabled: true } },
+  );
+  const events = await collect(stream);
+  const result = await stream.result();
+
+  assert.equal(concatDeltas(events, "thinking_delta", 0), "hmm");
+  assert.equal(concatDeltas(events, "text_delta", 1), "hi");
+  assert.deepEqual(result.content, [
+    { type: "thinking", thinking: "hmm" },
+    { type: "text", text: "hi" },
+  ]);
+});

--- a/crates/agent-gui/test/providers/text-only-failover.test.mjs
+++ b/crates/agent-gui/test/providers/text-only-failover.test.mjs
@@ -327,3 +327,37 @@ test("DeepSeek title-style text requests preserve explicit thinking-off and work
   assert.equal(streamCalls[0].options.deepSeekThinking, "disabled");
   assert.equal(streamCalls[0].options.workdir, "/workspace");
 });
+
+test("text mode forwards thinking deltas without leaking them into the answer", async () => {
+  const message = makeAssistantMessage({
+    content: [
+      { type: "thinking", thinking: "weighing options" },
+      { type: "text", text: "Answer" },
+    ],
+  });
+  streamImpl = () =>
+    makeSourceStream([
+      { type: "start", partial: message },
+      { type: "thinking_start", contentIndex: 0, partial: message },
+      { type: "thinking_delta", contentIndex: 0, delta: "weighing ", partial: message },
+      { type: "thinking_delta", contentIndex: 0, delta: "options", partial: message },
+      { type: "thinking_end", contentIndex: 0, content: "weighing options", partial: message },
+      { type: "text_start", contentIndex: 1, partial: message },
+      { type: "text_delta", contentIndex: 1, delta: "Answer", partial: message },
+      { type: "done", reason: "stop", message },
+    ]);
+
+  const thinking = [];
+  const deltas = [];
+  const final = await streamAssistantMessage(
+    baseParams({
+      onTextDelta: (delta) => deltas.push(delta),
+      onThinkingDelta: (delta) => thinking.push(delta),
+    }),
+  );
+
+  assert.deepEqual(thinking, ["weighing ", "options"]);
+  assert.deepEqual(deltas, ["Answer"]);
+  assert.equal(deltas.join("").includes("<think>"), false);
+  assert.equal(final.content[0].thinking, "weighing options");
+});


### PR DESCRIPTION
## Linked issue

Closes #670

## Summary

Ollama / llama.cpp 的 OpenAI 兼容层对推理模型（qwen3 / deepseek-r1 / gpt-oss）会把思考过程以字面量 `<think>...</think>` **内联在 `content` 字段里**，而不是走独立的 `reasoning_content` 字段。pi-ai 只解析 `reasoning_content` / `reasoning` / `reasoning_text`，对字面量标签零处理，标签因此原样落进 `text_delta` 被当成正文渲染。

本 PR 修两个独立缺陷：

**1. 内联 `<think>` 无人解析。** 新增事件流包装器 `wrapInlineThinkTagStream`，挂在 `piAiAdapter.ts` 的 `openai-completions` 分支（`withStreamRetry` 工厂内部，每次重试拿到全新状态）。它把源 `contentIndex 0` 开头的 `<think>` 块拆成独立 thinking 块。chat 与 agent 两种模式共用这一个收敛点，一处包装同时生效。

**2. chat 模式压根没接思考渲染。** `textOnlyRuntime.ts` 的 `streamAssistantMessage` 此前没有 `onThinkingDelta` 参数，事件循环直接丢弃 `thinking_*`，只有 agent 模式接了。这意味着即便供应商正确走了 `reasoning_content`，chat 模式流式期间同样看不到思考——该缺陷独立于缺陷 1 存在。本 PR 补上参数与转发，并在 `runTextConversationTurn.ts` 镜像 agent 模式的渲染逻辑。

只修缺陷 1 的话，推理会在流式期间彻底消失、等回答结束才突然冒出一个面板，所以两个必须一起修。

### 几个刻意的设计取舍

- **无新增设置项。** 只在源 `contentIndex === 0` 的 text 块**开头**（允许前导空白）识别 `<think>`。走 `reasoning_content` 的供应商索引 0 已经是 native thinking 块，天然被排除，不需要开关。正文中段出现的 `<think>` 不受影响。
- **`event.partial` 逐事件改写，而不只改最终消息。** `pi-agent-core` 把 `event.partial` 直接 push 进 `context.messages`，`agentRunner` 又用 `partial.content[contentIndex]` 取工具调用做规范化。partial 不改写会导致原始标签回传给模型，且索引偏移后工具调用静默丢失。
- **`text_end.content` 严格等于我们实际发出的 `text_delta` 之和。** `createStreamingTextReconciler.reconcileFinalText` 会做差量比对并补发差异，直接转发源内容会把 `<think>` 重新注入 UI。
- **拆分后思考块无条件保留（哪怕为空）**，否则事件流的 `contentIndex` 位移会和最终消息的数组下标对不上。索引位移 `shift` 只在正文块真正存在后才变 1，所以 `<think>` 未闭合（截断响应）时后续块保持原索引。
- **未命中时恒等透传**：排除 `<think>` 后原样返回源事件对象，零行为变化。

## Change scope

- Modules: agent-gui（model providers / 流式事件层 + chat 模式转录渲染）
- Key paths:
  - `crates/agent-gui/src/lib/providers/runtime/inlineThinkTagStream.ts`（新增，核心包装器）
  - `crates/agent-gui/src/lib/providers/service/piAiAdapter.ts`（挂载，+7/-2）
  - `crates/agent-gui/src/lib/providers/runtime/textOnlyRuntime.ts`（新增 `onThinkingDelta`，+4）
  - `crates/agent-gui/src/pages/chat/turns/runTextConversationTurn.ts`（chat 模式思考渲染，+32）
  - `crates/agent-gui/test/providers/inline-think-tag-stream.test.mjs`（新增，12 例）
  - `crates/agent-gui/test/providers/text-only-failover.test.mjs`（+1 例）

无需改 gateway：远程 UI 的 `turnReducer.applyThinkingEvent` 已经消费 `{ type: "thinking" }` 事件。

## Screenshots / preview

前后对比（左：修复前，右：修复后）。用 `RoundContent` 组件在浏览器里静态渲染，喂进去的 thinking / 正文文本是下方那次真实 llama.cpp 运行的原样输出：

![inline think tag before / after](https://raw.githubusercontent.com/xiaozhou26/LiveAgent/pr-671-assets/docs/preview/pr-671-inline-think.png)

修复前推理文字直接接在答案前面连成一段（`<think>` 标签本身被 markdown 当 HTML 吞掉，所以不可见，这正是用户看到的样子）；修复后推理收进「思考过程」折叠面板，正文只剩解题步骤与答案。

下面是同一改动的真实流式运行日志。用真实 pi-ai 链路打本地 llama.cpp（Qwen3 27B，`http://127.0.0.1:11434/v1`），同一 prompt 对比包装器前后的事件流，按通道分栏：

**修复前** —— 全部内容挤在一个 `text_delta` 通道，`<think>` 标签可见：

```
【正文 text_delta】 <think>
   We need answer Chinese. Simple chicken rabbit problem. ... r=3, c=5.
   </think>
   设鸡有 \(x\) 只，兔有 \(y\) 只。...
   **答案：鸡 5 只，兔 3 只。**

最终 content 结构: [{"type":"text","chars":393}]
```

**修复后** —— 推理走 `thinking_delta@0`，答案走 `text_delta@1`，两条通道完全分开：

```
【思考 thinking_delta@0】 We need answer in Chinese likely. ... y=3, x=5.
【正文 text_delta@1】 设鸡有 \(x\) 只，兔有 \(y\) 只。... **答：鸡有 5 只，兔有 3 只。**

最终 content 结构: [{"type":"thinking","chars":294},{"type":"text","chars":230}]
正文是否残留 <think>: false
```

关键点：思考是**流式**进 thinking 通道的（不是等结束才切出来），UI 上会实时看到「思考过程」面板增长；答案开始时现有的 `collapseThinking` 会让面板自动收起。最终消息里是两个独立 content 块，落库与回传给模型的上下文都不再带 `<think>`。

## Verification

- `cd crates/agent-gui && node --test test/providers/inline-think-tag-stream.test.mjs test/providers/text-only-failover.test.mjs` → 20/20 通过
- `pnpm --filter liveagent test:frontend` → 除 3 例既有失败外全绿。这 3 例（`composer caret measurement...`、`a truncated snapshot never claims...`、`preset scripts stay in sync...`）在干净的 `upstream/main@dbca2cd1` 上同样失败，与本改动无关，已逐一复现确认
- `npx biome lint`（4 个改动文件）→ 0 error
- `npx tsc --noEmit` → 0 error
- 端到端：本地 llama.cpp + Qwen3 27B，chat 模式实跑，见上方日志

新增测试覆盖：标签跨 chunk 切分、无标签恒等透传、疑似后被排除、`<think>` 未闭合、闭合后空白处理与 reconciler 契约（`text_end` 等于各 delta 之和）、工具调用索引位移及截断变体不位移、标签出现在正文中段、索引 0 已是 native thinking 块、无终结事件时 `result()` 改写、思考中途中断的 `error` 改写、以及经 `streamSimpleByApi` 确认包装器已挂载。

未覆盖：agent 模式带工具调用的真机验证——手头的 llama.cpp 端点 capabilities 只报 `completion`，不支持函数调用。索引重映射由单测覆盖（工具调用移位 + 截断不移位两种情况）。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.
