### PR TITLE
fix(chat): 限制窄分栏引用弹层宽度

### DIFF
--- a/crates/agent-gui/test/chat/mention-popup-layout.test.mjs
+++ b/crates/agent-gui/test/chat/mention-popup-layout.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const { resolveMentionPopupHorizontalLayout } = createTsModuleLoader().loadModule(
+  "@liveagent/ui/lib/chat/mentionPopupLayout.ts",
+);
+
+test("narrow workbench panes keep the popup at the composer width", () => {
+  assert.deepEqual(resolveMentionPopupHorizontalLayout({ left: 16, width: 288 }, 1200), {
+    left: 16,
+    width: 288,
+  });
+});
+
+test("the rightmost pane is clamped inside the viewport", () => {
+  assert.deepEqual(resolveMentionPopupHorizontalLayout({ left: 930, width: 288 }, 1200), {
+    left: 900,
+    width: 288,
+  });
+});
+
+test("extremely narrow viewports still return a renderable layout", () => {
+  const layout = resolveMentionPopupHorizontalLayout({ left: 0, width: 380 }, 8);
+  assert.deepEqual(layout, { left: 3.5, width: 1 });
+  assert.ok(layout.left + layout.width <= 8);
+});
+
+test("popup CSS no longer overrides the measured composer width", () => {
+  const css = readFileSync(
+    new URL("../../../agent-ui/src/styles/common-settings.css", import.meta.url),
+    "utf8",
+  );
+  const rule = css.match(/\.mention-popup-enter \{[\s\S]*?\}/)?.[0] ?? "";
+  assert.match(rule, /min-width:\s*0/);
+  assert.doesNotMatch(rule, /380px/);
+});

--- a/crates/agent-ui/src/components/chat/MentionComposerOverlays.tsx
+++ b/crates/agent-ui/src/components/chat/MentionComposerOverlays.tsx
@@ -9,6 +9,7 @@ import {
   Paperclip,
 } from "@liveagent/ui/components/IconSet";
 import { useLocale } from "@liveagent/ui/i18n/index";
+import { resolveMentionPopupHorizontalLayout } from "@liveagent/ui/lib/chat/mentionPopupLayout";
 import { cn } from "@liveagent/ui/lib/shared/utils";
 import { type RefObject, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -79,9 +80,10 @@ export function Popup({
 
     const update = () => {
       const rect = inputSurface.getBoundingClientRect();
-      popup.style.left = `${rect.left}px`;
+      const horizontal = resolveMentionPopupHorizontalLayout(rect, window.innerWidth);
+      popup.style.left = `${horizontal.left}px`;
       popup.style.bottom = `${Math.max(8, window.innerHeight - rect.top + 8)}px`;
-      popup.style.width = `${rect.width}px`;
+      popup.style.width = `${horizontal.width}px`;
     };
 
     update();

--- a/crates/agent-ui/src/lib/chat/mentionPopupLayout.ts
+++ b/crates/agent-ui/src/lib/chat/mentionPopupLayout.ts
@@ -1,0 +1,26 @@
+const MENTION_POPUP_VIEWPORT_MARGIN_PX = 12;
+
+export type MentionPopupHorizontalLayout = {
+  left: number;
+  width: number;
+};
+
+export function resolveMentionPopupHorizontalLayout(
+  anchor: { left: number; width: number },
+  viewportWidth: number,
+): MentionPopupHorizontalLayout {
+  const safeViewportWidth = Math.max(1, Number.isFinite(viewportWidth) ? viewportWidth : 1);
+  const margin = Math.min(
+    MENTION_POPUP_VIEWPORT_MARGIN_PX,
+    Math.max(0, (safeViewportWidth - 1) / 2),
+  );
+  const availableWidth = Math.max(1, safeViewportWidth - margin * 2);
+  const anchorWidth = Number.isFinite(anchor.width) ? anchor.width : availableWidth;
+  const width = Math.min(Math.max(1, anchorWidth), availableWidth);
+  const anchorLeft = Number.isFinite(anchor.left) ? anchor.left : margin;
+  const left = Math.min(
+    Math.max(margin, anchorLeft),
+    Math.max(margin, safeViewportWidth - margin - width),
+  );
+  return { left, width };
+}

--- a/crates/agent-ui/src/styles/common-settings.css
+++ b/crates/agent-ui/src/styles/common-settings.css
@@ -124,7 +124,7 @@
   .mention-popup-enter {
     animation: mentionPopupIn 0.15s cubic-bezier(0.16, 1, 0.3, 1);
     transform-origin: bottom center;
-    min-width: min(380px, calc(100vw - 24px));
+    min-width: 0;
   }
 
   .mention-popup-item {


### PR DESCRIPTION
## Summary

- 移除 @ 引用弹层遗留的 380px CSS 最小宽度
- 弹层宽度以所属 Composer 卡片实测宽度为准
- 新增 12px 视口边缘钳制，覆盖最右侧 Pane 和极窄窗口
- Desktop 与 Gateway WebUI 继续复用同一布局实现

## Screenshots / preview

修复前复现：窄 Pane 中弹层仍被 380px 最小宽度撑开并跨出所属输入区。修复后弹层匹配 Composer 宽度，并在视口两侧保留 12px 安全边距。

![窄 Pane 中引用弹层越界的修复前复现](https://raw.githubusercontent.com/yovinchen/LiveAgent/651851211795335d244f8ff1b3e2552b937d7f7f/.github/pr-assets/2026-08/pr-693-popup-width-reproduction.png)

## Validation

- 288px 窄输入区、最右侧 Pane、极窄视口布局测试
- @liveagent/ui typecheck 与 lint
- liveagent lint
- Desktop GUI production build
- Gateway WebUI production build
- git diff --check

Closes #690
