### PR TITLE
fix(chat): make conversation search explicitly global

### DIFF
--- a/crates/agent-gateway/web/src/lib/gatewaySocketShared.ts
+++ b/crates/agent-gateway/web/src/lib/gatewaySocketShared.ts
@@ -882,6 +882,7 @@ export function isUnsupportedChatPrepareError(error: unknown) {
 }
 
 export const RECOVERABLE_MEMORY_MANAGE_COMMANDS = new Set([
+  "chat_history_search",
   "memory_list",
   "memory_read",
   "memory_search",

--- a/crates/agent-gateway/web/src/shims/tauriCore.ts
+++ b/crates/agent-gateway/web/src/shims/tauriCore.ts
@@ -153,6 +153,8 @@ export async function invoke<T>(command: string, args?: Record<string, unknown>)
         totalCount: response.total_count,
       } as T;
     }
+    case "chat_history_search":
+      return invokeGatewayMemory<T>(command, args);
     case "chat_history_workdirs":
       return (await getGatewayWebSocketClient(loadToken().trim()).listHistoryWorkdirs()) as T;
     case "system_create_project_folder":

--- a/crates/agent-gui/src-tauri/src/commands/history/chat_history/search.rs
+++ b/crates/agent-gui/src-tauri/src/commands/history/chat_history/search.rs
@@ -590,7 +590,7 @@ fn search_chat_history_fts_with_refresh(
     Ok(matches)
 }
 
-fn search_chat_history_sync(
+pub(crate) fn search_chat_history_sync(
     args: ChatHistorySearchArgs,
 ) -> Result<ChatHistorySearchResponse, String> {
     let query = args.query.trim();

--- a/crates/agent-gui/src-tauri/src/commands/history/chat_history/tests.rs
+++ b/crates/agent-gui/src-tauri/src/commands/history/chat_history/tests.rs
@@ -1510,6 +1510,62 @@ mod tests {
     }
 
     #[test]
+    fn chat_history_search_spans_all_workdirs_and_chat_mode() {
+        let conn = open_test_db().expect("open test db");
+        for (index, (id, cwd)) in [
+            ("project-a", Some("/tmp/project-a")),
+            ("project-b", Some("/tmp/project-b")),
+            ("chat-mode", None),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let mut conversation = sample_conversation();
+            conversation.id = id.to_string();
+            conversation.title = format!("Global search {id}");
+            conversation.cwd = cwd.map(str::to_string);
+            conversation.updated_at += index as i64;
+            upsert_chat_history_header(&conn, &conversation).expect("upsert global search header");
+            upsert_single_segment(
+                &conn,
+                id,
+                &ChatHistorySegmentInput {
+                    segment_index: 0,
+                    segment_id: format!("segment-{id}"),
+                    summary_json: None,
+                    messages_json: format!(
+                        r#"[{{"id":"message-{id}","role":"user","content":"global-session-marker","timestamp":1700000000001}}]"#
+                    ),
+                    message_count: 1,
+                    start_message_id: Some(format!("message-{id}")),
+                    end_message_id: Some(format!("message-{id}")),
+                    created_at: 1_700_000_000_000,
+                    updated_at: 1_700_000_000_001 + index as i64,
+                },
+            )
+            .expect("upsert global search segment");
+        }
+
+        let matches = search_chat_history_fts_with_refresh(
+            &conn,
+            "global-session-marker",
+            MAX_HISTORY_SEARCH_LIMIT,
+            &default_history_search_filter(),
+        )
+        .expect("search global history");
+        let conversation_ids = matches
+            .iter()
+            .map(|item| item.conversation_id.as_str())
+            .collect::<std::collections::HashSet<_>>();
+
+        assert_eq!(
+            conversation_ids,
+            std::collections::HashSet::from(["project-a", "project-b", "chat-mode"]),
+            "global search must not inherit the active workdir filter"
+        );
+    }
+
+    #[test]
     fn resolve_share_allows_empty_persisted_history() {
         let conn = open_test_db().expect("open test db");
         let conversation = sample_conversation();

--- a/crates/agent-gui/src-tauri/src/services/gateway_bridge.rs
+++ b/crates/agent-gui/src-tauri/src/services/gateway_bridge.rs
@@ -1244,6 +1244,13 @@ fn handle_memory_manage_sync(
                 chat_history::search_chat_history_for_memory_sync(&history_args)?;
             serde_json::to_value(response)
         }
+        "chat_history_search" => {
+            let args = parse_memory_args::<chat_history::ChatHistorySearchArgs>(
+                &request.args_json,
+                command,
+            )?;
+            serde_json::to_value(chat_history::search_chat_history_sync(args)?)
+        }
         "memory_write" => {
             let args = parse_memory_args::<MemoryWriteArgs>(&request.args_json, command)?;
             serde_json::to_value(memory_store.write(args)?)

--- a/crates/agent-gui/src/lib/shortcuts/globalShortcuts.ts
+++ b/crates/agent-gui/src/lib/shortcuts/globalShortcuts.ts
@@ -30,8 +30,7 @@ export interface GlobalShortcutFailure {
   error: string;
 }
 
-export const GLOBAL_SHORTCUT_STORAGE_KEY = "liveagent.globalShortcuts.v1";
-export const GLOBAL_SHORTCUT_BINDINGS_CHANGED_EVENT = "liveagent:global-shortcut-bindings-changed";
+const GLOBAL_SHORTCUT_STORAGE_KEY = "liveagent.globalShortcuts.v1";
 
 export const SHORTCUT_MODIFIER_ORDER = ["Ctrl", "Shift", "Alt", "Super"] as const;
 export type ShortcutModifier = (typeof SHORTCUT_MODIFIER_ORDER)[number];
@@ -111,16 +110,6 @@ export function globalShortcutDisplayToken(token: string, isMac: boolean): strin
   return globalShortcutKeyDisplayLabel(token);
 }
 
-/** 与设置页键帽使用同一套显示规则，供侧栏展示当前实际启用的绑定。 */
-export function formatGlobalShortcutAccelerator(accelerator: string, isMac: boolean): string {
-  const tokens = accelerator
-    .split("+")
-    .map((token) => token.trim())
-    .filter(Boolean)
-    .map((token) => globalShortcutDisplayToken(token, isMac));
-  return tokens.join(isMac ? "" : " ");
-}
-
 /** KeyboardEvent.code -> 修饰键 token；非修饰键返回 null。 */
 export function modifierFromEventCode(code: string): ShortcutModifier | null {
   switch (code) {
@@ -172,7 +161,6 @@ export function readGlobalShortcutBindings(): GlobalShortcutBindings {
 export function writeGlobalShortcutBindings(bindings: GlobalShortcutBindings): void {
   try {
     window.localStorage.setItem(GLOBAL_SHORTCUT_STORAGE_KEY, JSON.stringify(bindings));
-    window.dispatchEvent(new Event(GLOBAL_SHORTCUT_BINDINGS_CHANGED_EVENT));
   } catch {
     // localStorage 不可用时静默忽略（例如隐私模式）。
   }

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -133,7 +133,6 @@ import { skillMentionInjection } from "../lib/chat/skills/mentionInjection";
 import { tauriGitClient } from "../lib/git/tauriGitClient";
 import { buildMemoryOverviewSection } from "../lib/memory/prompts/injection";
 import { createProviderRuntimeConfig, toModelValue } from "../lib/providers/llm";
-import { inferRuntimePlatform } from "../lib/runtimePlatform";
 import {
   findProviderModelConfig,
   getChatRuntimeReasoningLevelsForProvider,
@@ -157,12 +156,6 @@ import {
   workspaceProjectPathKey,
 } from "../lib/settings";
 import { tauriSftpClient } from "../lib/sftp/tauriSftpClient";
-import {
-  formatGlobalShortcutAccelerator,
-  GLOBAL_SHORTCUT_BINDINGS_CHANGED_EVENT,
-  GLOBAL_SHORTCUT_STORAGE_KEY,
-  readGlobalShortcutBindings,
-} from "../lib/shortcuts/globalShortcuts";
 import { createGuiSidebarBackend } from "../lib/sidebar/guiSidebarBackend";
 import { desktopSttTransport } from "../lib/stt/desktopSttTransport";
 import { createSubagentStoreManager } from "../lib/subagents";
@@ -276,16 +269,6 @@ const ConversationPaneHost = lazy(async () => ({
 const RestorableConversationPaneHost = lazy(async () => ({
   default: (await import("./chat/surfaces/ConversationPaneHost")).RestorableConversationPaneHost,
 }));
-
-function readConversationSearchShortcutLabel(): string | undefined {
-  const binding = readGlobalShortcutBindings().searchConversations;
-  if (!binding?.enabled) return undefined;
-  const label = formatGlobalShortcutAccelerator(
-    binding.accelerator,
-    inferRuntimePlatform() === "macos",
-  );
-  return label || undefined;
-}
 
 export function ChatPage(props: ChatPageProps) {
   const {
@@ -416,23 +399,6 @@ export function ChatPage(props: ChatPageProps) {
   }, [sidebarStore]);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [conversationSearchRequestKey, setConversationSearchRequestKey] = useState(0);
-  const [conversationSearchShortcutLabel, setConversationSearchShortcutLabel] = useState<
-    string | undefined
-  >(readConversationSearchShortcutLabel);
-  useEffect(() => {
-    const refreshShortcutLabel = () => {
-      setConversationSearchShortcutLabel(readConversationSearchShortcutLabel());
-    };
-    const handleStorage = (event: StorageEvent) => {
-      if (event.key === GLOBAL_SHORTCUT_STORAGE_KEY) refreshShortcutLabel();
-    };
-    window.addEventListener(GLOBAL_SHORTCUT_BINDINGS_CHANGED_EVENT, refreshShortcutLabel);
-    window.addEventListener("storage", handleStorage);
-    return () => {
-      window.removeEventListener(GLOBAL_SHORTCUT_BINDINGS_CHANGED_EVENT, refreshShortcutLabel);
-      window.removeEventListener("storage", handleStorage);
-    };
-  }, []);
   const { remoteRuntimeStatus, setRemoteRuntimeStatus } = useGatewayStatus({
     remote: settings.remote,
   });
@@ -3926,7 +3892,6 @@ export function ChatPage(props: ChatPageProps) {
         isOpen={sidebarOpen}
         fontScale={settings.customSettings.fontScale.sidebar}
         conversationSearchRequestKey={conversationSearchRequestKey}
-        conversationSearchShortcutLabel={conversationSearchShortcutLabel}
         activeView={activeView}
         showProjects={isAgentMode}
         projects={workspaceProjects}

--- a/crates/agent-gui/test/chat/conversation-search.test.mjs
+++ b/crates/agent-gui/test/chat/conversation-search.test.mjs
@@ -6,6 +6,11 @@ test("conversation mention search uses complete indexed history, deduplicates, a
   const calls = [];
   const { searchMentionConversations } = createTsModuleLoader({
     mocks: {
+      "@liveagent/ui/lib/chat/historySearch": {
+        async searchChatHistory() {
+          throw new Error("mention search must not use global navigation search");
+        },
+      },
       "@liveagent/ui/lib/memory/api": {
         async memorySearch(args) {
           calls.push(args);
@@ -70,6 +75,11 @@ test("conversation mention search skips the backend for an empty query", async (
   let calls = 0;
   const { searchMentionConversations } = createTsModuleLoader({
     mocks: {
+      "@liveagent/ui/lib/chat/historySearch": {
+        async searchChatHistory() {
+          throw new Error("empty mention search must not use global navigation search");
+        },
+      },
       "@liveagent/ui/lib/memory/api": {
         async memorySearch() {
           calls += 1;
@@ -86,25 +96,45 @@ test("conversation mention search skips the backend for an empty query", async (
   assert.equal(calls, 0);
 });
 
-test("sidebar conversation search includes the current conversation and returns content previews", async () => {
+test("sidebar conversation search uses the global history API and ranks without filtering workdirs", async () => {
   const { searchPersistedConversations } = createTsModuleLoader({
     mocks: {
-      "@liveagent/ui/lib/memory/api": {
-        async memorySearch(args) {
-          assert.deepEqual(args, { query: "release notes", includeHistory: true, limit: 80 });
+      "@liveagent/ui/lib/chat/historySearch": {
+        async searchChatHistory(args) {
+          assert.deepEqual(args, { query: "release notes", limit: 80 });
           return {
-            matches: [],
-            historyMatches: [
+            matches: [
               {
-                conversationId: "current",
+                conversationId: "other-workspace",
+                title: "Remote release notes",
+                cwd: "/repo/b",
+                snippet: "assistant: [release notes] from another workspace",
+                score: 12,
+                updatedAt: 60,
+              },
+              {
+                conversationId: "current-workspace",
                 title: "Release planning",
                 cwd: "/repo/a",
                 snippet: "assistant: [release notes] are ready",
                 score: 4,
                 updatedAt: 50,
               },
+              {
+                conversationId: "global-chat",
+                title: "Chat without a workspace",
+                cwd: null,
+                snippet: "user: [release notes]",
+                score: 8,
+                updatedAt: 55,
+              },
             ],
           };
+        },
+      },
+      "@liveagent/ui/lib/memory/api": {
+        async memorySearch() {
+          throw new Error("sidebar navigation search must not use memory_search");
         },
       },
     },
@@ -115,13 +145,73 @@ test("sidebar conversation search includes the current conversation and returns 
     currentWorkdir: "/repo/a",
   });
 
-  assert.deepEqual(results, [
+  assert.deepEqual(
+    results.map((result) => result.id),
+    ["current-workspace", "other-workspace", "global-chat"],
+  );
+  assert.equal(results[0].searchPreview, "assistant: [release notes] are ready");
+});
+
+test("global history API invokes the dedicated chat history command", async () => {
+  const calls = [];
+  const { searchChatHistory } = createTsModuleLoader({
+    mocks: {
+      "@liveagent/app/shims/tauriCore": {
+        async invoke(command, args) {
+          calls.push({ command, args });
+          return { matches: [] };
+        },
+      },
+    },
+  }).loadModule("@liveagent/ui/lib/chat/historySearch");
+
+  assert.deepEqual(await searchChatHistory({ query: "global", limit: 12 }), { matches: [] });
+  assert.deepEqual(calls, [
     {
-      id: "current",
-      title: "Release planning",
-      cwd: "/repo/a",
-      updatedAt: 50,
-      searchPreview: "assistant: [release notes] are ready",
+      command: "chat_history_search",
+      args: { args: { query: "global", limit: 12 } },
+    },
+  ]);
+});
+
+test("Gateway shim forwards global history search without a workdir scope", async () => {
+  const calls = [];
+  const gatewayRoot = new URL("../../../agent-gateway/web", import.meta.url).pathname;
+  const { invoke } = createTsModuleLoader({
+    rootDir: gatewayRoot,
+    mocks: {
+      "../lib/gatewaySocket": {
+        getGatewayWebSocketClient(token) {
+          assert.equal(token, "gateway-token");
+          return {
+            async memoryManage(payload) {
+              calls.push(payload);
+              return { matches: [] };
+            },
+          };
+        },
+      },
+      "../lib/storage": {
+        loadToken() {
+          return "gateway-token";
+        },
+      },
+      "./browserPathPrompt": {
+        async promptPathInBrowser() {
+          throw new Error("path prompt must not be used by history search");
+        },
+      },
+    },
+  }).loadModule("src/shims/tauriCore");
+
+  assert.deepEqual(
+    await invoke("chat_history_search", { args: { query: "global", limit: 12 } }),
+    { matches: [] },
+  );
+  assert.deepEqual(calls, [
+    {
+      command: "chat_history_search",
+      args: { query: "global", limit: 12 },
     },
   ]);
 });

--- a/crates/agent-gui/test/chat/sidebar-conversation-search-ui.test.mjs
+++ b/crates/agent-gui/test/chat/sidebar-conversation-search-ui.test.mjs
@@ -32,9 +32,9 @@ test("sidebar exposes a Codex-style conversation search entry", () => {
   assert.match(sidebarSource, /chat-history-search-button/);
   assert.match(sidebarSource, /t\("chat\.searchConversations"\)/);
   assert.match(sidebarSource, /conversationSearchRequestKey/);
-  assert.match(sidebarSource, /conversationSearchShortcutLabel/);
   assert.match(sidebarSource, /setConversationSearchOpen\(true\)/);
   assert.match(sidebarSource, /<ConversationSearchDialog/);
+  assert.doesNotMatch(sidebarSource, /conversationSearchShortcutLabel|<kbd/);
   assert.doesNotMatch(sidebarSource, /⌘K \/ Ctrl\+K|event\.key\.toLowerCase\(\) !== "k"/);
 });
 

--- a/crates/agent-gui/test/chat/sidebar-conversation-search-ui.test.mjs
+++ b/crates/agent-gui/test/chat/sidebar-conversation-search-ui.test.mjs
@@ -19,6 +19,14 @@ const rustAppSource = readFileSync(
   new URL("../../src-tauri/src/lib.rs", import.meta.url),
   "utf8",
 );
+const gatewayShimSource = readFileSync(
+  new URL("../../../agent-gateway/web/src/shims/tauriCore.ts", import.meta.url),
+  "utf8",
+);
+const gatewayBridgeSource = readFileSync(
+  new URL("../../src-tauri/src/services/gateway_bridge.rs", import.meta.url),
+  "utf8",
+);
 
 test("sidebar exposes a Codex-style conversation search entry", () => {
   assert.match(sidebarSource, /chat-history-search-button/);
@@ -48,4 +56,11 @@ test("conversation search opens history directly instead of creating a composer 
   assert.match(dialogSource, /chat\.recentConversation/);
   assert.match(dialogSource, /item\.searchPreview/);
   assert.doesNotMatch(dialogSource, /conversationMention|ReadConversation|MentionComposer/);
+});
+
+test("global conversation search is routed by both Desktop and Gateway", () => {
+  assert.match(dialogSource, /searchPersistedConversations/);
+  assert.match(gatewayShimSource, /case "chat_history_search"/);
+  assert.match(gatewayBridgeSource, /"chat_history_search" =>/);
+  assert.match(gatewayBridgeSource, /search_chat_history_sync/);
 });

--- a/crates/agent-gui/test/settings/global-shortcuts.test.mjs
+++ b/crates/agent-gui/test/settings/global-shortcuts.test.mjs
@@ -115,25 +115,6 @@ test("writeGlobalShortcutBindings round-trips through readGlobalShortcutBindings
   });
 });
 
-test("writeGlobalShortcutBindings announces same-window binding changes", async () => {
-  const storage = createMemoryLocalStorage();
-  const eventTarget = new EventTarget();
-  eventTarget.localStorage = storage;
-  let changeCount = 0;
-  eventTarget.addEventListener("liveagent:global-shortcut-bindings-changed", () => {
-    changeCount += 1;
-  });
-  await withWindow(eventTarget.localStorage, async () => {
-    // withWindow installs a plain object; expose the EventTarget methods used by the module.
-    globalThis.window.dispatchEvent = eventTarget.dispatchEvent.bind(eventTarget);
-    const { writeGlobalShortcutBindings } = loadGlobalShortcuts();
-    writeGlobalShortcutBindings({
-      searchConversations: { accelerator: "Super+KeyK", enabled: true },
-    });
-  });
-  assert.equal(changeCount, 1);
-});
-
 test("applyGlobalShortcuts registers only enabled bindings with non-empty accelerators", async () => {
   const calls = [];
   const { applyGlobalShortcuts } = loadGlobalShortcuts({
@@ -160,12 +141,6 @@ test("applyGlobalShortcuts registers only enabled bindings with non-empty accele
     },
   ]);
   assert.deepEqual(failures, [{ action: "summon", accelerator: "Ctrl+KeyA", error: "taken" }]);
-});
-
-test("formatGlobalShortcutAccelerator follows the settings keyboard labels", () => {
-  const { formatGlobalShortcutAccelerator } = loadGlobalShortcuts();
-  assert.equal(formatGlobalShortcutAccelerator("Super+Shift+KeyK", true), "⌘⇧K");
-  assert.equal(formatGlobalShortcutAccelerator("Ctrl+ArrowUp", false), "Ctrl ↑");
 });
 
 test("applyGlobalShortcuts tolerates non-Tauri environments and bad responses", async () => {

--- a/crates/agent-ui/src/components/chat/ChatHistorySidebar.tsx
+++ b/crates/agent-ui/src/components/chat/ChatHistorySidebar.tsx
@@ -184,7 +184,6 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
     isOpen,
     fontScale = 1,
     conversationSearchRequestKey,
-    conversationSearchShortcutLabel,
     activeView = "chat",
     showProjects = false,
     projects = [],
@@ -1293,21 +1292,12 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
               disabled={sectionsDisabled}
               onClick={() => setConversationSearchOpen(true)}
               className="chat-history-search-button h-[30px] w-full justify-start gap-3 rounded-lg px-3 text-[calc(14px*var(--zone-font-scale,1))] font-normal leading-5 text-foreground/80 shadow-none transition-colors hover:bg-foreground/[0.08] hover:text-foreground focus-visible:bg-foreground/[0.08]"
-              title={
-                conversationSearchShortcutLabel
-                  ? `${t("chat.searchConversations")} (${conversationSearchShortcutLabel})`
-                  : t("chat.searchConversations")
-              }
+              title={t("chat.searchConversations")}
             >
               <Search className="h-4 w-4 shrink-0 text-foreground/85" />
               <span className="min-w-0 flex-1 truncate text-left">
                 {t("chat.searchConversations")}
               </span>
-              {conversationSearchShortcutLabel ? (
-                <kbd className="hidden rounded border border-border/50 bg-background/40 px-1 py-px text-[9px] font-medium leading-4 text-muted-foreground/70 min-[220px]:inline-flex">
-                  {conversationSearchShortcutLabel}
-                </kbd>
-              ) : null}
             </Button>
             <Button
               type="button"

--- a/crates/agent-ui/src/components/chat/ChatHistorySidebarTypes.ts
+++ b/crates/agent-ui/src/components/chat/ChatHistorySidebarTypes.ts
@@ -54,8 +54,6 @@ export type ChatHistorySidebarProps = {
   fontScale?: number;
   /** Incremented by the desktop host when its configured search shortcut fires. */
   conversationSearchRequestKey?: number;
-  /** Display label for the enabled desktop shortcut (for example, ⌘⇧K). */
-  conversationSearchShortcutLabel?: string;
   activeView?: "chat" | "skills-hub" | "mcp-hub";
   showProjects?: boolean;
   // Pre-sorted by the container (pinned/running/activity); rendered as-is.
@@ -203,7 +201,6 @@ export type ChatHistorySidebarContainerSource = Required<
     | "isOpen"
     | "fontScale"
     | "conversationSearchRequestKey"
-    | "conversationSearchShortcutLabel"
     | "onNewConversation"
     | "onSelectConversation"
     | "canShareConversations"
@@ -269,12 +266,7 @@ type ChatHistorySidebarBaseState = Pick<
 export function buildChatHistorySidebarBaseProps(
   source: Pick<
     ChatHistorySidebarContainerSource,
-    | "currentConversationId"
-    | "isOpen"
-    | "fontScale"
-    | "conversationSearchRequestKey"
-    | "conversationSearchShortcutLabel"
-    | "activeView"
+    "currentConversationId" | "isOpen" | "fontScale" | "conversationSearchRequestKey" | "activeView"
   >,
   state: ChatHistorySidebarBaseState,
 ) {
@@ -297,7 +289,6 @@ export function buildChatHistorySidebarBaseProps(
     isOpen: source.isOpen,
     fontScale: source.fontScale,
     conversationSearchRequestKey: source.conversationSearchRequestKey,
-    conversationSearchShortcutLabel: source.conversationSearchShortcutLabel,
     activeView: source.activeView,
   };
 }

--- a/crates/agent-ui/src/lib/chat/conversationSearch.ts
+++ b/crates/agent-ui/src/lib/chat/conversationSearch.ts
@@ -1,4 +1,8 @@
 import type { MentionComposerConversation } from "@liveagent/ui/components/chat/MentionComposerModel";
+import {
+  type ChatHistorySearchResponse,
+  searchChatHistory,
+} from "@liveagent/ui/lib/chat/historySearch";
 import { memorySearch } from "@liveagent/ui/lib/memory/api";
 
 const HISTORY_SEARCH_FETCH_LIMIT = 80;
@@ -16,23 +20,17 @@ export type PersistedConversationSearchResult = {
   searchPreview?: string;
 };
 
-export async function searchPersistedConversations(params: {
-  query: string;
-  currentWorkdir?: string;
-  excludeConversationId?: string;
-  limit?: number;
-}): Promise<PersistedConversationSearchResult[]> {
-  const query = params.query.trim();
-  if (!query) return [];
-
-  const response = await memorySearch({
-    query,
-    includeHistory: true,
-    limit: HISTORY_SEARCH_FETCH_LIMIT,
-  });
+function normalizeHistoryMatches(
+  matches: ChatHistorySearchResponse["matches"],
+  params: {
+    currentWorkdir?: string;
+    excludeConversationId?: string;
+    limit?: number;
+  },
+): PersistedConversationSearchResult[] {
   const excludedId = params.excludeConversationId?.trim();
   const byConversation = new Map<string, PersistedConversationSearchResult & { score: number }>();
-  for (const match of response.historyMatches ?? []) {
+  for (const match of matches) {
     const id = match.conversationId.trim();
     const title = match.title.trim();
     if (!id || !title || id === excludedId) continue;
@@ -62,14 +60,37 @@ export async function searchPersistedConversations(params: {
     .map(({ score: _score, ...conversation }) => conversation);
 }
 
+export async function searchPersistedConversations(params: {
+  query: string;
+  currentWorkdir?: string;
+  excludeConversationId?: string;
+  limit?: number;
+}): Promise<PersistedConversationSearchResult[]> {
+  const query = params.query.trim();
+  if (!query) return [];
+
+  const response = await searchChatHistory({
+    query,
+    limit: HISTORY_SEARCH_FETCH_LIMIT,
+  });
+  return normalizeHistoryMatches(response.matches ?? [], params);
+}
+
 export async function searchMentionConversations(params: {
   query: string;
   currentConversationId: string;
   currentWorkdir?: string;
   limit?: number;
 }): Promise<MentionComposerConversation[]> {
-  return searchPersistedConversations({
-    query: params.query,
+  const query = params.query.trim();
+  if (!query) return [];
+
+  const response = await memorySearch({
+    query,
+    includeHistory: true,
+    limit: HISTORY_SEARCH_FETCH_LIMIT,
+  });
+  return normalizeHistoryMatches(response.historyMatches ?? [], {
     currentWorkdir: params.currentWorkdir,
     excludeConversationId: params.currentConversationId,
     limit: params.limit,

--- a/crates/agent-ui/src/lib/chat/historySearch.ts
+++ b/crates/agent-ui/src/lib/chat/historySearch.ts
@@ -1,0 +1,33 @@
+import { invoke } from "@liveagent/app/shims/tauriCore";
+
+export type ChatHistorySearchMatch = {
+  source: "message" | "segment" | string;
+  conversationId: string;
+  title: string;
+  cwd?: string | null;
+  segmentIndex: number;
+  segmentId: string;
+  messageIndex?: number | null;
+  messageId?: string | null;
+  role?: string | null;
+  snippet: string;
+  score: number;
+  rawScore?: number | null;
+  updatedAt: number;
+};
+
+export type ChatHistorySearchArgs = {
+  query: string;
+  limit?: number;
+};
+
+export type ChatHistorySearchResponse = {
+  matches: ChatHistorySearchMatch[];
+};
+
+/** Search the persisted conversation database across every workspace. */
+export async function searchChatHistory(
+  args: ChatHistorySearchArgs,
+): Promise<ChatHistorySearchResponse> {
+  return invoke<ChatHistorySearchResponse>("chat_history_search", { args });
+}


### PR DESCRIPTION
## Summary

- move sidebar navigation search from the generic memory search channel to a dedicated `chat_history_search` API
- route the same global history command through Desktop and Gateway without a workdir filter
- keep the current workspace as a ranking preference only and preserve the separate Composer mention-search semantics
- keep the configurable Desktop shortcut behavior while removing its visual badge from the sidebar search button
- add frontend, Gateway transport, and Rust coverage for other workspaces and conversations without a workdir

## Screenshots / preview

The search dialog remains unchanged. The sidebar search button intentionally shows no shortcut badge even when a shortcut is configured.

![Conversation history search dialog](https://github.com/user-attachments/assets/7be36129-55ab-46e1-b0d1-1f4d30d74cc1)

## Verification

- `make check-all`: 19 of 21 steps passed locally
- `mise exec -- cargo test --workspace --all-targets`: 1001 passed, 3 ignored, 0 failed outside the restricted sandbox
- targeted conversation search and shortcut tests: 17 passed
- shared UI typecheck passed
- Desktop and Gateway WebUI production builds passed
- changed-file Biome checks and `git diff --check` passed

The two local Make failures are baseline/environment-only: Shared UI lint reports formatting in three untouched `origin/main` files, and the sandboxed Rust test step cannot perform process and user-directory operations; the same Rust suite passes outside the sandbox.

Closes #750