### PR TITLE
fix(release): Linux 发布 job 改装官方 protoc，修复 ubuntu-22.04 上 proto3 optional 构建失败

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -283,9 +283,24 @@ jobs:
             libwebkit2gtk-4.1-dev \
             libxdo-dev \
             patchelf \
-            protobuf-compiler \
             rpm \
+            unzip \
             wget
+
+      # ubuntu-22.04 的 apt protobuf-compiler 是 3.12，不支持 proto3 `optional`
+      # （prost-build 不会传 --experimental_allow_proto3_optional），改装官方 release。
+      # protoc 只是宿主构建工具，不影响产物 glibc 基线。
+      - name: Install protobuf compiler
+        env:
+          PROTOC_VERSION: "34.0"
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+          sudo unzip -oq /tmp/protoc.zip -d /usr/local 'bin/protoc' 'include/*'
+          sudo chmod +x /usr/local/bin/protoc
+          echo "PROTOC=/usr/local/bin/protoc" >> "$GITHUB_ENV"
+          /usr/local/bin/protoc --version
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Linked issue

Closes #746

## Summary

v1.3.1 的 `Desktop Release` 在 Linux x64 job 失败：`src-tauri/build.rs` 编译 `gateway.proto` 时 protoc 报 `This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set`，`Publish GitHub Release` 随之被跳过。

根因是 db6b7b92 为压低 glibc 基线把该 job 从 `ubuntu-latest`（24.04）降到 `ubuntu-22.04`，而 22.04 apt 的 `protobuf-compiler` 是 **3.12.4**（24.04 是 3.21.12）。protoc 3.12 把 proto3 `optional` 视为实验特性，prost-build 不会传那个开关，于是 panic。macOS / Windows 分别用 brew / choco 装最新 protoc，所以只有 Linux 挂。

修法保留 `ubuntu-22.04`（`Verify glibc baseline` 步骤依赖它），只把 protoc 来源换掉：

- apt 列表移除 `protobuf-compiler`，补装 `unzip`；
- 新增 `Install protobuf compiler` 步骤，下载官方 protoc **34.0**（与 `mise.toml` 钉的版本一致）linux-x86_64 zip 解到 `/usr/local`，并写 `PROTOC=/usr/local/bin/protoc` 进 `GITHUB_ENV`，让 prost-build 明确使用它而不受系统残留版本影响。

protoc 是宿主端构建工具，不影响产物 glibc。没有选 `protoc-bin-vendored` / protox 改 `build.rs`，因为那会波及三端和本地开发的构建路径，作为发布热修范围过大。

## Change scope

- Modules: CI / release workflow
- Key paths:
  - `.github/workflows/desktop-release.yml`（仅 Linux x64 job）

## Screenshots / preview

失败 run 日志（https://github.com/Stack-Cairn/LiveAgent/actions/runs/33903019206/job/101121365671）：

```
Setting up protobuf-compiler (3.12.4-1ubuntu7.22.04.6) ...
...
thread 'main' panicked at crates/agent-gui/src-tauri/build.rs:44:10:
compile gateway protos: Custom { kind: Other, error: "protoc failed: proto/v2/gateway.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set.\n" }
```

对照上一次成功的 v1.3.0（run 33479438056）：

```
Image: ubuntu-24.04
Setting up protobuf-compiler (3.21.12-8.2ubuntu0.3) ...
```

<!-- 修复后的 Desktop Release run 截图由作者补充 -->

## Verification

- 用真实 release 资产对新步骤做了 dry run：`protoc-34.0-linux-x86_64.zip` 布局为 `bin/protoc` + `include/*`，unzip 过滤器命中；`bin/protoc` 为静态链接 x86-64 ELF，在 22.04 runner 上可直接运行。
- 工作流 YAML 解析通过，Linux job 步骤顺序为 apt 依赖 → 安装 protoc → rust-cache → 前端依赖 → 构建。
- `gateway.proto` 未 import well-known types，`include/` 目录非硬依赖，一并安装只是保险。
- 该 workflow 仅由 tag push / workflow_dispatch 触发，PR CI 不会跑到它；合入后需重新触发 v1.3.1 发布（重打 tag 或 workflow_dispatch）验证。

## Pre-submit checklist

- [x] A requirement issue is linked (or this is a trivial fix that needs no issue, as explained in the summary).
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration.（仅 CI 内部工具链变更，无用户可见行为，文档无需更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
