### PR TITLE
style(drag): 统一 Desktop 与 WebUI 的拖拽添加反馈

### DIFF
--- a/crates/agent-gateway/test/webui/session-workbench-web-drag.test.mjs
+++ b/crates/agent-gateway/test/webui/session-workbench-web-drag.test.mjs
@@ -361,7 +361,8 @@ test("an explicit dock close cascades to the leased pane via the closed event", 
 
 test("the canvas renders the drop preview and the drag ghost from dragState", () => {
   assert.match(viewSource, /dropPreview=\{\s*dragState\?\.previewRect/);
-  assert.ok(viewSource.includes("data-workbench-drag-ghost"));
+  assert.ok(viewSource.includes("<WorkbenchDragGhost"));
+  assert.ok(viewSource.includes("payload={workbenchController.dragState.payload}"));
 });
 
 test("pane chrome, sidebar and right dock all expose drag entry points", () => {

--- a/crates/agent-gateway/web/src/app/GatewayAppView.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayAppView.tsx
@@ -20,6 +20,7 @@ import { ScrollArea } from "@liveagent/ui/components/ui/scroll-area";
 import { PaneChrome } from "@liveagent/ui/components/workbench/PaneChrome";
 import { UnsupportedPaneSurface } from "@liveagent/ui/components/workbench/surfaces/UnsupportedPaneSurface";
 import { WorkbenchCanvas } from "@liveagent/ui/components/workbench/WorkbenchCanvas";
+import { WorkbenchDragGhost } from "@liveagent/ui/components/workbench/WorkbenchDragGhost";
 import { WorkbenchEmptyState } from "@liveagent/ui/components/workbench/WorkbenchEmptyState";
 import { WorkspaceOverlayHost } from "@liveagent/ui/components/workspace-editor/WorkspaceOverlayHost";
 import { isWorkspacePreviewPath } from "@liveagent/ui/components/workspace-editor/workspaceImagePreview";
@@ -1056,21 +1057,11 @@ export function GatewayAppView({ viewModel }: { viewModel: GatewayAppViewModel }
   // 拖拽幽灵:跟随指针的载荷标题,提交/取消后随 dragState 清空。
   const workbenchDragGhost =
     sessionWorkbench.enabled && workbenchController.dragState ? (
-      <div
+      <WorkbenchDragGhost
         ref={workbenchController.dragGhostRef}
-        data-workbench-drag-ghost=""
-        className="layer-popover pointer-events-none fixed max-w-[220px] truncate rounded-md border border-border bg-background/95 px-2.5 py-1 text-xs text-foreground shadow-md"
-        style={{
-          left: 0,
-          top: 0,
-          transform:
-            "translate3d(var(--workbench-drag-ghost-x, -9999px), var(--workbench-drag-ghost-y, -9999px), 0)",
-          willChange: "transform",
-        }}
-      >
-        {workbenchController.dragState.payload.title ||
-          translate("chat.pendingTitle", settings.locale)}
-      </div>
+        payload={workbenchController.dragState.payload}
+        fallbackTitle={translate("chat.pendingTitle", settings.locale)}
+      />
     ) : null;
   return (
     <LocaleContext.Provider value={localeContextValue}>

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -18,6 +18,7 @@ import {
   WORKBENCH_CANVAS_DIVIDER_SIZE,
   WorkbenchCanvas,
 } from "@liveagent/ui/components/workbench/WorkbenchCanvas";
+import { WorkbenchDragGhost } from "@liveagent/ui/components/workbench/WorkbenchDragGhost";
 import { WorkbenchEmptyState } from "@liveagent/ui/components/workbench/WorkbenchEmptyState";
 import { useWorkspaceOverlays } from "@liveagent/ui/components/workspace-editor/useWorkspaceOverlays";
 import { WorkspaceOverlayHost } from "@liveagent/ui/components/workspace-editor/WorkspaceOverlayHost";
@@ -3657,20 +3658,11 @@ export function ChatPage(props: ChatPageProps) {
 
   const workbenchDragGhost =
     sessionWorkbench.enabled && workbenchDragState ? (
-      <div
+      <WorkbenchDragGhost
         ref={workbenchDragGhostRef}
-        data-workbench-drag-ghost=""
-        className="layer-popover pointer-events-none fixed max-w-[220px] truncate rounded-md border border-border bg-background/95 px-2.5 py-1 text-xs text-foreground shadow-md"
-        style={{
-          left: 0,
-          top: 0,
-          transform:
-            "translate3d(var(--workbench-drag-ghost-x, -9999px), var(--workbench-drag-ghost-y, -9999px), 0)",
-          willChange: "transform",
-        }}
-      >
-        {workbenchDragState.payload.title || t("chat.pendingTitle")}
-      </div>
+        payload={workbenchDragState.payload}
+        fallbackTitle={t("chat.pendingTitle")}
+      />
     ) : null;
 
   return (

--- a/crates/agent-gui/test/chat/workbench-canvas-contracts.test.mjs
+++ b/crates/agent-gui/test/chat/workbench-canvas-contracts.test.mjs
@@ -19,6 +19,12 @@ const dividerLayerSource = readSource(
 const workbenchCanvasSource = readSource(
   "../../../agent-ui/src/components/workbench/WorkbenchCanvas.tsx",
 );
+const workbenchDragGhostSource = readSource(
+  "../../../agent-ui/src/components/workbench/WorkbenchDragGhost.tsx",
+);
+const dragAddIndicatorSource = readSource(
+  "../../../agent-ui/src/components/drag/DragAddIndicator.tsx",
+);
 const workspaceDropCommitSource = readSource(
   "../../../agent-ui/src/lib/workbench/workspaceDropCommit.ts",
 );
@@ -114,14 +120,17 @@ test("desktop exposes the same unavailable-drop feedback path as Web", () => {
   assert.match(chatPageSource, /workbench\.conversationAlreadyOpen/);
 });
 
-test("Desktop and Web render the same shared canvas, pane chrome, and drag ghost styling", () => {
+test("Desktop and Web render the same shared canvas, pane chrome, and drag ghost", () => {
   for (const source of [chatPageSource, gatewayViewSource]) {
     assert.match(source, /<WorkbenchCanvas/);
     assert.match(source, /<PaneChrome/);
+    assert.match(source, /<WorkbenchDragGhost/);
   }
-  const dragGhostClass =
-    /className="(layer-popover pointer-events-none fixed max-w-\[220px\][^"]+)"/;
-  assert.equal(chatPageSource.match(dragGhostClass)?.[1], gatewayViewSource.match(dragGhostClass)?.[1]);
+  assert.match(workbenchDragGhostSource, /payload\.kind !== "pane"/);
+  assert.match(workbenchDragGhostSource, /data-workbench-drag-operation/);
+  assert.match(workbenchDragGhostSource, /<DragAddIndicator/);
+  assert.match(dragAddIndicatorSource, /bg-emerald-500/);
+  assert.match(dragAddIndicatorSource, /<Plus/);
 
   const blockedBannerClass =
     /className="(flex shrink-0 items-center gap-2 border-b border-amber-500\/30[^"]+)"/;

--- a/crates/agent-gui/test/chat/workspace-path-drag.test.mjs
+++ b/crates/agent-gui/test/chat/workspace-path-drag.test.mjs
@@ -10,6 +10,7 @@ class DataTransferStub {
   #values = new Map();
   effectAllowed = "none";
   dropEffect = "none";
+  dragImage = null;
 
   get types() {
     return [...this.#values.keys()];
@@ -21,6 +22,10 @@ class DataTransferStub {
 
   setData(type, value) {
     this.#values.set(type, value);
+  }
+
+  setDragImage(element, x, y) {
+    this.dragImage = { element, x, y };
   }
 }
 
@@ -44,6 +49,32 @@ test("workspace path drag payload round-trips without becoming an upload", () =>
   assert.deepEqual(workspacePathDrag.readWorkspacePathDragPayload(transfer), payload);
   assert.equal(transfer.getData("text/plain"), payload.relativePath);
   workspacePathDrag.clearActiveWorkspacePathDrag();
+});
+
+test("workspace path drag uses the shared compact add indicator as its drag image", () => {
+  const transfer = new DataTransferStub();
+  const indicator = { dataset: { dragAddIndicator: "" } };
+  assert.equal(workspacePathDrag.setWorkspacePathDragImage(transfer, indicator), true);
+  assert.deepEqual(transfer.dragImage, {
+    element: indicator,
+    x: workspacePathDrag.WORKSPACE_PATH_DRAG_IMAGE_HOTSPOT_PX,
+    y: workspacePathDrag.WORKSPACE_PATH_DRAG_IMAGE_HOTSPOT_PX,
+  });
+  assert.equal(workspacePathDrag.setWorkspacePathDragImage(transfer, null), false);
+
+  const fileTreeSource = readFileSync(
+    new URL(
+      "../../../agent-ui/src/components/project-tools/file-tree/index.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(fileTreeSource, /<DragAddIndicator/);
+  assert.match(fileTreeSource, /data-workspace-path-drag-image/);
+  assert.match(
+    fileTreeSource,
+    /setWorkspacePathDragImage\(event\.dataTransfer, workspacePathDragImageRef\.current\)/,
+  );
 });
 
 test("an OS file drag is never claimed by a lingering workspace path payload", () => {

--- a/crates/agent-ui/src/components/drag/DragAddIndicator.tsx
+++ b/crates/agent-ui/src/components/drag/DragAddIndicator.tsx
@@ -1,0 +1,26 @@
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import { cn } from "../../lib/shared/utils";
+import { Plus } from "../IconSet";
+
+export type DragAddIndicatorProps = Omit<ComponentPropsWithoutRef<"div">, "children">;
+
+/** Shared pointer-following affordance for drag operations that add to a target. */
+export const DragAddIndicator = forwardRef<HTMLDivElement, DragAddIndicatorProps>(
+  function DragAddIndicator(props, ref) {
+    const { className, ...rest } = props;
+    return (
+      <div
+        {...rest}
+        ref={ref}
+        data-drag-add-indicator=""
+        aria-hidden="true"
+        className={cn(
+          "flex h-6 w-6 items-center justify-center rounded-full border-2 border-background bg-emerald-500 text-white shadow-[0_3px_10px_rgba(0,0,0,0.28)] ring-1 ring-emerald-700/20 dark:bg-emerald-400 dark:text-emerald-950 dark:ring-emerald-200/30",
+          className,
+        )}
+      >
+        <Plus className="h-4 w-4" strokeWidth={2.75} />
+      </div>
+    );
+  },
+);

--- a/crates/agent-ui/src/components/project-tools/file-tree/index.tsx
+++ b/crates/agent-ui/src/components/project-tools/file-tree/index.tsx
@@ -32,11 +32,13 @@ import {
 } from "react";
 import {
   finishWorkspacePathDrag,
+  setWorkspacePathDragImage,
   writeWorkspacePathDragPayload,
 } from "../../../lib/chat/workspacePathDrag";
 import { cn } from "../../../lib/shared/utils";
 import type { WorkspaceActivityClient } from "../../../lib/workspace-activity/types";
 import { getFileTypeIcon } from "../../chat/fileTypeIcons";
+import { DragAddIndicator } from "../../drag/DragAddIndicator";
 import { Button } from "../../ui/button";
 import { useConfirmDialog } from "../../ui/confirm-dialog";
 import { Input } from "../../ui/input";
@@ -167,6 +169,7 @@ export function FileTreeSurface(props: FileTreeSurfaceProps) {
   const [revealTarget, setRevealTarget] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const workspacePathDragImageRef = useRef<HTMLDivElement | null>(null);
   const { confirm: requestConfirmDialog, dialog: confirmDialog } = useConfirmDialog();
 
   const {
@@ -388,18 +391,19 @@ export function FileTreeSurface(props: FileTreeSurfaceProps) {
         event.preventDefault();
         return;
       }
-      if (
-        !writeWorkspacePathDragPayload(event.dataTransfer, {
-          kind: "workspacePath",
-          projectPathKey,
-          cwd,
-          relativePath: path,
-          entryKind: kind,
-          label: node.name,
-        })
-      ) {
+      const wrotePayload = writeWorkspacePathDragPayload(event.dataTransfer, {
+        kind: "workspacePath",
+        projectPathKey,
+        cwd,
+        relativePath: path,
+        entryKind: kind,
+        label: node.name,
+      });
+      if (!wrotePayload) {
         event.preventDefault();
+        return;
       }
+      setWorkspacePathDragImage(event.dataTransfer, workspacePathDragImageRef.current);
     },
     [cwd, isExternalPath, projectPathKey],
   );
@@ -589,6 +593,11 @@ export function FileTreeSurface(props: FileTreeSurfaceProps) {
 
   return (
     <div ref={panelRef} className="relative flex h-full min-h-0 select-none flex-col">
+      <DragAddIndicator
+        ref={workspacePathDragImageRef}
+        data-workspace-path-drag-image=""
+        className="pointer-events-none fixed -left-12 -top-12"
+      />
       <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
         <div className="relative min-w-0 flex-1">
           <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />

--- a/crates/agent-ui/src/components/workbench/WorkbenchDragGhost.tsx
+++ b/crates/agent-ui/src/components/workbench/WorkbenchDragGhost.tsx
@@ -1,0 +1,55 @@
+import { forwardRef } from "react";
+import type { WorkbenchDragPayload } from "../../lib/workbench/dragMachine";
+import { DragAddIndicator } from "../drag/DragAddIndicator";
+
+export type WorkbenchDragGhostProps = {
+  payload: WorkbenchDragPayload;
+  fallbackTitle: string;
+};
+
+/**
+ * Pointer-following feedback for Workbench drags.
+ *
+ * New surfaces use the same compact green copy affordance as Desktop's native
+ * workspace-path drag. Moving an existing pane keeps its title because that
+ * operation rearranges content instead of adding another surface.
+ */
+export const WorkbenchDragGhost = forwardRef<HTMLDivElement, WorkbenchDragGhostProps>(
+  function WorkbenchDragGhost(props, ref) {
+    const { payload, fallbackTitle } = props;
+    const isAddOperation = payload.kind !== "pane";
+    const title = payload.title || fallbackTitle;
+    const positionStyle = {
+      left: 0,
+      top: 0,
+      transform:
+        "translate3d(var(--workbench-drag-ghost-x, -9999px), var(--workbench-drag-ghost-y, -9999px), 0)",
+      willChange: "transform",
+    } as const;
+
+    if (isAddOperation) {
+      return (
+        <DragAddIndicator
+          ref={ref}
+          data-workbench-drag-ghost=""
+          data-workbench-drag-operation="add"
+          className="layer-popover pointer-events-none fixed"
+          style={positionStyle}
+        />
+      );
+    }
+
+    return (
+      <div
+        ref={ref}
+        data-workbench-drag-ghost=""
+        data-workbench-drag-operation="move"
+        aria-hidden="true"
+        className="layer-popover pointer-events-none fixed max-w-[220px] truncate rounded-md border border-border bg-background/95 px-2.5 py-1 text-xs text-foreground shadow-md"
+        style={positionStyle}
+      >
+        {title}
+      </div>
+    );
+  },
+);

--- a/crates/agent-ui/src/components/workbench/index.ts
+++ b/crates/agent-ui/src/components/workbench/index.ts
@@ -8,4 +8,5 @@ export * from "./surfaces/SshTerminalPaneSurface";
 export * from "./surfaces/UnsupportedPaneSurface";
 export * from "./TerminalPaneHost";
 export * from "./WorkbenchCanvas";
+export * from "./WorkbenchDragGhost";
 export * from "./WorkbenchEmptyState";

--- a/crates/agent-ui/src/lib/chat/workspacePathDrag.ts
+++ b/crates/agent-ui/src/lib/chat/workspacePathDrag.ts
@@ -4,6 +4,7 @@ export const WORKSPACE_PATH_DRAG_MIME = "application/x-liveagent-workspace-path+
 export const WORKSPACE_PATH_NATIVE_DRAG_OVER_EVENT = "liveagent:workspace-path-native-drag-over";
 export const WORKSPACE_PATH_NATIVE_DRAG_LEAVE_EVENT = "liveagent:workspace-path-native-drag-leave";
 export const WORKSPACE_PATH_NATIVE_DROP_EVENT = "liveagent:workspace-path-native-drop";
+export const WORKSPACE_PATH_DRAG_IMAGE_HOTSPOT_PX = 12;
 
 export type WorkspacePathDragPayload = {
   kind: "workspacePath";
@@ -172,6 +173,23 @@ export function writeWorkspacePathDragPayload(
   dataTransfer.effectAllowed = "copy";
   dataTransfer.setData(WORKSPACE_PATH_DRAG_MIME, JSON.stringify(payload));
   dataTransfer.setData("text/plain", payload.relativePath);
+  return true;
+}
+
+/**
+ * Replace the browser/WebView's full-row drag snapshot with the shared compact
+ * add affordance. Payload and drop routing remain owned by DataTransfer.
+ */
+export function setWorkspacePathDragImage(
+  dataTransfer: DataTransfer,
+  indicator: Element | null,
+): boolean {
+  if (!indicator || typeof dataTransfer.setDragImage !== "function") return false;
+  dataTransfer.setDragImage(
+    indicator,
+    WORKSPACE_PATH_DRAG_IMAGE_HOTSPOT_PX,
+    WORKSPACE_PATH_DRAG_IMAGE_HOTSPOT_PX,
+  );
   return true;
 }
 


### PR DESCRIPTION
## 变更说明

- 新增共享的绿色圆形添加指示器，统一 Desktop 与 WebUI 的文件拖拽反馈
- 普通文件行和搜索结果拖拽均使用自定义小型添加按钮，替代整行半透明预览
- 新增 Workbench 会话时复用相同添加反馈；已有 Pane 移动继续保留中性标题浮层
- 保持工作区路径协议、Composer 引用、终端插入和拖拽落点语义不变

## 验证

- 相关拖拽测试：50/50 通过
- `@liveagent/ui` typecheck 通过
- Desktop 前端构建通过
- Gateway WebUI 构建通过
- `git diff --check` 通过

## Screenshots / preview

Desktop / WebUI 文件拖拽反馈前后对比：

<img width="1200" height="720" alt="Desktop 与 WebUI 拖拽反馈前后对比" src="https://github.com/user-attachments/assets/a2715767-4020-4257-9496-0bb79f61deca" />

Closes #694

> 此 PR 基于 `feat/session-workbench-web`，因为文件树 Workbench Pane 与工作区路径拖拽由该分支提供。
