### PR TITLE
fix(chat): 移除 AskUserQuestion 各题选项数必须一致的校验

### DIFF
--- a/crates/agent-gui/src/lib/tools/askUserQuestionTools.ts
+++ b/crates/agent-gui/src/lib/tools/askUserQuestionTools.ts
@@ -149,7 +149,7 @@ const askUserQuestionParameters = Type.Object({
           ),
         }),
         {
-          description: `${ASK_USER_QUESTION_MIN_OPTIONS}-${ASK_USER_QUESTION_MAX_OPTIONS} mutually exclusive options (3-4 is ideal). Every question in one call must have the same number of options.`,
+          description: `${ASK_USER_QUESTION_MIN_OPTIONS}-${ASK_USER_QUESTION_MAX_OPTIONS} mutually exclusive options (3-4 is ideal).`,
         },
       ),
     }),

--- a/crates/agent-gui/src/lib/tools/askUserQuestionTools.ts
+++ b/crates/agent-gui/src/lib/tools/askUserQuestionTools.ts
@@ -119,7 +119,7 @@ const ASK_USER_QUESTION_TOOL_DESCRIPTION = `Ask the user up to ${ASK_USER_QUESTI
 The questions render as an interactive card; execution pauses until the user answers every question, then the selections come back as the tool result. If the user does not answer within ${ASK_USER_QUESTION_TIMEOUT_MINUTES} minutes, the recommended (or first) option of every question is auto-selected and execution continues — the result text tells you which happened.
 
 Rules:
-- Ask 1-${ASK_USER_QUESTION_MAX_QUESTIONS} focused questions per call; each question needs ${ASK_USER_QUESTION_MIN_OPTIONS}-${ASK_USER_QUESTION_MAX_OPTIONS} options (3-4 is ideal), and every question in one call must have the SAME number of options.
+- Ask 1-${ASK_USER_QUESTION_MAX_QUESTIONS} focused questions per call; each question needs ${ASK_USER_QUESTION_MIN_OPTIONS}-${ASK_USER_QUESTION_MAX_OPTIONS} options (3-4 is ideal); different questions may have different option counts.
 - Options must be short, concrete, and mutually exclusive. Set recommended=true on your suggested choice (at most one per question) — it is shown first and becomes the timeout fallback.
 - The UI automatically appends an "Other" free-text option to every question, so the user can always type their own answer. Do NOT add your own catch-all option (e.g. "Other", "Custom", "其他", "自定义"). When the user types an answer, the result marks it as user-typed and returns their exact words instead of a listed label — treat it as authoritative.
 - Give each question a short header (2-6 chars works best) — it becomes the tab label when several questions show at once.

--- a/crates/agent-gui/test/tools/ask-user-question-tools.test.mjs
+++ b/crates/agent-gui/test/tools/ask-user-question-tools.test.mjs
@@ -105,14 +105,15 @@ test("parseAskUserQuestionItems enforces limits, ids, and single recommendation"
     /duplicate question id/,
   );
 
-  // 同一轮各题选项数必须一致。
-  assert.throws(
-    () =>
-      shared.parseAskUserQuestionItems([
-        { prompt: "三个选项", options: [{ label: "a" }, { label: "b" }, { label: "c" }] },
-        { prompt: "两个选项", options: [{ label: "x" }, { label: "y" }] },
-      ]),
-    /same number of options/,
+  // 同一轮各题的选项数可以不同：卡片一次只渲染一题，高度本就随 prompt 与
+  // description 变化，强行对齐换不来布局稳定，只会白白拒掉合法提问。
+  const mixed = shared.parseAskUserQuestionItems([
+    { prompt: "三个选项", options: [{ label: "a" }, { label: "b" }, { label: "c" }] },
+    { prompt: "两个选项", options: [{ label: "x" }, { label: "y" }] },
+  ]);
+  assert.deepEqual(
+    mixed.map((question) => question.options.length),
+    [3, 2],
   );
 
   const parsed = shared.parseAskUserQuestionItems(buildQuestionsArgs().questions);

--- a/crates/agent-ui/src/lib/chat/askUserQuestion.ts
+++ b/crates/agent-ui/src/lib/chat/askUserQuestion.ts
@@ -124,7 +124,6 @@ export function parseAskUserQuestionItems(raw: unknown): AskUserQuestionItem[] {
     );
   }
   const seenIds = new Set<string>();
-  let expectedOptionCount = 0;
   return raw.map((value, index) => {
     if (!value || typeof value !== "object") {
       throw new Error(`AskUserQuestion questions[${index}] must be an object.`);
@@ -145,15 +144,6 @@ export function parseAskUserQuestionItems(raw: unknown): AskUserQuestionItem[] {
         `AskUserQuestion questions[${index}] needs ${ASK_USER_QUESTION_MIN_OPTIONS}-${ASK_USER_QUESTION_MAX_OPTIONS} options; got ${record.options.length}.`,
       );
     }
-    // 同一轮里各问题的选项数必须一致，保证卡片切 tab 时布局稳定。
-    if (index === 0) {
-      expectedOptionCount = record.options.length;
-    } else if (record.options.length !== expectedOptionCount) {
-      throw new Error(
-        `AskUserQuestion requires every question in one call to have the same number of options; questions[0] has ${expectedOptionCount} while questions[${index}] has ${record.options.length}.`,
-      );
-    }
-
     const labels = new Set<string>();
     let recommendedCount = 0;
     const options = record.options.map((optionValue, optionIndex) => {

--- a/docs/features/chat-runtime.md
+++ b/docs/features/chat-runtime.md
@@ -81,7 +81,7 @@ Hooks 支持 shell script 和 HTTP requests；公共设置 UI 位于 `agent-ui`�
 
 | 能力 | 语义 |
 |---|---|
-| 工具形态 | chat-only 内置工具；模型一次最多提 4 个问题，每题 2-6 个选项且**同轮各题选项数一致**，至多一个"推荐"项且**固定排在首位**。 |
+| 工具形态 | chat-only 内置工具；模型一次最多提 4 个问题，每题 2-6 个选项（**各题选项数可以不同**），至多一个"推荐"项且**固定排在首位**。 |
 | 挂起语义 | `execute` 在工具挂起表（toolCallId 键）上等待；用户提交后 resolve，停止按钮经 AbortSignal 以"未应答"落定（`details.cancelled`）；**3 分钟未作答按推荐项（缺省第一项）自动落定**（`details.timedOut`），卡片展示倒计时。**倒计时双端同源**：桌面端在网关上报的工具参数上盖 `__askUserQuestionDeadlineAt` 权威截止时间戳（`gatewayToolPreview` 统一盖章，execute 复用同一预置值），WebUI/重连场景按真实剩余时间倒数。 |
 | 卡片 UI | `crates/agent-ui/src/components/chat/AskUserQuestionCard.tsx`（共享实现）：多问题以顶部 tabs 切换，单选 + 推荐标记，全部作答后提交；应答落定后只读回显。**问题与选项全部生成完毕后整卡出现**（`runAgentConversationTurn` 跳过 AskUserQuestion 的 tool_call_delta，两端不做流式渐显）。 |
 | 双端应答 | GUI 直接调用 `answerAskUserQuestion`；WebUI 走 `chat_queue.tool_answer`（item_id=toolCallId，request_json=选择数组）由桌面端落到同一挂起表，协议零改动；远端应答**校验 conversation_id 与挂起提问所属会话一致**，防串会话应答。 |


### PR DESCRIPTION
## Linked issue

Closes #676

## Summary

`AskUserQuestion` 此前要求同一次调用里各题的选项数完全一致，否则工具调用直接失败。这是很自然会踩到的组合——第一问「优化目标是什么」有 4 个方向，第二问「是否需要先收集磁盘数据」只有是 / 否，就会被拒。

源码注释给的理由是「保证卡片切 tab 时布局稳定」，但卡片并不依赖这一点：

- 卡片一次只渲染一题，选项区是 `flex flex-col gap-1.5`，没有固定高度或网格；
- 卡片高度本就每题不同——`prompt` 长度、`description` 有无与长短都在变，选项数一致锁不住高度；
- 选项列表底部固定追加 UI 合成的「其他（自行输入）」行，选中后展开输入框，同一题内部高度就在变；
- 流式渲染走的 `sanitizeAskUserQuestionItems` 从不做这个检查，参数增量拼装过程中早就在渲染不等长的选项，并无问题。

代价则是一次合法提问直接失败、模型要重试一轮。故移除该校验。

同时移除工具描述与文档里的同一条规则。模型读的就是工具描述，只删校验、留着 "every question in one call must have the SAME number of options" 这句，模型仍会为了凑齐选项数硬塞或砍掉选项，改动等于没生效。

其余校验一条未动：每题 2-6 个选项、最多 4 题、选项 label 不重复、问题 id 不重复、每题至多一个 `recommended`——这些拦的是真正会让卡片出问题的输入。

## Change scope

- Modules: agent-ui / agent-gui
- Key paths:
  - `crates/agent-ui/src/lib/chat/askUserQuestion.ts` — 移除 `parseAskUserQuestionItems` 中的选项数一致校验与 `expectedOptionCount`
  - `crates/agent-gui/src/lib/tools/askUserQuestionTools.ts` — 工具描述与参数 schema 描述同步去掉这条规则
  - `crates/agent-gui/test/tools/ask-user-question-tools.test.mjs` — 原断言「抛错」改为断言不等长选项能正常解析
  - `docs/features/chat-runtime.md` — 「同轮各题选项数一致」改为「各题选项数可以不同」

## Screenshots / preview

改动后，同一次调用里 `questions[0]` 4 项、`questions[1]` 2 项的卡片渲染（上下两张是同一张卡片的两个 tab，分别停在第一问与第二问）：

![AskUserQuestionCard with 4 and 2 options](https://raw.githubusercontent.com/xiaozhou26/LiveAgent/pr-677-assets/pr-assets/ask-user-question-mixed-option-counts.png)

> 截图取自本地预览页直接挂载共享组件 `AskUserQuestionCard`（`interactive` 态），非完整会话；组件与 props 均为线上同一份。

两题选项数不同，tab 切换、单选、推荐标记、底部「其他（自行输入）」行与倒计时 / 提交条均正常——卡片本来就不依赖各题选项数一致。

改动前，同样的参数在工具执行阶段就被拒，卡片直接显示「失败」：

```
AskUserQuestion requires every question in one call to have the same number of options;
questions[0] has 4 while questions[1] has 2.
```

## Verification

`node --test crates/agent-gui/test/tools/ask-user-question-tools.test.mjs` —— 19 passed / 0 failed。

已更新既有测试：原本断言不等长选项会抛错，现改为断言其能正常解析并保留各自的选项数。改动文件 `biome lint` 无告警。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.
