### PR TITLE
fix(hub): 移除 Hub 页头重复的侧栏开关并修复 MCP 行窄屏重叠

### DIFF
--- a/crates/agent-gateway/web/src/agent-ui-adapters/hubChrome.tsx
+++ b/crates/agent-gateway/web/src/agent-ui-adapters/hubChrome.tsx
@@ -1,5 +1,3 @@
-export const usesOverlayTitleBar = false;
-
 export function HubTitleBar() {
   return null;
 }

--- a/crates/agent-gateway/web/src/app/GatewayAppView.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayAppView.tsx
@@ -1443,8 +1443,6 @@ export function GatewayAppView({ viewModel }: { viewModel: GatewayAppViewModel }
                 settings={settings}
                 setSettings={setSettings}
                 isAgentMode={isAgentMode}
-                sidebarOpen={sidebarOpen}
-                onOpenSidebar={() => setSidebarOpen(true)}
                 initialSkills={availableSkills}
                 initialSkillsRootDir={skillsRootDir}
                 className="contents"

--- a/crates/agent-gui/src/agent-ui-adapters/hubChrome.tsx
+++ b/crates/agent-gui/src/agent-ui-adapters/hubChrome.tsx
@@ -1,6 +1,4 @@
-import { isMacOsTauri, MacOsTitleBarSpacer } from "../components/MacOsTitleBarSpacer";
-
-export const usesOverlayTitleBar = isMacOsTauri();
+import { MacOsTitleBarSpacer } from "../components/MacOsTitleBarSpacer";
 
 export function HubTitleBar() {
   return <MacOsTitleBarSpacer />;

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -4082,8 +4082,6 @@ export function ChatPage(props: ChatPageProps) {
           settings={settings}
           setSettings={setSettings}
           isAgentMode={isAgentMode}
-          sidebarOpen={sidebarOpen}
-          onOpenSidebar={handleOpenSidebar}
           initialSkills={availableSkills}
           initialSkillsRootDir={skillsRootDir}
           className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background"

--- a/crates/agent-ui/src/application/ApplicationView.tsx
+++ b/crates/agent-ui/src/application/ApplicationView.tsx
@@ -17,8 +17,6 @@ type ApplicationViewProps = {
   settings: AppSettings;
   setSettings: (updater: (prev: AppSettings) => AppSettings) => void;
   isAgentMode: boolean;
-  sidebarOpen: boolean;
-  onOpenSidebar: () => void;
   initialSkills?: SkillSummary[];
   initialSkillsRootDir?: string;
   className?: string;
@@ -34,8 +32,6 @@ export function ApplicationView(props: ApplicationViewProps) {
     settings,
     setSettings,
     isAgentMode,
-    sidebarOpen,
-    onOpenSidebar,
     initialSkills,
     initialSkillsRootDir,
     className,
@@ -54,19 +50,11 @@ export function ApplicationView(props: ApplicationViewProps) {
         initialSkills={initialSkills}
         initialRootDir={initialSkillsRootDir}
         isAgentMode={isAgentMode}
-        sidebarOpen={sidebarOpen}
-        onOpenSidebar={onOpenSidebar}
       />
     );
   } else if (activeView === "mcp-hub") {
     content = (
-      <McpHubPage
-        settings={settings}
-        setSettings={setSettings}
-        isAgentMode={isAgentMode}
-        sidebarOpen={sidebarOpen}
-        onOpenSidebar={onOpenSidebar}
-      />
+      <McpHubPage settings={settings} setSettings={setSettings} isAgentMode={isAgentMode} />
     );
   } else {
     const { containerProps, content: chatContent } = chat;

--- a/crates/agent-ui/src/components/hub/HubChrome.tsx
+++ b/crates/agent-ui/src/components/hub/HubChrome.tsx
@@ -1,9 +1,6 @@
-import { HubTitleBar, usesOverlayTitleBar } from "@liveagent/adapters/hubChrome";
-import { PanelLeft } from "@liveagent/ui/components/IconSet";
+import { HubTitleBar } from "@liveagent/adapters/hubChrome";
 import type { ReactNode } from "react";
-import { useLocale } from "../../i18n";
 import { cn } from "../../lib/shared/utils";
-import { Button } from "../ui/button";
 
 export function HubBackdrop(props: { tone?: "amber" | "violet" | "neutral" }) {
   const { tone = "neutral" } = props;
@@ -32,6 +29,9 @@ export function HubBackdrop(props: { tone?: "amber" | "violet" | "neutral" }) {
   );
 }
 
+// 侧栏开关不在这里渲染：AppWorkbenchChrome(ChatHeader)常驻于所有视图之上，
+// 侧栏收起时已经提供了同一个按钮。Hub 自己再画一个就会在窄屏上叠出两枚
+// PanelLeft(#501 之前 Hub 页面没有顶栏，才需要自带一枚)。
 export function HubHeader(props: {
   icon?: ReactNode;
   title: string;
@@ -39,12 +39,8 @@ export function HubHeader(props: {
   tone?: "amber" | "violet" | "neutral";
   actions?: ReactNode;
   prominent?: boolean;
-  sidebarOpen: boolean;
-  onOpenSidebar: () => void;
 }) {
-  const { icon, title, subtitle, actions, prominent = false, sidebarOpen, onOpenSidebar } = props;
-  const { t } = useLocale();
-  const showSidebarButton = !sidebarOpen && !usesOverlayTitleBar;
+  const { icon, title, subtitle, actions, prominent = false } = props;
   return (
     <>
       <HubTitleBar />
@@ -54,23 +50,10 @@ export function HubHeader(props: {
           prominent ? "pb-5 pt-8" : "pb-3 pt-6",
         )}
       >
-        {showSidebarButton ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={onOpenSidebar}
-            title={t("tooltip.openSidebar")}
-            className="absolute left-3 top-5 h-9 w-9 rounded-lg text-muted-foreground hover:bg-background/70 hover:text-foreground"
-          >
-            <PanelLeft className="h-4.5 w-4.5" />
-          </Button>
-        ) : null}
         <div
           className={cn(
             "mx-auto flex w-full max-w-[1320px] gap-4",
             prominent ? "items-end" : "items-center",
-            showSidebarButton && "pl-11 lg:pl-0",
           )}
         >
           {icon ? (

--- a/crates/agent-ui/src/pages/mcp-hub/McpHubPage.tsx
+++ b/crates/agent-ui/src/pages/mcp-hub/McpHubPage.tsx
@@ -17,8 +17,6 @@ type McpHubPageProps = {
   settings: AppSettings;
   setSettings: (updater: (prev: AppSettings) => AppSettings) => void;
   isAgentMode: boolean;
-  sidebarOpen: boolean;
-  onOpenSidebar: () => void;
 };
 
 type McpHubView = "installed" | "store" | "import";
@@ -30,7 +28,7 @@ function isMcpHubView(value: unknown): value is McpHubView {
 }
 
 export function McpHubPage(props: McpHubPageProps) {
-  const { settings, setSettings, sidebarOpen, onOpenSidebar } = props;
+  const { settings, setSettings } = props;
   const { t } = useLocale();
   const [view, setView] = useState<McpHubView>("installed");
   const [editing, setEditing] = useState<EditingState | null>(null);
@@ -108,8 +106,6 @@ export function McpHubPage(props: McpHubPageProps) {
               </Button>
             </div>
           }
-          sidebarOpen={sidebarOpen}
-          onOpenSidebar={onOpenSidebar}
         />
 
         <div className="hub-scroll min-h-0 flex-1 overflow-hidden px-5 pb-6 sm:px-6 lg:px-8 xl:px-10">

--- a/crates/agent-ui/src/pages/mcp-hub/McpServerCard.tsx
+++ b/crates/agent-ui/src/pages/mcp-hub/McpServerCard.tsx
@@ -204,7 +204,10 @@ export const McpServerCard = memo(function McpServerCard(props: {
   const docsLink = resolveMcpDocsHref(server.docsUrl);
 
   return (
-    <article className="skill-card-enter group flex min-h-16 w-full items-center gap-3 bg-card px-4 py-3 text-left transition-colors hover:bg-muted/30">
+    // 容器查询挂在 article 上:行宽 < 520px(手机、或桌面侧栏占位后的窄内容区)
+    // 时把 计数/策略/编辑/删除 整组换到第二行。此前四组里只有名称列可收缩,
+    // 其余全是 shrink-0,窄屏下名称列被挤成 0 宽,文字溢出到徽章底下(重叠)。
+    <article className="skill-card-enter group @container flex min-h-16 w-full flex-wrap items-center gap-3 bg-card px-4 py-3 text-left transition-colors hover:bg-muted/30">
       <ResourceActivationSwitch
         checked={enabled}
         compact
@@ -213,17 +216,19 @@ export const McpServerCard = memo(function McpServerCard(props: {
       />
 
       <div className="flex min-w-0 flex-1 flex-col">
-        <div className="flex min-w-0 items-center gap-1.5">
+        <div className="flex min-w-0 items-center gap-1.5 @max-[520px]:flex-wrap">
+          {/* truncate 必须落在 button 自身:SearchHighlight 渲出的是 inline span,
+              overflow/text-overflow 对 inline 盒无效,文字会越过 button 边界。 */}
           <button
             type="button"
             onClick={onEdit}
             title={t("settings.edit")}
-            className="min-w-0 rounded-sm text-left outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            className="min-w-0 truncate rounded-sm text-left outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
           >
             <SearchHighlight
               text={displayName}
               query={searchQuery}
-              className="truncate text-[13px] font-semibold text-foreground"
+              className="text-[13px] font-semibold text-foreground"
             />
           </button>
           {docsLink ? (
@@ -256,71 +261,78 @@ export const McpServerCard = memo(function McpServerCard(props: {
         ) : null}
       </div>
 
-      {argsCount > 0 || envCount > 0 || headerCount > 0 ? (
-        <div className="flex max-w-48 shrink-0 flex-wrap justify-end gap-1">
-          {argsCount > 0 ? (
-            <ConfigurationCount count={argsCount} label={t("mcpHub.previewArgs")} />
-          ) : null}
-          {envCount > 0 ? (
-            <ConfigurationCount count={envCount} label={t("mcpHub.previewEnv")} />
-          ) : null}
-          {headerCount > 0 ? (
-            <ConfigurationCount count={headerCount} label={t("mcpHub.previewHeaders")} />
-          ) : null}
-        </div>
-      ) : null}
+      {/* 窄行时 basis-full 强制整组换行:计数靠左、操作靠右(ml-auto);宽行时
+          还是原来的一行四组。计数组自身允许折行,不再用 max-w-48 硬夹。 */}
+      <div className="flex shrink-0 items-center gap-3 @max-[520px]:basis-full @max-[520px]:flex-wrap">
+        {argsCount > 0 || envCount > 0 || headerCount > 0 ? (
+          <div className="flex min-w-0 max-w-48 flex-wrap justify-end gap-1 @max-[520px]:max-w-none @max-[520px]:justify-start">
+            {argsCount > 0 ? (
+              <ConfigurationCount count={argsCount} label={t("mcpHub.previewArgs")} />
+            ) : null}
+            {envCount > 0 ? (
+              <ConfigurationCount count={envCount} label={t("mcpHub.previewEnv")} />
+            ) : null}
+            {headerCount > 0 ? (
+              <ConfigurationCount count={headerCount} label={t("mcpHub.previewHeaders")} />
+            ) : null}
+          </div>
+        ) : null}
 
-      <div className="grid shrink-0 grid-cols-[auto_2rem_2rem] items-center gap-1.5">
-        <ToolPolicyToggle
-          value={policy}
-          ariaLabel={displayName}
-          onChange={onPolicyChange}
-          size="sm"
-        />
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          onClick={onEdit}
-          title={t("settings.edit")}
-          className="h-8 w-8 text-muted-foreground"
-        >
-          <Settings className="h-3.5 w-3.5" />
-        </Button>
-        <ConfirmDeletePopover
-          name={server.id || `Server ${idx + 1}`}
-          onConfirm={() => {
-            // OAuth server 删除时同步清理 keychain 条目（best effort，失败不阻塞
-            // 删除，但要留痕——卡片随删除卸载，无处挂 error 态，与 mcpManagerTools
-            // 的 runtimeWarnings 对应的最低限度是 console.warn）。
-            if (isOauthServer(server) && !isGatewayWebuiRuntime()) {
-              void mcpOauthClear(server.id).catch((err: unknown) => {
-                console.warn(`[mcp-hub] failed to clear OAuth credentials for ${server.id}:`, err);
-              });
-            }
-            setSettings((prev) =>
-              removeWorkspaceResourceReferences(
-                updateMcp(prev, {
-                  servers: prev.mcp.servers.filter((_, index) => index !== idx),
-                }),
-                { mcpServerIds: [server.id] },
-              ),
-            );
-          }}
-        >
-          {(open) => (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={open}
-              className="h-8 w-8 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-              title={t("settings.delete")}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
-          )}
-        </ConfirmDeletePopover>
+        <div className="grid shrink-0 grid-cols-[auto_2rem_2rem] items-center gap-1.5 @max-[520px]:ml-auto">
+          <ToolPolicyToggle
+            value={policy}
+            ariaLabel={displayName}
+            onChange={onPolicyChange}
+            size="sm"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={onEdit}
+            title={t("settings.edit")}
+            className="h-8 w-8 text-muted-foreground"
+          >
+            <Settings className="h-3.5 w-3.5" />
+          </Button>
+          <ConfirmDeletePopover
+            name={server.id || `Server ${idx + 1}`}
+            onConfirm={() => {
+              // OAuth server 删除时同步清理 keychain 条目（best effort，失败不阻塞
+              // 删除，但要留痕——卡片随删除卸载，无处挂 error 态，与 mcpManagerTools
+              // 的 runtimeWarnings 对应的最低限度是 console.warn）。
+              if (isOauthServer(server) && !isGatewayWebuiRuntime()) {
+                void mcpOauthClear(server.id).catch((err: unknown) => {
+                  console.warn(
+                    `[mcp-hub] failed to clear OAuth credentials for ${server.id}:`,
+                    err,
+                  );
+                });
+              }
+              setSettings((prev) =>
+                removeWorkspaceResourceReferences(
+                  updateMcp(prev, {
+                    servers: prev.mcp.servers.filter((_, index) => index !== idx),
+                  }),
+                  { mcpServerIds: [server.id] },
+                ),
+              );
+            }}
+          >
+            {(open) => (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={open}
+                className="h-8 w-8 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                title={t("settings.delete")}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </ConfirmDeletePopover>
+        </div>
       </div>
     </article>
   );

--- a/crates/agent-ui/src/pages/skills-hub/SkillsHubPage.tsx
+++ b/crates/agent-ui/src/pages/skills-hub/SkillsHubPage.tsx
@@ -135,20 +135,10 @@ type SkillsHubPageProps = {
   initialSkills?: SkillSummary[];
   initialRootDir?: string;
   isAgentMode: boolean;
-  sidebarOpen: boolean;
-  onOpenSidebar: () => void;
 };
 
 export function SkillsHubPage(props: SkillsHubPageProps) {
-  const {
-    settings,
-    setSettings,
-    initialSkills,
-    initialRootDir,
-    isAgentMode,
-    sidebarOpen,
-    onOpenSidebar,
-  } = props;
+  const { settings, setSettings, initialSkills, initialRootDir, isAgentMode } = props;
   const { t } = useLocale();
   const lockedByChatMode = !isAgentMode;
 
@@ -1503,8 +1493,6 @@ export function SkillsHubPage(props: SkillsHubPageProps) {
               </Button>
             </div>
           }
-          sidebarOpen={sidebarOpen}
-          onOpenSidebar={onOpenSidebar}
         />
 
         <div className="hub-scroll min-h-0 flex-1 overflow-hidden px-5 pb-6 sm:px-6 lg:px-8 xl:px-10">


### PR DESCRIPTION
## Linked issue

Closes #744

## Summary

两个问题都出在 `agent-ui` 共享层，GUI 与 WebUI 一处改动两端生效。

**1. 窄视口下 Hub 页面左上角出现两个侧栏折叠按钮**

`HubHeader` 自带的那枚侧栏开关是 #501 之前的遗留：彼时 Hub 页面上方没有顶栏，需要自带一枚。#501 把 `AppWorkbenchChrome` 提升为常驻所有视图之上后，侧栏收起时顶栏已经渲染了功能完全相同的按钮，于是叠出两枚。macOS 桌面端因为走覆盖式标题栏（`usesOverlayTitleBar` 为真时不渲染）恰好躲开了，Windows / Linux 桌面端与 WebUI 都会复现。

- 删掉 `HubHeader` 里的按钮及配套的 `pl-11` 标题缩进；
- 沿调用链移除随之失去用途的 `sidebarOpen` / `onOpenSidebar`：`McpHubPage`、`SkillsHubPage`、`ApplicationView`，以及 GUI 的 `ChatPage`、WebUI 的 `GatewayAppView` 两个调用点；
- 两端适配器 `hubChrome.tsx` 里的 `usesOverlayTitleBar` 导出至此再无引用，一并删除（`HubTitleBar` 保留，macOS 仍需要那段红绿灯让位的垂直占位）。

**2. MCP Hub 已配置行在窄屏下元素重叠**

`McpServerCard` 一行内开关、名称列、计数徽章、策略/编辑/删除四组元素中，只有名称列可收缩，其余全部 `shrink-0`。窄屏下名称列被挤压至零宽，服务器名与传输方式徽章溢出到右侧徽章和策略按钮组底下。

- `article` 上挂 `@container`，行宽 < 520px 时把计数徽章与操作组整体换到第二行（计数靠左、操作 `ml-auto` 靠右），宽屏维持原来的单行布局。阈值沿用仓库既有的 `@max-[520px]` 档；
- `truncate` 从 `SearchHighlight` 渲出的 inline `span` 移到 `button` 自身。`overflow` / `text-overflow` 对 inline 盒不生效，原先的截断从未真正起作用，这也是名称能越过边界的直接原因；
- 计数组的 `max-w-48` 硬夹只在宽屏保留，换行后放开。

## Change scope

- Modules: agent-ui（GUI / WebUI 共享）、agent-gui、agent-gateway/web
- Key paths:
  - `crates/agent-ui/src/components/hub/HubChrome.tsx`（删除重复按钮与两个 prop）
  - `crates/agent-ui/src/pages/mcp-hub/McpServerCard.tsx`（容器查询换行 + truncate 修正）
  - `crates/agent-ui/src/application/ApplicationView.tsx`、`pages/mcp-hub/McpHubPage.tsx`、`pages/skills-hub/SkillsHubPage.tsx`（prop 链收敛）
  - `crates/agent-gui/src/agent-ui-adapters/hubChrome.tsx`、`crates/agent-gateway/web/src/agent-ui-adapters/hubChrome.tsx`（移除 `usesOverlayTitleBar`）
  - `crates/agent-gui/src/pages/ChatPage.tsx`、`crates/agent-gateway/web/src/app/GatewayAppView.tsx`（调用点）

## Screenshots / preview

<!-- 待补充 -->

## Verification

在本分支（基于 `main@ef0c6617`）复跑：

- `pnpm typecheck:ui` ✅
- `pnpm check:ui-boundaries` ✅
- `pnpm build:gui` ✅ / `pnpm build:webui` ✅
- 改动文件 `biome check` 无诊断（`lint:ui` 全仓存量诊断与基线一致，均在无关文件）
- 针对 hub / `ApplicationView` / server card 源码契约的测试：GUI 侧 `mcp-hub-tabs`、`workbench-dom-boundaries`、`chat-transcript-scroller`、`workspace-resource-settings`、`skills-hub-deferred-content` 共 31 项全通过；WebUI 侧 `workbench-chrome` 4 项全通过
- 视觉验证：用临时挂载页在 390px 与 1200px 两个宽度下渲染 `ApplicationView` 截图确认——390px 下两个 Hub 均只剩一枚折叠按钮，MCP 五行（含长名称、多计数徽章）全部正常折行无重叠；1200px 下单行布局与改动前一致。临时文件验证后已删除，未进入本 PR

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
