### PR TITLE
refactor(settings): 精简上下文占用展示分区的文案与布局

### DIFF
--- a/crates/agent-ui/src/i18n/translations/enUSSettings.ts
+++ b/crates/agent-ui/src/i18n/translations/enUSSettings.ts
@@ -668,11 +668,16 @@ export const EN_US_SETTINGS_TRANSLATIONS = {
     "Model used to generate commit messages in Git review. Follows the current chat model when unselected or unavailable.",
   "settings.customSettingsModelEmpty": "No active models are configured for the current providers.",
   "settings.composerContextDisplay": "Context usage display",
-  "settings.composerContextDisplayDesc":
-    "Stats bar shows only the conversation stats bar below the card (context usage readout included); Both shows the stats bar plus the always-visible usage ring at the composer's lower right; Usage ring shows only the ring. All three keep the manual compaction entry at ≥50% usage.",
+  "settings.composerContextDisplayHint":
+    "Choose how the composer shows context usage. Every mode keeps the manual compaction entry at ≥50% usage.",
   "settings.composerContextDisplayStatsBar": "Stats bar",
   "settings.composerContextDisplayBoth": "Both",
   "settings.composerContextDisplayRing": "Usage ring",
+  "settings.composerContextDisplayStatsBarDesc": "Only the conversation stats bar below the card.",
+  "settings.composerContextDisplayBothDesc":
+    "The stats bar plus the usage ring at the composer's lower right.",
+  "settings.composerContextDisplayRingDesc":
+    "Only the always-visible usage ring at the composer's lower right.",
   "settings.failoverTitle": "Auto Failover",
   "settings.failoverToggleHint":
     "When a {vendor} request fails, retry it on the next {vendor} provider in the queue with the same model, staying on the provider that succeeds. Never crosses vendors.",

--- a/crates/agent-ui/src/i18n/translations/zhCNSettings.ts
+++ b/crates/agent-ui/src/i18n/translations/zhCNSettings.ts
@@ -641,11 +641,14 @@ export const ZH_CN_SETTINGS_TRANSLATIONS = {
     "Git 审查中生成提交说明使用的模型，未选择或失效时跟随当前对话模型。",
   "settings.customSettingsModelEmpty": "当前 Provider 未配置模型。",
   "settings.composerContextDisplay": "上下文占用展示",
-  "settings.composerContextDisplayDesc":
-    "「状态栏」只显示卡片下方的会话统计状态栏（上下文占用读数含在其中）；「都显示」同时显示状态栏与输入框右下角的常显用量环；「用量环」只显示用量环。三档都保留占用 ≥50% 时的手动压缩入口。",
+  "settings.composerContextDisplayHint":
+    "选择输入区展示上下文占用的方式。无论哪一档，占用 ≥50% 时都保留手动压缩入口。",
   "settings.composerContextDisplayStatsBar": "状态栏",
   "settings.composerContextDisplayBoth": "都显示",
   "settings.composerContextDisplayRing": "用量环",
+  "settings.composerContextDisplayStatsBarDesc": "仅显示卡片下方的会话统计状态栏。",
+  "settings.composerContextDisplayBothDesc": "状态栏与输入框右下角的用量环同时显示。",
+  "settings.composerContextDisplayRingDesc": "仅显示输入框右下角的常显用量环。",
   "settings.failoverTitle": "自动故障转移",
   "settings.failoverToggleHint":
     "{vendor} 请求失败时按队列顺序切换到下一个 {vendor} 供应商重试（模型不变），成功后停留在该供应商。不会跨厂商转移。",

--- a/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
+++ b/crates/agent-ui/src/pages/settings/ProvidersSection.tsx
@@ -21,6 +21,7 @@ import {
 } from "@liveagent/app/lib/settings";
 import type { SettingsSectionProps } from "@liveagent/app/pages/settings/types";
 import {
+  Activity,
   ChevronDown,
   Pencil,
   Plus,
@@ -33,7 +34,6 @@ import {
   X,
 } from "@liveagent/ui/components/IconSet";
 import { Button } from "@liveagent/ui/components/ui/button";
-import { Label } from "@liveagent/ui/components/ui/label";
 import { NumberInput } from "@liveagent/ui/components/ui/number-input";
 import { SegmentedSlider } from "@liveagent/ui/components/ui/segmented-slider";
 import { Sheet, SheetContent, SheetTitle } from "@liveagent/ui/components/ui/sheet";
@@ -392,6 +392,12 @@ function CustomSettingsDrawer(
   const { settings, setSettings, providerType, onClose } = props;
   const { t } = useLocale();
   const modelOptions = useMemo(() => buildModelOptions(settings), [settings]);
+  // 上下文占用展示三档的动态描述：只解释当前选中档，取代原先罗列三档的长段落。
+  const contextDisplayModeDesc = {
+    statsBar: t("settings.composerContextDisplayStatsBarDesc"),
+    both: t("settings.composerContextDisplayBothDesc"),
+    ring: t("settings.composerContextDisplayRingDesc"),
+  } as const;
 
   function handleModelSettingChange(
     key: "conversationTitleModel" | "commitMessageModel",
@@ -465,14 +471,18 @@ function CustomSettingsDrawer(
               </div>
             </section>
             {/* Composer 上下文占用展示样式（三档滑块，docs/design/composer-context-stats-bar.md §4.7）：
-                从左到右 状态栏 / 都显示 / 用量环，对应 statsBar / both / ring。 */}
+                从左到右 状态栏 / 都显示 / 用量环，对应 statsBar / both / ring。
+                通用说明收进分区头的提示气泡，滑块下方只保留当前档位的一行动态描述。 */}
             <section className="py-5">
-              <div className="flex items-center justify-between gap-3">
-                <Label className="text-[12.5px] font-medium text-foreground/85">
-                  {t("settings.composerContextDisplay")}
-                </Label>
+              <DrawerSectionHeader
+                icon={<Activity className="h-3.5 w-3.5" />}
+                title={t("settings.composerContextDisplay")}
+                hint={t("settings.composerContextDisplayHint")}
+              />
+              <div className="mt-3.5 space-y-2">
                 <SegmentedSlider
                   aria-label={t("settings.composerContextDisplay")}
+                  className="w-full"
                   value={settings.customSettings.composerContextDisplay}
                   options={[
                     { value: "statsBar", label: t("settings.composerContextDisplayStatsBar") },
@@ -485,10 +495,10 @@ function CustomSettingsDrawer(
                     )
                   }
                 />
+                <p className="text-[11px] leading-relaxed text-muted-foreground/70">
+                  {contextDisplayModeDesc[settings.customSettings.composerContextDisplay]}
+                </p>
               </div>
-              <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground/80">
-                {t("settings.composerContextDisplayDesc")}
-              </p>
             </section>
             <FailoverSettingsCard
               settings={settings}

--- a/docs/design/composer-context-stats-bar.md
+++ b/docs/design/composer-context-stats-bar.md
@@ -232,6 +232,10 @@ statsBar={
 - **滑块 UI**：新增通用组件 `SegmentedSlider`（`components/ui/segmented-slider.tsx`）——等宽分段 + 滑动指示块，底层同名原生 radio，方向键换档、Tab 进出分组由浏览器原生承担；`ProvidersSection` 抽屉用它替换 Switch。i18n 标题改为「上下文占用展示」，新增三档标签 key `settings.composerContextDisplayStatsBar` / `...Both` / `...Ring`（zhCN/enUS）。
 - **测试**：`normalization.test.mjs` 改覆盖三态归一化、gateway 同步携带 `"both"`；`context-usage.test.mjs` 与 `conversation-stats-bar.test.mjs` 的源码断言改为三档语义。
 
+### 4.8 修订（2026-08-31）：设置抽屉该分区的布局重构与文案精简（已落地）
+
+纯 UI/文案调整，设置字段与组件裁决逻辑零改动。原「裸标签 + 滑块 + 罗列三档的四行长段落」改为与抽屉其他分区一致的形态：`DrawerSectionHeader`（Activity 图标 + 标题 + 提示气泡）+ 通栏 `SegmentedSlider` + 滑块下方一行只描述**当前选中档**的动态说明。「≥50% 保留手动压缩入口」这类通用信息收进分区头的提示气泡。i18n：删除长段落 key `settings.composerContextDisplayDesc`，新增 `...Hint`（气泡）与 `...StatsBarDesc` / `...BothDesc` / `...RingDesc`（单行档位描述，zhCN/enUS）。
+
 ## 5. 方案取舍：为什么不先做后端聚合
 
 | | A. 纯前端（本方案） | B. 后端聚合命令 |


### PR DESCRIPTION
## Linked issue

Closes #683

## Summary

供应商设置抽屉里的「上下文占用展示」原先是裸标签 + 三档滑块 + 一段罗列三档差异的长说明。这次只改这一小块展示层：

- 分区对齐抽屉其他区块：`DrawerSectionHeader`（Activity 图标 + 标题 + 提示气泡）+ 通栏 `SegmentedSlider`
- 长段落改成「只解释当前选中档」的一行动态说明；「≥50% 保留手动压缩入口」收进分区头气泡
- 三档语义、设置字段与 composer 裁决逻辑不变（`statsBar` / `both` / `ring`）

## Change scope

- Modules: agent-ui
- Key paths:
  - `crates/agent-ui/src/pages/settings/ProvidersSection.tsx`
  - `crates/agent-ui/src/i18n/translations/zhCNSettings.ts`
  - `crates/agent-ui/src/i18n/translations/enUSSettings.ts`
  - `docs/design/composer-context-stats-bar.md`

## Screenshots / preview

<!-- 截图待补 -->

## Verification

- [x] `pnpm typecheck:ui` 通过
- [x] i18n 一致性测试通过（shared-translations + translations）
- [x] 触及 `ProvidersSection` 的源码断言测试通过（portal-layering / provider-copy-config / provider-edit-deeplink / context-usage）
- [x] `pnpm check:fast` 全部通过
- 未改设置字段与 composer 裁决逻辑，因此没有新增行为测试

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.

Made with [Cursor](https://cursor.com)