### PR TITLE
feat: add OrcaRouter as a built-in provider

### DIFF
--- a/.github/pr-assets/2026-08/pr-702-orcarouter-provider-preview.svg
+++ b/.github/pr-assets/2026-08/pr-702-orcarouter-provider-preview.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="220" viewBox="0 0 640 220">
+  <defs>
+    <style>
+      .card { fill: #ffffff; stroke: #e4e4e7; }
+      .card-hover { fill: #fafafa; }
+      .title { font: 600 14px system-ui, -apple-system, sans-serif; fill: #18181b; }
+      .muted { font: 12px system-ui, -apple-system, sans-serif; fill: #71717a; }
+      .badge { font: 11px system-ui, -apple-system, sans-serif; fill: #71717a; }
+      .tab-active { fill: #ffffff; stroke: #d4d4d8; }
+      .tab { font: 500 13px system-ui, -apple-system, sans-serif; fill: #71717a; }
+      .tab-on { font: 500 13px system-ui, -apple-system, sans-serif; fill: #18181b; }
+      .pill { fill: #f4f4f5; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="640" height="220" rx="12" fill="#fafafa"/>
+  <text x="16" y="30" font-family="system-ui, sans-serif" font-size="13" font-weight="500" fill="#18181b">Settings · Providers</text>
+
+  <!-- Provider tabs row -->
+  <rect x="16" y="44" width="380" height="36" rx="9" fill="#e4e4e7"/>
+  <rect x="18" y="46" width="74" height="32" rx="7" fill="#ffffff" stroke="#d4d4d8"/>
+  <text x="34" y="66" class="tab-on">OpenAI</text>
+  <text x="112" y="66" class="tab">Anthropic</text>
+  <text x="206" y="66" class="tab">Gemini</text>
+  <text x="292" y="66" class="tab">Grok</text>
+  <text x="362" y="66" class="tab">DeepSeek</text>
+
+  <!-- Provider card: OrcaRouter -->
+  <rect x="16" y="92" width="608" height="64" rx="12" class="card" stroke-width="1"/>
+  <circle cx="46" cy="112" r="4" fill="#d4d4d8"/>
+  <circle cx="46" cy="124" r="4" fill="#d4d4d8"/>
+  <circle cx="58" cy="112" r="4" fill="#d4d4d8"/>
+  <circle cx="58" cy="124" r="4" fill="#d4d4d8"/>
+  <text x="82" y="118" font-family="system-ui, sans-serif" font-size="14" font-weight="600" fill="#18181b">OrcaRouter</text>
+  <text x="82" y="140" class="muted">https://api.orcarouter.ai/v1 · 0 active models</text>
+  <!-- edit + delete icon buttons -->
+  <g stroke="#71717a" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M560 108 l2-2 a2.5 2.5 0 0 1 3.5 0 l3 3 a2.5 2.5 0 0 1 0 3.5 l-9 9 l-4.5 1 l1-4.5 z"/>
+    <path d="M596 106 h12 M602 106 v10 a2 2 0 0 0 4 0 v-10 M597 108 v-2 a2 2 0 0 1 2-2 h8 a2 2 0 0 1 2 2 v2"/>
+  </g>
+
+  <!-- Provider card: DeepSeek (existing built-in, for context) -->
+  <rect x="16" y="164" width="608" height="40" rx="12" class="card" stroke-width="1" opacity="0.55"/>
+  <circle cx="46" cy="184" r="4" fill="#d4d4d8"/>
+  <circle cx="46" cy="196" r="4" fill="#d4d4d8"/>
+  <circle cx="58" cy="184" r="4" fill="#d4d4d8"/>
+  <circle cx="58" cy="196" r="4" fill="#d4d4d8"/>
+  <text x="82" y="188" class="title">DeepSeek</text>
+  <text x="82" y="202" class="muted">https://api.deepseek.com · 0 active models</text>
+</svg>

--- a/crates/agent-gui/test/settings/normalization.test.mjs
+++ b/crates/agent-gui/test/settings/normalization.test.mjs
@@ -277,22 +277,33 @@ test("gemini provider normalization keeps native routing and model limits", () =
   assert.equal(provider.models[0].maxOutputToken, 65_536);
 });
 
-test("DeepSeek is the fifth built-in provider with Responses search enabled", () => {
+test("DeepSeek and OrcaRouter are built-in providers with Responses search enabled", () => {
   const providers = settings.getBuiltinCustomProviders();
   assert.deepEqual(
     providers.map((provider) => provider.type),
-    ["claude_code", "codex", "gemini", "xai", "deepseek"],
+    ["claude_code", "codex", "gemini", "xai", "deepseek", "codex"],
   );
 
-  const provider = providers.at(-1);
-  assert.equal(provider.id, "builtin-deepseek");
-  assert.equal(provider.name, "DeepSeek");
-  assert.equal(provider.baseUrl, "https://api.deepseek.com");
-  assert.equal(provider.reasoning, "high");
-  assert.equal(provider.promptCachingEnabled, false);
-  assert.equal(provider.promptCacheHintMode, undefined);
-  assert.equal(provider.nativeWebSearchEnabled, true);
-  assert.equal(provider.requestFormat, undefined);
+  const deepseek = providers.find((provider) => provider.type === "deepseek");
+  assert.equal(deepseek.id, "builtin-deepseek");
+  assert.equal(deepseek.name, "DeepSeek");
+  assert.equal(deepseek.baseUrl, "https://api.deepseek.com");
+  assert.equal(deepseek.reasoning, "high");
+  assert.equal(deepseek.promptCachingEnabled, false);
+  assert.equal(deepseek.promptCacheHintMode, undefined);
+  assert.equal(deepseek.nativeWebSearchEnabled, true);
+  assert.equal(deepseek.requestFormat, undefined);
+
+  const orcarouter = providers.find((provider) => provider.id === "builtin-orcarouter");
+  assert.equal(orcarouter.type, "codex");
+  assert.equal(orcarouter.name, "OrcaRouter");
+  assert.equal(orcarouter.baseUrl, "https://api.orcarouter.ai/v1");
+  assert.equal(orcarouter.requestFormat, "openai-responses");
+  assert.equal(orcarouter.promptCachingEnabled, true);
+  assert.equal(orcarouter.promptCacheHintMode, "auto");
+  assert.equal(orcarouter.reasoning, "high");
+  assert.equal(orcarouter.nativeWebSearchEnabled, true);
+  assert.equal(orcarouter.useSystemProxy, false);
 });
 
 test("DeepSeek provider normalization keeps native routing and native search", () => {

--- a/crates/agent-ui/src/lib/settings/index.ts
+++ b/crates/agent-ui/src/lib/settings/index.ts
@@ -338,6 +338,24 @@ export function getBuiltinCustomProviders(): CustomProvider[] {
       useSystemProxy: false,
       usageQuery: getDefaultUsageQueryConfig(),
     },
+    {
+      id: "builtin-orcarouter",
+      name: "OrcaRouter",
+      type: "codex",
+      baseUrl: "https://api.orcarouter.ai/v1",
+      isFullUrl: false,
+      apiKey: "",
+      customHeaders: [],
+      models: [],
+      activeModels: [],
+      requestFormat: "openai-responses",
+      reasoning: "high",
+      promptCachingEnabled: true,
+      promptCacheHintMode: "auto",
+      nativeWebSearchEnabled: true,
+      useSystemProxy: false,
+      usageQuery: getDefaultUsageQueryConfig(),
+    },
   ];
 }
 


### PR DESCRIPTION
## Linked issue

Closes #701

## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a first-class provider in the Settings → Providers panel, mirroring the built-in Codex entry. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents — like OpenRouter it exposes a provider/model namespace across many models, but also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. Users of this local-first agent desktop can now select OrcaRouter directly instead of entering a custom Base URL.

- Modules: agent-ui / agent-gui (settings + normalization tests)
- Key paths: `crates/agent-ui/src/lib/settings/index.ts`, `crates/agent-gui/test/settings/normalization.test.mjs`

## Screenshots / preview

Preview of the Settings → Providers panel with the new **OrcaRouter** built-in card (type `codex`, Base URL `https://api.orcarouter.ai/v1`):

![OrcaRouter built-in provider card](https://raw.githubusercontent.com/armyluki-wq/LiveAgent/feat/orcarouter-builtin-provider/.github/pr-assets/2026-08/pr-702-orcarouter-provider-preview.svg)

Live request-response example from the L3 check (Responses API, Bearer auth):

```
POST https://api.orcarouter.ai/v1/responses
{ "model": "orcarouter/fusion-mini", "input": "Reply with exactly: OK", "reasoning": { "effort": "low" }, ... }
HTTP 200  {"id":"resp_...","status":"completed","output":[{"content":[{"text":"OK"}]}]}
```

## Verification

- `pnpm lint:ui` / `pnpm lint:gui` / `pnpm typecheck:ui` / `pnpm build:gui` — all green
- `pnpm --filter liveagent test:frontend` — 2824 pass, 0 fail (updated built-in provider list assertion)
- `node scripts/check-ui-boundaries.mjs` — passed
- L3 live test against `https://api.orcarouter.ai/v1/responses` with a real key — HTTP 200

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
