### PR TITLE
fix(providers): 文本类附件改走 Read，PDF 仅官方端点原生内联，修复兼容中转 Invalid request

### DIFF
--- a/crates/agent-gui/src/lib/providers/deepSeekAttachments.ts
+++ b/crates/agent-gui/src/lib/providers/deepSeekAttachments.ts
@@ -1,6 +1,8 @@
 import type { Context, UserMessage } from "@earendil-works/pi-ai";
 import {
   getUserMessageAttachments,
+  locateUploadedFilesInstructionHeader,
+  matchesUploadedFileInstructionLine,
   type PendingUploadedFile,
   parsePastedTextDisplayReferences,
 } from "@liveagent/ui/lib/chat/uploadedFiles";
@@ -11,11 +13,6 @@ type NativeAttachmentCommandResponse = {
   data: string;
   sizeBytes: number;
 };
-
-const UPLOAD_INSTRUCTION_LINES = [
-  "The user attached the files below to this message.",
-  "Use Read with these exact paths before analyzing or modifying them:",
-] as const;
 
 function decodeBase64Utf8(data: string) {
   const binary = atob(data);
@@ -49,18 +46,16 @@ async function readLargePaste(workdir: string, file: PendingUploadedFile) {
 }
 
 function removeUploadInstructionLine(content: string, file: PendingUploadedFile) {
-  const absolutePath = file.absolutePath?.trim();
-  if (!absolutePath) return content;
-  const target = `- ${absolutePath} (${file.kind})`;
-  const lines = content.split("\n").filter((line) => line !== target);
-  const instructionIndex = lines.findIndex(
-    (line, index) =>
-      line === UPLOAD_INSTRUCTION_LINES[0] && lines[index + 1] === UPLOAD_INSTRUCTION_LINES[1],
-  );
-  if (instructionIndex < 0) return lines.join("\n");
+  if (!file.absolutePath?.trim()) return content;
+  const lines = content
+    .split("\n")
+    .filter((line) => !matchesUploadedFileInstructionLine(line, file));
+  const header = locateUploadedFilesInstructionHeader(lines);
+  if (!header) return lines.join("\n");
+  const instructionIndex = header.index;
 
   const hasRemainingFile = lines
-    .slice(instructionIndex + UPLOAD_INSTRUCTION_LINES.length)
+    .slice(instructionIndex + header.length)
     .some((line) => line.startsWith("- "));
   if (hasRemainingFile) return lines.join("\n");
 
@@ -68,10 +63,7 @@ function removeUploadInstructionLine(content: string, file: PendingUploadedFile)
     instructionIndex > 0 && lines[instructionIndex - 1] === ""
       ? instructionIndex - 1
       : instructionIndex;
-  lines.splice(
-    removeFrom,
-    UPLOAD_INSTRUCTION_LINES.length + (removeFrom < instructionIndex ? 1 : 0),
-  );
+  lines.splice(removeFrom, header.length + (removeFrom < instructionIndex ? 1 : 0));
   return lines.join("\n");
 }
 

--- a/crates/agent-gui/src/lib/providers/nativeResponsesAttachments.ts
+++ b/crates/agent-gui/src/lib/providers/nativeResponsesAttachments.ts
@@ -1,7 +1,10 @@
 import type { Api, Context, Model } from "@earendil-works/pi-ai";
 import {
   getUserMessageAttachments,
+  matchesUploadedFileInstructionLine,
   type PendingUploadedFile,
+  UPLOADED_FILES_INSTRUCTION_HEADER_TEXTS,
+  UPLOADED_FILES_READ_PAGING_HINT,
 } from "@liveagent/ui/lib/chat/uploadedFiles";
 import { invoke } from "@tauri-apps/api/core";
 
@@ -48,17 +51,11 @@ type AnthropicNativeAttachmentContentPart =
     }
   | {
       type: "document";
-      source:
-        | {
-            type: "base64";
-            media_type: string;
-            data: string;
-          }
-        | {
-            type: "text";
-            media_type: "text/plain";
-            data: string;
-          };
+      source: {
+        type: "base64";
+        media_type: string;
+        data: string;
+      };
       title?: string;
     };
 
@@ -74,30 +71,45 @@ type GeminiNativeAttachmentCandidate = {
   requestBytes: number;
 };
 
-const WORKSPACE_UPLOAD_INSTRUCTION = [
-  "The user attached the files below to this message.",
-  "Use Read with these exact paths before analyzing or modifying them:",
-].join("\n");
+/**
+ * 原生内联策略（按附件 kind 分层，五家 provider 统一）：
+ *
+ * - image：各家都是标准 block（input_image / image_url / image / inlineData），
+ *   兼容中转也认，零往返成本，保留原生内联。codex / gemini 分支沿用原有的
+ *   model.input 含 "image" 门控；anthropic 分支按 modelFactory 的约定不读
+ *   model.input（见 buildAnthropicNativeAttachmentContentPart）。
+ * - pdf：document / input_file / inlineData 都是各家专有结构，第三方
+ *   Anthropic/OpenAI/Gemini 兼容中转普遍不认（Kimi Coding、z.ai 等直接 400
+ *   "Invalid request"），只在各家官方端点内联；其余端点退回 Read（lopdf 抽文本）。
+ * - text / word / spreadsheet / notebook / archive：一律不内联，走 Read。
+ *   这正是在兼容中转上出错的类型，而 Read 对它们的结果与内联等价。
+ *
+ * 用户消息里原本的两行 Read 指令头（uploadedFiles.ts）在至少一个附件被内联时
+ * 换成下面的版本，并给被内联的附件行加 "inlined" 标注，让模型明确知道哪些
+ * 已经在请求里、哪些必须 Read。
+ */
+function buildNativeUploadInstruction(requestLabel: string, inputLabel: string) {
+  return [
+    `Attachments marked "inlined" below are included in this ${requestLabel} request as native ${inputLabel} inputs; analyze those directly. Every other listed file is only available through Read.`,
+    `Use Read with the exact paths for files that are not inlined before analyzing or modifying them. ${UPLOADED_FILES_READ_PAGING_HINT}`,
+  ].join("\n");
+}
 
-const NATIVE_UPLOAD_INSTRUCTION = [
-  "The attached files are inlined into this OpenAI Responses request as native inputs when supported, and are also readable at the exact paths below.",
-  "Analyze the native attachments directly first. Use Read only when you need exact file access, edits, or native attachment content is unavailable:",
-].join("\n");
+const NATIVE_UPLOAD_INSTRUCTION = buildNativeUploadInstruction("OpenAI Responses", "input");
 
-const OPENAI_CHAT_COMPLETIONS_NATIVE_UPLOAD_INSTRUCTION = [
-  "The attached images are inlined into this OpenAI Chat Completions request as native image inputs when supported, and are also readable at the exact paths below.",
-  "Analyze the native image attachments directly first. Use Read only when you need exact file access, edits, or native attachment content is unavailable:",
-].join("\n");
+const OPENAI_CHAT_COMPLETIONS_NATIVE_UPLOAD_INSTRUCTION = buildNativeUploadInstruction(
+  "OpenAI Chat Completions",
+  "image",
+);
 
-const ANTHROPIC_NATIVE_UPLOAD_INSTRUCTION = [
-  "The attached files are inlined into this Anthropic Messages request as native image/document inputs when supported, and are also readable at the exact paths below.",
-  "Analyze the native attachments directly first. Use Read only when you need exact file access, edits, or native attachment content is unavailable:",
-].join("\n");
+const ANTHROPIC_NATIVE_UPLOAD_INSTRUCTION = buildNativeUploadInstruction(
+  "Anthropic Messages",
+  "image/document",
+);
 
-const GEMINI_NATIVE_UPLOAD_INSTRUCTION = [
-  "The attached files are inlined into this Gemini request as native inlineData inputs when supported, and are also readable at the exact paths below.",
-  "Analyze the native attachments directly first. Use Read only when you need exact file access, edits, or native attachment content is unavailable:",
-].join("\n");
+const GEMINI_NATIVE_UPLOAD_INSTRUCTION = buildNativeUploadInstruction("Gemini", "inlineData");
+
+const INLINED_ATTACHMENT_LINE_SUFFIX = "; inlined";
 
 const GEMINI_INLINE_NATIVE_ATTACHMENT_MAX_REQUEST_BYTES = 20 * 1024 * 1024;
 const GEMINI_INLINE_NATIVE_ATTACHMENT_REQUEST_RESERVE_BYTES = 256 * 1024;
@@ -107,22 +119,12 @@ const GEMINI_INLINE_NATIVE_ATTACHMENT_DATA_BUDGET_BYTES =
 
 const NATIVE_IMAGE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
 
-const NATIVE_INPUT_FILE_KINDS = new Set<PendingUploadedFile["kind"]>([
-  "text",
-  "pdf",
-  "notebook",
-  "word",
-  "spreadsheet",
-]);
-
 const ANTHROPIC_NATIVE_IMAGE_MIME_TYPES = new Set([
   "image/png",
   "image/jpeg",
   "image/gif",
   "image/webp",
 ]);
-
-const ANTHROPIC_NATIVE_DOCUMENT_MIME_TYPES = new Set(["application/pdf", "text/plain"]);
 
 const GEMINI_NATIVE_IMAGE_MIME_TYPES = new Set([
   "image/png",
@@ -132,14 +134,55 @@ const GEMINI_NATIVE_IMAGE_MIME_TYPES = new Set([
   "image/heif",
 ]);
 
-const GEMINI_NATIVE_DOCUMENT_MIME_TYPES = new Set([
-  "application/pdf",
-  "text/plain",
-  "text/markdown",
-  "text/html",
-  "text/xml",
-  "application/json",
-]);
+const PDF_MIME_TYPE = "application/pdf";
+
+function parseHostname(baseUrl: string | undefined) {
+  if (!baseUrl?.trim()) return undefined;
+  try {
+    return new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * PDF 只在各家官方端点原生内联。判断依据是请求 baseUrl 的主机名，而不是
+ * provider 类型——`claude_code` / `codex` / `gemini` 类型同样用于第三方兼容
+ * 中转（Kimi Coding、z.ai、各类 new-api 等），它们不接受专有 document 结构。
+ */
+function supportsNativePdfInline(model: Model<Api>, baseUrl: string | undefined) {
+  const hostname = parseHostname(baseUrl);
+  if (!hostname) return false;
+  switch (model.api) {
+    case "openai-responses":
+      return (
+        hostname === "api.openai.com" ||
+        hostname.endsWith(".api.openai.com") ||
+        hostname === "chatgpt.com" ||
+        hostname === "api.x.ai"
+      );
+    case "anthropic-messages":
+      return hostname === "api.anthropic.com";
+    case "google-generative-ai":
+      return hostname === "generativelanguage.googleapis.com";
+    default:
+      return false;
+  }
+}
+
+/**
+ * 附件 kind 是否进入原生内联候选。image 总是候选（MIME 与模型图片能力沿用各
+ * adapter 原有的筛法），pdf 仅官方端点，其余 kind 一律交给 Read。
+ */
+function isNativeInlineCandidate(
+  file: PendingUploadedFile,
+  model: Model<Api>,
+  baseUrl: string | undefined,
+) {
+  if (file.kind === "image") return true;
+  if (file.kind === "pdf") return supportsNativePdfInline(model, baseUrl);
+  return false;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object";
@@ -183,15 +226,6 @@ function buildDataUrl(mimeType: string, data: string) {
   return `data:${mimeType};base64,${data}`;
 }
 
-function decodeBase64Utf8(data: string) {
-  const binary = atob(data);
-  const bytes = new Uint8Array(binary.length);
-  for (let index = 0; index < binary.length; index += 1) {
-    bytes[index] = binary.charCodeAt(index);
-  }
-  return new TextDecoder().decode(bytes);
-}
-
 function estimateJsonRequestBytes(value: unknown) {
   try {
     return new TextEncoder().encode(JSON.stringify(value)).byteLength;
@@ -232,12 +266,12 @@ async function readNativeAttachment(params: {
 async function buildNativeAttachmentContentPart(params: {
   workdir: string;
   model: Model<Api>;
+  baseUrl?: string;
   file: PendingUploadedFile;
 }): Promise<NativeAttachmentContentPart | null> {
-  const { file, model, workdir } = params;
-  if (file.kind === "archive") return null;
+  const { file, model, workdir, baseUrl } = params;
+  if (!isNativeInlineCandidate(file, model, baseUrl)) return null;
   if (file.kind === "image" && !modelSupportsImageInput(model)) return null;
-  if (file.kind !== "image" && !NATIVE_INPUT_FILE_KINDS.has(file.kind)) return null;
 
   const attachment = await readNativeAttachment({ workdir, file });
   const mimeType = normalizeMimeType(attachment.mimeType);
@@ -252,6 +286,7 @@ async function buildNativeAttachmentContentPart(params: {
     };
   }
 
+  if (mimeType !== PDF_MIME_TYPE) return null;
   return {
     type: "input_file",
     filename: file.fileName || file.relativePath.split("/").pop() || "attachment",
@@ -282,28 +317,77 @@ async function buildOpenAIChatCompletionsNativeAttachmentContentPart(params: {
   };
 }
 
+function replaceUploadInstructionHeader(text: string, nativeInstruction: string) {
+  for (const header of UPLOADED_FILES_INSTRUCTION_HEADER_TEXTS) {
+    if (text.includes(header)) {
+      return text.replace(header, nativeInstruction);
+    }
+  }
+  return `${text}\n\n${nativeInstruction}`;
+}
+
+function annotateInlinedAttachmentLines(text: string, inlinedFiles: PendingUploadedFile[]) {
+  if (inlinedFiles.length === 0) return text;
+  return text
+    .split("\n")
+    .map((line) => {
+      if (inlinedFiles.some((file) => matchesUploadedFileInstructionLine(line, file))) {
+        return `${line}${INLINED_ATTACHMENT_LINE_SUFFIX}`;
+      }
+      return line;
+    })
+    .join("\n");
+}
+
+function rewriteNativeUploadInstructionText(params: {
+  text: string;
+  nativeInstruction: string;
+  inlinedFiles: PendingUploadedFile[];
+}) {
+  return annotateInlinedAttachmentLines(
+    replaceUploadInstructionHeader(params.text, params.nativeInstruction),
+    params.inlinedFiles,
+  );
+}
+
+function applyTypedNativeUploadInstruction(params: {
+  content: unknown[];
+  type: string;
+  nativeInstruction: string;
+  inlinedFiles: PendingUploadedFile[];
+}) {
+  const next = params.content.slice();
+  for (let index = 0; index < next.length; index += 1) {
+    const part = next[index];
+    if (!isRecord(part) || part.type !== params.type || typeof part.text !== "string") {
+      continue;
+    }
+    next[index] = {
+      ...part,
+      text: rewriteNativeUploadInstructionText({
+        text: part.text,
+        nativeInstruction: params.nativeInstruction,
+        inlinedFiles: params.inlinedFiles,
+      }),
+    };
+    return next;
+  }
+  return [{ type: params.type, text: params.nativeInstruction }, ...next];
+}
+
 function normalizeUserContent(content: unknown): unknown[] {
   if (Array.isArray(content)) return content.slice();
   if (typeof content === "string") return [{ type: "input_text", text: content }];
   return [];
 }
 
-function applyNativeUploadInstruction(content: unknown[]) {
-  const next = content.slice();
-  for (let index = 0; index < next.length; index += 1) {
-    const part = next[index];
-    if (!isRecord(part) || part.type !== "input_text" || typeof part.text !== "string") {
-      continue;
-    }
-    next[index] = {
-      ...part,
-      text: part.text.includes(WORKSPACE_UPLOAD_INSTRUCTION)
-        ? part.text.replace(WORKSPACE_UPLOAD_INSTRUCTION, NATIVE_UPLOAD_INSTRUCTION)
-        : `${part.text}\n\n${NATIVE_UPLOAD_INSTRUCTION}`,
-    };
-    return next;
-  }
-  return [{ type: "input_text", text: NATIVE_UPLOAD_INSTRUCTION }, ...next];
+function applyNativeUploadInstruction(content: unknown[], inlinedFiles: PendingUploadedFile[]) {
+  return applyTypedNativeUploadInstruction({
+    content,
+    type: "input_text",
+    nativeInstruction: NATIVE_UPLOAD_INSTRUCTION,
+    inlinedFiles,
+  });
 }
 
 function normalizeOpenAIChatCompletionsUserContent(content: unknown): unknown[] {
@@ -312,25 +396,16 @@ function normalizeOpenAIChatCompletionsUserContent(content: unknown): unknown[] 
   return [];
 }
 
-function applyOpenAIChatCompletionsNativeUploadInstruction(content: unknown[]) {
-  const next = content.slice();
-  for (let index = 0; index < next.length; index += 1) {
-    const part = next[index];
-    if (!isRecord(part) || part.type !== "text" || typeof part.text !== "string") {
-      continue;
-    }
-    next[index] = {
-      ...part,
-      text: part.text.includes(WORKSPACE_UPLOAD_INSTRUCTION)
-        ? part.text.replace(
-            WORKSPACE_UPLOAD_INSTRUCTION,
-            OPENAI_CHAT_COMPLETIONS_NATIVE_UPLOAD_INSTRUCTION,
-          )
-        : `${part.text}\n\n${OPENAI_CHAT_COMPLETIONS_NATIVE_UPLOAD_INSTRUCTION}`,
-    };
-    return next;
-  }
-  return [{ type: "text", text: OPENAI_CHAT_COMPLETIONS_NATIVE_UPLOAD_INSTRUCTION }, ...next];
+function applyOpenAIChatCompletionsNativeUploadInstruction(
+  content: unknown[],
+  inlinedFiles: PendingUploadedFile[],
+) {
+  return applyTypedNativeUploadInstruction({
+    content,
+    type: "text",
+    nativeInstruction: OPENAI_CHAT_COMPLETIONS_NATIVE_UPLOAD_INSTRUCTION,
+    inlinedFiles,
+  });
 }
 
 function normalizeAnthropicUserContent(content: unknown): unknown[] {
@@ -339,22 +414,16 @@ function normalizeAnthropicUserContent(content: unknown): unknown[] {
   return [];
 }
 
-function applyAnthropicNativeUploadInstruction(content: unknown[]) {
-  const next = content.slice();
-  for (let index = 0; index < next.length; index += 1) {
-    const part = next[index];
-    if (!isRecord(part) || part.type !== "text" || typeof part.text !== "string") {
-      continue;
-    }
-    next[index] = {
-      ...part,
-      text: part.text.includes(WORKSPACE_UPLOAD_INSTRUCTION)
-        ? part.text.replace(WORKSPACE_UPLOAD_INSTRUCTION, ANTHROPIC_NATIVE_UPLOAD_INSTRUCTION)
-        : `${part.text}\n\n${ANTHROPIC_NATIVE_UPLOAD_INSTRUCTION}`,
-    };
-    return next;
-  }
-  return [{ type: "text", text: ANTHROPIC_NATIVE_UPLOAD_INSTRUCTION }, ...next];
+function applyAnthropicNativeUploadInstruction(
+  content: unknown[],
+  inlinedFiles: PendingUploadedFile[],
+) {
+  return applyTypedNativeUploadInstruction({
+    content,
+    type: "text",
+    nativeInstruction: ANTHROPIC_NATIVE_UPLOAD_INSTRUCTION,
+    inlinedFiles,
+  });
 }
 
 function normalizeGeminiUserParts(parts: unknown): unknown[] {
@@ -363,7 +432,7 @@ function normalizeGeminiUserParts(parts: unknown): unknown[] {
   return [];
 }
 
-function applyGeminiNativeUploadInstruction(parts: unknown[]) {
+function applyGeminiNativeUploadInstruction(parts: unknown[], inlinedFiles: PendingUploadedFile[]) {
   const next = parts.slice();
   for (let index = 0; index < next.length; index += 1) {
     const part = next[index];
@@ -372,9 +441,11 @@ function applyGeminiNativeUploadInstruction(parts: unknown[]) {
     }
     next[index] = {
       ...part,
-      text: part.text.includes(WORKSPACE_UPLOAD_INSTRUCTION)
-        ? part.text.replace(WORKSPACE_UPLOAD_INSTRUCTION, GEMINI_NATIVE_UPLOAD_INSTRUCTION)
-        : `${part.text}\n\n${GEMINI_NATIVE_UPLOAD_INSTRUCTION}`,
+      text: rewriteNativeUploadInstructionText({
+        text: part.text,
+        nativeInstruction: GEMINI_NATIVE_UPLOAD_INSTRUCTION,
+        inlinedFiles,
+      }),
     };
     return next;
   }
@@ -417,17 +488,23 @@ function isAnthropicToolResultTurn(message: Record<string, unknown>) {
 async function buildNativeContentParts(params: {
   workdir: string;
   model: Model<Api>;
+  baseUrl?: string;
   files: PendingUploadedFile[];
 }) {
   const parts: NativeAttachmentContentPart[] = [];
+  const inlinedFiles: PendingUploadedFile[] = [];
   for (const file of params.files) {
     try {
       const part = await buildNativeAttachmentContentPart({
         workdir: params.workdir,
         model: params.model,
+        baseUrl: params.baseUrl,
         file,
       });
-      if (part) parts.push(part);
+      if (part) {
+        parts.push(part);
+        inlinedFiles.push(file);
+      }
     } catch (error) {
       console.warn(
         `[native-responses-attachments] skipped ${file.relativePath}:`,
@@ -435,7 +512,7 @@ async function buildNativeContentParts(params: {
       );
     }
   }
-  return parts;
+  return { parts, inlinedFiles };
 }
 
 async function buildOpenAIChatCompletionsNativeContentParts(params: {
@@ -444,6 +521,7 @@ async function buildOpenAIChatCompletionsNativeContentParts(params: {
   files: PendingUploadedFile[];
 }) {
   const parts: OpenAIChatCompletionsNativeAttachmentContentPart[] = [];
+  const inlinedFiles: PendingUploadedFile[] = [];
   for (const file of params.files) {
     try {
       const part = await buildOpenAIChatCompletionsNativeAttachmentContentPart({
@@ -451,7 +529,10 @@ async function buildOpenAIChatCompletionsNativeContentParts(params: {
         model: params.model,
         file,
       });
-      if (part) parts.push(part);
+      if (part) {
+        parts.push(part);
+        inlinedFiles.push(file);
+      }
     } catch (error) {
       console.warn(
         `[openai-chat-completions-native-attachments] skipped ${file.relativePath}:`,
@@ -459,17 +540,20 @@ async function buildOpenAIChatCompletionsNativeContentParts(params: {
       );
     }
   }
-  return parts;
+  return { parts, inlinedFiles };
 }
 
 async function buildAnthropicNativeAttachmentContentPart(params: {
   workdir: string;
+  model: Model<Api>;
+  baseUrl?: string;
   file: PendingUploadedFile;
 }): Promise<AnthropicNativeAttachmentContentPart | null> {
-  const { file, workdir } = params;
-  if (file.kind !== "image" && file.kind !== "pdf" && file.kind !== "text") {
-    return null;
-  }
+  const { file, model, workdir, baseUrl } = params;
+  if (!isNativeInlineCandidate(file, model, baseUrl)) return null;
+  // Anthropic 分支不读 model.input：modelFactory 给所有自定义 Anthropic 模型
+  // 硬编码 input: ["text"]，且用户 inputModalities 覆盖也不作用于此处。
+  // 若在这里加图片门控，k3 / glm 等一切非目录模型的图片内联都会失效。
 
   const attachment = await readNativeAttachment({ workdir, file });
   const mimeType = normalizeMimeType(attachment.mimeType);
@@ -487,18 +571,7 @@ async function buildAnthropicNativeAttachmentContentPart(params: {
     };
   }
 
-  if (!ANTHROPIC_NATIVE_DOCUMENT_MIME_TYPES.has(mimeType)) return null;
-  if (file.kind === "text") {
-    return {
-      type: "document",
-      source: {
-        type: "text",
-        media_type: "text/plain",
-        data: decodeBase64Utf8(attachment.data),
-      },
-      title: file.fileName || file.relativePath.split("/").pop() || undefined,
-    };
-  }
+  if (mimeType !== PDF_MIME_TYPE) return null;
   return {
     type: "document",
     source: {
@@ -512,16 +585,24 @@ async function buildAnthropicNativeAttachmentContentPart(params: {
 
 async function buildAnthropicNativeContentParts(params: {
   workdir: string;
+  model: Model<Api>;
+  baseUrl?: string;
   files: PendingUploadedFile[];
 }) {
   const parts: AnthropicNativeAttachmentContentPart[] = [];
+  const inlinedFiles: PendingUploadedFile[] = [];
   for (const file of params.files) {
     try {
       const part = await buildAnthropicNativeAttachmentContentPart({
         workdir: params.workdir,
+        model: params.model,
+        baseUrl: params.baseUrl,
         file,
       });
-      if (part) parts.push(part);
+      if (part) {
+        parts.push(part);
+        inlinedFiles.push(file);
+      }
     } catch (error) {
       console.warn(
         `[anthropic-native-attachments] skipped ${file.relativePath}:`,
@@ -529,18 +610,17 @@ async function buildAnthropicNativeContentParts(params: {
       );
     }
   }
-  return parts;
+  return { parts, inlinedFiles };
 }
 
 async function buildGeminiNativeAttachmentContentPart(params: {
   workdir: string;
   model: Model<Api>;
+  baseUrl?: string;
   file: PendingUploadedFile;
 }): Promise<GeminiNativeAttachmentCandidate | null> {
-  const { file, model, workdir } = params;
-  if (file.kind === "archive" || file.kind === "word" || file.kind === "spreadsheet") {
-    return null;
-  }
+  const { file, model, workdir, baseUrl } = params;
+  if (!isNativeInlineCandidate(file, model, baseUrl)) return null;
   if ((file.kind === "image" || file.kind === "pdf") && !modelSupportsImageInput(model)) {
     return null;
   }
@@ -554,7 +634,7 @@ async function buildGeminiNativeAttachmentContentPart(params: {
 
   if (file.kind === "image") {
     if (!GEMINI_NATIVE_IMAGE_MIME_TYPES.has(mimeType)) return null;
-  } else if (!GEMINI_NATIVE_DOCUMENT_MIME_TYPES.has(mimeType)) {
+  } else if (mimeType !== PDF_MIME_TYPE) {
     return null;
   }
 
@@ -572,19 +652,22 @@ async function buildGeminiNativeAttachmentContentPart(params: {
 async function buildGeminiNativeContentParts(params: {
   workdir: string;
   model: Model<Api>;
+  baseUrl?: string;
   files: PendingUploadedFile[];
   availableRequestBytes: number;
 }) {
   const parts: GeminiNativeAttachmentContentPart[] = [];
+  const inlinedFiles: PendingUploadedFile[] = [];
   let usedRequestBytes = 0;
   if (params.availableRequestBytes <= 0) {
-    return { parts, usedRequestBytes };
+    return { parts, inlinedFiles, usedRequestBytes };
   }
   for (const file of params.files) {
     try {
       const candidate = await buildGeminiNativeAttachmentContentPart({
         workdir: params.workdir,
         model: params.model,
+        baseUrl: params.baseUrl,
         file,
       });
       if (!candidate) continue;
@@ -592,6 +675,7 @@ async function buildGeminiNativeContentParts(params: {
         continue;
       }
       parts.push(candidate.part);
+      inlinedFiles.push(file);
       usedRequestBytes += candidate.requestBytes;
     } catch (error) {
       console.warn(
@@ -600,7 +684,7 @@ async function buildGeminiNativeContentParts(params: {
       );
     }
   }
-  return { parts, usedRequestBytes };
+  return { parts, inlinedFiles, usedRequestBytes };
 }
 
 function isGeminiFunctionResponseTurn(item: Record<string, unknown>) {
@@ -629,6 +713,7 @@ async function applyNativeAttachmentsToResponsesPayload(params: {
   context: Context;
   model: Model<Api>;
   workdir: string;
+  baseUrl?: string;
 }) {
   const payload = params.payload;
   if (!isRecord(payload) || !Array.isArray(payload.input)) return payload;
@@ -653,12 +738,13 @@ async function applyNativeAttachmentsToResponsesPayload(params: {
       continue;
     }
 
-    const nativeParts = await buildNativeContentParts({
+    const nativeContent = await buildNativeContentParts({
       workdir: params.workdir,
       model: params.model,
+      baseUrl: params.baseUrl,
       files,
     });
-    if (nativeParts.length === 0) {
+    if (nativeContent.parts.length === 0) {
       nextInput.push(item);
       continue;
     }
@@ -666,8 +752,11 @@ async function applyNativeAttachmentsToResponsesPayload(params: {
     nextInput.push({
       ...item,
       content: [
-        ...applyNativeUploadInstruction(normalizeUserContent(item.content)),
-        ...nativeParts,
+        ...applyNativeUploadInstruction(
+          normalizeUserContent(item.content),
+          nativeContent.inlinedFiles,
+        ),
+        ...nativeContent.parts,
       ],
     });
     changed = true;
@@ -709,12 +798,12 @@ async function applyNativeAttachmentsToOpenAICompletionsPayload(params: {
       continue;
     }
 
-    const nativeParts = await buildOpenAIChatCompletionsNativeContentParts({
+    const nativeContent = await buildOpenAIChatCompletionsNativeContentParts({
       workdir: params.workdir,
       model: params.model,
       files,
     });
-    if (nativeParts.length === 0) {
+    if (nativeContent.parts.length === 0) {
       nextMessages.push(message);
       continue;
     }
@@ -724,8 +813,9 @@ async function applyNativeAttachmentsToOpenAICompletionsPayload(params: {
       content: [
         ...applyOpenAIChatCompletionsNativeUploadInstruction(
           normalizeOpenAIChatCompletionsUserContent(message.content),
+          nativeContent.inlinedFiles,
         ),
-        ...nativeParts,
+        ...nativeContent.parts,
       ],
     });
     changed = true;
@@ -739,6 +829,7 @@ async function applyNativeAttachmentsToAnthropicPayload(params: {
   context: Context;
   model: Model<Api>;
   workdir: string;
+  baseUrl?: string;
 }) {
   const payload = params.payload;
   if (!isRecord(payload) || !Array.isArray(payload.messages)) return payload;
@@ -763,11 +854,13 @@ async function applyNativeAttachmentsToAnthropicPayload(params: {
       continue;
     }
 
-    const nativeParts = await buildAnthropicNativeContentParts({
+    const nativeContent = await buildAnthropicNativeContentParts({
       workdir: params.workdir,
+      model: params.model,
+      baseUrl: params.baseUrl,
       files,
     });
-    if (nativeParts.length === 0) {
+    if (nativeContent.parts.length === 0) {
       nextMessages.push(message);
       continue;
     }
@@ -775,8 +868,11 @@ async function applyNativeAttachmentsToAnthropicPayload(params: {
     nextMessages.push({
       ...message,
       content: [
-        ...applyAnthropicNativeUploadInstruction(normalizeAnthropicUserContent(message.content)),
-        ...nativeParts,
+        ...applyAnthropicNativeUploadInstruction(
+          normalizeAnthropicUserContent(message.content),
+          nativeContent.inlinedFiles,
+        ),
+        ...nativeContent.parts,
       ],
     });
     changed = true;
@@ -790,6 +886,7 @@ async function applyNativeAttachmentsToGeminiPayload(params: {
   context: Context;
   model: Model<Api>;
   workdir: string;
+  baseUrl?: string;
 }) {
   const payload = params.payload;
   if (!isRecord(payload) || !Array.isArray(payload.contents)) return payload;
@@ -824,11 +921,11 @@ async function applyNativeAttachmentsToGeminiPayload(params: {
     const nativeContent = await buildGeminiNativeContentParts({
       workdir: params.workdir,
       model: params.model,
+      baseUrl: params.baseUrl,
       files,
       availableRequestBytes: remainingNativeRequestBytes,
     });
-    const nativeParts = nativeContent.parts;
-    if (nativeParts.length === 0) {
+    if (nativeContent.parts.length === 0) {
       nextContents.push(item);
       continue;
     }
@@ -837,8 +934,11 @@ async function applyNativeAttachmentsToGeminiPayload(params: {
     nextContents.push({
       ...item,
       parts: [
-        ...nativeParts,
-        ...applyGeminiNativeUploadInstruction(normalizeGeminiUserParts(item.parts)),
+        ...nativeContent.parts,
+        ...applyGeminiNativeUploadInstruction(
+          normalizeGeminiUserParts(item.parts),
+          nativeContent.inlinedFiles,
+        ),
       ],
     });
     changed = true;
@@ -856,6 +956,7 @@ export function attachOpenAIResponsesNativeAttachments<
     model: Model<Api>;
     providerId: string;
     workdir?: string;
+    baseUrl?: string;
   },
 ): TOptions {
   if (
@@ -883,6 +984,7 @@ export function attachOpenAIResponsesNativeAttachments<
         context: params.context as Context,
         model,
         workdir: params.workdir ?? "",
+        baseUrl: params.baseUrl,
       });
     },
   };
@@ -897,6 +999,7 @@ export function attachOpenAICompletionsNativeAttachments<
     model: Model<Api>;
     providerId: string;
     workdir?: string;
+    baseUrl?: string;
   },
 ): TOptions {
   if (
@@ -938,6 +1041,7 @@ export function attachAnthropicMessagesNativeAttachments<
     model: Model<Api>;
     providerId: string;
     workdir?: string;
+    baseUrl?: string;
   },
 ): TOptions {
   if (
@@ -965,6 +1069,7 @@ export function attachAnthropicMessagesNativeAttachments<
         context: params.context as Context,
         model,
         workdir: params.workdir ?? "",
+        baseUrl: params.baseUrl,
       });
     },
   };
@@ -979,6 +1084,7 @@ export function attachGeminiGenerativeAINativeAttachments<
     model: Model<Api>;
     providerId: string;
     workdir?: string;
+    baseUrl?: string;
   },
 ): TOptions {
   if (
@@ -1006,19 +1112,21 @@ export function attachGeminiGenerativeAINativeAttachments<
         context: params.context as Context,
         model,
         workdir: params.workdir ?? "",
+        baseUrl: params.baseUrl,
       });
     },
   };
 }
 
 export const __nativeResponsesAttachmentsTest = {
-  WORKSPACE_UPLOAD_INSTRUCTION,
   NATIVE_UPLOAD_INSTRUCTION,
   OPENAI_CHAT_COMPLETIONS_NATIVE_UPLOAD_INSTRUCTION,
   ANTHROPIC_NATIVE_UPLOAD_INSTRUCTION,
   GEMINI_NATIVE_UPLOAD_INSTRUCTION,
+  INLINED_ATTACHMENT_LINE_SUFFIX,
   applyNativeAttachmentsToResponsesPayload,
   applyNativeAttachmentsToOpenAICompletionsPayload,
   applyNativeAttachmentsToAnthropicPayload,
   applyNativeAttachmentsToGeminiPayload,
+  supportsNativePdfInline,
 };

--- a/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts
@@ -159,24 +159,28 @@ const DEFAULT_PAYLOAD_INTERCEPTORS: readonly PayloadInterceptor[] = [
         model: params.model,
         providerId: params.providerId,
         workdir: params.workdir,
+        baseUrl: params.baseUrl,
       });
       nextOptions = attachOpenAICompletionsNativeAttachments(nextOptions, {
         context: params.context,
         model: params.model,
         providerId: params.providerId,
         workdir: params.workdir,
+        baseUrl: params.baseUrl,
       });
       nextOptions = attachAnthropicMessagesNativeAttachments(nextOptions, {
         context: params.context,
         model: params.model,
         providerId: params.providerId,
         workdir: params.workdir,
+        baseUrl: params.baseUrl,
       });
       return attachGeminiGenerativeAINativeAttachments(nextOptions, {
         context: params.context,
         model: params.model,
         providerId: params.providerId,
         workdir: params.workdir,
+        baseUrl: params.baseUrl,
       });
     },
   },

--- a/crates/agent-gui/test/chat/messages.test.mjs
+++ b/crates/agent-gui/test/chat/messages.test.mjs
@@ -226,6 +226,23 @@ test("uploaded file helpers preserve display text and strip model-hidden metadat
   ]);
   assert.match(message.content, /The user attached the files below/);
   assert.match(message.content, /Use Read with these exact paths/);
+  assert.match(message.content, /keep paging/);
+  assert.match(message.content, /\/workspace\/src\/App\.tsx \(text, 2 KB\)/);
+  assert.equal(
+    uploadedFiles.formatUploadedFileInstructionLine(fileA),
+    "- /workspace/src/App.tsx (text, 2 KB)",
+  );
+  assert.equal(
+    uploadedFiles.matchesUploadedFileInstructionLine(
+      "- /workspace/src/App.tsx (text, 2 KB)",
+      fileA,
+    ),
+    true,
+  );
+  assert.equal(
+    uploadedFiles.matchesUploadedFileInstructionLine("- /workspace/src/App.tsx (text)", fileA),
+    true,
+  );
 
   const projected = conversationState.createConversationStateFromContext({
     messages: [message],
@@ -319,9 +336,9 @@ test("uploaded file helpers preserve office and archive attachment kinds", () =>
     },
   ]);
   assert.ok(message);
-  assert.match(message.content, /\/\.liveagent\/uploads\/1\/report\.docx \(word\)/);
-  assert.match(message.content, /\/\.liveagent\/uploads\/1\/workbook\.xlsx \(spreadsheet\)/);
-  assert.match(message.content, /\/\.liveagent\/uploads\/1\/assets\.zip \(archive\)/);
+  assert.match(message.content, /\/\.liveagent\/uploads\/1\/report\.docx \(word, 4 KB\)/);
+  assert.match(message.content, /\/\.liveagent\/uploads\/1\/workbook\.xlsx \(spreadsheet, 8 KB\)/);
+  assert.match(message.content, /\/\.liveagent\/uploads\/1\/assets\.zip \(archive, 16 KB\)/);
   assert.deepEqual(
     uploadedFiles.getUserMessageAttachments(message).map((file) => file.kind),
     ["word", "spreadsheet", "archive"],

--- a/crates/agent-gui/test/providers/deepseek-attachments.test.mjs
+++ b/crates/agent-gui/test/providers/deepseek-attachments.test.mjs
@@ -104,11 +104,11 @@ test("DeepSeek inlines multiple large pastes while preserving ordinary Read atta
   assert.match(content, /first pasted body\n第二行/);
   assert.match(content, /second pasted body/);
   assert.doesNotMatch(content, /\[Pasted text/);
-  assert.doesNotMatch(content, /paste-1\.txt \(text\)/);
-  assert.doesNotMatch(content, /paste-2\.txt \(text\)/);
+  assert.doesNotMatch(content, /paste-1\.txt \(text/);
+  assert.doesNotMatch(content, /paste-2\.txt \(text/);
   assert.match(content, /Use Read with these exact paths/);
-  assert.match(content, /\/workspace\/docs\/report\.pdf \(pdf\)/);
-  assert.match(content, /\/workspace\/docs\/notes\.txt \(text\)/);
+  assert.match(content, /\/workspace\/docs\/report\.pdf \(pdf, 100 B\)/);
+  assert.match(content, /\/workspace\/docs\/notes\.txt \(text, 30 B\)/);
 
   const wire = JSON.stringify(context);
   assert.doesNotMatch(wire, /input_file/);

--- a/crates/agent-gui/test/providers/native-responses-attachments.test.mjs
+++ b/crates/agent-gui/test/providers/native-responses-attachments.test.mjs
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 
+const OFFICIAL_OPENAI_BASE_URL = "https://api.openai.com/v1";
+const OFFICIAL_ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1";
+const OFFICIAL_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+const KIMI_RELAY_BASE_URL = "https://api.kimi.com/coding";
+
 function createLoader(invoke) {
   return createTsModuleLoader({
     mocks: {
@@ -53,6 +58,7 @@ test("OpenAI Responses native attachment adapter adds input_image and input_file
       context: { messages: [message] },
       model: { api: "openai-responses", input: ["text", "image"] },
       workdir: "/workspace",
+      baseUrl: OFFICIAL_OPENAI_BASE_URL,
     });
 
   assert.equal(calls.length, 2);
@@ -63,8 +69,10 @@ test("OpenAI Responses native attachment adapter adds input_image and input_file
   assert.equal(result.input[0].content[0].type, "input_text");
   assert.match(
     result.input[0].content[0].text,
-    /Analyze the native attachments directly first/,
+    /included in this OpenAI Responses request/,
   );
+  assert.match(result.input[0].content[0].text, /screenshot\.png \(image, 5 B\); inlined/);
+  assert.match(result.input[0].content[0].text, /report\.pdf \(pdf, 3 B\); inlined/);
   assert.equal(result.input[0].content[1].type, "input_image");
   assert.equal(result.input[0].content[1].image_url, "data:image/png;base64,aW1hZ2U=");
   assert.equal(result.input[0].content[2].type, "input_file");
@@ -258,6 +266,7 @@ test("Anthropic Messages native attachment adapter adds image and document block
       context: { messages: [message] },
       model: { api: "anthropic-messages", input: ["text", "image"] },
       workdir: "/workspace",
+      baseUrl: OFFICIAL_ANTHROPIC_BASE_URL,
     });
 
   assert.equal(calls.length, 2);
@@ -285,22 +294,27 @@ test("Anthropic Messages native attachment adapter adds image and document block
   });
 });
 
-test("Anthropic Messages native attachment adapter sends text files as text documents", async () => {
-  const calls = [];
-  const loader = createLoader(async (command, args) => {
-    calls.push({ command, args });
-    return { mimeType: "text/plain", data: "SGVsbG8gQ2xhdWRl", sizeBytes: 12 };
+test("Anthropic Messages native attachment adapter keeps text files on the Read path", async () => {
+  const loader = createLoader(async () => {
+    throw new Error("should not read text attachments for native inline");
   });
   const uploadedFiles = loader.loadModule("@liveagent/ui/lib/chat/uploadedFiles.ts");
   const nativeAttachments = loader.loadModule("src/lib/providers/nativeResponsesAttachments.ts");
 
   const message = uploadedFiles.createUserMessageWithUploads("Summarize this", [
     {
-      relativePath: "uploads/1/notes.txt",
-      absolutePath: "/workspace/uploads/1/notes.txt",
-      fileName: "notes.txt",
+      relativePath: "uploads/1/notes.md",
+      absolutePath: "/workspace/uploads/1/notes.md",
+      fileName: "notes.md",
       kind: "text",
       sizeBytes: 12,
+    },
+    {
+      relativePath: "uploads/1/table.csv",
+      absolutePath: "/workspace/uploads/1/table.csv",
+      fileName: "table.csv",
+      kind: "text",
+      sizeBytes: 48,
     },
   ]);
   const payload = {
@@ -313,17 +327,224 @@ test("Anthropic Messages native attachment adapter sends text files as text docu
       context: { messages: [message] },
       model: { api: "anthropic-messages", input: ["text", "image"] },
       workdir: "/workspace",
+      baseUrl: OFFICIAL_ANTHROPIC_BASE_URL,
+    });
+
+  assert.equal(result, payload);
+  assert.match(payload.messages[0].content, /Use Read with these exact paths/);
+  assert.match(payload.messages[0].content, /notes\.md \(text, 12 B\)/);
+  assert.match(payload.messages[0].content, /table\.csv \(text, 48 B\)/);
+  assert.doesNotMatch(payload.messages[0].content, /; inlined/);
+});
+
+test("Anthropic Messages native attachment adapter keeps PDFs on the Read path at relay endpoints", async () => {
+  const loader = createLoader(async () => {
+    throw new Error("should not read PDF attachments on third-party Anthropic relays");
+  });
+  const uploadedFiles = loader.loadModule("@liveagent/ui/lib/chat/uploadedFiles.ts");
+  const nativeAttachments = loader.loadModule("src/lib/providers/nativeResponsesAttachments.ts");
+
+  const message = uploadedFiles.createUserMessageWithUploads("Inspect", [
+    {
+      relativePath: "uploads/1/report.pdf",
+      absolutePath: "/workspace/uploads/1/report.pdf",
+      fileName: "report.pdf",
+      kind: "pdf",
+      sizeBytes: 3,
+    },
+  ]);
+  const payload = {
+    messages: [{ role: "user", content: message.content }],
+  };
+
+  const result = await nativeAttachments.__nativeResponsesAttachmentsTest
+    .applyNativeAttachmentsToAnthropicPayload({
+      payload,
+      context: { messages: [message] },
+      model: { api: "anthropic-messages", input: ["text", "image"] },
+      workdir: "/workspace",
+      baseUrl: KIMI_RELAY_BASE_URL,
+    });
+
+  assert.equal(result, payload);
+  assert.match(payload.messages[0].content, /report\.pdf \(pdf, 3 B\)/);
+  assert.doesNotMatch(JSON.stringify(result), /"type":"document"/);
+});
+
+test("OpenAI Responses native attachment adapter keeps PDFs on the Read path at relay endpoints", async () => {
+  const loader = createLoader(async () => {
+    throw new Error("should not read PDF attachments on third-party OpenAI relays");
+  });
+  const uploadedFiles = loader.loadModule("@liveagent/ui/lib/chat/uploadedFiles.ts");
+  const nativeAttachments = loader.loadModule("src/lib/providers/nativeResponsesAttachments.ts");
+
+  const message = uploadedFiles.createUserMessageWithUploads("Inspect", [
+    {
+      relativePath: "uploads/1/report.pdf",
+      absolutePath: "/workspace/uploads/1/report.pdf",
+      fileName: "report.pdf",
+      kind: "pdf",
+      sizeBytes: 3,
+    },
+  ]);
+  const payload = {
+    input: [{ role: "user", content: [{ type: "input_text", text: message.content }] }],
+  };
+
+  const result = await nativeAttachments.__nativeResponsesAttachmentsTest
+    .applyNativeAttachmentsToResponsesPayload({
+      payload,
+      context: { messages: [message] },
+      model: { api: "openai-responses", input: ["text", "image"] },
+      workdir: "/workspace",
+      baseUrl: "https://relay.example.com/v1",
+    });
+
+  assert.equal(result, payload);
+  assert.match(payload.input[0].content[0].text, /report\.pdf \(pdf, 3 B\)/);
+  assert.doesNotMatch(JSON.stringify(result), /input_file/);
+});
+
+test("OpenAI Responses native attachment adapter never inlines text or office files", async () => {
+  const loader = createLoader(async () => {
+    throw new Error("should not read text or office attachments for native inline");
+  });
+  const uploadedFiles = loader.loadModule("@liveagent/ui/lib/chat/uploadedFiles.ts");
+  const nativeAttachments = loader.loadModule("src/lib/providers/nativeResponsesAttachments.ts");
+
+  const message = uploadedFiles.createUserMessageWithUploads("Inspect", [
+    {
+      relativePath: "uploads/1/notes.md",
+      absolutePath: "/workspace/uploads/1/notes.md",
+      fileName: "notes.md",
+      kind: "text",
+      sizeBytes: 20,
+    },
+    {
+      relativePath: "uploads/1/table.csv",
+      absolutePath: "/workspace/uploads/1/table.csv",
+      fileName: "table.csv",
+      kind: "text",
+      sizeBytes: 40,
+    },
+    {
+      relativePath: "uploads/1/report.docx",
+      absolutePath: "/workspace/uploads/1/report.docx",
+      fileName: "report.docx",
+      kind: "word",
+      sizeBytes: 80,
+    },
+    {
+      relativePath: "uploads/1/sheet.xlsx",
+      absolutePath: "/workspace/uploads/1/sheet.xlsx",
+      fileName: "sheet.xlsx",
+      kind: "spreadsheet",
+      sizeBytes: 90,
+    },
+  ]);
+  const payload = {
+    input: [{ role: "user", content: [{ type: "input_text", text: message.content }] }],
+  };
+
+  const result = await nativeAttachments.__nativeResponsesAttachmentsTest
+    .applyNativeAttachmentsToResponsesPayload({
+      payload,
+      context: { messages: [message] },
+      model: { api: "openai-responses", input: ["text", "image"] },
+      workdir: "/workspace",
+      baseUrl: OFFICIAL_OPENAI_BASE_URL,
+    });
+
+  assert.equal(result, payload);
+  assert.doesNotMatch(JSON.stringify(result), /input_file/);
+});
+
+test("mixed image and markdown only inlines the image and marks that line", async () => {
+  const calls = [];
+  const loader = createLoader(async (command, args) => {
+    calls.push({ command, args });
+    return { mimeType: "image/png", data: "aW1hZ2U=", sizeBytes: 5 };
+  });
+  const uploadedFiles = loader.loadModule("@liveagent/ui/lib/chat/uploadedFiles.ts");
+  const nativeAttachments = loader.loadModule("src/lib/providers/nativeResponsesAttachments.ts");
+
+  const message = uploadedFiles.createUserMessageWithUploads("Inspect these", [
+    {
+      relativePath: "uploads/1/screenshot.png",
+      absolutePath: "/workspace/uploads/1/screenshot.png",
+      fileName: "screenshot.png",
+      kind: "image",
+      sizeBytes: 5,
+    },
+    {
+      relativePath: "uploads/1/ARCHITECTURE.md",
+      absolutePath: "/workspace/uploads/1/ARCHITECTURE.md",
+      fileName: "ARCHITECTURE.md",
+      kind: "text",
+      sizeBytes: 15455,
+    },
+  ]);
+  const payload = {
+    messages: [{ role: "user", content: message.content }],
+  };
+
+  const result = await nativeAttachments.__nativeResponsesAttachmentsTest
+    .applyNativeAttachmentsToAnthropicPayload({
+      payload,
+      context: { messages: [message] },
+      model: { api: "anthropic-messages", input: ["text", "image"] },
+      workdir: "/workspace",
+      baseUrl: KIMI_RELAY_BASE_URL,
     });
 
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].args.kind, "text");
-  assert.equal(result.messages[0].content[1].type, "document");
-  assert.equal(result.messages[0].content[1].title, "notes.txt");
-  assert.deepEqual(result.messages[0].content[1].source, {
-    type: "text",
-    media_type: "text/plain",
-    data: "Hello Claude",
+  assert.equal(calls[0].args.kind, "image");
+  assert.equal(result.messages[0].content[1].type, "image");
+  assert.match(result.messages[0].content[0].text, /screenshot\.png \(image, 5 B\); inlined/);
+  assert.match(result.messages[0].content[0].text, /ARCHITECTURE\.md \(text, 15 KB\)/);
+  assert.doesNotMatch(result.messages[0].content[0].text, /ARCHITECTURE\.md \(text, 15 KB\); inlined/);
+  assert.doesNotMatch(JSON.stringify(result), /"type":"document"/);
+});
+
+test("PDF native inline is limited to official provider hosts", () => {
+  const loader = createLoader(async () => {
+    throw new Error("unused");
   });
+  const nativeAttachments = loader.loadModule("src/lib/providers/nativeResponsesAttachments.ts");
+  const { supportsNativePdfInline } = nativeAttachments.__nativeResponsesAttachmentsTest;
+
+  assert.equal(
+    supportsNativePdfInline({ api: "anthropic-messages" }, OFFICIAL_ANTHROPIC_BASE_URL),
+    true,
+  );
+  assert.equal(
+    supportsNativePdfInline({ api: "anthropic-messages" }, KIMI_RELAY_BASE_URL),
+    false,
+  );
+  assert.equal(
+    supportsNativePdfInline({ api: "openai-responses" }, OFFICIAL_OPENAI_BASE_URL),
+    true,
+  );
+  assert.equal(
+    supportsNativePdfInline({ api: "openai-responses" }, "https://relay.example.com/v1"),
+    false,
+  );
+  assert.equal(
+    supportsNativePdfInline({ api: "openai-responses" }, "https://api.x.ai/v1"),
+    true,
+  );
+  assert.equal(
+    supportsNativePdfInline({ api: "google-generative-ai" }, OFFICIAL_GEMINI_BASE_URL),
+    true,
+  );
+  assert.equal(
+    supportsNativePdfInline({ api: "google-generative-ai" }, "https://proxy.xf233.io"),
+    false,
+  );
+  assert.equal(
+    supportsNativePdfInline({ api: "openai-completions" }, OFFICIAL_OPENAI_BASE_URL),
+    false,
+  );
 });
 
 test("Anthropic Messages native attachment adapter preserves Read fallback for unsupported files", async () => {
@@ -455,6 +676,7 @@ test("Gemini native attachment adapter adds inlineData parts", async () => {
       context: { messages: [message] },
       model: { api: "google-generative-ai", input: ["text", "image"] },
       workdir: "/workspace",
+      baseUrl: OFFICIAL_GEMINI_BASE_URL,
     });
 
   assert.equal(calls.length, 2);
@@ -478,6 +700,74 @@ test("Gemini native attachment adapter adds inlineData parts", async () => {
     result.contents[0].parts[2].text,
     /Gemini request as native inlineData inputs/,
   );
+});
+
+test("Gemini native attachment adapter keeps PDFs on the Read path at relay endpoints", async () => {
+  const loader = createLoader(async () => {
+    throw new Error("should not read PDF attachments on third-party Gemini relays");
+  });
+  const uploadedFiles = loader.loadModule("@liveagent/ui/lib/chat/uploadedFiles.ts");
+  const nativeAttachments = loader.loadModule("src/lib/providers/nativeResponsesAttachments.ts");
+
+  const message = uploadedFiles.createUserMessageWithUploads("Inspect", [
+    {
+      relativePath: "uploads/1/report.pdf",
+      absolutePath: "/workspace/uploads/1/report.pdf",
+      fileName: "report.pdf",
+      kind: "pdf",
+      sizeBytes: 3,
+    },
+  ]);
+  const payload = {
+    contents: [{ role: "user", parts: [{ text: message.content }] }],
+  };
+
+  const result = await nativeAttachments.__nativeResponsesAttachmentsTest
+    .applyNativeAttachmentsToGeminiPayload({
+      payload,
+      context: { messages: [message] },
+      model: { api: "google-generative-ai", input: ["text", "image"] },
+      workdir: "/workspace",
+      baseUrl: "https://proxy.xf233.io",
+    });
+
+  assert.equal(result, payload);
+  assert.match(payload.contents[0].parts[0].text, /report\.pdf \(pdf, 3 B\)/);
+  assert.doesNotMatch(JSON.stringify(result), /inlineData/);
+});
+
+test("Gemini native attachment adapter keeps text files on the Read path", async () => {
+  const loader = createLoader(async () => {
+    throw new Error("should not read text attachments for native inline");
+  });
+  const uploadedFiles = loader.loadModule("@liveagent/ui/lib/chat/uploadedFiles.ts");
+  const nativeAttachments = loader.loadModule("src/lib/providers/nativeResponsesAttachments.ts");
+
+  const message = uploadedFiles.createUserMessageWithUploads("Summarize this", [
+    {
+      relativePath: "uploads/1/notes.md",
+      absolutePath: "/workspace/uploads/1/notes.md",
+      fileName: "notes.md",
+      kind: "text",
+      sizeBytes: 12,
+    },
+  ]);
+  const payload = {
+    contents: [{ role: "user", parts: [{ text: message.content }] }],
+  };
+
+  const result = await nativeAttachments.__nativeResponsesAttachmentsTest
+    .applyNativeAttachmentsToGeminiPayload({
+      payload,
+      context: { messages: [message] },
+      model: { api: "google-generative-ai", input: ["text", "image"] },
+      workdir: "/workspace",
+      baseUrl: OFFICIAL_GEMINI_BASE_URL,
+    });
+
+  assert.equal(result, payload);
+  assert.match(payload.contents[0].parts[0].text, /notes\.md \(text, 12 B\)/);
+  assert.doesNotMatch(JSON.stringify(result), /inlineData/);
 });
 
 test("Gemini native attachment adapter follows Gemini image MIME support", async () => {

--- a/crates/agent-ui/src/lib/chat/uploadedFiles.ts
+++ b/crates/agent-ui/src/lib/chat/uploadedFiles.ts
@@ -165,18 +165,88 @@ export function splitUserAttachmentsForDisplay(files: PendingUploadedFile[], tex
   };
 }
 
+/**
+ * 附件指令的两行固定头。provider 原生内联适配器（nativeResponsesAttachments）
+ * 按整段精确匹配把它替换成"部分附件已内联"的版本；DeepSeek 大段粘贴内联
+ * （deepSeekAttachments）按整段精确匹配在所有附件行都被移除后删掉它。
+ * 改文案必须保持这两处仍能命中，所以只在这里定义一次。
+ *
+ * 第二行顺带告诉模型 Read 是分窗口返回的：Read 每次只给一段（文本默认 200
+ * 行、PDF 默认 5 页、notebook 默认 20 cell），并在结果里报告总量；这里提前
+ * 提醒它翻到底，避免模型只读了第一窗就开始总结。这段提示单独导出，供
+ * nativeResponsesAttachments 拼"部分附件已内联"版本的指令头时复用。
+ */
+export const UPLOADED_FILES_READ_PAGING_HINT =
+  "Read returns a bounded window per call and reports the total size, so keep paging (start_line/limit, page_start/page_limit, or cell_start/cell_limit) until you have read each file completely:";
+
+export const UPLOADED_FILES_INSTRUCTION_HEADER_LINES = [
+  "The user attached the files below to this message.",
+  `Use Read with these exact paths before analyzing or modifying them. ${UPLOADED_FILES_READ_PAGING_HINT}`,
+] as const;
+
+/** 改文案前落库的历史消息仍带这版头；匹配时两版都认。 */
+const LEGACY_UPLOADED_FILES_INSTRUCTION_HEADER_LINES = [
+  "The user attached the files below to this message.",
+  "Use Read with these exact paths before analyzing or modifying them:",
+] as const;
+
+const UPLOADED_FILES_INSTRUCTION_HEADER_VARIANTS: readonly (readonly string[])[] = [
+  UPLOADED_FILES_INSTRUCTION_HEADER_LINES,
+  LEGACY_UPLOADED_FILES_INSTRUCTION_HEADER_LINES,
+];
+
+/** 当前与历史两版附件指令头的整段文本，供按字符串替换的调用方使用。 */
+export const UPLOADED_FILES_INSTRUCTION_HEADER_TEXTS: readonly string[] =
+  UPLOADED_FILES_INSTRUCTION_HEADER_VARIANTS.map((lines) => lines.join("\n"));
+
+/**
+ * 在按行拆开的消息里定位附件指令头（当前或历史格式）。返回头的起始下标
+ * 与行数；找不到返回 null。
+ */
+export function locateUploadedFilesInstructionHeader(lines: readonly string[]) {
+  for (let index = 0; index < lines.length; index += 1) {
+    for (const header of UPLOADED_FILES_INSTRUCTION_HEADER_VARIANTS) {
+      if (header.every((line, offset) => lines[index + offset] === line)) {
+        return { index, length: header.length };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * 单个附件在指令里的一行。格式是跨模块契约：deepSeekAttachments 按整行精确
+ * 匹配删除已内联的粘贴行，nativeResponsesAttachments 给原生内联的附件加标注。
+ * 带上体积让模型对"一窗读不完"有预期。
+ */
+export function formatUploadedFileInstructionLine(file: PendingUploadedFile) {
+  const absolutePath = typeof file.absolutePath === "string" ? file.absolutePath.trim() : "";
+  if (!absolutePath) return "";
+  const size =
+    Number.isFinite(file.sizeBytes) && file.sizeBytes >= 0
+      ? `, ${formatUploadedFileSize(Math.floor(file.sizeBytes))}`
+      : "";
+  return `- ${absolutePath} (${file.kind}${size})`;
+}
+
+/**
+ * 判断指令里的某一行是否就是该附件。除当前格式外也接受不带体积的旧格式
+ * `- <absolutePath> (<kind>)`，让已落库的历史会话继续能被精确匹配。
+ */
+export function matchesUploadedFileInstructionLine(line: string, file: PendingUploadedFile) {
+  const current = formatUploadedFileInstructionLine(file);
+  if (!current) return false;
+  if (line === current) return true;
+  const absolutePath = typeof file.absolutePath === "string" ? file.absolutePath.trim() : "";
+  return line === `- ${absolutePath} (${file.kind})`;
+}
+
 export function buildUploadedFilesInstruction(files: PendingUploadedFile[]) {
   // 模型读取路径只认导入时返回的绝对路径（工作区内原地引用、工作区外落
   // 暂存区）。旧版本仅持久化相对路径的附件不再列出——新方案下无法定位。
-  const lines = files
-    .filter((file) => typeof file.absolutePath === "string" && file.absolutePath.trim())
-    .map((file) => `- ${file.absolutePath} (${file.kind})`);
+  const lines = files.map(formatUploadedFileInstructionLine).filter((line) => line.length > 0);
   if (lines.length === 0) return "";
-  return [
-    "The user attached the files below to this message.",
-    "Use Read with these exact paths before analyzing or modifying them:",
-    ...lines,
-  ].join("\n");
+  return [...UPLOADED_FILES_INSTRUCTION_HEADER_LINES, ...lines].join("\n");
 }
 
 export function buildUserMessageContentWithUploads(userText: string, files: PendingUploadedFile[]) {


### PR DESCRIPTION
## Linked issue

Closes #726

## Summary

`claude_code` / `codex` / `gemini` 三种 provider 类型同样被用来接 Kimi Coding、z.ai、各类 new-api 等第三方兼容中转，而原生附件内联只按 provider **类型**门控，会把 Anthropic `document`、OpenAI Responses `input_file`、Gemini `inlineData` 这类专有 content block 发给不认识它们的端点。md / csv 等 `kind: "text"` 附件（以及 PDF）在 Kimi Coding 上直接 400 `Invalid request`；docx / xlsx 因本就不内联、只带路径让模型 Read 而一直正常。

按附件 kind 分层，五家 provider 统一策略，而不是一刀切全部走 Read：

| kind | 改动后 | 理由 |
|---|---|---|
| text / word / spreadsheet / notebook / archive | 一律不内联，走 Read | 正是出错的类型；Read 对它们的结果与内联等价（图片/PDF/docx/xlsx/ipynb Read 均已支持） |
| image | 保留原生内联 | `image` 是各家标准 block，兼容中转都认，零往返成本；codex/gemini 沿用原有 `model.input` 门控，anthropic 按 `modelFactory` 约定不读 `model.input` |
| pdf | 新增 `supportsNativePdfInline(model, baseUrl)`，按主机名只放行 `api.anthropic.com` / `api.openai.com` / `chatgpt.com` / `api.x.ai` / `generativelanguage.googleapis.com`，其余退回 Read | 官方端点的页面渲染（扫描件、表格、图表）价值大，lopdf 只抽文本层；中转端点不认专有结构 |

配套改动：

- 附件指令头第二行补上"Read 分窗口返回、请翻页读完"的提示，附件行带上体积（`- /path/x.md (text, 15 KB)`），缓解全部走 Read 后"只读第一窗就总结"的风险。
- 指令头与附件行格式收敛为 `uploadedFiles.ts` 单一定义源（`UPLOADED_FILES_INSTRUCTION_HEADER_LINES` / `UPLOADED_FILES_READ_PAGING_HINT` / `formatUploadedFileInstructionLine`），并提供 `locateUploadedFilesInstructionHeader` / `matchesUploadedFileInstructionLine` 同时匹配新旧两版格式，已落库历史会话不受影响；`deepSeekAttachments.ts` 改用这组 helper。
- 有附件被内联时，指令头换成"标注 `inlined` 的直接分析、其余必须 Read"的版本，并在对应附件行末追加 `; inlined`，模型能明确区分两类附件。

## Change scope

- Modules: agent-gui（providers）、agent-ui（GUI / WebUI 共享）
- Key paths:
  - `crates/agent-gui/src/lib/providers/nativeResponsesAttachments.ts`（分层策略、官方主机判断、指令头改写与 inlined 标注）
  - `crates/agent-gui/src/lib/providers/runtime/payloadPipeline.ts`（向四个 adapter 透传 `baseUrl`）
  - `crates/agent-gui/src/lib/providers/deepSeekAttachments.ts`（改用共享 helper）
  - `crates/agent-ui/src/lib/chat/uploadedFiles.ts`（指令头 / 附件行单一定义源、新旧格式匹配）
  - `crates/agent-gui/test/providers/native-responses-attachments.test.mjs`、`test/chat/messages.test.mjs`、`test/providers/deepseek-attachments.test.mjs`

## Screenshots / preview

后端 payload 行为改动，无 UI 变化。以下为线上失败记录与修复前后的 wire payload 对比。

**修复前**（`~/.liveagent/chat-history.sqlite3`，Kimi Coding `k3` 上传 `ARCHITECTURE.md`）：

```json
{ "role": "assistant", "api": "anthropic-messages", "model": "k3", "stopReason": "error",
  "errorMessage": "Invalid request Error", "usage": { "input": 0, "output": 0 } }
```

同类 GLM 中转透传的上游校验错误（点明根因）：

```
messages.4.content.list[...].1: Input tag 'document' found using 'type' does not match
any of the expected tags: 'text', 'image', 'tool_use', 'tool_result', ...
```

**修复前发往中转的 user content**（被拒绝）：

```json
[
  { "type": "text", "text": "这是什么\n\nThe attached files are inlined into this Anthropic Messages request as native image/document inputs ...\n- /…/ARCHITECTURE.md (text)" },
  { "type": "document", "source": { "type": "text", "media_type": "text/plain", "data": "…15 KB…" }, "title": "ARCHITECTURE.md" }
]
```

**修复后**（文本类不内联，payload 原样透传，模型用 Read 读取）：

```json
"这是什么\n\nThe user attached the files below to this message.\nUse Read with these exact paths before analyzing or modifying them. Read returns a bounded window per call and reports the total size, so keep paging (start_line/limit, page_start/page_limit, or cell_start/cell_limit) until you have read each file completely:\n- /…/ARCHITECTURE.md (text, 15 KB)"
```

**修复后图片 + markdown 混合**（只内联图片并标注，markdown 走 Read）：

```json
[
  { "type": "text", "text": "…Attachments marked \"inlined\" below are included in this Anthropic Messages request as native image/document inputs; analyze those directly. Every other listed file is only available through Read.\nUse Read with the exact paths for files that are not inlined …\n- /…/screenshot.png (image, 5 B); inlined\n- /…/ARCHITECTURE.md (text, 15 KB)" },
  { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": "…" } }
]
```

## Verification

- `node --test` 定向套件（native-responses-attachments / deepseek-attachments / messages / llm-interceptors / paste-newline-pipeline / edit-resend-*）105/105 ✅
- `pnpm run test:frontend`（agent-gui 完整前端套件）2870/2870 ✅
- `pnpm exec tsc --noEmit -p .`（agent-gui）与 `pnpm --filter @liveagent/ui typecheck` ✅
- `biome check` 全部改动源文件 ✅
- 新增/更新测试：
  - Anthropic / OpenAI Responses / Gemini 三家在中转端点 PDF 退回 Read（不出现 `document` / `input_file` / `inlineData`）
  - Anthropic / OpenAI / Gemini 文本与 office 类附件永不内联
  - 图片 + markdown 混合只内联图片并给该行加 `; inlined` 标注
  - `supportsNativePdfInline` 官方主机白名单
  - 指令行新格式（含体积）与旧格式（不含体积）均能被 `matchesUploadedFileInstructionLine` 匹配
- 已确认 `payloadPipeline` 收到的 `baseUrl` 是用户配置的上游地址而非本地代理地址（`requestOptions.ts` 用它生成代理请求；`anthropicCache.ts` 同样用它判断官方主机），官方端点判断成立。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.（仓库文档中无描述附件内联策略的内容，策略说明写在 `nativeResponsesAttachments.ts` 头部注释）

Made with [Cursor](https://cursor.com)