### PR TITLE
fix(cua): keep hidden_command mut only on Windows

### DIFF
--- a/crates/agent-gui/src-tauri/src/services/cua_driver/mod.rs
+++ b/crates/agent-gui/src-tauri/src/services/cua_driver/mod.rs
@@ -183,14 +183,18 @@ fn candidate_paths() -> Vec<PathBuf> {
 /// `CREATE_NO_WINDOW` 只影响是否分配控制台，stdout / stderr 仍照常通过
 /// 管道拿到。非 Windows 平台没有这个概念，helper 退化成 `Command::new`。
 fn hidden_command(program: impl AsRef<std::ffi::OsStr>) -> Command {
-    let mut command = Command::new(program);
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        let mut command = Command::new(program);
         command.creation_flags(CREATE_NO_WINDOW);
+        command
     }
-    command
+    #[cfg(not(target_os = "windows"))]
+    {
+        Command::new(program)
+    }
 }
 
 fn run_capture(program: &Path, args: &[&str]) -> Result<String, String> {


### PR DESCRIPTION
## Linked issue

Closes #678

## Summary

Non-Windows `cargo check` of `liveagent` warned that `hidden_command` did not need `mut`, because the only mutation is `CREATE_NO_WINDOW` behind `#[cfg(target_os = "windows")]`. Split the helper so Windows still hides the console window and other platforms just return `Command::new`.

## Change scope

- Modules: agent-gui / src-tauri (`cua_driver`)
- Key paths:
  - `crates/agent-gui/src-tauri/src/services/cua_driver/mod.rs`

## Screenshots / preview

N/A — compile-warning fix only; no UI or runtime behavior change on macOS/Linux. Windows still sets `CREATE_NO_WINDOW`.

## Verification

- `cargo check --manifest-path crates/agent-gui/src-tauri/Cargo.toml --lib` on macOS: finished clean, no `unused_mut`.
- No new tests: the change is cfg-gated construction, not a new code path.

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.

Made with [Cursor](https://cursor.com)