### PR TITLE
fix(release): CI 构建的 macOS DMG 丢失自定义背景与图标布局

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,13 +49,17 @@ build:
 desktop-build-macos: check-rust-target-$(DESKTOP_MACOS_TARGET)
 	pnpm --dir $(AGENT_GUI_DIR) tauri build --config $(DESKTOP_MACOS_TAURI_CONFIG) --target $(DESKTOP_MACOS_TARGET)
 
+# tauri-bundler skips the Finder AppleScript that writes the DMG .DS_Store (background,
+# window size, icon positions) whenever CI=true. Hosted macOS runners do have a GUI
+# session, so release builds opt back in — the same default tauri-action ships with.
 desktop-build-macos-release: check-rust-target-$(DESKTOP_MACOS_TARGET) check-macos-signing-identity check-macos-notary-profile
-	env -u APPLE_ID -u APPLE_PASSWORD -u APPLE_API_ISSUER -u APPLE_API_KEY -u APPLE_API_KEY_PATH APPLE_SIGNING_IDENTITY="$(APPLE_SIGNING_IDENTITY)" pnpm --dir $(AGENT_GUI_DIR) tauri build $(DESKTOP_RELEASE_TAURI_CONFIG_FLAGS) --target $(DESKTOP_MACOS_TARGET)
+	env -u APPLE_ID -u APPLE_PASSWORD -u APPLE_API_ISSUER -u APPLE_API_KEY -u APPLE_API_KEY_PATH APPLE_SIGNING_IDENTITY="$(APPLE_SIGNING_IDENTITY)" TAURI_BUNDLER_DMG_IGNORE_CI=true pnpm --dir $(AGENT_GUI_DIR) tauri build $(DESKTOP_RELEASE_TAURI_CONFIG_FLAGS) --target $(DESKTOP_MACOS_TARGET)
 	@set -e; \
 	app_path="target/$(DESKTOP_MACOS_TARGET)/release/bundle/macos/$(DESKTOP_MACOS_APP_NAME).app"; \
 	dmg_path="$$(find "target/$(DESKTOP_MACOS_TARGET)/release/bundle/dmg" -maxdepth 1 -name '$(DESKTOP_MACOS_APP_NAME)_*.dmg' -print -quit)"; \
 	if [ ! -d "$$app_path" ]; then echo "macOS app not found: $$app_path"; exit 1; fi; \
 	if [ -z "$$dmg_path" ] || [ ! -f "$$dmg_path" ]; then echo "macOS dmg not found under target/$(DESKTOP_MACOS_TARGET)/release/bundle/dmg"; exit 1; fi; \
+	scripts/release/verify-macos-dmg-layout.sh "$$dmg_path" "$(DESKTOP_MACOS_APP_NAME)"; \
 	codesign --verify --deep --strict --verbose=4 "$$app_path"; \
 	codesign --force --timestamp --sign "$(APPLE_SIGNING_IDENTITY)" "$$dmg_path"; \
 	xcrun notarytool submit "$$dmg_path" --keychain-profile "$(DESKTOP_MACOS_NOTARY_PROFILE)" --wait; \
@@ -247,6 +251,7 @@ desktop-verify-macos:
 	dmg_path="$$(find "target/$(DESKTOP_MACOS_TARGET)/release/bundle/dmg" -maxdepth 1 -name '$(DESKTOP_MACOS_APP_NAME)_*.dmg' -print -quit)"; \
 	if [ ! -d "$$app_path" ]; then echo "macOS app not found: $$app_path"; exit 1; fi; \
 	if [ -z "$$dmg_path" ] || [ ! -f "$$dmg_path" ]; then echo "macOS dmg not found under target/$(DESKTOP_MACOS_TARGET)/release/bundle/dmg"; exit 1; fi; \
+	scripts/release/verify-macos-dmg-layout.sh "$$dmg_path" "$(DESKTOP_MACOS_APP_NAME)"; \
 	codesign -dv --verbose=4 "$$app_path" 2>&1; \
 	codesign --verify --deep --strict --verbose=4 "$$app_path"; \
 	xcrun stapler validate -v "$$dmg_path"; \

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -142,6 +142,8 @@ Keychain 中必须是带私钥的 `Developer ID Application` identity。若 macO
 | Windows x64 | `windows-latest` | `LiveAgent-vX.Y.Z-Windows-x64.msi`、`LiveAgent-vX.Y.Z-Windows-x64-Setup.exe`，以及 updater 使用的 `.zip` / `.sig`。 |
 | Linux x64 | `ubuntu-latest` | `LiveAgent-vX.Y.Z-Linux-x86_64.AppImage`、`.deb`、`.rpm`，以及 updater 使用的 `.tar.gz` / `.sig`。 |
 
+macOS DMG 的安装窗口布局（背景图、窗口尺寸、图标位置）由 `tauri.conf.json > bundle > macOS > dmg` 配置，tauri-bundler 通过 AppleScript 驱动 Finder 写入 DMG 根目录的 `.DS_Store` 来落盘。tauri-bundler 只要检测到 `CI=true` 就会跳过这一步，产出没有任何布局的白底 DMG；GitHub 托管的 macOS runner 实际具备 GUI 会话，因此 `make desktop-build-macos-release` 固定设置 `TAURI_BUNDLER_DMG_IGNORE_CI=true` 让布局在 CI 中照常生效，并在签名、公证之前用 `scripts/release/verify-macos-dmg-layout.sh` 挂载 DMG 校验 `.DS_Store`、`.background/`、`LiveAgent.app` 与 `Applications` 链接是否齐全，缺失即中止发布。本地排查时可以直接对任意 DMG 运行该脚本。
+
 发布 job 会在上传平台产物后生成并上传 `latest.json`。桌面端「设置 -> 关于」会根据用户是否允许预发布，从 GitHub Releases 中筛选带 `latest.json` 的正式 / 预发布版本；未允许预发布时只检查正式 Release。
 
 ## 桌面版本号来源

--- a/scripts/release/verify-macos-dmg-layout.sh
+++ b/scripts/release/verify-macos-dmg-layout.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Mounts a Tauri-built DMG read-only and asserts that the Finder installer layout
+# (background, window size, icon positions) was actually baked into it.
+#
+# tauri-bundler applies that layout by driving Finder through AppleScript, and it
+# persists as a `.DS_Store` at the DMG root. When the bundler sees `CI=true` it passes
+# `--skip-jenkins` to bundle_dmg and silently skips that step, yielding a DMG that opens
+# as a plain white Finder window. Release builds opt back in via
+# `TAURI_BUNDLER_DMG_IGNORE_CI=true`; this guard makes sure a regression never ships.
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <dmg-path> [app-name]" >&2
+}
+
+fail() {
+  echo "verify-macos-dmg-layout: $*" >&2
+  exit 1
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  usage
+  exit 2
+fi
+
+for command_name in hdiutil mktemp find; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
+done
+
+dmg_path="$1"
+app_name="${2:-LiveAgent}"
+test -f "$dmg_path" || fail "DMG not found: $dmg_path"
+
+mount_point="$(mktemp -d "${TMPDIR:-/tmp}/liveagent-dmg-verify.XXXXXX")"
+mounted=0
+cleanup() {
+  if [ "$mounted" -eq 1 ]; then
+    hdiutil detach "$mount_point" -quiet -force >/dev/null 2>&1 || true
+  fi
+  rmdir -- "$mount_point" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+hdiutil attach "$dmg_path" -readonly -nobrowse -noautoopen -noverify -mountpoint "$mount_point" >/dev/null
+mounted=1
+
+failures=0
+check() {
+  local description="$1"
+  shift
+  if "$@"; then
+    echo "  ok    $description"
+  else
+    echo "  FAIL  $description"
+    failures=$((failures + 1))
+  fi
+}
+
+has_background_image() {
+  find "$1/.background" -maxdepth 1 -type f -print -quit 2>/dev/null | grep -q .
+}
+
+echo "Verifying Finder layout of $dmg_path"
+check "$app_name.app bundle present" test -d "$mount_point/$app_name.app"
+check "Applications symlink present" test -L "$mount_point/Applications"
+check ".background/ image present" has_background_image "$mount_point"
+check ".DS_Store present (Finder window size, background, icon positions)" test -s "$mount_point/.DS_Store"
+
+if [ "$failures" -ne 0 ]; then
+  fail "$failures check(s) failed. The DMG would open as a plain Finder window without the configured background and icon layout.
+  When building on CI, make sure TAURI_BUNDLER_DMG_IGNORE_CI=true is set: tauri-bundler skips the Finder AppleScript whenever CI=true.
+  See https://github.com/tauri-apps/tauri/issues/1731 and Stack-Cairn/LiveAgent#558."
+fi
+
+echo "DMG Finder layout verified: $dmg_path"


### PR DESCRIPTION
## Linked issue

Closes #558

## Summary

v1.2.6 的 `LiveAgent-v1.2.6-macOS-aarch64.dmg` 与 `-x64.dmg` 挂载后均含 `.background/background.png`、`.VolumeIcon.icns`、`LiveAgent.app`、`Applications` 链接，但缺少 `.DS_Store`，Finder 因此显示默认白底窗口，`tauri.conf.json` 里的 660×400 窗口、背景图和图标位置全部没有生效。

根因不是 issue 中推测的"GitHub runner 无法可靠操作 Finder"，而是 tauri-bundler（CLI 2.11.4，`crates/tauri-bundler/src/bundle/macos/dmg/mod.rs`）的确定性行为：只要 `CI=true` 且未设置 `TAURI_BUNDLER_DMG_IGNORE_CI=true`，就给 `bundle_dmg` 追加 `--skip-jenkins`，脚本随即跳过负责写 `.DS_Store` 的 Finder AppleScript 并打印 "This will result in a DMG without any custom background or icons positioning"。GitHub Actions 对所有 job 固定注入 `CI=true`，而 `desktop-release.yml` 直接调用 `make desktop-build-macos-release` → `pnpm tauri build`，没有任何绕过，所以每次发布都必然命中。Tauri 官方 `tauri-action` 对 macOS 默认就注入 `TAURI_BUNDLER_DMG_IGNORE_CI=true`；[tauri-action#740](https://github.com/tauri-apps/tauri-action/issues/740) 中多位用户在 `macos-latest`（含 Apple Silicon）确认 GitHub 托管 runner 具备 GUI 会话、AppleScript 可正常执行，[tauri#1731](https://github.com/tauri-apps/tauri/issues/1731) 维护者也推荐这一变量。

因此采用最小根治方案，而非 issue 建议的 `dmgbuild` 重写整条打包链路：

- **`Makefile` `desktop-build-macos-release`**：`tauri build` 命令追加 `TAURI_BUNDLER_DMG_IGNORE_CI=true`。放在 release 配方而非 workflow，是因为这个配方才是"发布构建"的定义，任何 CI 调用它都能得到正确布局；本地 `CI` 未设置时该变量是无操作。
- **新增 `scripts/release/verify-macos-dmg-layout.sh`**：只读挂载 DMG，校验 `LiveAgent.app`、`Applications` 链接、`.background/` 图片、非空 `.DS_Store` 四项，缺失即 exit 1 并提示根因；`trap` 保证异常路径也卸载并清理临时目录。在 `tauri build` 之后、DMG `codesign`/`notarytool` 之前调用，布局回归时立即失败，不浪费一次公证往返。`desktop-verify-macos` 同样接入。
- **`docs/operations/deployment.md`**：「桌面产物」下补充机制说明与本地排查方式。

## Change scope

- Modules: release 构建脚本 / 运维文档
- Key paths:
  - `Makefile`（`desktop-build-macos-release`、`desktop-verify-macos`）
  - `scripts/release/verify-macos-dmg-layout.sh`（新增）
  - `docs/operations/deployment.md`

## Screenshots / preview

非 UI 改动。以下为本机用 `tauri bundle`（复用已编译二进制，仅重跑打包）复现 CI 行为与验证修复的日志（`-v` 输出节选）。

**修复前 —— `CI=true`，等价于 GitHub Actions 现状，命令行带 `--skip-jenkins`：**

```text
Running [tauri_bundler::utils] Command `.../bundle_dmg.sh --volname LiveAgent --icon LiveAgent.app 180 210 --app-drop-link 480 210 --window-size 660 400 --hide-extension LiveAgent.app --background .../dmg/background.png --volicon .../icon.icns --skip-jenkins LiveAgent_1.3.0-dev.0_aarch64.dmg LiveAgent.app`
Will skip running AppleScript to configure DMG aesthetics because of --skip-jenkins option.
This will result in a DMG without any custom background or icons positioning.

$ scripts/release/verify-macos-dmg-layout.sh target/aarch64-apple-darwin/release/bundle/dmg/LiveAgent_1.3.0-dev.0_aarch64.dmg
Verifying Finder layout of target/aarch64-apple-darwin/release/bundle/dmg/LiveAgent_1.3.0-dev.0_aarch64.dmg
  ok    LiveAgent.app bundle present
  ok    Applications symlink present
  ok    .background/ image present
  FAIL  .DS_Store present (Finder window size, background, icon positions)
verify-macos-dmg-layout: 1 check(s) failed. The DMG would open as a plain Finder window without the configured background and icon layout.
  When building on CI, make sure TAURI_BUNDLER_DMG_IGNORE_CI=true is set: tauri-bundler skips the Finder AppleScript whenever CI=true.
exit=1
```

**修复后 —— `CI=true TAURI_BUNDLER_DMG_IGNORE_CI=true`，`--skip-jenkins` 消失，AppleScript 执行：**

```text
Running [tauri_bundler::utils] Command `.../bundle_dmg.sh --volname LiveAgent --icon LiveAgent.app 180 210 --app-drop-link 480 210 --window-size 660 400 --hide-extension LiveAgent.app --background .../dmg/background.png --volicon .../icon.icns LiveAgent_1.3.0-dev.0_aarch64.dmg LiveAgent.app`
Running AppleScript to make Finder stuff pretty: /usr/bin/osascript ".../createdmg.tmp.XXXXXXXXXX.Ew4lM7Rp66" "dmg.HePeIs"
waited 1 seconds for .DS_STORE to be created.
Done running the AppleScript...

$ scripts/release/verify-macos-dmg-layout.sh target/aarch64-apple-darwin/release/bundle/dmg/LiveAgent_1.3.0-dev.0_aarch64.dmg
Verifying Finder layout of target/aarch64-apple-darwin/release/bundle/dmg/LiveAgent_1.3.0-dev.0_aarch64.dmg
  ok    LiveAgent.app bundle present
  ok    Applications symlink present
  ok    .background/ image present
  ok    .DS_Store present (Finder window size, background, icon positions)
DMG Finder layout verified: target/aarch64-apple-darwin/release/bundle/dmg/LiveAgent_1.3.0-dev.0_aarch64.dmg
exit=0
```

修复后 `.DS_Store` 解析出 `bwsp` 窗口边界 `{{10, 980}, {660, 400}}`（与配置一致）、`icvp` 背景设置及 4 条 `Iloc` 图标位置记录。

## Verification

- 下载 v1.2.6 的 aarch64 / x64 两个发布 DMG 挂载检查，均缺 `.DS_Store`，其余文件齐全，确认 issue 现象且 x64 同样受影响。
- 阅读 v1.2.6 `macOS Apple Silicon` job 日志：`Running bundle_dmg.sh` 静默完成、无报错，与 `--skip-jenkins` 被动跳过的行为一致。
- 本机 `tauri bundle` 两组对照见上文日志；守卫脚本对修复前 DMG exit 1、修复后 exit 0；无参 exit 2、文件不存在 exit 1；运行后无残留挂载与临时目录。
- `make -n desktop-build-macos-release` / `make -n desktop-verify-macos` 确认配方展开正确（`TAURI_BUNDLER_DMG_IGNORE_CI=true` 位于 `tauri build` 命令，守卫位于 `codesign` 之前）。
- 无法在本机模拟 GitHub runner 的 TCC 环境；若 runner 上 osascript 被拒，`bundle_dmg` 会 exit 64 使 `tauri build` 失败，属于响亮失败而非静默劣化。建议合并后先用预发布 tag 走一遍 `desktop-release.yml` 确认。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.

Made with [Cursor](https://cursor.com)