### PR TITLE
fix(settings): 自定义字体输入崩溃 (#645) 与非 ASCII 字体名静默回退

### DIFF
--- a/crates/agent-gateway/test/webui/font-family.test.mjs
+++ b/crates/agent-gateway/test/webui/font-family.test.mjs
@@ -33,7 +33,16 @@ test("font family normalizer keeps freeform stacks and rejects unsafe values", (
   );
   assert.equal(fontFamily.normalizeFontFamily("rounded"), "rounded");
   assert.equal(fontFamily.normalizeFontFamily("serif"), "serif");
+  assert.equal(fontFamily.normalizeFontFamily("微软雅黑"), "微软雅黑");
+  assert.equal(
+    fontFamily.normalizeFontFamily('苹方-简, "Microsoft YaHei", sans-serif'),
+    '苹方-简, "Microsoft YaHei", sans-serif',
+  );
+  assert.equal(fontFamily.normalizeFontFamily("맑은 고딕"), "맑은 고딕");
+  assert.equal(fontFamily.normalizeFontFamily("My_Custom_Font"), "My_Custom_Font");
   assert.equal(fontFamily.normalizeFontFamily('Inter; background: red'), "");
+  assert.equal(fontFamily.normalizeFontFamily("微软雅黑; color: red"), "");
+  assert.equal(fontFamily.normalizeFontFamily("url(微软雅黑)"), "");
   assert.equal(fontFamily.normalizeFontFamily("url(https://evil.example/font.woff2)"), "");
   assert.equal(fontFamily.normalizeFontFamily("x".repeat(201)), "");
 });

--- a/crates/agent-gui/test/system/font-family.test.mjs
+++ b/crates/agent-gui/test/system/font-family.test.mjs
@@ -33,7 +33,16 @@ test("font family normalizer keeps freeform stacks and rejects unsafe values", (
   );
   assert.equal(fontFamily.normalizeFontFamily("rounded"), "rounded");
   assert.equal(fontFamily.normalizeFontFamily("serif"), "serif");
+  assert.equal(fontFamily.normalizeFontFamily("微软雅黑"), "微软雅黑");
+  assert.equal(
+    fontFamily.normalizeFontFamily('苹方-简, "Microsoft YaHei", sans-serif'),
+    '苹方-简, "Microsoft YaHei", sans-serif',
+  );
+  assert.equal(fontFamily.normalizeFontFamily("맑은 고딕"), "맑은 고딕");
+  assert.equal(fontFamily.normalizeFontFamily("My_Custom_Font"), "My_Custom_Font");
   assert.equal(fontFamily.normalizeFontFamily('Inter; background: red'), "");
+  assert.equal(fontFamily.normalizeFontFamily("微软雅黑; color: red"), "");
+  assert.equal(fontFamily.normalizeFontFamily("url(微软雅黑)"), "");
   assert.equal(fontFamily.normalizeFontFamily("url(https://evil.example/font.woff2)"), "");
   assert.equal(fontFamily.normalizeFontFamily("x".repeat(201)), "");
 });

--- a/crates/agent-ui/src/lib/shared/fontFamily.ts
+++ b/crates/agent-ui/src/lib/shared/fontFamily.ts
@@ -53,7 +53,9 @@ const MAX_FONT_FAMILY_LENGTH = 200;
 
 // Reject values that could break out of a CSS declaration or inject external resources.
 const UNSAFE_FONT_FAMILY_PATTERN = /[;{}<>\\]|url\s*\(|@import|expression\s*\(/i;
-const ALLOWED_FONT_FAMILY_PATTERN = /^[\w\s,"'\-.+]+$/u;
+// Allow Unicode letters/numbers so localized family names (微软雅黑, 苹方, ...) pass;
+// the unsafe pattern above already blocks the CSS injection vectors.
+const ALLOWED_FONT_FAMILY_PATTERN = /^[\p{L}\p{N}\s,"'\-.+]+$/u;
 
 type LocalFontData = {
   family?: string;

--- a/crates/agent-ui/src/lib/shared/fontFamily.ts
+++ b/crates/agent-ui/src/lib/shared/fontFamily.ts
@@ -54,8 +54,9 @@ const MAX_FONT_FAMILY_LENGTH = 200;
 // Reject values that could break out of a CSS declaration or inject external resources.
 const UNSAFE_FONT_FAMILY_PATTERN = /[;{}<>\\]|url\s*\(|@import|expression\s*\(/i;
 // Allow Unicode letters/numbers so localized family names (微软雅黑, 苹方, ...) pass;
-// the unsafe pattern above already blocks the CSS injection vectors.
-const ALLOWED_FONT_FAMILY_PATTERN = /^[\p{L}\p{N}\s,"'\-.+]+$/u;
+// keep `_` since quoteFontFamilyName treats it as a valid identifier character.
+// The unsafe pattern above already blocks the CSS injection vectors.
+const ALLOWED_FONT_FAMILY_PATTERN = /^[\p{L}\p{N}\s,"'\-.+_]+$/u;
 
 type LocalFontData = {
   family?: string;

--- a/crates/agent-ui/src/pages/settings/SystemSettingsForm.tsx
+++ b/crates/agent-ui/src/pages/settings/SystemSettingsForm.tsx
@@ -675,12 +675,13 @@ export function SystemSettingsForm(props: SettingsSectionProps) {
                         spellCheck={false}
                         autoComplete="off"
                         placeholder={t("settings.fontFamilyPlaceholder")}
-                        onChange={(event) =>
+                        onChange={(event) => {
+                          const value = event.currentTarget.value;
                           setCustomFontDrafts((current) => ({
                             ...current,
-                            [key]: event.currentTarget.value,
-                          }))
-                        }
+                            [key]: value,
+                          }));
+                        }}
                         onBlur={() => commitCustomFontFamily(key)}
                         onKeyDown={(event) => {
                           if (event.key === "Enter") {


### PR DESCRIPTION
修复 系统设置→字体 的两个问题：

## 1. 修复 #645：切换自定义字体时渲染崩溃

`SystemSettingsForm.tsx` 自定义字体输入框的 `onChange` 在 setState updater 函数体内读取 `event.currentTarget.value`。React 合成事件在分发结束后会将 `currentTarget` 置空，而 updater 被延迟到渲染阶段执行，因此选中"自定义…"后在输入框敲第一个字符即抛出：

```
TypeError: Cannot read properties of null (reading 'value')
```

错误被 AppErrorBoundary 捕获，整个设置面板进入错误态（即 issue 中的"渲染错误"）。

修复：在事件处理器内同步读取 `event.currentTarget.value`，再传入 updater。

## 2. 修复非 ASCII 字体名被静默回退为系统默认

`fontFamily.ts` 的字体名白名单 `/^[\w\s,"'\-.+]+$/u` 仅允许 ASCII 字符，`微软雅黑`、`苹方`、`맑은 고딕` 等本地化字体名会被判为非法并**静默丢弃**（归一化为空串 = 默认字体栈），失焦提交后下拉框跳回"系统默认"且无任何提示。

修复：白名单放宽为 Unicode 字母/数字（`\p{L}\p{N}`）；CSS 注入防线（`url(` / `@import` / `expression(` / `;{}<>\`）保持不变，`a;b`、`url(x)` 等仍被拒绝（已验证）。

## 验证

- 修复前：自定义字体输入首字符即崩，设置面板被错误边界接管；输入 `微软雅黑` 失焦后静默回退系统默认
- 修复后：输入/提交均正常，`微软雅黑` 等中文字体名生效，界面字体立即变化；注入用例全部仍被拒绝

Fixes #645
<img width="1479" height="498" alt="ScreenShot_2026-08-30_000313_009" src="https://github.com/user-attachments/assets/ced60ced-820a-4f57-8928-a4c0f1f4a53e" />
