### PR TITLE
fix(release): Linux 发布包改在 ubuntu-22.04 构建并校验 glibc 基线

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -234,7 +234,10 @@ jobs:
 
   linux:
     name: Linux x64
-    runs-on: ubuntu-latest
+    # 必须在 Ubuntu 22.04 (glibc 2.35) 上构建,产物才符合 README 承诺的 Ubuntu 22.04+ / Debian 12+。
+    # 若用 ubuntu-latest(24.04, glibc 2.39)构建,二进制会引用 GLIBC_2.38/2.39,在 22.04 上启动即退出 (#714)。
+    # 该 runner 与 Ubuntu 22.04 LTS 标准支持同在 2027-04 前退役;届时需迁移到 ubuntu:22.04 容器构建。
+    runs-on: ubuntu-22.04
     needs: release-metadata
     env:
       LIVEAGENT_APP_VERSION: ${{ needs.release-metadata.outputs.app_version }}
@@ -290,6 +293,9 @@ jobs:
           LIVEAGENT_UPDATER_PUBLIC_KEY: ${{ secrets.TAURI_UPDATER_PUBLIC_KEY }}
           LIVEAGENT_UPDATE_REPOSITORY: ${{ github.repository }}
         run: pnpm tauri build --config src-tauri/tauri.linux.release.conf.json --config "$LIVEAGENT_TAURI_VERSION_CONFIG" --target x86_64-unknown-linux-gnu --bundles appimage deb rpm
+
+      - name: Verify glibc baseline
+        run: bash scripts/release/verify-linux-glibc-baseline.sh
 
       - name: Strip bundled Wayland libraries and re-sign AppImage
         env:

--- a/scripts/release/verify-linux-glibc-baseline.sh
+++ b/scripts/release/verify-linux-glibc-baseline.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Asserts that the compiled Linux release binary does not require GLIBC symbol
+# versions newer than the supported baseline.
+#
+# The README promises Ubuntu 22.04+ / Debian 12+, so the binary must not need
+# anything above GLIBC 2.35. Building on a newer host (for example the
+# ubuntu-latest runner, Ubuntu 24.04 / glibc 2.39) silently links against
+# GLIBC_2.38/2.39 and the app exits at dynamic-link time on Ubuntu 22.04 with
+# "version `GLIBC_2.38' not found". This guard keeps that regression from shipping.
+#
+# Usage: verify-linux-glibc-baseline.sh [binary ...]
+# Without arguments it inspects the release binary produced by `tauri build`.
+# Override the baseline with LIVEAGENT_GLIBC_BASELINE (default 2.35).
+set -euo pipefail
+
+readonly DEFAULT_BASELINE="2.35"
+baseline="${LIVEAGENT_GLIBC_BASELINE:-$DEFAULT_BASELINE}"
+
+fail() {
+  echo "verify-linux-glibc-baseline: $*" >&2
+  exit 1
+}
+
+# Returns 0 when version $1 is strictly greater than version $2.
+version_gt() {
+  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]
+}
+
+for command_name in objdump grep sed sort awk; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
+done
+
+binaries=()
+if [ "$#" -gt 0 ]; then
+  binaries=("$@")
+else
+  for candidate in \
+    "target/x86_64-unknown-linux-gnu/release/liveagent" \
+    "crates/agent-gui/src-tauri/target/x86_64-unknown-linux-gnu/release/liveagent" \
+    "target/release/liveagent" \
+    "crates/agent-gui/src-tauri/target/release/liveagent"; do
+    [ -f "$candidate" ] && binaries+=("$candidate")
+  done
+fi
+
+[ "${#binaries[@]}" -gt 0 ] || fail "no LiveAgent release binary found to inspect (build it first or pass a path)"
+
+status=0
+for binary in "${binaries[@]}"; do
+  test -f "$binary" || fail "binary not found: $binary"
+
+  mapfile -t versions < <(
+    objdump -T "$binary" 2>/dev/null \
+      | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' \
+      | sed 's/^GLIBC_//' \
+      | sort -Vu
+  )
+
+  if [ "${#versions[@]}" -eq 0 ]; then
+    echo "warn: no GLIBC version symbols found in $binary" >&2
+    continue
+  fi
+
+  echo "==> $binary"
+  echo "    required: $(printf 'GLIBC_%s ' "${versions[@]}")"
+  echo "    highest : GLIBC_${versions[-1]} (baseline GLIBC_$baseline)"
+
+  offending=()
+  for version in "${versions[@]}"; do
+    version_gt "$version" "$baseline" && offending+=("$version")
+  done
+
+  if [ "${#offending[@]}" -gt 0 ]; then
+    echo "    FAIL  requires GLIBC newer than baseline: $(printf 'GLIBC_%s ' "${offending[@]}")" >&2
+    for version in "${offending[@]}"; do
+      echo "      symbols requiring GLIBC_$version:" >&2
+      # objdump prints the version either bare (GLIBC_2.38) or parenthesised ((GLIBC_2.38)).
+      objdump -T "$binary" 2>/dev/null | awk -v token="GLIBC_$version" '
+        { for (i = 1; i <= NF; i++) if ($i == token || $i == "(" token ")") { print "        " $0; break } }
+      ' >&2 || true
+    done
+    status=1
+  else
+    echo "    ok    within baseline"
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  fail "Linux binary requires a newer GLIBC than the supported baseline (GLIBC_$baseline).
+  Build the Linux release on that baseline (the ubuntu-22.04 runner, or an ubuntu:22.04 container)
+  so the artifacts run on Ubuntu 22.04+ / Debian 12+. See Stack-Cairn/LiveAgent#714."
+fi
+
+echo "GLIBC baseline verified (<= GLIBC_$baseline): ${binaries[*]}"


### PR DESCRIPTION
## Linked issue

Closes #714

## Summary

**问题**:`LiveAgent-v1.3.0-Linux-x86_64.deb` 在 Ubuntu 22.04.5 上启动即退出(退出码 1),即便 WebKitGTK 4.1 / GTK 3 / AppIndicator 依赖都已装好:

```text
/usr/bin/liveagent: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /usr/bin/liveagent)
/usr/bin/liveagent: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /usr/bin/liveagent)
```

**根因**:`desktop-release.yml` 的 `linux` job 跑在 `ubuntu-latest` 上,而该标签已指向 Ubuntu 24.04(glibc 2.39)。在其上编出的 `liveagent` 二进制会引用 `GLIBC_2.38/2.39` 符号,Ubuntu 22.04 只有 glibc 2.35,动态链接阶段直接失败——与 README「Linux x86_64 支持 Ubuntu 22.04+ / Debian 12+」的承诺相矛盾。

**修复**(对应 issue 建议 ① + ②):

1. **把 `linux` job 固定到 `ubuntu-22.04` runner**。产物 glibc 基线回到 2.35,同时覆盖 Debian 12(glibc 2.36),README 现有说明因此变为准确,无需改动。
2. **新增 `scripts/release/verify-linux-glibc-baseline.sh`,并在 `Build Linux bundles` 之后作为 `Verify glibc baseline` 步骤执行**。它用 `objdump -T` 读取编译出的 `liveagent` ELF 所需的最高 `GLIBC_x.y` 符号版本,一旦超过基线(默认 2.35,可用 `LIVEAGENT_GLIBC_BASELINE` 覆盖)就让发布失败并逐条列出超标符号。以后无论是有人改回 `ubuntu-latest`,还是某个依赖悄悄拉进新符号,都会在发布前被拦下,而不是等用户装完才发现。

脚本命名、`fail()` 前缀、英文头注释与结尾 `Stack-Cairn/LiveAgent#NNN` 引用方式均对齐 #721 新增的 `verify-macos-dmg-layout.sh`。

> **维护者需知**:`ubuntu-22.04` runner 自 2026-09-17 起进入弃用期(间歇 brownout),2027-04-17 彻底下线([actions/runner-images#14254](https://github.com/actions/runner-images/issues/14254))——与 Ubuntu 22.04 LTS 自身的标准支持结束期重合,所以固定到 22.04 与其支持周期是对齐的。届时所有更新的 Ubuntu runner glibc 都 > 2.35,若仍要维持该基线,长期方案是改在 `ubuntu:22.04` 容器内构建;本 PR 未一并做容器化,以免大幅改写签名与 AppImage(无 FUSE)打包链路且无法在本地实机验证。此后续方向已写入 workflow 注释。

## Change scope

- Modules: release CI(Desktop Release workflow)/ `scripts/release`
- Key paths:
  - `.github/workflows/desktop-release.yml` — `linux` job `runs-on: ubuntu-latest` → `ubuntu-22.04`(附原因注释);新增 `Verify glibc baseline` 步骤
  - `scripts/release/verify-linux-glibc-baseline.sh` — 新增,glibc 符号版本基线守卫

## Screenshots / preview

纯 CI / 发布链路变更,无 UI。以下为守卫脚本的实际运行日志(WSL,GNU objdump 2.44)。

**① 复现 #714 场景**——对一个引用 `GLIBC_2.38/2.39` 的二进制运行,正确失败并指出超标符号(这正是 24.04 上编出的包会被拦下的样子):

```text
==> liveagent
    required: GLIBC_2.2.5 GLIBC_2.38 GLIBC_2.39
    highest : GLIBC_2.39 (baseline GLIBC_2.35)
    FAIL  requires GLIBC newer than baseline: GLIBC_2.38 GLIBC_2.39
      symbols requiring GLIBC_2.38:
        0000000000000000      DF *UND* 0000000000000000  GLIBC_2.38  memfd_create
      symbols requiring GLIBC_2.39:
        0000000000000000      DF *UND* 0000000000000000  GLIBC_2.39  __isoc23_strtol
verify-linux-glibc-baseline: Linux binary requires a newer GLIBC than the supported baseline (GLIBC_2.35).
  Build the Linux release on that baseline (the ubuntu-22.04 runner, or an ubuntu:22.04 container)
  so the artifacts run on Ubuntu 22.04+ / Debian 12+. See Stack-Cairn/LiveAgent#714.
# exit 1
```

**② 合规的 22.04 构建**——最高仅需 `GLIBC_2.35`,通过:

```text
==> liveagent
    required: GLIBC_2.2.5 GLIBC_2.34 GLIBC_2.35
    highest : GLIBC_2.35 (baseline GLIBC_2.35)
    ok    within baseline
GLIBC baseline verified (<= GLIBC_2.35): liveagent
# exit 0
```

**③ 对真实 ELF(`/bin/ls`,需要 `GLIBC_2.38`)用默认基线 2.35**——只精确标出 `GLIBC_2.38`,低于基线的 2.2.5 ~ 2.34 不误报:

```text
==> /bin/ls
    required: GLIBC_2.2.5 GLIBC_2.3 GLIBC_2.3.4 GLIBC_2.4 GLIBC_2.14 GLIBC_2.16 GLIBC_2.17 GLIBC_2.28 GLIBC_2.33 GLIBC_2.34 GLIBC_2.38
    highest : GLIBC_2.38 (baseline GLIBC_2.35)
    FAIL  requires GLIBC newer than baseline: GLIBC_2.38
      symbols requiring GLIBC_2.38:
        0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.38) __isoc23_strtoumax
# exit 1
```

## Verification

- 守卫脚本 7 组用例全部通过(真实 `objdump`,含 `bash -n` 语法检查):
  - 真实二进制 `/bin/ls`:基线 2.99 → 通过;基线 2.2 → 失败;默认 2.35 → 仅标出 `GLIBC_2.38`,失败。
  - 模拟 #714 的 `GLIBC_2.38/2.39` 二进制 → 失败并列出符号;最高 `GLIBC_2.35` 的二进制 → 通过。
  - 未找到二进制 → 明确报错退出 1。
  - `objdump -T` 两种版本列格式(带括号 `(GLIBC_2.38)` 与不带括号)均能匹配;`sort -V` 版本排序 `2.2.5 < 2.3 < 2.3.4 < 2.4 < 2.14 < … < 2.38` 正确。
- workflow YAML 结构校验:`runs-on` 为 `ubuntu-22.04`,`Verify glibc baseline` 紧跟 `Build Linux bundles` 之后。
- `git diff --check`(CI「Diff Hygiene」同款)通过;两个文件在 git 索引中均为 LF,与现有 `postprocess-linux-appimage.sh` 一致。
- 分支基于最新 `upstream/main`(`581d6017`);`desktop-release.yml` 在上游期间无改动,无冲突。
- 无需新增测试:变更为 CI 配置 + 独立 bash 守卫脚本,守卫本身即是对发布产物的自动化检查。
- **未在本地执行**:完整的 GitHub Actions 发布流水线(需 tag 推送 / `workflow_dispatch` 与签名 secrets)。建议合并后用一个预发布 tag 触发 `Desktop Release`,确认 `Verify glibc baseline` 步骤对真实产物输出 `highest : GLIBC_2.35` 并通过。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration. —— README 已写明「Ubuntu 22.04+ / Debian 12+」,本修复正是让该说明成立,故无需改动;构建基线的原因与后续迁移方向已记录在 workflow 注释与脚本头注释中。
