### PR TITLE
fix(settings): cc-switch 导入识别 Claude Desktop 供应商数据

### DIFF
--- a/crates/agent-gui/src-tauri/src/commands/config/settings/ccs_import.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/ccs_import.rs
@@ -122,34 +122,46 @@ fn list_ccswitch_liveagent_providers_from_db(
 
     let conn = Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
         .map_err(|e| format!("打开 ccswitch 数据库失败 {}：{e}", path.display()))?;
+    // meta 是 ccswitch providers 表的独立列（TEXT NOT NULL DEFAULT '{}'），
+    // Claude Desktop 的接入模式、上游格式与模型路由都存在这里，而不在
+    // settings_config。极老的 v0 库尚未迁移出 meta 列（LiveAgent 只读打开、
+    // 不会触发 ccswitch 迁移），这种库也早于 Claude Desktop 支持，退化为
+    // 空 meta 查询即可。
+    let has_meta_column = ccswitch_providers_has_meta_column(&conn);
+    let meta_select = if has_meta_column { "meta" } else { "NULL" };
+    let sql = format!(
+        "SELECT id, app_type, name, settings_config, {meta_select} AS meta
+         FROM providers
+         WHERE app_type IN (
+           'codex',
+           'claude', 'claude-code', 'claude_code',
+           'claude-desktop', 'claude_desktop', 'claudeDesktop',
+           'gemini',
+           'grokbuild', 'grok-build', 'grok_build', 'grok', 'xai',
+           'deepseek'
+         )
+         ORDER BY
+           CASE app_type
+             WHEN 'claude' THEN 0
+             WHEN 'claude-code' THEN 0
+             WHEN 'claude_code' THEN 0
+             WHEN 'claude-desktop' THEN 0
+             WHEN 'claude_desktop' THEN 0
+             WHEN 'claudeDesktop' THEN 0
+             WHEN 'codex' THEN 1
+             WHEN 'gemini' THEN 2
+             WHEN 'grokbuild' THEN 3
+             WHEN 'grok-build' THEN 3
+             WHEN 'grok_build' THEN 3
+             WHEN 'grok' THEN 3
+             WHEN 'xai' THEN 3
+             WHEN 'deepseek' THEN 4
+             ELSE 5
+           END,
+           COALESCE(sort_index, 999999), created_at ASC, id ASC"
+    );
     let mut stmt = conn
-        .prepare(
-            "SELECT id, app_type, name, settings_config
-             FROM providers
-             WHERE app_type IN (
-               'codex',
-               'claude', 'claude-code', 'claude_code',
-               'gemini',
-               'grokbuild', 'grok-build', 'grok_build', 'grok', 'xai',
-               'deepseek'
-             )
-             ORDER BY
-               CASE app_type
-                 WHEN 'claude' THEN 0
-                 WHEN 'claude-code' THEN 0
-                 WHEN 'claude_code' THEN 0
-                 WHEN 'codex' THEN 1
-                 WHEN 'gemini' THEN 2
-                 WHEN 'grokbuild' THEN 3
-                 WHEN 'grok-build' THEN 3
-                 WHEN 'grok_build' THEN 3
-                 WHEN 'grok' THEN 3
-                 WHEN 'xai' THEN 3
-                 WHEN 'deepseek' THEN 4
-                 ELSE 5
-               END,
-               COALESCE(sort_index, 999999), created_at ASC, id ASC",
-        )
+        .prepare(&sql)
         .map_err(|e| format!("读取 ccswitch providers 表失败：{e}"))?;
     let rows = stmt
         .query_map([], |row| {
@@ -158,22 +170,45 @@ fn list_ccswitch_liveagent_providers_from_db(
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
                 row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
             ))
         })
         .map_err(|e| format!("查询 ccswitch providers 失败：{e}"))?;
 
     let mut providers = Vec::new();
     for row in rows {
-        let (source_id, app_type, name, settings_config) =
+        let (source_id, app_type, name, settings_config, meta_str) =
             row.map_err(|e| format!("读取 ccswitch provider 行失败：{e}"))?;
         let Ok(config) = serde_json::from_str::<Value>(&settings_config) else {
             continue;
         };
-        if let Some(provider) = ccs_provider_from_value(&source_id, &app_type, &name, &config) {
+        // meta 解析失败按空处理，不影响该行其余字段的导入。
+        let meta = meta_str
+            .as_deref()
+            .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+            .unwrap_or(Value::Null);
+        if let Some(provider) =
+            ccs_provider_from_value(&source_id, &app_type, &name, &config, &meta)
+        {
             providers.push(provider);
         }
     }
     Ok(providers)
+}
+
+fn ccswitch_providers_has_meta_column(conn: &Connection) -> bool {
+    let Ok(mut stmt) = conn.prepare("PRAGMA table_info(providers)") else {
+        return false;
+    };
+    let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(1)) else {
+        return false;
+    };
+    for name in rows.flatten() {
+        if name == "meta" {
+            return true;
+        }
+    }
+    false
 }
 
 fn ccs_provider_from_value(
@@ -181,8 +216,19 @@ fn ccs_provider_from_value(
     app_type: &str,
     name: &str,
     config: &Value,
+    meta: &Value,
 ) -> Option<CcsProviderImportItem> {
     let mapped_provider_type = ccs_provider_type_from_app_type(app_type)?;
+
+    // Claude Desktop（ccswitch app_type=claude-desktop）供应商归入 Anthropic 协议标签，
+    // 但只有 Anthropic 原生格式的才可直接作为 claude_code 导入：代理模式声明的
+    // openai_chat / openai_responses / gemini_native 上游需要本地转协议，直接当作
+    // Anthropic 供应商导入会得到协议不符的坏配置，这里跳过。
+    let is_claude_desktop = ccs_is_claude_desktop_app_type(app_type);
+    if is_claude_desktop && !ccs_claude_desktop_is_anthropic(meta) {
+        return None;
+    }
+
     let mapped_base_url = ccs_extract_base_url(mapped_provider_type, config).unwrap_or_default();
     let provider_type = if mapped_provider_type == "codex"
         && ccs_is_chat_protocol(config)
@@ -194,6 +240,18 @@ fn ccs_provider_from_value(
     };
     let base_url = ccs_extract_base_url(provider_type, config).unwrap_or_default();
     let api_key = ccs_extract_api_key(provider_type, config).unwrap_or_default();
+
+    let mut models = ccs_extract_models(provider_type, config);
+    if is_claude_desktop {
+        // Claude Desktop 的模型不写在 env，而是 meta.claudeDesktopModelRoutes：
+        // 直连模式 route_id 即模型名，映射模式取 route.model 的真实上游模型。
+        for model in ccs_extract_claude_desktop_models(meta) {
+            if !models.iter().any(|item| item == &model) {
+                models.push(model);
+            }
+        }
+    }
+
     Some(CcsProviderImportItem {
         source_id: source_id.to_string(),
         app_type: app_type.to_string(),
@@ -224,20 +282,70 @@ fn ccs_provider_from_value(
         } else {
             "openai-responses".to_string()
         },
-        models: ccs_extract_models(provider_type, config),
+        models,
     })
 }
 
 fn ccs_provider_type_from_app_type(app_type: &str) -> Option<&'static str> {
     match app_type.trim().to_ascii_lowercase().as_str() {
         "codex" => Some("codex"),
-        "claude" | "claude-code" | "claude_code" => Some("claude_code"),
+        // Claude Desktop 与 Claude Code CLI 同为 Anthropic 协议供应商。
+        "claude" | "claude-code" | "claude_code" | "claude-desktop" | "claude_desktop"
+        | "claudedesktop" => Some("claude_code"),
         "gemini" => Some("gemini"),
         "deepseek" => Some("deepseek"),
         // CC-Switch Grok Build 应用桶（与上游 AppType::GrokBuild 别名对齐）。
         "grokbuild" | "grok-build" | "grok_build" | "grok" | "xai" => Some("xai"),
         _ => None,
     }
+}
+
+fn ccs_is_claude_desktop_app_type(app_type: &str) -> bool {
+    matches!(
+        app_type.trim().to_ascii_lowercase().as_str(),
+        "claude-desktop" | "claude_desktop" | "claudedesktop"
+    )
+}
+
+/// Claude Desktop 供应商是否使用 Anthropic 原生上游格式。
+///
+/// ccswitch 直连模式固定写 meta.apiFormat = "anthropic"；映射（proxy）模式可以声明
+/// openai_chat / openai_responses / gemini_native 等格式，由 ccswitch 内置网关转协议。
+/// 缺省（历史数据无 apiFormat）按 Anthropic 处理，与 ccswitch 的默认值一致。
+fn ccs_claude_desktop_is_anthropic(meta: &Value) -> bool {
+    match meta.get("apiFormat").and_then(Value::as_str) {
+        Some(format) => format.trim().eq_ignore_ascii_case("anthropic") || format.trim().is_empty(),
+        None => true,
+    }
+}
+
+/// 从 meta.claudeDesktopModelRoutes 提取 Claude Desktop 的模型列表。
+///
+/// 路由表形如 { "<route_id>": { "model": "<上游模型>", ... } }：直连模式下 route_id
+/// 就是模型名（model 字段同值）；映射模式下 model 字段才是真实上游模型。统一优先取
+/// model 字段，为空时回退 route_id。
+fn ccs_extract_claude_desktop_models(meta: &Value) -> Vec<String> {
+    let Some(routes) = meta
+        .get("claudeDesktopModelRoutes")
+        .and_then(Value::as_object)
+    else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for (route_id, route) in routes {
+        let model = route
+            .get("model")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| route_id.trim());
+        if model.is_empty() || out.iter().any(|item| item == model) {
+            continue;
+        }
+        out.push(model.to_string());
+    }
+    out.sort();
+    out
 }
 
 fn ccs_extract_models(provider_type: &str, config: &Value) -> Vec<String> {

--- a/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
+++ b/crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs
@@ -1862,6 +1862,7 @@ mod tests {
             "deepseek",
             "DeepSeek Official",
             &config,
+            &json!({}),
         )
         .expect("deepseek provider should import");
 
@@ -1884,10 +1885,10 @@ mod tests {
         });
 
         let official_item =
-            ccs_provider_from_value("official", "codex", "Official", &official)
+            ccs_provider_from_value("official", "codex", "Official", &official, &json!({}))
                 .expect("official config should import");
         let aggregate_item =
-            ccs_provider_from_value("aggregate", "codex", "Aggregate", &aggregate)
+            ccs_provider_from_value("aggregate", "codex", "Aggregate", &aggregate, &json!({}))
                 .expect("aggregate config should import");
 
         assert_eq!(official_item.provider_type, "deepseek");
@@ -1908,6 +1909,7 @@ mod tests {
             "grokbuild",
             "PackyCode",
             &config,
+            &json!({}),
         )
         .expect("grokbuild provider should import");
 
@@ -1927,12 +1929,256 @@ mod tests {
             "grokbuild",
             "Grok Official",
             &config,
+            &json!({}),
         )
         .expect("official grok seed should still map");
         assert_eq!(item.provider_type, "xai");
         assert_eq!(item.base_url, "");
         assert_eq!(item.api_key, "");
         assert_eq!(item.request_format, "openai-responses");
+    }
+
+    #[test]
+    fn ccs_maps_claude_desktop_app_type_to_claude_code() {
+        assert_eq!(
+            ccs_provider_type_from_app_type("claude-desktop"),
+            Some("claude_code")
+        );
+        assert_eq!(
+            ccs_provider_type_from_app_type("claude_desktop"),
+            Some("claude_code")
+        );
+        assert_eq!(
+            ccs_provider_type_from_app_type("claudeDesktop"),
+            Some("claude_code")
+        );
+    }
+
+    #[test]
+    fn ccs_imports_claude_desktop_direct_mode_provider() {
+        // 与 cc-switch Claude Desktop 直连模式写库形状对齐：
+        // env 存 ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN，模型在 meta 的路由表里。
+        let config = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://relay.example.test/",
+                "ANTHROPIC_AUTH_TOKEN": "sk-desktop"
+            }
+        });
+        let meta = json!({
+            "claudeDesktopMode": "direct",
+            "apiFormat": "anthropic",
+            "claudeDesktopModelRoutes": {
+                "claude-sonnet-4-5": { "model": "claude-sonnet-4-5" },
+                "claude-opus-4-5": { "model": "claude-opus-4-5" }
+            }
+        });
+        let item = ccs_provider_from_value(
+            "desktop-1",
+            "claude-desktop",
+            "Desktop Relay",
+            &config,
+            &meta,
+        )
+        .expect("claude desktop direct provider should import");
+
+        assert_eq!(item.provider_type, "claude_code");
+        assert_eq!(item.app_type, "claude-desktop");
+        assert_eq!(item.base_url, "https://relay.example.test");
+        assert_eq!(item.api_key, "sk-desktop");
+        assert_eq!(
+            item.models,
+            vec!["claude-opus-4-5", "claude-sonnet-4-5"]
+        );
+    }
+
+    #[test]
+    fn ccs_imports_claude_desktop_proxy_mode_anthropic_upstream() {
+        // 映射模式 + Anthropic 上游：模型取 route.model（真实上游模型）。
+        let config = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://gateway.example.test",
+                "ANTHROPIC_API_KEY": "sk-proxy"
+            }
+        });
+        let meta = json!({
+            "claudeDesktopMode": "proxy",
+            "apiFormat": "anthropic",
+            "claudeDesktopModelRoutes": {
+                "claude-sonnet-4-5": { "model": "kimi-k2", "labelOverride": "Kimi" }
+            }
+        });
+        let item = ccs_provider_from_value(
+            "desktop-2",
+            "claude-desktop",
+            "Desktop Proxy",
+            &config,
+            &meta,
+        )
+        .expect("anthropic-format proxy provider should import");
+
+        assert_eq!(item.provider_type, "claude_code");
+        assert_eq!(item.api_key, "sk-proxy");
+        assert_eq!(item.models, vec!["kimi-k2"]);
+    }
+
+    #[test]
+    fn ccs_skips_claude_desktop_non_anthropic_upstreams() {
+        // 映射模式声明 openai_chat / openai_responses / gemini_native 上游时，
+        // 依赖 cc-switch 内置网关转协议，不能直接当 Anthropic 供应商导入。
+        let config = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.openai.example.test/v1",
+                "ANTHROPIC_AUTH_TOKEN": "sk-openai"
+            }
+        });
+        for format in ["openai_chat", "openai_responses", "gemini_native"] {
+            let meta = json!({
+                "claudeDesktopMode": "proxy",
+                "apiFormat": format,
+                "claudeDesktopModelRoutes": {
+                    "claude-sonnet-4-5": { "model": "gpt-5.2" }
+                }
+            });
+            assert!(
+                ccs_provider_from_value("desktop-3", "claude-desktop", "GPT", &config, &meta)
+                    .is_none(),
+                "{format} upstream should be skipped"
+            );
+        }
+    }
+
+    #[test]
+    fn ccs_imports_claude_desktop_official_seed_without_meta_format() {
+        // 官方种子 settings_config 为 {"env":{}}，meta 无 apiFormat：
+        // 应按 Anthropic 处理并保留（前端以空 base_url/api_key 置灰）。
+        let config = json!({ "env": {} });
+        let item = ccs_provider_from_value(
+            "claude-desktop-official",
+            "claude-desktop",
+            "Claude Desktop 官方",
+            &config,
+            &json!({}),
+        )
+        .expect("official claude desktop seed should map");
+        assert_eq!(item.provider_type, "claude_code");
+        assert_eq!(item.base_url, "");
+        assert_eq!(item.api_key, "");
+        assert!(item.models.is_empty());
+    }
+
+    #[test]
+    fn ccs_db_query_returns_claude_desktop_rows_with_meta() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("cc-switch.db");
+        {
+            let conn = Connection::open(&db_path).expect("create ccswitch db");
+            conn.execute_batch(
+                "CREATE TABLE providers (
+                   id TEXT NOT NULL,
+                   app_type TEXT NOT NULL,
+                   name TEXT NOT NULL,
+                   settings_config TEXT NOT NULL,
+                   category TEXT,
+                   created_at INTEGER,
+                   sort_index INTEGER,
+                   meta TEXT NOT NULL DEFAULT '{}',
+                   is_current BOOLEAN NOT NULL DEFAULT 0,
+                   PRIMARY KEY (id, app_type)
+                 );",
+            )
+            .expect("create providers table");
+            let insert = |id: &str, app_type: &str, name: &str, config: &str, meta: &str| {
+                conn.execute(
+                    "INSERT INTO providers (id, app_type, name, settings_config, meta, created_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, 1)",
+                    rusqlite::params![id, app_type, name, config, meta],
+                )
+                .expect("insert provider row");
+            };
+            insert(
+                "cli-1",
+                "claude",
+                "CLI Relay",
+                r#"{"env":{"ANTHROPIC_BASE_URL":"https://cli.example.test","ANTHROPIC_AUTH_TOKEN":"sk-cli"}}"#,
+                "{}",
+            );
+            insert(
+                "desktop-direct",
+                "claude-desktop",
+                "Desktop Relay",
+                r#"{"env":{"ANTHROPIC_BASE_URL":"https://desktop.example.test","ANTHROPIC_AUTH_TOKEN":"sk-desktop"}}"#,
+                r#"{"claudeDesktopMode":"direct","apiFormat":"anthropic","claudeDesktopModelRoutes":{"claude-sonnet-4-5":{"model":"claude-sonnet-4-5"}}}"#,
+            );
+            insert(
+                "desktop-openai",
+                "claude-desktop",
+                "Desktop OpenAI Proxy",
+                r#"{"env":{"ANTHROPIC_BASE_URL":"https://openai.example.test/v1","ANTHROPIC_AUTH_TOKEN":"sk-openai"}}"#,
+                r#"{"claudeDesktopMode":"proxy","apiFormat":"openai_chat","claudeDesktopModelRoutes":{"claude-sonnet-4-5":{"model":"gpt-5.2"}}}"#,
+            );
+        }
+
+        let providers =
+            list_ccswitch_liveagent_providers_from_db(&db_path).expect("query providers");
+        let ids: Vec<&str> = providers
+            .iter()
+            .map(|item| item.source_id.as_str())
+            .collect();
+        assert!(ids.contains(&"cli-1"), "claude CLI row should import");
+        assert!(
+            ids.contains(&"desktop-direct"),
+            "claude desktop direct row should import"
+        );
+        assert!(
+            !ids.contains(&"desktop-openai"),
+            "non-anthropic desktop upstream should be skipped"
+        );
+
+        let desktop = providers
+            .iter()
+            .find(|item| item.source_id == "desktop-direct")
+            .expect("desktop provider present");
+        assert_eq!(desktop.provider_type, "claude_code");
+        assert_eq!(desktop.base_url, "https://desktop.example.test");
+        assert_eq!(desktop.api_key, "sk-desktop");
+        assert_eq!(desktop.models, vec!["claude-sonnet-4-5"]);
+    }
+
+    #[test]
+    fn ccs_db_query_tolerates_missing_meta_column() {
+        // ccswitch v0 老库没有 meta 列；LiveAgent 只读打开、不做迁移，
+        // 查询需退化为空 meta 而不是整体失败。
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("cc-switch.db");
+        {
+            let conn = Connection::open(&db_path).expect("create ccswitch db");
+            conn.execute_batch(
+                "CREATE TABLE providers (
+                   id TEXT NOT NULL,
+                   app_type TEXT NOT NULL,
+                   name TEXT NOT NULL,
+                   settings_config TEXT NOT NULL,
+                   sort_index INTEGER,
+                   created_at INTEGER,
+                   PRIMARY KEY (id, app_type)
+                 );",
+            )
+            .expect("create legacy providers table");
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, created_at)
+                 VALUES ('cli-legacy', 'claude', 'Legacy CLI',
+                         '{\"env\":{\"ANTHROPIC_BASE_URL\":\"https://legacy.example.test\",\"ANTHROPIC_AUTH_TOKEN\":\"sk-legacy\"}}', 1)",
+                [],
+            )
+            .expect("insert legacy provider row");
+        }
+
+        let providers =
+            list_ccswitch_liveagent_providers_from_db(&db_path).expect("query legacy providers");
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].source_id, "cli-legacy");
+        assert_eq!(providers[0].provider_type, "claude_code");
+        assert_eq!(providers[0].base_url, "https://legacy.example.test");
     }
 
     // ===== 配置备份：采集 / 校验 / 应用 =====


### PR DESCRIPTION
## Linked issue

Closes #644

## Summary

CC Switch 导入功能此前只识别 Claude Code CLI 的供应商数据（`app_type` 为 `claude` / `claude-code` / `claude_code`），漏掉了 Claude Code Desktop 写入的 `claude-desktop` 条目，导致只使用桌面版的用户在 Anthropic 协议页签下看到空的导入列表。

本 PR 让导入逻辑识别 Claude Desktop 供应商数据：

- SQL 查询的 `app_type` 白名单加入 `claude-desktop` 及其别名，并读取 `meta` 列——Claude Desktop 的接入模式、上游格式与模型路由存在这一列，而不在 `settings_config`；
- `claude-desktop` 映射为 `claude_code` 供应商类型，与 CLI 供应商同在 Anthropic 页签展示；凭据提取复用现有逻辑（桌面版同样把 `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` 写在 `env` 里），前端零改动；
- 模型从 `meta.claudeDesktopModelRoutes` 提取：直连模式路由 ID 即模型名，映射模式取 `route.model` 的真实上游模型；
- 映射模式声明 `openai_chat` / `openai_responses` / `gemini_native` 上游格式的条目跳过导入——这类配置依赖 cc-switch 内置网关转协议，直接按 Anthropic 供应商导入会得到协议不符的坏配置；
- 兼容兜底：LiveAgent 只读打开 cc-switch 数据库、不会触发其迁移，极老的 v0 库没有 `meta` 列，先用 `PRAGMA table_info` 探测，缺列时退化为 `NULL AS meta` 查询，避免整个导入功能失效。

## Change scope

- Modules: agent-gui / src-tauri（settings 后端，前端无改动）
- Key paths:
  - `crates/agent-gui/src-tauri/src/commands/config/settings/ccs_import.rs`
  - `crates/agent-gui/src-tauri/src/commands/config/settings/tests.rs`

## Screenshots / preview

修复后，仅使用 Claude Desktop 的 cc-switch 数据在 Anthropic 页签可见（官方种子无凭据，按既有行为置灰展示）：

![CC Switch 导入弹窗中显示 Claude Desktop 供应商](https://raw.githubusercontent.com/xiaozhou26/LiveAgent/assets-claude-desktop-644/claude-desktop-import-644.png)

## Verification

- `cd crates/agent-gui/src-tauri && cargo test ccs_`：12 个用例全部通过，其中新增 6 个——app_type 映射、直连模式导入、映射模式 Anthropic 上游导入、非 Anthropic 上游跳过、官方种子兜底，以及真实 SQLite 库级查询（含缺 `meta` 列的老库兜底）。
- `cargo clippy --lib`：改动文件无新增警告。
- Windows 本地 `tauri build` 后手动验证导入弹窗（见上方截图）。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.
