### PR TITLE
fix(chat): 去重 Composer 应用提及

### DIFF
--- a/crates/agent-gui/test/chat/app-mention-dedup.test.mjs
+++ b/crates/agent-gui/test/chat/app-mention-dedup.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDomTestEnv } from "../helpers/dom-test-env.mjs";
+
+const env = await createDomTestEnv();
+const {
+  APP_MENTION_NAME_ATTR,
+  collectAppMentionKeys,
+  createAppMentionChip,
+  enforceUniqueAppMentionsInEditor,
+  sanitizeAppMentionSegments,
+} = env.loadModule("@liveagent/ui/components/chat/MentionComposerInternals.tsx");
+
+function app(name, path, bundleId) {
+  return { name, path, ...(bundleId ? { bundleId } : {}) };
+}
+
+function segment(value) {
+  return { type: "appMention", app: value };
+}
+
+test("draft and paste segments retain only the first stable app identity", () => {
+  const editor = document.createElement("div");
+  editor.appendChild(createAppMentionChip(app("Music", "/Applications/Music.app", "com.apple.Music")));
+
+  const fresh = segment(app("Notes", "/Applications/Notes.app", "com.apple.Notes"));
+  const result = sanitizeAppMentionSegments(editor, [
+    segment(app("Renamed Music", "/tmp/other.app", "com.apple.Music")),
+    fresh,
+    segment(app("Notes Copy", "/tmp/notes.app", "com.apple.Notes")),
+  ]);
+
+  assert.deepEqual(result, [fresh]);
+});
+
+test("draft restore dedupes within the incoming batch when the editor is cleared", () => {
+  const editor = document.createElement("div");
+  const first = segment(app("Tool", "/Applications/Tool.app"));
+  const result = sanitizeAppMentionSegments(
+    editor,
+    [first, segment(app("Tool renamed", "/Applications/Tool.app"))],
+    { includeExistingChips: false },
+  );
+
+  assert.deepEqual(result, [first]);
+});
+
+test("native DOM paste removes duplicate and malformed chips", () => {
+  const editor = document.createElement("div");
+  editor.append(
+    createAppMentionChip(app("Tool", "/Applications/Tool.app")),
+    createAppMentionChip(app("Tool", "/Applications/Tool.app")),
+  );
+  const malformed = document.createElement("span");
+  malformed.setAttribute(APP_MENTION_NAME_ATTR, "");
+  editor.appendChild(malformed);
+
+  enforceUniqueAppMentionsInEditor(editor);
+
+  assert.equal(editor.children.length, 1);
+  assert.equal(collectAppMentionKeys(editor).length, 1);
+});
+
+test.after(() => env.cleanup());

--- a/crates/agent-gui/test/chat/mention-app-suggestions.test.mjs
+++ b/crates/agent-gui/test/chat/mention-app-suggestions.test.mjs
@@ -92,14 +92,17 @@ test("app suggestions ride the @ trigger and are host-gated by the mentionApps p
   assert.match(composer, /insertAppMentionChip\(mentionCtx, suggestion\.app\)/);
 });
 
-test("the root popup folds installed apps into a dedicated submenu", () => {
+test("the root popup folds available installed apps into a dedicated submenu", () => {
   // 根级只呈现类别入口；应用候选和文件、会话候选一样，进入二级菜单后
   // 才生成。应用子菜单沿用统一的 30 项上限，不再为根级混排而裁到 3 项。
   assert.match(model, /category: "apps" \| "files" \| "conversations"/);
   assert.match(model, /MentionMenuMode = "root" \| "apps" \| "files" \| "conversations"/);
   assert.match(composer, /\{ type: "category", category: "apps" \}/);
   assert.match(composer, /if \(mentionMenuMode === "apps"\)/);
-  assert.match(composer, /sortAppsByMentionRecency\(mentionApps, readAppMentionRecents\(\)\)/);
+  assert.match(
+    composer,
+    /sortAppsByMentionRecency\(availableMentionApps, readAppMentionRecents\(\)\)/,
+  );
   assert.match(composer, /if \(next\.length >= MAX_SUGGESTIONS\) break/);
   assert.doesNotMatch(composer, /MAX_APP_SUGGESTIONS/);
   assert.match(overlays, /mode === "apps"/);
@@ -114,7 +117,10 @@ test("selecting an app records it and the next @ popup ranks recents first", () 
   // 选中即落榜单（localStorage 版本化键），下次 @ 会话开启时重读并把
   // 最近使用的应用排到分组最前；未上榜的保持宿主的字母序。
   assert.match(composer, /recordAppMentionUse\(suggestion\.app\)/);
-  assert.match(composer, /sortAppsByMentionRecency\(mentionApps, readAppMentionRecents\(\)\)/);
+  assert.match(
+    composer,
+    /sortAppsByMentionRecency\(availableMentionApps, readAppMentionRecents\(\)\)/,
+  );
   const recency = source(agentUiRoot, "lib/chat/appMentionRecency.ts");
   assert.match(recency, /"liveagent\.app-mention-recents\.v1"/);
   // 身份键必须复用图标注册表的同一份裁决（bundle id > path > name），
@@ -173,6 +179,15 @@ test("selecting an app records it and the next @ popup ranks recents first", () 
     apps.map((app) => app.name),
     ["Arc", "Mail", "Safari", "Terminal"],
   );
+});
+
+test("an app already mentioned is excluded and cannot be inserted again", () => {
+  assert.match(composer, /const selectedAppMentionKeys = useMemo/);
+  assert.match(composer, /const availableMentionApps = useMemo/);
+  assert.match(composer, /availableMentionApps\.length > 0/);
+  assert.match(composer, /collectAppMentionKeys\(editor\)\.includes\(key\)/);
+  assert.match(composer, /sanitizeAppMentionSegments\(/);
+  assert.match(composer, /enforceUniqueAppMentionsInEditor\(el\)/);
 });
 
 test("the chip shows the real app logo via the icon registry, never via DOM attributes", () => {

--- a/crates/agent-ui/src/components/chat/MentionComposer.tsx
+++ b/crates/agent-ui/src/components/chat/MentionComposer.tsx
@@ -11,6 +11,7 @@ import {
 import { ClipboardPaste, Copy, ScanText, Scissors } from "@liveagent/ui/components/IconSet";
 import { useLocale } from "@liveagent/ui/i18n/index";
 import {
+  appMentionRecencyKey,
   readAppMentionRecents,
   recordAppMentionUse,
   sortAppsByMentionRecency,
@@ -51,6 +52,7 @@ import {
   CommitMentionTooltip,
   type ComposerContextMenuState,
   clampComposerContextMenuPosition,
+  collectAppMentionKeys,
   commitMentionFromElement,
   countLargePasteLines,
   createAppMentionChip,
@@ -71,6 +73,7 @@ import {
   editorTextIsEmpty,
   ejectCaretFromChip,
   enforceConversationMentionConstraintsInEditor,
+  enforceUniqueAppMentionsInEditor,
   ensureTrailingCaretAnchor,
   extractClipboardFiles,
   formatCommitMentionToken,
@@ -125,6 +128,7 @@ import {
   removeStaleCaretAnchorsAroundSelection,
   resolveComposerSelection,
   resolveComposerSelectionText,
+  sanitizeAppMentionSegments,
   sanitizeConversationMentionSegments,
   scheduleComposerSelectionScroll,
   selectComposerContents,
@@ -518,6 +522,20 @@ export const MentionComposer = memo(
     );
     const conversationMentionLimitReached =
       selectedConversationIds.size >= MAX_CONVERSATION_MENTIONS;
+    const selectedAppMentionKey = collectAppMentionKeys(editorRef.current).sort().join("\n");
+    const selectedAppMentionKeys = useMemo(
+      () => new Set(selectedAppMentionKey ? selectedAppMentionKey.split("\n") : []),
+      [selectedAppMentionKey],
+    );
+    const availableMentionApps = useMemo(() => {
+      const seen = new Set(selectedAppMentionKeys);
+      return mentionApps.filter((app) => {
+        const key = appMentionRecencyKey(app);
+        if (!key || seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+    }, [mentionApps, selectedAppMentionKeys]);
     const suggestions = useMemo<MentionSuggestion[]>(() => {
       if (mentionCtx === null) {
         return [];
@@ -541,7 +559,7 @@ export const MentionComposer = memo(
       if (mentionMenuMode === "root") {
         // 根级只展示引用类别，候选实体全部收进各自的二级菜单。
         const categories: MentionSuggestion[] = [
-          ...(mentionApps.length > 0
+          ...(availableMentionApps.length > 0
             ? ([{ type: "category", category: "apps" }] satisfies MentionSuggestion[])
             : []),
           { type: "category", category: "files" },
@@ -567,7 +585,7 @@ export const MentionComposer = memo(
 
       if (mentionMenuMode === "apps") {
         const next: MentionSuggestion[] = [];
-        const orderedApps = sortAppsByMentionRecency(mentionApps, readAppMentionRecents());
+        const orderedApps = sortAppsByMentionRecency(availableMentionApps, readAppMentionRecents());
         for (const app of orderedApps) {
           const haystack = `${app.name}\n${app.bundleId ?? ""}\n${app.path}`.toLowerCase();
           if (normalizedMentionQuery && !haystack.includes(normalizedMentionQuery)) continue;
@@ -624,7 +642,7 @@ export const MentionComposer = memo(
       conversationMentionsEnabled,
       conversationSearchResults,
       enabledSkills,
-      mentionApps,
+      availableMentionApps,
       mentionCtx,
       mentionMenuMode,
       mentionSessionSearchIndex,
@@ -980,11 +998,15 @@ export const MentionComposer = memo(
           closeCommitTooltip();
           closeComposerContextMenu();
 
-          const sanitizedSegments = sanitizeConversationMentionSegments(el, draft.segments, {
-            currentConversationId,
-            conversationMentionsEnabled,
-            includeExistingChips: false,
-          });
+          const sanitizedSegments = sanitizeAppMentionSegments(
+            el,
+            sanitizeConversationMentionSegments(el, draft.segments, {
+              currentConversationId,
+              conversationMentionsEnabled,
+              includeExistingChips: false,
+            }),
+            { includeExistingChips: false },
+          );
           for (const segment of sanitizedSegments) {
             if (segment.type === "largePaste") {
               largePastesRef.current.set(segment.paste.id, segment.paste);
@@ -1331,6 +1353,11 @@ export const MentionComposer = memo(
           }
           insertConversationMentionChip(mentionCtx, suggestion.conversation);
         } else if (suggestion.type === "app") {
+          const editor = editorRef.current;
+          const key = appMentionRecencyKey(suggestion.app);
+          if (!editor || !key || collectAppMentionKeys(editor).includes(key)) {
+            return;
+          }
           insertAppMentionChip(mentionCtx, suggestion.app);
           // 记入最近使用榜单：下次 @ 弹层把该应用排到应用分组最前。
           recordAppMentionUse(suggestion.app);
@@ -1440,6 +1467,7 @@ export const MentionComposer = memo(
           currentConversationId,
           conversationMentionsEnabled,
         });
+        enforceUniqueAppMentionsInEditor(el);
         closeMentionSession();
         refreshEmptyState();
         refreshMention();
@@ -1464,10 +1492,13 @@ export const MentionComposer = memo(
         serializedSegments &&
         insertComposerSegmentsAtSelection(
           el,
-          sanitizeConversationMentionSegments(el, serializedSegments, {
-            currentConversationId,
-            conversationMentionsEnabled,
-          }),
+          sanitizeAppMentionSegments(
+            el,
+            sanitizeConversationMentionSegments(el, serializedSegments, {
+              currentConversationId,
+              conversationMentionsEnabled,
+            }),
+          ),
           largePastesRef.current,
         )
       ) {
@@ -2015,10 +2046,13 @@ export const MentionComposer = memo(
           if (editor) {
             insertComposerSegmentsAtSelection(
               editor,
-              sanitizeConversationMentionSegments(editor, restoredSegments, {
-                currentConversationId,
-                conversationMentionsEnabled,
-              }),
+              sanitizeAppMentionSegments(
+                editor,
+                sanitizeConversationMentionSegments(editor, restoredSegments, {
+                  currentConversationId,
+                  conversationMentionsEnabled,
+                }),
+              ),
               largePastesRef.current,
             );
           }
@@ -2046,10 +2080,13 @@ export const MentionComposer = memo(
           editor &&
           insertComposerSegmentsAtSelection(
             editor,
-            sanitizeConversationMentionSegments(editor, serializedSegments, {
-              currentConversationId,
-              conversationMentionsEnabled,
-            }),
+            sanitizeAppMentionSegments(
+              editor,
+              sanitizeConversationMentionSegments(editor, serializedSegments, {
+                currentConversationId,
+                conversationMentionsEnabled,
+              }),
+            ),
             largePastesRef.current,
           )
         ) {

--- a/crates/agent-ui/src/components/chat/MentionComposerInternals.tsx
+++ b/crates/agent-ui/src/components/chat/MentionComposerInternals.tsx
@@ -7,6 +7,7 @@ import {
 import { getFileTypeIconSvg } from "@liveagent/ui/components/chat/fileTypeIcons";
 import { SKILL_ICON_SVG_MARKUP } from "@liveagent/ui/components/IconSet";
 import { getAppMentionIconDataUrl } from "@liveagent/ui/lib/chat/appMentionIcons";
+import { appMentionRecencyKey } from "@liveagent/ui/lib/chat/appMentionRecency";
 import { normalizeLogicalLineEndings } from "@liveagent/ui/lib/chat/composerText";
 import {
   type CodeMentionReference,
@@ -766,6 +767,48 @@ export function appMentionFromElement(el: HTMLElement): MentionComposerAppMentio
     bundleId: el.getAttribute(APP_MENTION_BUNDLE_ID_ATTR)?.trim() || undefined,
     path: el.getAttribute(APP_MENTION_PATH_ATTR)?.trim() ?? "",
   });
+}
+
+export function collectAppMentionKeys(root: HTMLElement | null) {
+  if (!root) return [];
+  return [...root.querySelectorAll<HTMLElement>(`[${APP_MENTION_NAME_ATTR}]`)]
+    .map(appMentionFromElement)
+    .filter((app): app is MentionComposerAppMention => app !== null)
+    .map(appMentionRecencyKey)
+    .filter(Boolean);
+}
+
+export function sanitizeAppMentionSegments(
+  root: HTMLElement,
+  segments: MentionComposerDraftSegment[],
+  options: { includeExistingChips?: boolean } = {},
+): MentionComposerDraftSegment[] {
+  const selectedKeys = new Set<string>();
+  if (options.includeExistingChips !== false) {
+    for (const key of collectAppMentionKeys(root)) selectedKeys.add(key);
+  }
+  return segments.filter((segment) => {
+    if (segment.type !== "appMention") return true;
+    const key = appMentionRecencyKey(segment.app);
+    if (!key || selectedKeys.has(key)) return false;
+    selectedKeys.add(key);
+    return true;
+  });
+}
+
+/** Native paste can bypass the segment pipeline. Retain only the first chip
+ * for each stable app identity there as well. */
+export function enforceUniqueAppMentionsInEditor(root: HTMLElement) {
+  const selectedKeys = new Set<string>();
+  for (const chip of [...root.querySelectorAll<HTMLElement>(`[${APP_MENTION_NAME_ATTR}]`)]) {
+    const app = appMentionFromElement(chip);
+    const key = app ? appMentionRecencyKey(app) : "";
+    if (!key || selectedKeys.has(key)) {
+      chip.remove();
+      continue;
+    }
+    selectedKeys.add(key);
+  }
 }
 
 export function clipboardRecord(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary

- 已引入应用从 @ 应用候选中移除，候选耗尽时隐藏应用入口
- 选择动作按 bundleId > path > name 再做实时 DOM 防重
- 草稿恢复、结构化剪贴板和原生粘贴共用去重约束
- 保持最近使用排序、图标与序列化行为不变

## Screenshots / preview

修复前复现：同一应用可被连续插入两次。修复后，候选、选择、草稿恢复和粘贴入口都会统一收敛为一个应用提及。

![同一应用重复引入的修复前复现](https://raw.githubusercontent.com/yovinchen/LiveAgent/651851211795335d244f8ff1b3e2552b937d7f7f/.github/pr-assets/2026-08/pr-691-app-mention-reproduction.png)

## Validation

- node --test：22/22 聚焦测试通过
- @liveagent/ui typecheck
- @liveagent/ui lint
- liveagent lint
- Desktop GUI production build
- Gateway WebUI production build
- git diff --check

Closes #688
