### PR TITLE
fix(providers): 纯文本模型的工具结果图片降级为说明文字，不再让会话永久失败

### DIFF
--- a/crates/agent-gui/src/lib/providers/deepSeekNative.ts
+++ b/crates/agent-gui/src/lib/providers/deepSeekNative.ts
@@ -15,6 +15,7 @@ import { createParser } from "eventsource-parser";
 import { inlineDeepSeekLargePastes } from "./deepSeekAttachments";
 import { resolveMaxTokens } from "./runtime/common";
 import { clampOpenAIReasoningEffort } from "./runtime/thinkingLevels";
+import { omitToolResultImages } from "./runtime/toolResultImageFallback";
 import type { StreamOptionsEx, ToolChoice } from "./runtime/types";
 
 export const DEEPSEEK_RESPONSES_API = "deepseek-responses";
@@ -94,15 +95,22 @@ function mapToolChoice(
   return { type: "function", name: toolChoice.name };
 }
 
-function assertTextOnlyContext(context: Context) {
+/**
+ * User-attached images are rejected up front: pi-ai forwards them as
+ * input_image unconditionally and DeepSeek's wire never accepts them.
+ *
+ * Tool-result images are deliberately NOT rejected here. They originate from
+ * tools (Browser screenshot, Read on an image file) rather than the user, and
+ * a thrown error would fail every later turn of the conversation because the
+ * tool result stays in history. They are degraded to a text notice instead
+ * (see omitToolResultImages).
+ */
+function assertNoUserImageInput(context: Context) {
   for (const message of context.messages) {
     if (message.role === "user" && Array.isArray(message.content)) {
       if (message.content.some((block) => block.type === "image")) {
         throw new Error("DeepSeek Responses does not support image input.");
       }
-    }
-    if (message.role === "toolResult" && message.content.some((block) => block.type === "image")) {
-      throw new Error("DeepSeek Responses does not support image tool results.");
     }
   }
 }
@@ -253,8 +261,11 @@ export function streamDeepSeekResponses(
 
   void (async () => {
     try {
-      assertTextOnlyContext(context);
-      const preparedContext = await inlineDeepSeekLargePastes(context, options.workdir);
+      assertNoUserImageInput(context);
+      // Forced (not gated on model.input): the DeepSeek wire never accepts
+      // image tool results, whatever capabilities the model object declares.
+      const textOnlyContext = omitToolResultImages(context, model.id);
+      const preparedContext = await inlineDeepSeekLargePastes(textOnlyContext, options.workdir);
       const responseCapture: DeepSeekResponseCapture = { outputByIndex: new Map() };
       const captureTasks: Promise<void>[] = [];
       const baseFetch = options.fetch ?? globalThis.fetch;

--- a/crates/agent-gui/src/lib/providers/runtime/toolResultImageFallback.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/toolResultImageFallback.ts
@@ -1,0 +1,93 @@
+import type {
+  Api,
+  Context,
+  ImageContent,
+  Message,
+  Model,
+  TextContent,
+  ToolResultMessage,
+} from "@earendil-works/pi-ai";
+
+/**
+ * Tool results (Browser screenshot, Read on an image file, ...) may carry
+ * inline image blocks. When the active model cannot consume images, those
+ * blocks must not reach the wire: pi-ai silently drops them for some
+ * protocols, and a hard rejection permanently bricks the conversation
+ * because the offending tool result stays in history for every later turn.
+ *
+ * This helper replaces such blocks with an explicit notice so the request
+ * still goes out and the model knows why the image is missing and what to
+ * do instead. Only the outbound request context is rewritten; persisted
+ * messages keep their images for the UI and for vision-capable models.
+ */
+
+export function modelAcceptsImageInput(model: Pick<Model<Api>, "input">): boolean {
+  return Array.isArray(model.input) && model.input.includes("image");
+}
+
+function estimateBase64Bytes(data: string): number {
+  const trimmed = data.trim();
+  if (!trimmed) return 0;
+  const padding = trimmed.endsWith("==") ? 2 : trimmed.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((trimmed.length * 3) / 4) - padding);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function buildOmittedToolResultImagesNotice(
+  images: readonly ImageContent[],
+  modelId: string,
+): string {
+  const noun = images.length === 1 ? "image" : "images";
+  const lines = images.map((image, index) => {
+    const mimeType = image.mimeType?.trim() || "image";
+    const bytes = estimateBase64Bytes(image.data);
+    return `${index + 1}. ${mimeType}${bytes > 0 ? ` (~${formatBytes(bytes)})` : ""}`;
+  });
+  return [
+    `[${images.length} ${noun} omitted from this tool result]`,
+    ...lines,
+    `The active model (${modelId}) does not accept image input, so the image bytes were not sent.`,
+    "Do not repeat the same image-producing action expecting to see it. Rely on text output instead (for example a page snapshot or file text), or ask the user to switch to a vision-capable model.",
+  ].join("\n");
+}
+
+function replaceToolResultImages(message: ToolResultMessage, modelId: string): ToolResultMessage {
+  const images = message.content.filter((block): block is ImageContent => block.type === "image");
+  if (images.length === 0) return message;
+  const textBlocks = message.content.filter((block): block is TextContent => block.type === "text");
+  const notice: TextContent = {
+    type: "text",
+    text: buildOmittedToolResultImagesNotice(images, modelId),
+  };
+  return { ...message, content: [...textBlocks, notice] };
+}
+
+/**
+ * Replace every tool-result image block with a text notice, regardless of the
+ * declared model capabilities. Use this for protocols whose wire format never
+ * accepts image tool results. Returns the same object when nothing changes.
+ */
+export function omitToolResultImages(context: Context, modelId: string): Context {
+  let changed = false;
+  const messages: Message[] = context.messages.map((message) => {
+    if (message.role !== "toolResult") return message;
+    const next = replaceToolResultImages(message, modelId);
+    if (next !== message) changed = true;
+    return next;
+  });
+  return changed ? { ...context, messages } : context;
+}
+
+/**
+ * Capability-gated variant: leaves the context untouched for models that
+ * declare image input, otherwise behaves like {@link omitToolResultImages}.
+ */
+export function omitToolResultImagesForTextOnlyModel(context: Context, model: Model<Api>): Context {
+  if (modelAcceptsImageInput(model)) return context;
+  return omitToolResultImages(context, model.id);
+}

--- a/crates/agent-gui/src/lib/providers/service/piAiAdapter.ts
+++ b/crates/agent-gui/src/lib/providers/service/piAiAdapter.ts
@@ -21,6 +21,7 @@ import {
   resolveAnthropicThinkingRuntime,
   resolveGeminiThinkingRuntime,
 } from "../runtime/thinkingLevels";
+import { omitToolResultImagesForTextOnlyModel } from "../runtime/toolResultImageFallback";
 import type { StreamOptionsEx, ToolChoice } from "../runtime/types";
 import type { LlmAdapter } from "./types";
 
@@ -30,6 +31,11 @@ import type { LlmAdapter } from "./types";
 // 各分支为 streamByApi.ts 原实现的原样搬移（PR-1 行为等价不变量）：分支内的
 // withStreamRetry 包装位置、toolChoice 映射、thinking runtime 解析、注释
 // 一并保留，不做任何重写。判定基准是 PR-0 golden 快照零修改通过。
+//
+// 唯一的入口侧处理：对 openai-completions / openai-responses / google 三协议，
+// 纯文本模型（model.input 不含 "image"）的工具结果图片在进 pi-ai 前替换为
+// 说明文字。pi-ai 对这三协议本就按 model.input 静默丢弃这些图片，模型只会
+// 看到"see image below"却没有图；这里让缺图原因与替代做法对模型显式可见。
 // ============================================================================
 
 function mapToolChoiceToOpenAI(
@@ -180,13 +186,28 @@ export const piAiAdapter: LlmAdapter = {
   stream(model, context, options) {
     switch (model.api) {
       case "anthropic-messages":
+        // 不按 model.input 剥离工具结果图片：自定义 anthropic 模型的 input 是
+        // 保守默认值（["text"]），中转背后的模型可能具备视觉，pi-ai 该协议
+        // 也不看 model.input，与附件路径口径一致（见 modelFactory 注释）。
         return streamAnthropicMessages(model, context, options);
       case "openai-completions":
-        return streamOpenAICompletionsApi(model, context, options);
+        return streamOpenAICompletionsApi(
+          model,
+          omitToolResultImagesForTextOnlyModel(context, model),
+          options,
+        );
       case "openai-responses":
-        return streamOpenAIResponsesApi(model, context, options);
+        return streamOpenAIResponsesApi(
+          model,
+          omitToolResultImagesForTextOnlyModel(context, model),
+          options,
+        );
       case "google-generative-ai":
-        return streamGoogleGenerativeAi(model, context, options);
+        return streamGoogleGenerativeAi(
+          model,
+          omitToolResultImagesForTextOnlyModel(context, model),
+          options,
+        );
       default:
         // 注册表按 apis 路由到这里，正常不可达；防御分支保持同一错误文案。
         throw new Error(`Unsupported model API: ${model.api}`);

--- a/crates/agent-gui/test/providers/deepseek-native.test.mjs
+++ b/crates/agent-gui/test/providers/deepseek-native.test.mjs
@@ -691,3 +691,75 @@ test("DeepSeek rejects image input before sending a request", async () => {
   assert.equal(result.stopReason, "error");
   assert.match(result.errorMessage, /does not support image input/);
 });
+
+test("DeepSeek degrades image tool results to text instead of failing the request", async () => {
+  // Regression: a Browser screenshot (or Read on an image) used to throw
+  // "does not support image tool results" before fetch, and since the tool
+  // result stays in history every later turn failed the same way.
+  const screenshotBase64 = "/9j/4AAQSkZJRgABAQAAAQABAAD".repeat(64);
+  const calls = [];
+  const context = createContext({
+    messages: [
+      { role: "user", content: "screenshot the page", timestamp: 1 },
+      assistant({
+        content: [
+          {
+            type: "toolCall",
+            id: "call_shot|browser-1",
+            name: "Browser",
+            arguments: { action: "screenshot" },
+          },
+        ],
+        stopReason: "toolUse",
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_shot|browser-1",
+        toolName: "Browser",
+        content: [
+          { type: "text", text: "Page: http://127.0.0.1:8899/\nScreenshot captured (see image below)." },
+          { type: "image", data: screenshotBase64, mimeType: "image/jpeg" },
+        ],
+        details: { kind: "browser", action: "screenshot", hasScreenshot: true },
+        isError: false,
+        timestamp: 3,
+      },
+      { role: "user", content: "skip the failing item and continue", timestamp: 4 },
+    ],
+    tools: [
+      {
+        name: "Browser",
+        description: "browser",
+        parameters: { type: "object", properties: {}, additionalProperties: true },
+      },
+    ],
+  });
+  const stream = deepseek.streamDeepSeekResponses(createModel(), context, {
+    apiKey: "sk-test",
+    streamRetry: { disabled: true },
+    fetch: async (_url, init) => {
+      calls.push(JSON.parse(String(init.body)));
+      return responseFromEvents(
+        completedSearchResponseEvents({ includeFunctionCall: false }).events,
+      );
+    },
+  });
+  const { result } = await consume(stream);
+
+  assert.equal(result.stopReason, "stop", result.errorMessage);
+  assert.equal(calls.length, 1);
+  const wire = JSON.stringify(calls[0]);
+  assert.ok(!wire.includes(screenshotBase64), "screenshot bytes must not reach the wire");
+  assert.ok(!wire.includes("input_image"), "no image parts may reach the wire");
+
+  const toolOutput = calls[0].input.find((item) => item.type === "function_call_output");
+  assert.ok(toolOutput, "tool result must still be sent");
+  assert.equal(toolOutput.call_id, "call_shot");
+  assert.equal(typeof toolOutput.output, "string");
+  assert.match(toolOutput.output, /Screenshot captured/);
+  assert.match(toolOutput.output, /1 image omitted from this tool result/);
+  assert.match(toolOutput.output, /deepseek-v4-flash.*does not accept image input/);
+
+  // The caller's context is not mutated: the UI keeps rendering the image.
+  assert.equal(context.messages[2].content[1].type, "image");
+});

--- a/crates/agent-gui/test/providers/pi-ai-adapter-image-fallback.test.mjs
+++ b/crates/agent-gui/test/providers/pi-ai-adapter-image-fallback.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+// ============================================================================
+// pi-ai 适配器入口侧的工具结果图片降级。
+//
+// 纯文本模型（model.input 不含 "image"）下，openai-completions / openai-responses /
+// google 三协议在进 pi-ai 前把工具结果里的 image 块替换成说明文字；
+// anthropic-messages 刻意不做（自定义模型的 input 是保守默认值，中转背后可能
+// 具备视觉）。本文件按"传给 pi-ai stream() 的 context"逐协议锁定这条口径。
+// ============================================================================
+
+function createUsage() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function createSourceStream(model) {
+  const assistant = {
+    role: "assistant",
+    content: [{ type: "text", text: "ok" }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: createUsage(),
+    stopReason: "stop",
+    timestamp: 1,
+  };
+  const events = [
+    { type: "start", partial: { ...assistant, content: [] } },
+    { type: "done", reason: "stop", message: assistant },
+  ];
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const event of events) yield event;
+    },
+    async result() {
+      return assistant;
+    },
+  };
+}
+
+const SCREENSHOT = "/9j/4AAQSkZJRgABAQAAAQABAAD".repeat(16);
+
+function buildContext() {
+  return {
+    systemPrompt: "You are precise.",
+    messages: [
+      { role: "user", content: "screenshot the page", timestamp: 1 },
+      {
+        role: "toolResult",
+        toolCallId: "call_shot",
+        toolName: "Browser",
+        content: [
+          { type: "text", text: "Screenshot captured (see image below)." },
+          { type: "image", data: SCREENSHOT, mimeType: "image/jpeg" },
+        ],
+        details: { kind: "browser", action: "screenshot", hasScreenshot: true },
+        isError: false,
+        timestamp: 2,
+      },
+    ],
+  };
+}
+
+function createModel(api, provider, input) {
+  return {
+    id: `${provider}-model`,
+    name: `${provider}-model`,
+    api,
+    provider,
+    baseUrl: "https://relay.example.test/v1",
+    reasoning: false,
+    input,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8_192,
+  };
+}
+
+const API_MODULES = {
+  "anthropic-messages": "@earendil-works/pi-ai/api/anthropic-messages",
+  "openai-completions": "@earendil-works/pi-ai/api/openai-completions",
+  "openai-responses": "@earendil-works/pi-ai/api/openai-responses",
+  "google-generative-ai": "@earendil-works/pi-ai/api/google-generative-ai",
+};
+
+async function captureContext(model) {
+  const captured = [];
+  const mocks = Object.fromEntries(
+    Object.values(API_MODULES).map((specifier) => [
+      specifier,
+      {
+        stream(streamModel, context) {
+          captured.push(context);
+          return createSourceStream(streamModel);
+        },
+      },
+    ]),
+  );
+  const loader = createTsModuleLoader({ mocks });
+  const { streamSimpleByApi } = loader.loadModule("src/lib/providers/runtime/streamByApi.ts");
+  const context = buildContext();
+  const stream = streamSimpleByApi(model, context, {
+    apiKey: "sk-test",
+    streamRetry: { disabled: true },
+  });
+  await stream.result();
+  assert.equal(captured.length, 1, `expected exactly one pi-ai stream call for ${model.api}`);
+  return { original: context, passed: captured[0] };
+}
+
+function assertDegraded(model, { original, passed }) {
+  assert.notEqual(passed, original, `${model.api}: text-only model must get a rewritten context`);
+  const toolResult = passed.messages[1];
+  assert.ok(
+    toolResult.content.every((block) => block.type === "text"),
+    `${model.api}: no image blocks may reach pi-ai`,
+  );
+  assert.equal(toolResult.content[0].text, "Screenshot captured (see image below).");
+  assert.match(toolResult.content[1].text, /1 image omitted from this tool result/);
+  assert.match(toolResult.content[1].text, new RegExp(`${model.id}.*does not accept image input`));
+  assert.ok(!JSON.stringify(passed).includes(SCREENSHOT), `${model.api}: bytes must not leak`);
+  // 调用方的 context 不被改写：UI 仍渲染图片，切到视觉模型后图片仍可发送。
+  assert.equal(original.messages[1].content[1].type, "image");
+}
+
+for (const [api, provider] of [
+  ["openai-completions", "openai"],
+  ["openai-responses", "openai"],
+  ["google-generative-ai", "google"],
+]) {
+  test(`${api}: text-only model gets tool-result images replaced by a notice`, async () => {
+    const model = createModel(api, provider, ["text"]);
+    assertDegraded(model, await captureContext(model));
+  });
+
+  test(`${api}: vision model keeps tool-result images and context identity`, async () => {
+    const model = createModel(api, provider, ["text", "image"]);
+    const { original, passed } = await captureContext(model);
+    assert.equal(passed, original);
+    assert.equal(passed.messages[1].content[1].type, "image");
+  });
+}
+
+test("anthropic-messages: tool-result images pass through even when model.input is text-only", async () => {
+  const model = createModel("anthropic-messages", "anthropic", ["text"]);
+  const { original, passed } = await captureContext(model);
+  assert.equal(passed, original);
+  assert.equal(passed.messages[1].content[1].type, "image");
+});

--- a/crates/agent-gui/test/providers/tool-result-image-fallback.test.mjs
+++ b/crates/agent-gui/test/providers/tool-result-image-fallback.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
+
+const loader = createTsModuleLoader();
+const {
+  buildOmittedToolResultImagesNotice,
+  modelAcceptsImageInput,
+  omitToolResultImages,
+  omitToolResultImagesForTextOnlyModel,
+} = loader.loadModule("src/lib/providers/runtime/toolResultImageFallback.ts");
+
+const JPEG_BASE64 = "A".repeat(1024 * 4); // ~3 KB once decoded
+
+function textOnlyModel(overrides = {}) {
+  return {
+    id: "deepseek-v4-flash",
+    name: "DeepSeek V4 Flash",
+    api: "deepseek-responses",
+    provider: "deepseek",
+    baseUrl: "https://api.deepseek.com",
+    input: ["text"],
+    reasoning: false,
+    contextWindow: 128_000,
+    maxTokens: 8_192,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    ...overrides,
+  };
+}
+
+function screenshotToolResult(overrides = {}) {
+  return {
+    role: "toolResult",
+    toolCallId: "call_1|browser-1",
+    toolName: "Browser",
+    content: [
+      {
+        type: "text",
+        text: "Page: http://127.0.0.1:8899/file-a.txt\nScreenshot captured (see image below).",
+      },
+      { type: "image", data: JPEG_BASE64, mimeType: "image/jpeg" },
+    ],
+    details: { kind: "browser", action: "screenshot", hasScreenshot: true },
+    isError: false,
+    timestamp: 3,
+    ...overrides,
+  };
+}
+
+function buildContext(messages) {
+  return { systemPrompt: "You are precise.", messages };
+}
+
+test("modelAcceptsImageInput reads the declared input modalities", () => {
+  assert.equal(modelAcceptsImageInput({ input: ["text"] }), false);
+  assert.equal(modelAcceptsImageInput({ input: ["text", "image"] }), true);
+  assert.equal(modelAcceptsImageInput({ input: undefined }), false);
+});
+
+test("omitToolResultImages replaces image blocks with a notice and keeps the tool text", () => {
+  const original = screenshotToolResult();
+  const context = buildContext([
+    { role: "user", content: "take a screenshot", timestamp: 1 },
+    {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1|browser-1", name: "Browser", arguments: {} }],
+      api: "deepseek-responses",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "toolUse",
+      timestamp: 2,
+    },
+    original,
+  ]);
+
+  const next = omitToolResultImages(context, "deepseek-v4-flash");
+
+  assert.notEqual(next, context, "a changed context must be a new object");
+  assert.equal(next.systemPrompt, context.systemPrompt);
+  assert.equal(next.messages.length, 3);
+  assert.equal(next.messages[0], context.messages[0], "untouched messages keep identity");
+  assert.equal(next.messages[1], context.messages[1], "untouched messages keep identity");
+
+  const toolResult = next.messages[2];
+  assert.deepEqual(
+    toolResult.content.map((block) => block.type),
+    ["text", "text"],
+  );
+  assert.equal(toolResult.content[0].text, original.content[0].text);
+  assert.match(toolResult.content[1].text, /1 image omitted from this tool result/);
+  assert.match(toolResult.content[1].text, /image\/jpeg \(~3\.0 KB\)/);
+  assert.match(toolResult.content[1].text, /deepseek-v4-flash.*does not accept image input/);
+  assert.match(toolResult.content[1].text, /switch to a vision-capable model/);
+  assert.ok(!JSON.stringify(toolResult).includes(JPEG_BASE64), "image bytes must not leak");
+  assert.equal(toolResult.toolCallId, original.toolCallId);
+  assert.equal(toolResult.toolName, original.toolName);
+  assert.deepEqual(toolResult.details, original.details, "UI details are preserved");
+
+  // The persisted message must not be mutated: the UI still renders the image.
+  assert.equal(original.content.length, 2);
+  assert.equal(original.content[1].type, "image");
+});
+
+test("omitToolResultImages returns the same context when no tool result carries images", () => {
+  const context = buildContext([
+    { role: "user", content: "hello", timestamp: 1 },
+    screenshotToolResult({
+      content: [{ type: "text", text: "Page snapshot (a11y tree): ..." }],
+    }),
+  ]);
+  assert.equal(omitToolResultImages(context, "any-model"), context);
+});
+
+test("omitToolResultImages leaves user image blocks alone", () => {
+  const userImage = {
+    role: "user",
+    content: [
+      { type: "text", text: "describe" },
+      { type: "image", data: "AAAA", mimeType: "image/png" },
+    ],
+    timestamp: 1,
+  };
+  const context = buildContext([userImage]);
+  assert.equal(omitToolResultImages(context, "any-model"), context);
+});
+
+test("image-only tool results still yield a text notice", () => {
+  const context = buildContext([
+    screenshotToolResult({
+      toolName: "Read",
+      content: [
+        { type: "image", data: "AAAA", mimeType: "image/png" },
+        { type: "image", data: "BBBB", mimeType: "image/webp" },
+      ],
+    }),
+  ]);
+  const [toolResult] = omitToolResultImages(context, "m").messages;
+  assert.equal(toolResult.content.length, 1);
+  assert.equal(toolResult.content[0].type, "text");
+  assert.match(toolResult.content[0].text, /2 images omitted/);
+  assert.match(toolResult.content[0].text, /1\. image\/png/);
+  assert.match(toolResult.content[0].text, /2\. image\/webp/);
+});
+
+test("omitToolResultImagesForTextOnlyModel is gated on model.input", () => {
+  const context = buildContext([screenshotToolResult()]);
+
+  const vision = textOnlyModel({ input: ["text", "image"] });
+  assert.equal(omitToolResultImagesForTextOnlyModel(context, vision), context);
+
+  const textOnly = textOnlyModel();
+  const degraded = omitToolResultImagesForTextOnlyModel(context, textOnly);
+  assert.notEqual(degraded, context);
+  assert.ok(degraded.messages[0].content.every((block) => block.type === "text"));
+});
+
+test("notice formats byte sizes from base64 length", () => {
+  const notice = buildOmittedToolResultImagesNotice(
+    [
+      { type: "image", data: "QUJD", mimeType: "image/png" }, // "ABC" -> 3 B
+      { type: "image", data: "A".repeat(2_000_000), mimeType: "image/jpeg" },
+      { type: "image", data: "", mimeType: "" },
+    ],
+    "model-x",
+  );
+  assert.match(notice, /1\. image\/png \(~3 B\)/);
+  assert.match(notice, /2\. image\/jpeg \(~1\.4 MB\)/);
+  assert.match(notice, /3\. image$/m);
+});


### PR DESCRIPTION
## Linked issue

Closes #729

## Summary

`Browser` 截图、`Read` 图片文件等工具结果带 `image` 块时，DeepSeek Responses 适配器的 `assertTextOnlyContext` 在发请求前直接 `throw "does not support image tool results"`，`usage` 全 0。由于这条 toolResult 永久留在历史里，之后用户发任何消息都在本地被同一断言拦下，会话实质报废，只能重开。同一会话里 `Image` 工具显示 SVG 却不报错，是因为 `requestContextSanitizer.ts` 只给 `Image` 工具做了内联字节替换为文字的特例。

问题的本质是：**工具结果里的 image 块到了一个吃不了图片的模型/协议，而适配器把"能力不匹配"变成了硬错误**。修复原则是只改出站请求 context、不动持久化消息（UI 继续显示截图，以后切到视觉模型仍能看到），并把降级做成对模型可见的说明文字，而不是静默丢图。

没有选在共享 seam（`streamSimpleByApi` / 请求净化器）统一剥图：`service/types.ts` 约定 seam 不解释 context；更关键的是 `claude_code` 自定义模型的 `input: ["text"]` 只是保守默认值，代码库刻意在该路径不信 `model.input`（中转背后的模型可能有视觉，见 `modelFactory.ts` 注释），一刀切会造成回退。因此策略落在各适配器内部，共用一个 helper：

- **新增 `runtime/toolResultImageFallback.ts`**：`omitToolResultImages(context, modelId)` 把所有 toolResult 的 image 块替换为一段说明（保留原文本；无变化时返回同一对象，保持 context 同一性）；`omitToolResultImagesForTextOnlyModel(context, model)` 是按 `model.input` 门控的版本。说明文字告知模型省略了几张图、mime/大小、原因，以及不要重复截图、改用文本输出（如 snapshot）或请用户切换视觉模型。
- **`deepSeekNative.ts`**：`assertTextOnlyContext` → `assertNoUserImageInput`，用户直接上传图片仍前置拒绝（pi-ai 会无条件下发 `input_image`，DeepSeek 线上必拒）；工具结果图片改为强制降级，不看 `model.input`，因为 DeepSeek 协议本身就不收图。
- **`service/piAiAdapter.ts`**：`openai-completions` / `openai-responses` / `google-generative-ai` 三协议在纯文本模型下同样应用降级。pi-ai 对这三个协议本就按 `model.input` 静默丢图，模型只看到「Screenshot captured (see image below)」却没有图；现在缺图原因显式可见。`anthropic-messages` 刻意不处理，注释说明原因。

对 issue 里那条已卡死的会话不需要特殊处理：下一次发送时，历史里的截图 toolResult 会在适配器内被替换为说明文字，请求正常发出。

## Change scope

- Modules: agent-gui / providers
- Key paths:
  - `crates/agent-gui/src/lib/providers/runtime/toolResultImageFallback.ts`（新增）
  - `crates/agent-gui/src/lib/providers/deepSeekNative.ts`
  - `crates/agent-gui/src/lib/providers/service/piAiAdapter.ts`
  - `crates/agent-gui/test/providers/tool-result-image-fallback.test.mjs`（新增）
  - `crates/agent-gui/test/providers/pi-ai-adapter-image-fallback.test.mjs`（新增）
  - `crates/agent-gui/test/providers/deepseek-native.test.mjs`

## Screenshots / preview

<!-- TODO(@su-fen): 补充桌面端截图（修复前报错 / 修复后会话继续）。 -->

非 UI 改动，以下为线格式层面的修复前后对照。

**修复前 —— `~/.liveagent/chat-history.sqlite3` 会话 `b03e3b2f…` 的记录，请求根本没发出，用户再发消息仍是同一错误：**

```json
{ "role": "toolResult", "toolName": "Browser",
  "content": [
    { "type": "text", "text": "Page: http://127.0.0.1:8899/file-a.txt\nScreenshot captured (see image below)." },
    { "type": "image", "mimeType": "image/jpeg", "data": "/9j/4AAQ…<44144 chars>" } ] }
{ "role": "assistant", "api": "deepseek-responses", "stopReason": "error",
  "errorMessage": "DeepSeek Responses does not support image tool results.", "usage": { "input": 0, "output": 0 } }
{ "role": "user", "content": "跳过报错测试项继续" }
{ "role": "assistant", "api": "deepseek-responses", "stopReason": "error",
  "errorMessage": "DeepSeek Responses does not support image tool results.", "usage": { "input": 0, "output": 0 } }
```

**修复后 —— 同一 context 走 `streamDeepSeekResponses`（mock fetch 截获请求体），请求发出，`function_call_output` 只含文本：**

```text
POST https://api.deepseek.com/responses
{
  "type": "function_call_output",
  "call_id": "call_00_M5IzSZUWdSiZJLnnbYNT6710",
  "output": "Page: http://127.0.0.1:8899/file-a.txt\nScreenshot captured (see image below).\n[1 image omitted from this tool result]\n1. image/jpeg (~32.3 KB)\nThe active model (deepseek-v4-flash) does not accept image input, so the image bytes were not sent.\nDo not repeat the same image-producing action expecting to see it. Rely on text output instead (for example a page snapshot or file text), or ask the user to switch to a vision-capable model."
}
payload contains input_image: false
payload contains image bytes: false
```

## Verification

- `cd crates/agent-gui && node --test test/providers/tool-result-image-fallback.test.mjs test/providers/pi-ai-adapter-image-fallback.test.mjs test/providers/deepseek-native.test.mjs` → 22/22 通过。
- `cd crates/agent-gui && pnpm test:frontend` → 2926/2926 通过（含 `wire-payload-golden` / `transport-golden` / `llm-service-seam` / `provider-failover`，无快照变更）。
- `cd crates/agent-gui && npx tsc --noEmit -p . && npx biome check src/` 无错误。
- 新增 / 更新测试：
  - `tool-result-image-fallback.test.mjs`：helper 单测——替换与保留文本/`details`、不改原消息、无变化返回同对象、不碰用户图片、纯图结果、`model.input` 门控、大小格式化。
  - `deepseek-native.test.mjs`：新增回归用例复现 issue 场景（Browser 截图 toolResult + 后续用户消息），断言 fetch 真正发出、线上无 `input_image` / 图片字节、`function_call_output` 含原文本与说明、调用方 context 未被改写；原有「用户图片被拒绝」用例保持通过。
  - `pi-ai-adapter-image-fallback.test.mjs`：按协议锁定口径——三协议纯文本模型降级、视觉模型保持 context 同一性、`anthropic-messages` 原样透传。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.（无用户可见配置变化；相关行为说明写在代码注释中）

Made with [Cursor](https://cursor.com)