### PR TITLE
style(chat): plan mode 卡片视觉重构 —— 三态状态脊与正文排版收紧

### DIFF
--- a/crates/agent-ui/src/components/chat/PlanModeCard.tsx
+++ b/crates/agent-ui/src/components/chat/PlanModeCard.tsx
@@ -3,11 +3,12 @@
 // 即修改意见（正常发消息）；卡片只保留一个「批准并开始执行」快捷按钮。
 // 纯展示组件，按钮动作与待决状态由调用方注入；两端复用，端差异留在 ToolCallItem。
 
-import { Check, CheckCircle2, ListChecks } from "@liveagent/ui/components/IconSet";
+import { Check, CheckCircle2, ListChecks, Loader2 } from "@liveagent/ui/components/IconSet";
 import { Markdown } from "@liveagent/ui/components/Markdown";
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { useState } from "react";
 import type { PlanDecisionAnswer } from "../../lib/chat/planMode";
+import { cn } from "../../lib/shared/utils";
 
 export type PlanDecisionSubmitOutcome = { ok: boolean; message?: string };
 
@@ -33,6 +34,18 @@ export function PlanModeCard({
 
   const canApprove = pending && !approved && !readOnly && Boolean(onSubmit);
 
+  // 卡片有三种观感,而不是"已批准/其余"两种:
+  //   approved — 已落定批准;
+  //   pending  — 仍是会话的待决计划(只读视图下同样待决,只是本端不能操作);
+  //   inactive — 既未批准也不再待决。成因可能是被新计划取代、本轮被取消,或
+  //              历史/降级数据丢了标记,本端无从分辨,因此只陈述"不再待决"这个
+  //              确定事实,不臆断原因。
+  const tone: "approved" | "pending" | "inactive" = approved
+    ? "approved"
+    : pending
+      ? "pending"
+      : "inactive";
+
   const approve = async () => {
     if (!onSubmit || !canApprove || submitting) return;
     setSubmitting(true);
@@ -50,38 +63,90 @@ export function PlanModeCard({
   };
 
   return (
-    <div className="tool-expand overflow-hidden rounded-xl border border-border/45 bg-background/70 dark:border-white/[0.08] dark:bg-white/[0.03]">
-      <div className="flex items-center gap-2 border-b border-border/35 px-3 py-2 dark:border-white/[0.05]">
-        <ListChecks className="h-3.5 w-3.5 shrink-0 text-sky-600 dark:text-sky-400" />
-        <span className="text-[calc(12px*var(--zone-font-scale,1))] font-medium text-foreground/90">
+    <div
+      className={cn(
+        // 边框与兄弟工具卡保持一致,状态色只由左侧脊承担一处,避免多点强调互相稀释。
+        "tool-expand relative overflow-hidden rounded-xl border border-border/45 bg-background/70 dark:border-white/[0.08] dark:bg-white/[0.03]",
+        // 只有仍可拍板的计划值得从转录里浮起来;已落定的一律回落成安静的历史文档。
+        tone === "pending"
+          ? "shadow-[0_1px_2px_-1px_rgba(15,23,42,0.07),0_14px_32px_-26px_rgba(2,132,199,0.55)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_14px_32px_-24px_rgba(0,0,0,0.7)]"
+          : "dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]",
+      )}
+    >
+      {/* 状态脊：整条转录里只有这张卡片在等用户拍板。左侧色条是全卡唯一的强调,
+          既把它与普通工具行区分开,又用颜色承载三种状态。 */}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute inset-y-0 left-0 w-[3px]",
+          tone === "approved"
+            ? "bg-gradient-to-b from-emerald-400 to-emerald-500"
+            : tone === "pending"
+              ? "bg-gradient-to-b from-sky-400 via-sky-500 to-indigo-500 shadow-[2px_0_12px_-2px_rgba(2,132,199,0.5)]"
+              : "bg-border dark:bg-white/[0.12]",
+        )}
+      />
+
+      <div className="flex items-center gap-2 border-b border-border/35 px-3.5 py-2 dark:border-white/[0.05]">
+        <ListChecks
+          className={cn(
+            "h-3.5 w-3.5 shrink-0",
+            tone === "approved"
+              ? "text-emerald-600 dark:text-emerald-400"
+              : tone === "pending"
+                ? "text-sky-600 dark:text-sky-400"
+                : "text-muted-foreground/60",
+          )}
+        />
+        <span className="text-[calc(12px*var(--zone-font-scale,1))] font-medium tracking-[0.01em] text-foreground/90">
           {t("chat.planMode.cardTitle")}
         </span>
-        {approved ? (
-          <span className="ml-auto inline-flex shrink-0 items-center gap-1 text-[calc(11px*var(--zone-font-scale,1))] text-emerald-700 dark:text-emerald-300">
-            <CheckCircle2 className="h-3.5 w-3.5" />
-            {t("chat.planMode.approved")}
-          </span>
-        ) : null}
+
+        {/* 计划很长时按钮会落在视口外,表头状态让人不用滚到底也知道这份计划的处境。 */}
+        <span className="ml-auto inline-flex shrink-0 items-center gap-1.5 text-[calc(11px*var(--zone-font-scale,1))] leading-none text-muted-foreground">
+          {tone === "approved" ? (
+            <>
+              <CheckCircle2 className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+              {t("chat.planMode.approved")}
+            </>
+          ) : tone === "pending" ? (
+            <>
+              <span className="h-1.5 w-1.5 rounded-full bg-sky-500 dark:bg-sky-400" />
+              {t("chat.planMode.awaiting")}
+            </>
+          ) : (
+            <>
+              <span className="h-1.5 w-1.5 rounded-full border border-muted-foreground/45" />
+              {t("chat.planMode.inactive")}
+            </>
+          )}
+        </span>
       </div>
 
-      <div className="px-3.5 py-3">
-        <Markdown content={plan} className="font-chat text-sm" readOnly={readOnly} />
+      <div className="px-4 py-3.5">
+        <Markdown content={plan} className="plan-markdown font-chat" readOnly={readOnly} />
       </div>
 
       {canApprove ? (
-        <div className="flex items-center gap-2.5 border-t border-border/35 px-3 py-2 dark:border-white/[0.05]">
+        <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 border-t border-border/35 bg-foreground/[0.015] px-3.5 py-2.5 dark:border-white/[0.05] dark:bg-white/[0.015]">
           <button
             type="button"
             disabled={submitting}
             onClick={() => void approve()}
-            className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-primary px-3 text-[calc(12px*var(--zone-font-scale,1))] font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-40"
+            className="group/approve inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-primary px-3.5 text-[calc(12px*var(--zone-font-scale,1))] font-medium text-primary-foreground shadow-[0_1px_2px_-1px_rgba(15,23,42,0.25)] transition-[background-color,transform,box-shadow] duration-150 ease-out hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background active:scale-[0.98] disabled:pointer-events-none disabled:opacity-40 motion-reduce:transition-none motion-reduce:active:scale-100"
           >
-            <Check className="h-3.5 w-3.5" />
-            {t("chat.planMode.approve")}
+            {submitting ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" />
+            ) : (
+              <Check className="h-3.5 w-3.5" />
+            )}
+            {submitting ? t("chat.planMode.approving") : t("chat.planMode.approve")}
           </button>
-          <span className="min-w-0 truncate text-[calc(11px*var(--zone-font-scale,1))] text-muted-foreground">
-            {errorText || t("chat.planMode.replyHint")}
-          </span>
+          {errorText ? (
+            <span className="min-w-0 flex-1 text-[calc(11px*var(--zone-font-scale,1))] leading-[1.5] text-[hsl(var(--chat-error))]">
+              {errorText}
+            </span>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/crates/agent-ui/src/i18n/translations/enUSCommon.ts
+++ b/crates/agent-ui/src/i18n/translations/enUSCommon.ts
@@ -601,8 +601,10 @@ export const EN_US_COMMON_TRANSLATIONS = {
   "chat.askUser.timeoutHint": "until the recommended options are auto-selected",
   "chat.planMode.cardTitle": "Implementation plan",
   "chat.planMode.submitted": "Plan submitted — waiting for your reply",
-  "chat.planMode.replyHint": "Type \u201cyes\u201d to approve; anything else is feedback",
+  "chat.planMode.awaiting": "Awaiting approval",
+  "chat.planMode.inactive": "No longer active",
   "chat.planMode.approve": "Approve & start",
+  "chat.planMode.approving": "Approving\u2026",
   "chat.planMode.approved": "Approved",
   "chat.planMode.submitFailed": "Failed to submit, please retry",
   "chat.planMode.executePrompt":

--- a/crates/agent-ui/src/i18n/translations/zhCNCommon.ts
+++ b/crates/agent-ui/src/i18n/translations/zhCNCommon.ts
@@ -558,8 +558,10 @@ export const ZH_CN_COMMON_TRANSLATIONS = {
   "chat.askUser.timeoutHint": "后自动选择推荐项",
   "chat.planMode.cardTitle": "实施计划",
   "chat.planMode.submitted": "计划已提交，等待你的回复",
-  "chat.planMode.replyHint": "输入\u201c同意\u201d即批准；输入其他内容即修改意见",
+  "chat.planMode.awaiting": "等待批准",
+  "chat.planMode.inactive": "已失效",
   "chat.planMode.approve": "批准并开始执行",
+  "chat.planMode.approving": "提交中…",
   "chat.planMode.approved": "已批准",
   "chat.planMode.submitFailed": "提交失败，请重试",
   "chat.planMode.executePrompt":

--- a/crates/agent-ui/src/styles/common-components.css
+++ b/crates/agent-ui/src/styles/common-components.css
@@ -318,9 +318,12 @@
     @apply my-1.5 text-[calc(14px*var(--zone-font-scale,1))] leading-[1.72] text-foreground/90;
   }
   /* 计划里的标题就是阶段分节,层级本身不携带额外信息:统一收成一档字号,
-     靠字重与分节线区分,不再有 text-xl/text-lg 的落差。 */
+     靠字重与分节线区分,不再有 text-xl/text-lg 的落差。
+     字号带 ! —— Streamdown 把 text-3xl/text-2xl 直接写在 h1/h2 的 class 上,
+     那是 utilities 层,层级顺序上永远压过本文件所在的 components 层,单靠选择器
+     权重赢不了。 */
   .chat-markdown.plan-markdown [data-streamdown^="heading-"] {
-    @apply mb-1.5 mt-4 text-[calc(13px*var(--zone-font-scale,1))] font-semibold leading-[1.6] tracking-[0.01em] text-foreground;
+    @apply mb-1.5 mt-4 !text-[calc(13px*var(--zone-font-scale,1))] font-semibold leading-[1.6] tracking-[0.01em] text-foreground;
   }
   /* 标题 mt-4 特异性高于全局 first-child 重置;计划又以标题开头时会在卡片
      padding 之外再多出一段空白。同作用域补一条,压过标题规则。 */
@@ -330,7 +333,7 @@
   }
   .chat-markdown.plan-markdown [data-streamdown="heading-1"],
   .chat-markdown.plan-markdown [data-streamdown="heading-2"] {
-    @apply text-[calc(13.5px*var(--zone-font-scale,1))];
+    @apply !text-[calc(13.5px*var(--zone-font-scale,1))];
   }
   /* 非首个分节标题上方补一条发丝线,把"进入下一阶段"这件事画出来。
      流式渲染时 Streamdown 会给每个块包一层 display:contents 的方向 div

--- a/crates/agent-ui/src/styles/common-components.css
+++ b/crates/agent-ui/src/styles/common-components.css
@@ -297,6 +297,60 @@
     @apply my-7 border-border/60;
   }
 
+  /* Plan markdown — 计划卡片正文按"规格文档"排版而非聊天正文:更紧的行距与
+     压平的标题层级,让整份计划尽量在一屏内读完再决定是否批准。 */
+  .chat-markdown.plan-markdown {
+    @apply text-[calc(14px*var(--zone-font-scale,1))] leading-[1.72] text-foreground/90;
+  }
+  .chat-markdown.plan-markdown p {
+    @apply my-1.5 text-[calc(14px*var(--zone-font-scale,1))] leading-[1.72] text-foreground/90;
+  }
+  /* 计划里的标题就是阶段分节,层级本身不携带额外信息:统一收成一档字号,
+     靠字重与分节线区分,不再有 text-xl/text-lg 的落差。 */
+  .chat-markdown.plan-markdown [data-streamdown^="heading-"] {
+    @apply mb-1.5 mt-4 text-[calc(13px*var(--zone-font-scale,1))] font-semibold leading-[1.6] tracking-[0.01em] text-foreground;
+  }
+  .chat-markdown.plan-markdown [data-streamdown="heading-1"],
+  .chat-markdown.plan-markdown [data-streamdown="heading-2"] {
+    @apply text-[calc(13.5px*var(--zone-font-scale,1))];
+  }
+  /* 非首个分节标题上方补一条发丝线,把"进入下一阶段"这件事画出来。 */
+  .chat-markdown.plan-markdown > [data-streamdown="heading-1"]:not(:first-child),
+  .chat-markdown.plan-markdown > [data-streamdown="heading-2"]:not(:first-child) {
+    @apply border-t border-border/30 pt-3.5 dark:border-white/[0.06];
+  }
+  .chat-markdown.plan-markdown [data-streamdown="unordered-list"],
+  .chat-markdown.plan-markdown [data-streamdown="ordered-list"] {
+    @apply my-1.5 ml-0 space-y-1 pl-[1.15rem];
+  }
+  .chat-markdown.plan-markdown [data-streamdown="list-item"] {
+    @apply pl-0.5 text-[calc(14px*var(--zone-font-scale,1))] leading-[1.72] text-foreground/90;
+  }
+  /* 项目符号压到 muted:状态色只在左侧脊出现一处,正文不参与表达状态。 */
+  .chat-markdown.plan-markdown [data-streamdown="list-item"]::marker {
+    @apply text-muted-foreground/55;
+  }
+  .chat-markdown.plan-markdown
+    [data-streamdown="ordered-list"]
+    > [data-streamdown="list-item"]::marker {
+    @apply font-medium tabular-nums text-muted-foreground;
+  }
+  .chat-markdown.plan-markdown [data-streamdown="inline-code"] {
+    @apply px-1 py-px text-[calc(12.5px*var(--zone-font-scale,1))];
+  }
+  .chat-markdown.plan-markdown [data-streamdown="code-block"] {
+    @apply my-2.5;
+  }
+  .chat-markdown.plan-markdown [data-streamdown="code-block-body"] {
+    @apply rounded-lg p-3 text-[calc(12px*var(--zone-font-scale,1))];
+  }
+  .chat-markdown.plan-markdown [data-streamdown="blockquote"] {
+    @apply my-2 border-l-2 border-border/50 pl-3 not-italic text-muted-foreground dark:border-white/[0.12];
+  }
+  .chat-markdown.plan-markdown [data-streamdown="horizontal-rule"] {
+    @apply my-3.5 border-border/35;
+  }
+
   /* First/last child margin reset */
   .chat-markdown > *:first-child,
   .chat-markdown > *:first-child > *:first-child {

--- a/crates/agent-ui/src/styles/common-components.css
+++ b/crates/agent-ui/src/styles/common-components.css
@@ -297,8 +297,20 @@
     @apply my-7 border-border/60;
   }
 
+  /* First/last child margin reset */
+  .chat-markdown > *:first-child,
+  .chat-markdown > *:first-child > *:first-child {
+    margin-top: 0;
+  }
+  .chat-markdown > *:last-child,
+  .chat-markdown > *:last-child > *:last-child {
+    margin-bottom: 0;
+  }
+
   /* Plan markdown — 计划卡片正文按"规格文档"排版而非聊天正文:更紧的行距与
-     压平的标题层级,让整份计划尽量在一屏内读完再决定是否批准。 */
+     压平的标题层级,让整份计划尽量在一屏内读完再决定是否批准。
+     整块位于全局 first/last reset 之后:本作用域按更高特异性覆盖全局规则,
+     保持"特异性随源顺序递增",不触发 noDescendingSpecificity。 */
   .chat-markdown.plan-markdown {
     @apply text-[calc(14px*var(--zone-font-scale,1))] leading-[1.72] text-foreground/90;
   }
@@ -320,9 +332,18 @@
   .chat-markdown.plan-markdown [data-streamdown="heading-2"] {
     @apply text-[calc(13.5px*var(--zone-font-scale,1))];
   }
-  /* 非首个分节标题上方补一条发丝线,把"进入下一阶段"这件事画出来。 */
+  /* 非首个分节标题上方补一条发丝线,把"进入下一阶段"这件事画出来。
+     流式渲染时 Streamdown 会给每个块包一层 display:contents 的方向 div
+     (带 dir 属性),标题便不再是容器的直接子元素;两种层级各写一组,
+     静态/流式两种渲染模式都能命中。 */
   .chat-markdown.plan-markdown > [data-streamdown="heading-1"]:not(:first-child),
-  .chat-markdown.plan-markdown > [data-streamdown="heading-2"]:not(:first-child) {
+  .chat-markdown.plan-markdown > [data-streamdown="heading-2"]:not(:first-child),
+  .chat-markdown.plan-markdown
+    > [dir]:not(:first-child)
+    > [data-streamdown="heading-1"]:first-child,
+  .chat-markdown.plan-markdown
+    > [dir]:not(:first-child)
+    > [data-streamdown="heading-2"]:first-child {
     @apply border-t border-border/30 pt-3.5 dark:border-white/[0.06];
   }
   .chat-markdown.plan-markdown [data-streamdown="unordered-list"],
@@ -355,16 +376,6 @@
   }
   .chat-markdown.plan-markdown [data-streamdown="horizontal-rule"] {
     @apply my-3.5 border-border/35;
-  }
-
-  /* First/last child margin reset */
-  .chat-markdown > *:first-child,
-  .chat-markdown > *:first-child > *:first-child {
-    margin-top: 0;
-  }
-  .chat-markdown > *:last-child,
-  .chat-markdown > *:last-child > *:last-child {
-    margin-bottom: 0;
   }
 
   /* Context checkpoint animations */

--- a/crates/agent-ui/src/styles/common-components.css
+++ b/crates/agent-ui/src/styles/common-components.css
@@ -310,6 +310,12 @@
   .chat-markdown.plan-markdown [data-streamdown^="heading-"] {
     @apply mb-1.5 mt-4 text-[calc(13px*var(--zone-font-scale,1))] font-semibold leading-[1.6] tracking-[0.01em] text-foreground;
   }
+  /* 标题 mt-4 特异性高于全局 first-child 重置;计划又以标题开头时会在卡片
+     padding 之外再多出一段空白。同作用域补一条,压过标题规则。 */
+  .chat-markdown.plan-markdown > *:first-child,
+  .chat-markdown.plan-markdown > *:first-child > *:first-child {
+    margin-top: 0;
+  }
   .chat-markdown.plan-markdown [data-streamdown="heading-1"],
   .chat-markdown.plan-markdown [data-streamdown="heading-2"] {
     @apply text-[calc(13.5px*var(--zone-font-scale,1))];


### PR DESCRIPTION
## Linked issue

Closes #675

## Summary

Plan mode 审批卡片的两个问题：状态着色与实际数据状态对不上，以及正文排版被全局聊天样式覆盖。

**三态状态脊。** 卡片此前按「已批准 / 其余」二分着色，但数据实际有三态：当一份计划被新提交的计划取代后，`pending` 与 `approved` 同时为假，卡片却仍渲染成待决观感——有蓝色强调，却没有可点的按钮。修订计划的每一轮都会产生一张这样的卡片。

改为显式的 `tone` 三态：

| tone | 条件 | 表现 |
| --- | --- | --- |
| `approved` | 已批准 | emerald 脊 + CheckCircle |
| `pending` | 仍待决（含只读视图） | sky→indigo 渐变脊 + 外发光，浮起 |
| `inactive` | 既未批准也不再待决 | 中性灰脊 + 空心圈，回落为安静的历史文档 |

新增 `chat.planMode.inactive`。`inactive` 的成因可能是被新计划取代、本轮被取消，或历史 / 降级数据丢了标记，本端无从分辨，因此文案只陈述「不再待决」这一确定事实，不臆断原因。

**正文排版。** 卡片传给 `Markdown` 的 `text-sm` 从未生效——`.chat-markdown` 的 `p` / `list-item` 以更高优先级硬编码了 `15px` / `leading-8`。新增 `.chat-markdown.plan-markdown` 作用域收到 `14px` / `1.72`，并把标题层级压平到一档字号（计划里的标题就是阶段分节，层级本身不携带额外信息），靠字重与分节线区分。作用域限定使其他聊天表面不受影响。

标题字号那两条声明带 `!`：Streamdown 把 `text-3xl` / `text-2xl` 直接写在 `h1` / `h2` 的 class 上，那是 utilities 层，在 Tailwind v4 的层级顺序里永远压过本文件所在的 components 层，单靠选择器权重赢不了。

同时修复：

- 表头状态指示改按 `tone` 判定而非 `canApprove`。此前在 trajectory / 历史等只读视图下，一份真正待决的计划不显示任何状态。
- 状态色收敛到左侧脊一处。列表项目符号与引用块边框此前也是 sky，多点强调互相稀释，现已退回中性色。
- 深色模式此前是 `dark:shadow-none`，卡片完全没有浮起层次。改为 inset 顶部高光 + 真实投影。
- 按钮补上提交中的 loading 态与 `focus-visible` 焦点环，动画均带 `motion-reduce` 降级。
- 删除 `chat.planMode.replyHint`（「输入"同意"即批准」提示行）。

## Change scope

- Modules: agent-ui
- Key paths:
  - `crates/agent-ui/src/components/chat/PlanModeCard.tsx` — 三态 `tone` 推导、状态脊、表头状态、动作条
  - `crates/agent-ui/src/styles/common-components.css` — 新增 `.chat-markdown.plan-markdown` 作用域排版
  - `crates/agent-ui/src/i18n/translations/{zhCN,enUS}Common.ts` — 新增 `awaiting` / `inactive` / `approving`，删除 `replyHint`

## Screenshots / preview

桌面端实机截图，`pending` 态、浅色主题（卡片下半部分）：

![plan mode card — pending, light](https://raw.githubusercontent.com/xiaozhou26/LiveAgent/pr-674-assets/pr-assets/plan-mode-card-headings.png)

图中可核对的几点：

- 「验证方式」这一级标题与正文同档字号，只靠字重区分，上方一条发丝线承担分节——即上文说的标题层级压平；
- 左侧 sky→indigo 状态脊贯穿卡片，是全卡唯一的状态色来源；列表序号与正文均为中性色；
- 底部动作条只在可批准时出现。

## Verification

- `pnpm typecheck:ui` 通过；
- 改动文件 `biome lint` 无告警；
- 构建桌面端 exe，在浅色 / 深色下逐一核对三种状态的渲染与按钮可用性。

纯视觉改动，未改变 `PlanModeCard` 的对外 props 契约与 plan 决策数据流，故未新增测试。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [ ] Docs are updated for changes affecting user behavior, deployment, or configuration.
