### PR TITLE
feat(sidebar): 最近会话行首显示最后一轮使用的模型图标

### DIFF
--- a/crates/agent-ui/src/components/ProviderBrandIcon.tsx
+++ b/crates/agent-ui/src/components/ProviderBrandIcon.tsx
@@ -1,0 +1,36 @@
+import {
+  ClaudeIcon,
+  DeepseekIcon,
+  GeminiIcon,
+  GrokIcon,
+  OpenaiChatgptIcon,
+} from "@liveagent/ui/components/IconSet";
+import type { ProviderId } from "@liveagent/ui/lib/settings/types";
+import { cn } from "@liveagent/ui/lib/shared/utils";
+
+const KNOWN_PROVIDER_IDS: readonly ProviderId[] = [
+  "codex",
+  "claude_code",
+  "gemini",
+  "xai",
+  "deepseek",
+];
+
+// Sidebar rows carry providerId as a wide string: legacy rows persist "",
+// GUI optimistic rows may fall back to "pending", and web optimistic rows
+// store a custom provider *instance* id. Only enum hits may reach the icon —
+// anything else would render as the OpenAI fallback below.
+export function isKnownProviderId(value: string | undefined): value is ProviderId {
+  return (KNOWN_PROVIDER_IDS as readonly string[]).includes(value ?? "");
+}
+
+// Unmatched types (including "codex") fall through to the OpenAI icon; callers
+// that need "unknown renders nothing" must guard with isKnownProviderId first.
+export function ProviderBrandIcon({ type, className }: { type?: ProviderId; className?: string }) {
+  const cls = cn("h-4 w-4 shrink-0", className);
+  if (type === "claude_code") return <ClaudeIcon className={cls} />;
+  if (type === "gemini") return <GeminiIcon className={cls} />;
+  if (type === "xai") return <GrokIcon className={cls} />;
+  if (type === "deepseek") return <DeepseekIcon className={cls} />;
+  return <OpenaiChatgptIcon className={cn(cls, "fill-current dark:text-white")} />;
+}

--- a/crates/agent-ui/src/components/chat/ChatHistorySidebarRows.tsx
+++ b/crates/agent-ui/src/components/chat/ChatHistorySidebarRows.tsx
@@ -56,6 +56,7 @@ import {
 } from "react";
 import type { SidebarConversation } from "../../lib/sidebar/types";
 import type { WorkspaceProjectGroup } from "../../lib/workspaceProjectTypes";
+import { isKnownProviderId, ProviderBrandIcon } from "../ProviderBrandIcon";
 
 export type WorkspaceProjectRemoveOptions = {
   deleteWorktree?: boolean;
@@ -126,6 +127,8 @@ function areRenderedHistoryItemsEqual(previous: SidebarConversation, next: Sideb
   return (
     previous.id === next.id &&
     previous.title === next.title &&
+    previous.providerId === next.providerId &&
+    previous.model === next.model &&
     previous.cwd === next.cwd &&
     previous.isPinned === next.isPinned &&
     previous.isShared === next.isShared &&
@@ -698,6 +701,15 @@ export const HistoryRow = memo(function HistoryRow(props: HistoryRowProps) {
                     )}
                   >
                     {isSelected ? <Check className="h-3 w-3" /> : null}
+                  </span>
+                ) : null}
+                {!isSelectionMode && isKnownProviderId(item.providerId) ? (
+                  <span
+                    aria-hidden="true"
+                    title={item.model || undefined}
+                    className="flex h-4 w-4 shrink-0 items-center justify-center"
+                  >
+                    <ProviderBrandIcon type={item.providerId} />
                   </span>
                 ) : null}
                 <span className="sidebar-project-name-fade min-w-0 flex-1 overflow-hidden whitespace-nowrap text-[calc(14px*var(--zone-font-scale,1))] font-normal leading-5">

--- a/crates/agent-ui/src/components/chat/ComposerModelControls.tsx
+++ b/crates/agent-ui/src/components/chat/ComposerModelControls.tsx
@@ -12,20 +12,16 @@ import {
   ArrowDownAZ,
   Check,
   ChevronDown,
-  ClaudeIcon,
-  DeepseekIcon,
-  GeminiIcon,
   Globe,
   GlobeOff,
-  GrokIcon,
   Layers,
   Lightbulb,
   LightbulbOff,
-  OpenaiChatgptIcon,
   Pencil,
   Search,
   Sparkle,
 } from "@liveagent/ui/components/IconSet";
+import { ProviderBrandIcon } from "@liveagent/ui/components/ProviderBrandIcon";
 import { Button } from "@liveagent/ui/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@liveagent/ui/components/ui/popover";
 import { useLocale } from "@liveagent/ui/i18n/index";
@@ -65,15 +61,6 @@ const REASONING_COMPACT_I18N_KEYS: Record<ReasoningLevel, string> = {
   xhigh: "chat.runtime.reasoningCompact.xhigh",
   max: "chat.runtime.reasoningCompact.max",
 };
-
-function ProviderBrandIcon({ type, className }: { type: ProviderId; className?: string }) {
-  const cls = cn("h-4 w-4 shrink-0", className);
-  if (type === "claude_code") return <ClaudeIcon className={cls} />;
-  if (type === "gemini") return <GeminiIcon className={cls} />;
-  if (type === "xai") return <GrokIcon className={cls} />;
-  if (type === "deepseek") return <DeepseekIcon className={cls} />;
-  return <OpenaiChatgptIcon className={cn(cls, "fill-current dark:text-white")} />;
-}
 
 function RuntimeToggleChip(props: {
   pressed: boolean;

--- a/crates/agent-ui/src/pages/settings/ProviderPresentation.tsx
+++ b/crates/agent-ui/src/pages/settings/ProviderPresentation.tsx
@@ -118,6 +118,8 @@ export function getProviderLabel(type: ProviderId) {
   return PROVIDER_LABELS[type];
 }
 
+// TODO: converge with components/ProviderBrandIcon.tsx — this variant keeps the
+// settings-page sizing contract (height="1em" scales with surrounding text).
 export function ProviderBrandIcon({ type }: { type: ProviderId }) {
   if (type === "claude_code") return <ClaudeIcon height="1em" />;
   if (type === "gemini") return <GeminiIcon height="1em" />;

--- a/crates/agent-ui/src/pages/settings/modelPicker.tsx
+++ b/crates/agent-ui/src/pages/settings/modelPicker.tsx
@@ -1,15 +1,6 @@
 import type { ProviderId } from "@liveagent/app/lib/settings/index";
-import {
-  Check,
-  ChevronDown,
-  ClaudeIcon,
-  DeepseekIcon,
-  GeminiIcon,
-  GrokIcon,
-  OpenaiChatgptIcon,
-  Search,
-  Sparkles,
-} from "@liveagent/ui/components/IconSet";
+import { Check, ChevronDown, Search, Sparkles } from "@liveagent/ui/components/IconSet";
+import { ProviderBrandIcon } from "@liveagent/ui/components/ProviderBrandIcon";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -33,15 +24,6 @@ export type ModelPickerOption = {
   providerId?: string;
   providerType?: ProviderId;
 };
-
-function ProviderBrandIcon({ type, className }: { type?: ProviderId; className?: string }) {
-  const cls = cn("h-4 w-4 shrink-0", className);
-  if (type === "claude_code") return <ClaudeIcon className={cls} />;
-  if (type === "gemini") return <GeminiIcon className={cls} />;
-  if (type === "xai") return <GrokIcon className={cls} />;
-  if (type === "deepseek") return <DeepseekIcon className={cls} />;
-  return <OpenaiChatgptIcon className={cn(cls, "fill-current dark:text-white")} />;
-}
 
 type ModelGroup = {
   id: string;


### PR DESCRIPTION
## Linked issue

Closes #734

## Summary

侧栏「最近会话」每行只有标题,多供应商混用时看不出会话用的是哪个模型。本 PR 在每行标题左侧加一个 16px 供应商 logo,依据是最后一轮对话实际使用的模型——`chatHistory` 的 `provider_id` 每轮 upsert 覆写,天然就是这个语义,前端数据也已透传到 `SidebarConversation`,因此不涉及后端和数据结构变更:

- 新增共享组件 `ProviderBrandIcon`,并导出 `isKnownProviderId` 白名单守卫。侧栏的 `providerId` 是宽 string:老数据存的是空串、GUI 乐观行可能回退 `"pending"`、Web 端乐观行存的是自定义供应商实例 id。这些值不能进现有图标组件的 fallback 分支(会错显示成 OpenAI logo),守卫只放行五个枚举值,未命中不渲染图标、标题顶格;
- 图标悬停时原生 `title` 显示具体模型名,悬停行内其他区域仍显示会话标题(HTML title 取最内层元素,无冲突);多选模式下图标隐藏,让位给同为 `h-4 w-4` 的 checkbox,标题位置不跳动;
- `areRenderedHistoryItemsEqual` 补比较 `providerId` / `model`:该 memo 比较函数此前不含这两个字段,行内一旦展示模型信息,换模型后新一轮持久化时行不会重渲染,图标会停留在旧值。store 层 `reconcile.ts` 本就比较这两个字段,item 引用只在字段真变时更换,不会引入多余重渲染;
- 顺手把 `ComposerModelControls` 与 `modelPicker` 里两份字节等价的私有 `ProviderBrandIcon` 收敛到共享组件;`ProviderPresentation` 的版本尺寸契约不同(`height="1em"` 随文字缩放),保留并留了 TODO。

侧栏行组件在 `agent-ui` 由 GUI 与 WebUI 共用,一处改动两端生效。

## Change scope

- Modules: agent-ui(GUI / WebUI 共享)
- Key paths:
  - `crates/agent-ui/src/components/ProviderBrandIcon.tsx`(新增)
  - `crates/agent-ui/src/components/chat/ChatHistorySidebarRows.tsx`(行首图标 + memo 修复)
  - `crates/agent-ui/src/components/chat/ComposerModelControls.tsx`(私有副本收敛)
  - `crates/agent-ui/src/pages/settings/modelPicker.tsx`(私有副本收敛)
  - `crates/agent-ui/src/pages/settings/ProviderPresentation.tsx`(仅注释)

## Screenshots / preview

<img width="420" height="549" alt="86862bfcfff6b23746d9ce8280f49c51" src="https://github.com/user-attachments/assets/1064ccfc-6b01-4341-8749-52301703526a" />

## Verification

- `pnpm typecheck:ui` ✅
- `biome check` 新增文件无诊断;`lint:ui` 全仓与 main 基线错误数一致(480,均为本机 CRLF 存量格式问题),本 PR 未新增
- `pnpm test:webui` 685/685 ✅
- `pnpm test:gui` 2898 pass / 5 fail,失败集与 main 基线完全一致(已在无改动基线上复跑确认),与本 PR 无关
- 桌面端 dev 客户端人工验证:各供应商会话行 logo 正确(codex 显示 OpenAI 图标)、悬停图标显示模型名、空 `provider_id` 行不渲染图标、多选模式图标隐藏、换模型后新一轮对话持久化时图标更新

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [ ] Docs are updated for changes affecting user behavior, deployment, or configuration.
