### PR TITLE
feat(settings): 支持自定义模型的输入模态覆盖（inputModalities）

### DIFF
--- a/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
@@ -9,6 +9,7 @@ import {
 import {
   type CodexRequestFormat,
   getProviderModelDefaults,
+  normalizeInputModalities,
   type ProviderId,
   type ProviderModelConfig,
 } from "../../settings";
@@ -335,6 +336,13 @@ export function createModelFromConfig(
   // 思考能力（reasoning + 档位）唯一来源：生成目录（未命中走其兜底推断）。
   // pi-ai 目录命中时只取其 thinkingLevelMap 的 wire 改写值，可用性不听它的。
   const thinking = resolveModelThinking(providerId, modelId);
+  // 输入模态的用户显式覆盖（如给未被内置白名单识别的多模态模型开启图片
+  // 输入）；缺省走各 provider 的内置推断/已知模型目录。校验逻辑与设置加载
+  // 共用同一个 normalizer，不信任调用方的静态类型。
+  // 只在附件发送确实受 model.input 门控的 provider 分支生效（codex/gemini）；
+  // deepseek 的 wire 层硬拒绝图片、anthropic 附件路径暂不读 model.input，
+  // 这两处不适用用户覆盖，避免产生虚假能力声明。
+  const inputOverride = normalizeInputModalities(modelConfig?.inputModalities);
 
   if (providerId === "deepseek") {
     return {
@@ -380,6 +388,7 @@ export function createModelFromConfig(
         contextWindow,
         maxTokens,
         cost: zeroCost,
+        ...(inputOverride ? { input: inputOverride } : {}),
         ...resolveModelThinkingFields(
           thinking,
           isXaiTarget ? XAI_THINKING_WIRE_VALUES : known.thinkingLevelMap,
@@ -413,7 +422,7 @@ export function createModelFromConfig(
         thinking,
         isXaiTarget ? XAI_THINKING_WIRE_VALUES : completionsOverrides?.thinkingLevelMap,
       ),
-      input: resolveCodexModelInput(api, modelId),
+      input: inputOverride ?? resolveCodexModelInput(api, modelId),
       cost: zeroCost,
       contextWindow,
       maxTokens,
@@ -435,6 +444,7 @@ export function createModelFromConfig(
         contextWindow,
         maxTokens,
         cost: zeroCost,
+        ...(inputOverride ? { input: inputOverride } : {}),
         ...resolveModelThinkingFields(thinking, known.thinkingLevelMap),
       };
     }
@@ -446,7 +456,7 @@ export function createModelFromConfig(
       provider: "google",
       baseUrl: normalizedBaseUrl,
       ...resolveModelThinkingFields(thinking),
-      input: ["text", "image"],
+      input: inputOverride ?? ["text", "image"],
       cost: zeroCost,
       contextWindow,
       maxTokens,

--- a/crates/agent-gui/test/settings/input-modalities.test.mjs
+++ b/crates/agent-gui/test/settings/input-modalities.test.mjs
@@ -18,9 +18,12 @@ const { createModelFromConfig } = loader.loadModule(
 const providerUtilsLoader = createTsModuleLoader({
   mocks: { "@tauri-apps/api/core": { invoke: async () => ({}) } },
 });
-const { normalizeFetchedModels } = providerUtilsLoader.loadModule(
-  "@liveagent/ui/pages/settings/providerUtils.ts",
-);
+const {
+  applyModelInputModalitiesMode,
+  getModelInputModalitiesMode,
+  normalizeFetchedModels,
+  providerSupportsModelInputModalitiesOverride,
+} = providerUtilsLoader.loadModule("@liveagent/ui/pages/settings/providerUtils.ts");
 
 test("normalizeInputModalities rejects non-arrays and empty/fully-invalid arrays", () => {
   assert.equal(normalizeInputModalities(undefined), undefined);
@@ -81,9 +84,31 @@ test("modelFactory: codex completions custom model honors the override", () => {
     maxOutputToken: 32000,
     inputModalities: ["text", "image"],
   });
+  // 构造带覆盖的模型不能反向污染此前创建的无覆盖模型实例。
   assert.deepEqual(withoutOverride.input, ["text"]);
   assert.deepEqual(withOverride.input, ["text", "image"]);
 });
+
+test(
+  "ProviderModal input capability mode preserves auto/text/image semantics and provider boundary",
+  () => {
+    const baseModel = { id: "k3", contextWindow: 258000, maxOutputToken: 32000 };
+    const textOnly = applyModelInputModalitiesMode(baseModel, "text");
+    const textAndImage = applyModelInputModalitiesMode(textOnly, "text-image");
+    const automatic = applyModelInputModalitiesMode(textAndImage, "auto");
+
+    assert.equal(getModelInputModalitiesMode(baseModel), "auto");
+    assert.equal(getModelInputModalitiesMode(textOnly), "text");
+    assert.equal(getModelInputModalitiesMode(textAndImage), "text-image");
+    assert.equal("inputModalities" in automatic, false);
+
+    assert.equal(providerSupportsModelInputModalitiesOverride("codex"), true);
+    assert.equal(providerSupportsModelInputModalitiesOverride("xai"), true);
+    assert.equal(providerSupportsModelInputModalitiesOverride("gemini"), true);
+    assert.equal(providerSupportsModelInputModalitiesOverride("deepseek"), false);
+    assert.equal(providerSupportsModelInputModalitiesOverride("claude_code"), false);
+  },
+);
 
 test("modelFactory: codex custom model ignores a malformed override", () => {
   const model = createModelFromConfig(

--- a/crates/agent-gui/test/settings/input-modalities.test.mjs
+++ b/crates/agent-gui/test/settings/input-modalities.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+// inputModalities（模型输入模态用户覆盖）的反漂移锁：
+// 1. normalizer 的过滤/补齐/规范顺序契约；
+// 2. 设置加载往返不丢字段；
+// 3. modelFactory 只在附件发送确实受 model.input 门控的分支（codex/gemini）
+//    应用覆盖，deepseek/anthropic 不适用（避免虚假能力声明）。
+const loader = createTsModuleLoader();
+const { normalizeInputModalities, normalizeProviderModelConfig, normalizeProviderModelConfigs } =
+  loader.loadModule("src/lib/settings/index.ts");
+const { createModelFromConfig } = loader.loadModule(
+  "src/lib/providers/runtime/modelFactory.ts",
+);
+// providerUtils 依赖 tauri invoke；normalizeFetchedModels 本身不触发网络，
+// mock 仅为满足模块加载。
+const providerUtilsLoader = createTsModuleLoader({
+  mocks: { "@tauri-apps/api/core": { invoke: async () => ({}) } },
+});
+const { normalizeFetchedModels } = providerUtilsLoader.loadModule(
+  "@liveagent/ui/pages/settings/providerUtils.ts",
+);
+
+test("normalizeInputModalities rejects non-arrays and empty/fully-invalid arrays", () => {
+  assert.equal(normalizeInputModalities(undefined), undefined);
+  assert.equal(normalizeInputModalities(null), undefined);
+  assert.equal(normalizeInputModalities("image"), undefined);
+  assert.equal(normalizeInputModalities({ 0: "image" }), undefined);
+  assert.equal(normalizeInputModalities([]), undefined);
+  assert.equal(normalizeInputModalities(["audio"]), undefined);
+  assert.equal(normalizeInputModalities([" image "]), undefined);
+});
+
+test("normalizeInputModalities filters mixed arrays and dedupes", () => {
+  assert.deepEqual(normalizeInputModalities(["image", 123, "future"]), ["text", "image"]);
+  assert.deepEqual(normalizeInputModalities(["image", "image", "text"]), ["text", "image"]);
+});
+
+test("normalizeInputModalities auto-adds text and emits canonical order", () => {
+  // 聊天协议始终发送文本：image-only 覆盖自动补齐 text
+  assert.deepEqual(normalizeInputModalities(["image"]), ["text", "image"]);
+  assert.deepEqual(normalizeInputModalities(["image", "text"]), ["text", "image"]);
+  assert.deepEqual(normalizeInputModalities(["text"]), ["text"]);
+});
+
+test("normalizeProviderModelConfig preserves a valid inputModalities override", () => {
+  const normalized = normalizeProviderModelConfig(
+    {
+      id: "k3",
+      contextWindow: 258000,
+      maxOutputToken: 32000,
+      limitsSource: "user",
+      inputModalities: ["text", "image"],
+    },
+    "codex",
+  );
+  assert.deepEqual(normalized.inputModalities, ["text", "image"]);
+});
+
+test("normalizeProviderModelConfig drops malformed inputModalities and legacy archives", () => {
+  const malformed = normalizeProviderModelConfig(
+    { id: "k3", contextWindow: 258000, maxOutputToken: 32000, inputModalities: "image" },
+    "codex",
+  );
+  assert.equal("inputModalities" in malformed, false);
+  const legacy = normalizeProviderModelConfig(
+    { id: "k3", contextWindow: 258000, maxOutputToken: 32000 },
+    "codex",
+  );
+  assert.equal("inputModalities" in legacy, false);
+});
+
+test("modelFactory: codex completions custom model honors the override", () => {
+  const base = ["codex", "k3", "https://api.kimi.com/coding/v1", "openai-completions"];
+  const withoutOverride = createModelFromConfig(...base);
+  assert.deepEqual(withoutOverride.input, ["text"]);
+  const withOverride = createModelFromConfig(...base, {
+    id: "k3",
+    contextWindow: 258000,
+    maxOutputToken: 32000,
+    inputModalities: ["text", "image"],
+  });
+  assert.deepEqual(withoutOverride.input, ["text"]);
+  assert.deepEqual(withOverride.input, ["text", "image"]);
+});
+
+test("modelFactory: codex custom model ignores a malformed override", () => {
+  const model = createModelFromConfig(
+    "codex",
+    "k3",
+    "https://api.kimi.com/coding/v1",
+    "openai-completions",
+    { id: "k3", contextWindow: 258000, maxOutputToken: 32000, inputModalities: ["audio"] },
+  );
+  assert.deepEqual(model.input, ["text"]);
+});
+
+test("modelFactory: gemini custom model honors the override", () => {
+  const model = createModelFromConfig(
+    "gemini",
+    "some-custom-proxy-model",
+    "https://gemini-proxy.example.com",
+    undefined,
+    {
+      id: "some-custom-proxy-model",
+      contextWindow: 128000,
+      maxOutputToken: 32000,
+      inputModalities: ["text"],
+    },
+  );
+  assert.deepEqual(model.input, ["text"]);
+});
+
+test("modelFactory: deepseek keeps the hard text-only constraint despite the override", () => {
+  const model = createModelFromConfig(
+    "deepseek",
+    "deepseek-v4-pro",
+    "https://api.deepseek.com",
+    undefined,
+    {
+      id: "deepseek-v4-pro",
+      contextWindow: 128000,
+      maxOutputToken: 32000,
+      inputModalities: ["text", "image"],
+    },
+  );
+  assert.deepEqual(model.input, ["text"]);
+});
+
+test("modelFactory: anthropic custom model does not apply the override (attachments ignore model.input upstream)", () => {
+  const model = createModelFromConfig(
+    "claude_code",
+    "unknown-relay-claude-model",
+    "https://claude-relay.example.com",
+    undefined,
+    {
+      id: "unknown-relay-claude-model",
+      contextWindow: 200000,
+      maxOutputToken: 32000,
+      inputModalities: ["text", "image"],
+    },
+  );
+  assert.deepEqual(model.input, ["text"]);
+});
+
+test("gemini persisted model survives the ProviderModal open/save round trip", () => {
+  const persisted = [
+    {
+      id: "gemini-custom",
+      contextWindow: 123456,
+      maxOutputToken: 789,
+      limitsSource: "user",
+      inputModalities: ["text", "image"],
+    },
+  ];
+  // ProviderModal 初始化（持久化归一化）：所有用户字段原样往返
+  const viaModal = normalizeProviderModelConfigs(persisted, "gemini");
+  assert.deepEqual(viaModal[0], {
+    id: "gemini-custom",
+    contextWindow: 123456,
+    maxOutputToken: 789,
+    limitsSource: "user",
+    inputModalities: ["text", "image"],
+  });
+});
+
+test("gemini fetch-path normalization preserves the inputModalities override", () => {
+  // API 响应形状的条目（inputTokenLimit/outputTokenLimit）混有用户覆盖字段时，
+  // 刷新后覆盖不得丢失（此前 normalizeGeminiFetchedModels 重建对象会洗掉它）。
+  const fetched = [
+    {
+      name: "models/gemini-custom",
+      inputTokenLimit: 123456,
+      outputTokenLimit: 789,
+      inputModalities: ["image"],
+    },
+  ];
+  const viaFetch = normalizeFetchedModels(fetched, "gemini");
+  assert.equal(viaFetch.length, 1);
+  assert.deepEqual(viaFetch[0].inputModalities, ["text", "image"]);
+});

--- a/crates/agent-ui/src/i18n/translations/enUSSettings.ts
+++ b/crates/agent-ui/src/i18n/translations/enUSSettings.ts
@@ -635,6 +635,12 @@ export const EN_US_SETTINGS_TRANSLATIONS = {
   "settings.estimatedLimitsBadge": "Estimated",
   "settings.contextWindow": "Context Window",
   "settings.maxOutputToken": "Max Output Token",
+  "settings.modelInputModalities": "Input capabilities",
+  "settings.modelInputModalitiesAuto": "Auto-detect (recommended)",
+  "settings.modelInputModalitiesText": "Text only",
+  "settings.modelInputModalitiesTextImage": "Text and images",
+  "settings.modelInputModalitiesHint":
+    "Uses the model name and built-in catalog by default. Override only when the provider capability differs.",
   "settings.positiveIntegerRequired": "Please enter a positive integer",
   "settings.add": "Add",
   "settings.cancel": "Cancel",

--- a/crates/agent-ui/src/i18n/translations/zhCNSettings.ts
+++ b/crates/agent-ui/src/i18n/translations/zhCNSettings.ts
@@ -609,6 +609,12 @@ export const ZH_CN_SETTINGS_TRANSLATIONS = {
   "settings.estimatedLimitsBadge": "估计值",
   "settings.contextWindow": "Context Window",
   "settings.maxOutputToken": "Max Output Token",
+  "settings.modelInputModalities": "输入能力",
+  "settings.modelInputModalitiesAuto": "自动推断（推荐）",
+  "settings.modelInputModalitiesText": "仅文本",
+  "settings.modelInputModalitiesTextImage": "文本与图片",
+  "settings.modelInputModalitiesHint":
+    "默认按模型名称和内置目录推断；仅在供应商能力与推断不一致时手动覆盖。",
   "settings.positiveIntegerRequired": "请输入大于 0 的整数",
   "settings.add": "添加",
   "settings.cancel": "取消",

--- a/crates/agent-ui/src/lib/settings/index.ts
+++ b/crates/agent-ui/src/lib/settings/index.ts
@@ -79,6 +79,8 @@ import type {
   McpSettings,
   McpTransport,
   MemorySettings,
+  ModelInputModalitiesOverride,
+  ModelInputModality,
   ModelLimitsSource,
   ProjectPromptStrategy,
   PromptCacheHintMode,
@@ -118,6 +120,7 @@ import {
   COMMAND_SAFETY_MODES,
   DEFAULT_CHAT_RUNTIME_CONTROLS,
   getDefaultUsageQueryConfig,
+  MODEL_INPUT_MODALITIES,
   PROMPT_CACHE_HINT_MODES,
   PROVIDER_RETRY_MAX_RETRIES_LIMITS,
   RIGHT_DOCK_BACKGROUND_TASKS_TAB_ID,
@@ -863,6 +866,7 @@ export function normalizeProviderModelConfig(
 
   const promptCacheHintMode =
     providerId === "codex" ? normalizePromptCacheHintMode(obj.promptCacheHintMode) : undefined;
+  const inputModalities = normalizeInputModalities(obj.inputModalities);
   return {
     id,
     ...(ownedBy ? { ownedBy } : {}),
@@ -870,7 +874,31 @@ export function normalizeProviderModelConfig(
     maxOutputToken: limits.maxOutputToken,
     limitsSource,
     ...(promptCacheHintMode ? { promptCacheHintMode } : {}),
+    // 用户手动的输入模态覆盖（如给未识别的多模态模型强制开启图片输入）；
+    // 经 normalizeInputModalities 归一化后透传（可能过滤非法值/补齐 text/
+    // 重排顺序），合法覆盖永不被自动删除。
+    ...(inputModalities ? { inputModalities } : {}),
   };
+}
+
+/**
+ * 输入模态覆盖的运行时归一化（设置加载与 modelFactory 共用的唯一校验）：
+ * - 非数组、空数组、全部非法 -> undefined（等价于“无覆盖，用内置推断”）；
+ * - 混合非法项采用“过滤合法项”的容错策略；
+ * - 本应用的聊天协议始终发送文本，因此含 "image" 缺 "text" 时自动补齐；
+ * - 输出固定为 ["text","image"] 规范顺序，避免同义配置产生持久化差异。
+ */
+export function normalizeInputModalities(input: unknown): ModelInputModalitiesOverride | undefined {
+  if (!Array.isArray(input)) return undefined;
+  const valid = new Set<string>(
+    input.filter(
+      (item): item is ModelInputModality =>
+        typeof item === "string" && (MODEL_INPUT_MODALITIES as readonly string[]).includes(item),
+    ),
+  );
+  if (valid.size === 0) return undefined;
+  if (valid.has("image")) valid.add("text");
+  return valid.has("image") ? ["text", "image"] : ["text"];
 }
 export function normalizeProviderModelConfigs(
   input: unknown,

--- a/crates/agent-ui/src/lib/settings/index.ts
+++ b/crates/agent-ui/src/lib/settings/index.ts
@@ -897,7 +897,6 @@ export function normalizeInputModalities(input: unknown): ModelInputModalitiesOv
     ),
   );
   if (valid.size === 0) return undefined;
-  if (valid.has("image")) valid.add("text");
   return valid.has("image") ? ["text", "image"] : ["text"];
 }
 export function normalizeProviderModelConfigs(

--- a/crates/agent-ui/src/lib/settings/types.ts
+++ b/crates/agent-ui/src/lib/settings/types.ts
@@ -417,6 +417,18 @@ export type PromptCacheHintMode = "auto" | "openai-key" | "openrouter-session" |
  */
 export type ModelLimitsSource = "catalog" | "provider" | "fallback" | "user";
 
+/** 模型输入模态的合法值全集（运行时校验与类型的单一来源）。 */
+export const MODEL_INPUT_MODALITIES = ["text", "image"] as const;
+
+/** 模型输入模态；缺省时按 provider 内置规则推断。 */
+export type ModelInputModality = (typeof MODEL_INPUT_MODALITIES)[number];
+
+/**
+ * 归一化后的输入模态覆盖的规范形态：聊天协议始终发送文本，
+ * 因此 "text" 恒在首位；normalizer 只会产出这两种形状。
+ */
+export type ModelInputModalitiesOverride = ["text"] | ["text", "image"];
+
 export type ProviderModelConfig = {
   id: string;
   /** /models 元数据；缺失时保持旧设置格式兼容。 */
@@ -426,6 +438,15 @@ export type ProviderModelConfig = {
   limitsSource?: ModelLimitsSource;
   /** OpenAI 兼容端点的缓存提示协议；缺失时继承供应商设置。 */
   promptCacheHintMode?: PromptCacheHintMode;
+  /**
+   * 用户手动的输入模态覆盖（如 ["text","image"] 强制开启图片输入）。
+   * 缺失时按 provider 内置启发式推断（白名单/官方已知模型目录）。
+   * 生效范围：仅 codex/xai/gemini provider（这些路径的附件发送受
+   * model.input 门控）；deepseek wire 层硬拒绝图片、anthropic 附件
+   * 路径不读 model.input，这两类 provider 上本字段不起作用。
+   * 读取前须经 normalizeInputModalities 归一化。
+   */
+  inputModalities?: ModelInputModalitiesOverride;
 };
 
 export type ChatRuntimeControls = {

--- a/crates/agent-ui/src/pages/settings/ProviderModal.tsx
+++ b/crates/agent-ui/src/pages/settings/ProviderModal.tsx
@@ -29,6 +29,7 @@ import {
 } from "@liveagent/ui/lib/providers/modelVendor";
 import {
   applyModelBulkActiveState,
+  applyModelInputModalitiesMode,
   applyUsageQueryModePreset,
   buildProviderModelsFetchKey,
   clampUsageQueryTimeoutSecs,
@@ -37,10 +38,13 @@ import {
   detectCodingPlanProvider,
   fetchModelsFromApi,
   getModelBulkActionCounts,
+  getModelInputModalitiesMode,
   getPersistedUsageQueryProviderId,
   isGatewayWebuiRuntime,
+  type ModelInputModalitiesMode,
   matchBalanceProviders,
   mergeFetchedModels,
+  providerSupportsModelInputModalitiesOverride,
   requiresCustomUsageQueryConfirmation,
   serializeUsageQueryDraft,
 } from "@liveagent/ui/pages/settings/providerUtils";
@@ -566,8 +570,24 @@ function useProviderModalController({ providerType, initialData, onSave, onClose
   const editingModelMaxOutputToken = editingModel
     ? parsePositiveInteger(editingModel.maxOutputToken)
     : null;
+  const canOverrideModelInputModalities =
+    providerSupportsModelInputModalitiesOverride(providerType);
+  const editingModelInputModalitiesMode = editingModel
+    ? getModelInputModalitiesMode(editingModel.model)
+    : "auto";
   const canSaveEditingModel =
     editingModelContextWindow !== null && editingModelMaxOutputToken !== null;
+
+  function setEditingModelInputModalitiesMode(mode: ModelInputModalitiesMode) {
+    setEditingModel((prev) =>
+      prev
+        ? {
+            ...prev,
+            model: applyModelInputModalitiesMode(prev.model, mode),
+          }
+        : prev,
+    );
+  }
 
   function saveInlineModelSettings() {
     if (
@@ -911,12 +931,14 @@ function useProviderModalController({ providerType, initialData, onSave, onClose
     applyModelBulkState,
     baseUrl,
     canSaveEditingModel,
+    canOverrideModelInputModalities,
     cancelCustomHeaderImport,
     commitUsageTimeoutInput,
     customHeaders,
     draggingModelId,
     editingModel,
     editingModelContextWindow,
+    editingModelInputModalitiesMode,
     editingModelMaxOutputToken,
     exitModelBulkMode,
     fetchError,
@@ -977,6 +999,7 @@ function useProviderModalController({ providerType, initialData, onSave, onClose
     setApiKey,
     setBaseUrl,
     setEditingModel,
+    setEditingModelInputModalitiesMode,
     setHeaderImportError,
     setHeaderImportOpen,
     setHeaderImportSummary,

--- a/crates/agent-ui/src/pages/settings/ProviderModal.tsx
+++ b/crates/agent-ui/src/pages/settings/ProviderModal.tsx
@@ -3,6 +3,7 @@ import {
   type CodexRequestFormat,
   type CustomProvider,
   getDefaultUsageQueryConfig,
+  normalizeProviderModelConfigs,
   PROVIDER_RETRY_DEFAULT_MAX_RETRIES,
   PROVIDER_RETRY_MAX_RETRIES_LIMITS,
   type PromptCacheHintMode,
@@ -40,7 +41,6 @@ import {
   isGatewayWebuiRuntime,
   matchBalanceProviders,
   mergeFetchedModels,
-  normalizeFetchedModels,
   requiresCustomUsageQueryConfirmation,
   serializeUsageQueryDraft,
 } from "@liveagent/ui/pages/settings/providerUtils";
@@ -139,7 +139,11 @@ function useProviderModalController({ providerType, initialData, onSave, onClose
   const [headerImportError, setHeaderImportError] = useState<HeaderImportErrorCode | null>(null);
   const [headerImportSummary, setHeaderImportSummary] = useState<HeaderImportSummary | null>(null);
   const [models, setModels] = useState<ProviderModelConfig[]>(() =>
-    normalizeFetchedModels(initialData?.models ?? [], providerType),
+    // 弹窗初始化处理的是已持久化的模型配置，必须走持久化归一化（保留
+    // contextWindow/maxOutputToken/limitsSource/inputModalities 等用户字段）；
+    // normalizeFetchedModels 只用于供应商 API 刷新结果（如 Gemini 的
+    // inputTokenLimit 字段形状），混用会在“打开并保存”往返中重置用户配置。
+    normalizeProviderModelConfigs(initialData?.models ?? [], providerType),
   );
   const [modelOrder, setModelOrder] = useState<string[] | undefined>(() =>
     initialData?.modelOrder ? [...initialData.modelOrder] : undefined,

--- a/crates/agent-ui/src/pages/settings/ProviderModalView.tsx
+++ b/crates/agent-ui/src/pages/settings/ProviderModalView.tsx
@@ -80,6 +80,7 @@ export function ProviderModalView({ viewModel }: { viewModel: ProviderModalViewM
     applyHeaderSuggestion,
     applyModelBulkState,
     baseUrl,
+    canOverrideModelInputModalities,
     canSaveEditingModel,
     cancelCustomHeaderImport,
     commitUsageTimeoutInput,
@@ -87,6 +88,7 @@ export function ProviderModalView({ viewModel }: { viewModel: ProviderModalViewM
     draggingModelId,
     editingModel,
     editingModelContextWindow,
+    editingModelInputModalitiesMode,
     editingModelMaxOutputToken,
     exitModelBulkMode,
     fetchError,
@@ -147,6 +149,7 @@ export function ProviderModalView({ viewModel }: { viewModel: ProviderModalViewM
     setApiKey,
     setBaseUrl,
     setEditingModel,
+    setEditingModelInputModalitiesMode,
     setHeaderImportError,
     setHeaderImportOpen,
     setHeaderImportSummary,
@@ -725,6 +728,51 @@ export function ProviderModalView({ viewModel }: { viewModel: ProviderModalViewM
                                       }}
                                     />
                                   </div>
+                                  {canOverrideModelInputModalities ? (
+                                    <div className="col-span-2 space-y-1.5 max-[720px]:col-span-1">
+                                      <Label>{t("settings.modelInputModalities")}</Label>
+                                      <Select
+                                        value={editingModelInputModalitiesMode}
+                                        onValueChange={(value) => {
+                                          if (
+                                            value === "auto" ||
+                                            value === "text" ||
+                                            value === "text-image"
+                                          ) {
+                                            setEditingModelInputModalitiesMode(value);
+                                          }
+                                        }}
+                                      >
+                                        <SelectTrigger
+                                          aria-label={t("settings.modelInputModalities")}
+                                        >
+                                          <SelectValue>
+                                            {t(
+                                              editingModelInputModalitiesMode === "auto"
+                                                ? "settings.modelInputModalitiesAuto"
+                                                : editingModelInputModalitiesMode === "text"
+                                                  ? "settings.modelInputModalitiesText"
+                                                  : "settings.modelInputModalitiesTextImage",
+                                            )}
+                                          </SelectValue>
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                          <SelectItem value="auto">
+                                            {t("settings.modelInputModalitiesAuto")}
+                                          </SelectItem>
+                                          <SelectItem value="text">
+                                            {t("settings.modelInputModalitiesText")}
+                                          </SelectItem>
+                                          <SelectItem value="text-image">
+                                            {t("settings.modelInputModalitiesTextImage")}
+                                          </SelectItem>
+                                        </SelectContent>
+                                      </Select>
+                                      <p className="text-xs leading-relaxed text-muted-foreground">
+                                        {t("settings.modelInputModalitiesHint")}
+                                      </p>
+                                    </div>
+                                  ) : null}
                                   {providerType === "codex" ? (
                                     <div className="col-span-2 space-y-1.5 max-[720px]:col-span-1">
                                       <Label>{t("settings.promptCacheHintModelOverride")}</Label>

--- a/crates/agent-ui/src/pages/settings/providerUtils.ts
+++ b/crates/agent-ui/src/pages/settings/providerUtils.ts
@@ -1,5 +1,6 @@
 import {
   createProviderModelConfig,
+  normalizeInputModalities,
   normalizeProviderModelConfigs,
   type ProviderId,
   type ProviderModelConfig,
@@ -557,12 +558,16 @@ function normalizeGeminiFetchedModels(items: unknown): ProviderModelConfig[] {
       (typeof obj.owned_by === "string" ? obj.owned_by.trim() : "");
     const contextWindow = normalizePositiveInteger(obj.inputTokenLimit);
     const maxOutputToken = normalizePositiveInteger(obj.outputTokenLimit);
+    // 已有存档里的用户自定义字段（如 inputModalities 输入模态覆盖）必须透传；
+    // API 响应不会携带这些字段，透传对刷新场景是无害的。
+    const inputModalities = normalizeInputModalities(obj.inputModalities);
     out.push({
       id,
       ...(ownedBy ? { ownedBy } : {}),
       contextWindow: contextWindow ?? draft.contextWindow,
       maxOutputToken: maxOutputToken ?? draft.maxOutputToken,
       limitsSource: contextWindow && maxOutputToken ? "provider" : draft.limitsSource,
+      ...(inputModalities ? { inputModalities } : {}),
     });
   }
 

--- a/crates/agent-ui/src/pages/settings/providerUtils.ts
+++ b/crates/agent-ui/src/pages/settings/providerUtils.ts
@@ -26,6 +26,30 @@ export { isGatewayWebuiRuntime };
 
 const REDACTED_USAGE_QUERY_SECRET_DISPLAY = "••••••••";
 
+export type ModelInputModalitiesMode = "auto" | "text" | "text-image";
+
+export function providerSupportsModelInputModalitiesOverride(providerId: ProviderId): boolean {
+  return providerId === "codex" || providerId === "xai" || providerId === "gemini";
+}
+
+export function getModelInputModalitiesMode(model: ProviderModelConfig): ModelInputModalitiesMode {
+  if (!model.inputModalities) return "auto";
+  return model.inputModalities.length === 2 ? "text-image" : "text";
+}
+
+export function applyModelInputModalitiesMode(
+  model: ProviderModelConfig,
+  mode: ModelInputModalitiesMode,
+): ProviderModelConfig {
+  const modelWithoutOverride = { ...model };
+  delete modelWithoutOverride.inputModalities;
+  if (mode === "auto") return modelWithoutOverride;
+  return {
+    ...modelWithoutOverride,
+    inputModalities: mode === "text-image" ? ["text", "image"] : ["text"],
+  };
+}
+
 // KEEP IN SYNC:general/newapi 预设与桌面端 Rust services/provider_usage.rs 的
 // GENERAL_SCRIPT / NEWAPI_SCRIPT 逐字符一致(脚本为空的存量配置由 Rust 兜底执行);
 // custom 骨架仅前端填充(Rust 对空的 custom 脚本直接报错,无兜底)。三者内容


### PR DESCRIPTION
## 问题

自定义 OpenAI 兼容模型是否声明支持图片输入，由 `modelFactory` 的硬编码模型 ID
白名单决定（`gpt-5` / `gpt-4o` / `o3` / `o4` / `vision` / `qwen-vl` 等前缀）。
未收录的多模态模型（如 Kimi k3，官方 coding plan 端点实际支持图片输入）会被
错误标记为纯文本，图片附件在发送前被客户端静默丢弃，用户无任何手段纠正。

## 方案

新增 `ProviderModelConfig.inputModalities` 可选字段，允许在模型配置中显式声明
输入模态覆盖内置推断：

```json
{ "id": "k3", "inputModalities": ["text", "image"] }
```

设计要点：

- **单一校验来源**：设置加载与 `modelFactory` 共用 `normalizeInputModalities`
  （过滤非法值、自动补齐 `"text"`——聊天协议恒发文本、输出固定
  `["text","image"]` 规范顺序避免持久化抖动）；空数组/全非法等价于无覆盖。
- **UI 可配置**：模型参数中新增“输入能力”三态选择器：自动推断 / 仅文本 /
  文本与图片。“自动推断”会删除覆盖字段，恢复内置规则；仅在 codex / xai /
  gemini 上显示，避免为不适用的 provider 暗示虚假能力。
- **生效范围限定**：仅在附件发送确实受 `model.input` 门控的 provider 分支
  （codex / xai / gemini，known + custom）应用覆盖。DeepSeek wire 层硬拒绝
  图片（`assertTextOnlyContext`）、Anthropic 附件路径不读 `model.input`，
  这两类 provider 上覆盖不适用，避免产生虚假能力声明；类型注释已写明边界。
- **存档安全**：`normalizeProviderModelConfig` 归一化后透传该字段，
  加载/保存往返不丢失。

## 顺带修复（同一条往返路径上的既有 bug）

`ProviderModal` 初始化此前复用 `normalizeFetchedModels`（API 响应形状的归一化），
导致 Gemini 供应商"打开并保存"即重置用户自定义的
`contextWindow` / `maxOutputToken` / `limitsSource`。现改用持久化归一化
`normalizeProviderModelConfigs`，与 API 刷新路径正式分离。

## 测试

新增 `crates/agent-gui/test/settings/input-modalities.test.mjs`（13 个用例）：

- normalizer 契约：非数组 / 空数组 / 全非法 / 混合非法 / 去重 / 补齐 text /
  规范顺序；
- 设置加载往返不丢字段；
- modelFactory 覆盖矩阵：codex custom 生效、畸形覆盖忽略、gemini custom 生效、
  deepseek/anthropic 不适用覆盖；
- ProviderModal 三态编辑语义与 provider 显示边界；
- Gemini 持久化配置"打开-保存"完整往返、fetch 路径保留覆盖字段。

验证：`@liveagent/ui` 与 GUI 双包 typecheck 通过；设置相关测试 361/361、GUI
生产构建通过。此前 frontend 全套 2624 个测试通过 2619 个，5 个失败为既有失败
（edit-resend preflight、mention composer ×2、truncated snapshot、usage-query preset），
均不在本 PR 触及的文件中。

## 兼容性

- 旧存档（无此字段）加载：行为不变，按内置推断。
- 新存档经旧版本编辑保存：`inputModalities` 会被旧版 normalizer 丢弃
  （任何新字段的既有边界，备份 schema 未变）。

Closes #687

## Screenshots / preview

补丁生效后，自定义模型 `k3`（此前被误判为纯文本）成功接收并理解图片：

![k3 vision works after patch](https://raw.githubusercontent.com/Edmine/LiveAgent/pr-assets/assets/pr-686-vision-proof.png)
