### PR TITLE
fix(workbench): 修复工具标签点击切换与 worktree 开发启动误判

### DIFF
--- a/crates/agent-ui/src/lib/workbench/useWorkbenchDragSession.ts
+++ b/crates/agent-ui/src/lib/workbench/useWorkbenchDragSession.ts
@@ -32,9 +32,10 @@ export type WorkbenchDragPointerEvent = {
   clientX: number;
   clientY: number;
   /**
-   * The element that received pointer-down. Capturing on it keeps move/up
-   * events flowing while the pointer crosses xterm canvases, contenteditable
-   * composers, and the dock/canvas boundary.
+   * The element that received pointer-down. Once a drag activates, capturing
+   * on it keeps move/up events flowing across xterm canvases, contenteditable
+   * composers, and the dock/canvas boundary. Ordinary presses stay uncaptured
+   * so a nested button remains the target of the browser's click.
    */
   currentTarget?: EventTarget | null;
 };
@@ -182,15 +183,6 @@ export function useWorkbenchDragSession(params: UseWorkbenchDragSessionParams) {
     (payload: WorkbenchDragPayload, event: WorkbenchDragPointerEvent) => {
       if (!enabled || sessionRef.current.phase !== "idle") return;
       const captureElement = event.currentTarget instanceof Element ? event.currentTarget : null;
-      if (captureElement) {
-        try {
-          captureElement.setPointerCapture(event.pointerId);
-          pointerCaptureRef.current = { element: captureElement, pointerId: event.pointerId };
-        } catch {
-          // Capture is best-effort: window listeners still see the gesture
-          // when the host rejects setPointerCapture (inactive pointer, etc.).
-        }
-      }
       dispatch({
         type: "arm",
         payload,
@@ -238,6 +230,19 @@ export function useWorkbenchDragSession(params: UseWorkbenchDragSessionParams) {
             onUnavailableRef.current?.("canvas-too-narrow");
             teardown();
             return;
+          }
+          // Capturing the tab container on pointer-down retargets even a
+          // plain click away from its nested activation button. Window
+          // capture-phase listeners track the armed gesture until it becomes
+          // a real drag; only then may pointer capture change the target.
+          if (captureElement) {
+            try {
+              captureElement.setPointerCapture(event.pointerId);
+              pointerCaptureRef.current = { element: captureElement, pointerId: event.pointerId };
+            } catch {
+              // Capture is best-effort; window listeners still track the drag
+              // if the source disappeared or the host rejects capture.
+            }
           }
           if (canvasElement && geometry && canvasAllowsPointerSplit(geometry)) {
             const canvasRect = canvasElement.getBoundingClientRect();

--- a/scripts/dev-stack-paths.mjs
+++ b/scripts/dev-stack-paths.mjs
@@ -1,0 +1,24 @@
+import { createHash } from "node:crypto";
+import { existsSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function defaultDevStateDir(repoRoot, userKey) {
+  // /tmp and /private/tmp can name the same macOS checkout.
+  const checkout = realpathSync(repoRoot);
+  const key = createHash("sha256").update(checkout).digest("hex").slice(0, 12);
+  return join(tmpdir(), `liveagent-dev-stack-${userKey}-${key}`);
+}
+
+export function missingDevDependency(repoRoot, service) {
+  const entries =
+    service === "desktop"
+      ? [
+          "crates/agent-gui/node_modules/vite/bin/vite.js",
+          "crates/agent-gui/node_modules/@tauri-apps/cli/tauri.js",
+        ]
+      : service === "webui"
+        ? ["crates/agent-gateway/web/node_modules/vite/bin/vite.js"]
+        : [];
+  return entries.find((entry) => !existsSync(join(repoRoot, entry)));
+}

--- a/scripts/dev-stack-readiness.mjs
+++ b/scripts/dev-stack-readiness.mjs
@@ -1,0 +1,57 @@
+import { realpathSync } from "node:fs";
+import { join } from "node:path";
+
+export function matchesDesktopBackend(data, repoRoot, requireVisible = false) {
+  if (data?.app?.identifier !== "com.xiaofei.liveagent" || !data?.environment?.debug) return false;
+  try {
+    if (realpathSync(data.cwd) !== realpathSync(join(repoRoot, "crates/agent-gui/src-tauri")))
+      return false;
+  } catch {
+    return false;
+  }
+  return (
+    Array.isArray(data.windows) &&
+    data.windows.some(
+      (window) => window.label === "main" && (!requireVisible || window.visible === true),
+    )
+  );
+}
+
+// Vite can answer HTTP while Cargo is still compiling (or has already failed).
+// The debug bridge identifies the native process by its actual checkout and,
+// during initial startup, confirms that the frontend has revealed its window.
+export function desktopBackendReady(repoRoot, port, requireVisible = false) {
+  return new Promise((resolve) => {
+    const socket = new WebSocket(`ws://127.0.0.1:${port}`);
+    let finished = false;
+    const finish = (ready) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeout);
+      socket.close();
+      resolve(ready);
+    };
+    const timeout = setTimeout(() => finish(false), 2000);
+    socket.onerror = () => finish(false);
+    socket.onclose = () => finish(false);
+    socket.onopen = () =>
+      socket.send(
+        JSON.stringify({
+          id: "dev-stack-ready",
+          command: "invoke_tauri",
+          args: { command: "plugin:mcp-bridge|get_backend_state", args: {} },
+        }),
+      );
+    socket.onmessage = (event) => {
+      try {
+        const result = JSON.parse(event.data);
+        if (result.id !== "dev-stack-ready") return;
+        finish(
+          result.success === true && matchesDesktopBackend(result.data, repoRoot, requireVisible),
+        );
+      } catch {
+        finish(false);
+      }
+    };
+  });
+}

--- a/scripts/dev-stack.mjs
+++ b/scripts/dev-stack.mjs
@@ -9,6 +9,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  realpathSync,
   statSync,
   unlinkSync,
   unwatchFile,
@@ -16,15 +17,19 @@ import {
   writeFileSync,
 } from "node:fs";
 import { createConnection } from "node:net";
-import { homedir, tmpdir } from "node:os";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { defaultDevStateDir, missingDevDependency } from "./dev-stack-paths.mjs";
+import { desktopBackendReady } from "./dev-stack-readiness.mjs";
 
 const scriptPath = resolve(import.meta.filename);
-const repoRoot = resolve(import.meta.dirname, "..");
+const repoRoot = realpathSync(resolve(import.meta.dirname, ".."));
 const userKey =
-  typeof process.getuid === "function" ? String(process.getuid()) : (process.env.USERNAME ?? "user");
+  typeof process.getuid === "function"
+    ? String(process.getuid())
+    : (process.env.USERNAME ?? "user");
 const stateDir = resolve(
-  process.env.LIVEAGENT_DEV_STATE_DIR ?? join(tmpdir(), `liveagent-dev-stack-${userKey}`),
+  process.env.LIVEAGENT_DEV_STATE_DIR ?? defaultDevStateDir(repoRoot, userKey),
 );
 const gatewayDataDir = resolve(
   process.env.LIVEAGENT_GATEWAY_DATA_DIR ?? join(homedir(), ".liveagent/gateway"),
@@ -35,7 +40,8 @@ const ports = {
   webui: Number(process.env.LIVEAGENT_DEV_WEBUI_PORT ?? 5173),
 };
 const mcpBridgePort = Number(process.env.LIVEAGENT_DEV_MCP_BRIDGE_PORT ?? 9223);
-const gatewayToken = process.env.LIVEAGENT_GATEWAY_TOKEN ?? process.env.DEV_GATEWAY_TOKEN ?? "dev-token";
+const gatewayToken =
+  process.env.LIVEAGENT_GATEWAY_TOKEN ?? process.env.DEV_GATEWAY_TOKEN ?? "dev-token";
 const urls = Object.fromEntries(
   Object.entries(ports).map(([service, port]) => [service, `http://localhost:${port}`]),
 );
@@ -52,7 +58,7 @@ Environment variables:
   LIVEAGENT_DEV_WEBUI_PORT      WebUI Vite port (default: 5173)
   LIVEAGENT_DEV_DESKTOP_PORT    Desktop Vite port (default: 1420)
   LIVEAGENT_DEV_MCP_BRIDGE_PORT MCP Bridge port (default: 9223)
-  LIVEAGENT_DEV_STATE_DIR       State and log directory`);
+  LIVEAGENT_DEV_STATE_DIR       State and log directory (default: isolated per checkout)`);
 }
 
 function fail(message) {
@@ -92,7 +98,10 @@ function readState(service) {
 
 function writeState(state) {
   mkdirSync(stateDir, { recursive: true });
-  writeFileSync(statePath(state.service), `${JSON.stringify(state)}\n`);
+  writeFileSync(
+    statePath(state.service),
+    `${JSON.stringify({ ...state, repoRoot, port: ports[state.service] })}\n`,
+  );
 }
 
 function removeState(service, token) {
@@ -120,6 +129,11 @@ function stateIsFresh(state) {
 function managedState(service) {
   const state = readState(service);
   if (!state) return undefined;
+  if (state.repoRoot !== repoRoot || state.port !== ports[service]) {
+    fail(
+      `${service} state belongs to another checkout or port; use its original checkout/configuration to stop it, or choose a separate LIVEAGENT_DEV_STATE_DIR`,
+    );
+  }
   if (!processIsAlive(state.pid)) {
     removeState(service, state.token);
     return undefined;
@@ -145,11 +159,15 @@ async function portIsListening(port) {
   });
 }
 
-async function httpReady(service) {
+async function httpReady(service, requireVisible = false) {
   const url = service === "gateway" ? `${urls.gateway}/healthz` : `${urls[service]}/`;
   try {
     const response = await fetch(url, { signal: AbortSignal.timeout(2000) });
-    return response.ok;
+    return (
+      response.ok &&
+      (service !== "desktop" ||
+        (await desktopBackendReady(repoRoot, mcpBridgePort, requireVisible)))
+    );
   } catch {
     return false;
   }
@@ -295,7 +313,7 @@ function tail(file, lineCount) {
 
 async function waitUntilReady(service, timeoutSeconds) {
   for (let elapsed = 0; elapsed < timeoutSeconds; elapsed += 1) {
-    if (await httpReady(service)) return true;
+    if (await httpReady(service, true)) return true;
     const state = managedState(service);
     if (!state || !stateIsFresh(state)) return false;
     await wait(1000);
@@ -304,31 +322,46 @@ async function waitUntilReady(service, timeoutSeconds) {
 }
 
 async function startService(service) {
+  // A fresh worktree can spend several minutes compiling the native app.
+  const timeoutSeconds = service === "desktop" ? 600 : 60;
   const state = managedState(service);
   if (state) {
     if (!stateIsFresh(state)) {
-      console.error(`${service}: managed state is stale for pid ${state.pid}; refusing to replace it`);
+      console.error(
+        `${service}: managed state is stale for pid ${state.pid}; refusing to replace it`,
+      );
       return false;
     }
-    console.log(`${service}: already running (managed pid ${state.pid}, ${urls[service]})`);
-    return true;
-  }
-  if (await portIsListening(ports[service])) {
     if (await httpReady(service)) {
-      console.log(`${service}: already listening on port ${ports[service]} (external, ${urls[service]})`);
+      console.log(`${service}: already running (managed pid ${state.pid}, ${urls[service]})`);
       return true;
     }
-    console.error(`${service}: port ${ports[service]} has an unhealthy external listener; refusing to replace it`);
+    console.log(`${service}: waiting for managed pid ${state.pid} to become ready`);
+    return await waitUntilReady(service, timeoutSeconds);
+  }
+  if (await portIsListening(ports[service])) {
+    console.error(
+      `${service}: port ${ports[service]} is occupied by an unmanaged process (${urls[service]}); stop that process before starting this checkout. An HTTP response does not identify it as LiveAgent.`,
+    );
+    return false;
+  }
+
+  const missing = missingDevDependency(repoRoot, service);
+  if (missing) {
+    console.error(
+      `${service}: missing ${missing}; run "mise exec -- pnpm install --frozen-lockfile" from ${repoRoot} before starting this checkout`,
+    );
     return false;
   }
 
   const supervisor = launchSupervisor(service);
-  const timeoutSeconds = service === "desktop" ? 180 : 60;
   if (await waitUntilReady(service, timeoutSeconds)) {
     console.log(`${service}: started (managed pid ${supervisor.pid}, ${urls[service]})`);
     return true;
   }
-  console.error(`${service}: failed to become ready; last log lines:\n${tail(logPath(service), 30)}`);
+  console.error(
+    `${service}: failed to become ready; last log lines:\n${tail(logPath(service), 30)}`,
+  );
   await stopService(service);
   return false;
 }
@@ -365,7 +398,9 @@ async function stopService(service) {
     return true;
   }
   if (!stateIsFresh(state)) {
-    console.error(`${service}: managed heartbeat is stale for pid ${state.pid}; refusing to stop it`);
+    console.error(
+      `${service}: managed heartbeat is stale for pid ${state.pid}; refusing to stop it`,
+    );
     return false;
   }
 
@@ -392,7 +427,9 @@ async function statusService(service) {
     } else if (await httpReady(service)) {
       console.log(`${service}: ready (managed pid ${state.pid}, ${urls[service]})`);
     } else {
-      console.log(`${service}: starting or unhealthy (managed pid ${state.pid}, port ${ports[service]})`);
+      console.log(
+        `${service}: starting or unhealthy (managed pid ${state.pid}, port ${ports[service]})`,
+      );
     }
     return;
   }
@@ -441,7 +478,8 @@ async function main() {
   }
   validateConfiguration();
   if (action === "__run") {
-    if (!services.includes(target) || typeof process.argv[4] !== "string") fail("invalid supervisor arguments");
+    if (!services.includes(target) || typeof process.argv[4] !== "string")
+      fail("invalid supervisor arguments");
     await runService(target, process.argv[4]);
     return;
   }
@@ -454,20 +492,24 @@ async function main() {
   }
   if (action === "stop") {
     let failed = false;
-    for (const service of targetServices(target, true)) failed = !(await stopService(service)) || failed;
+    for (const service of targetServices(target, true))
+      failed = !(await stopService(service)) || failed;
     if (failed) process.exitCode = 1;
     return;
   }
   if (action === "restart") {
     let failed = false;
-    for (const service of targetServices(target, true)) failed = !(await stopService(service)) || failed;
+    for (const service of targetServices(target, true))
+      failed = !(await stopService(service)) || failed;
     for (const service of targetServices(target)) failed = !(await startService(service)) || failed;
     if (failed) process.exitCode = 1;
     return;
   }
   if (action === "status") {
     for (const service of targetServices(target)) await statusService(service);
-    console.log(`mcp-bridge: ${(await portIsListening(mcpBridgePort)) ? "ready" : "stopped"} (port ${mcpBridgePort})`);
+    console.log(
+      `mcp-bridge: ${(await portIsListening(mcpBridgePort)) ? "ready" : "stopped"} (port ${mcpBridgePort})`,
+    );
     return;
   }
   if (action === "logs") {


### PR DESCRIPTION
连续创建两个终端或项目工具后，鼠标无法切回先前标签。标签外层容器在 pointerdown 时立即捕获指针，导致后续 click 被重定向到容器，无法触发内部按钮的激活回调。本次将捕获推迟到超过 6px 阈值且确认允许拖拽之后，恢复普通点击与轻微移动时的标签切换，并保留真正拖拽的单次提交和取消处理。

同时修复 worktree 开发启动中的误判：状态目录按真实 checkout 隔离，管理记录校验 checkout 与端口；启动前检查前端依赖，遇到外部端口占用直接报错；桌面就绪检查通过现有 MCP Bridge 校验 debug 应用身份、原生进程 cwd，并在首次启动时等待窗口可见。冷启动等待时间增加到 10 分钟，已有受管理进程也需通过就绪检查。


<img width="451" height="157" alt="image" src="https://github.com/user-attachments/assets/23f5af1a-6420-4a6e-b4eb-a485e5b1f570" />

验证：

- 本地 72 项相关测试通过（55 项 UI/Workbench、17 项项目脚本）。
- 共享 UI TypeScript、修改的拖拽源码 Biome、git diff --check 通过。
- Chrome 验证终端与工具标签双向切换、阈值以下移动、单次拖拽提交、Escape 取消、键盘激活及关闭按钮。
- macOS 原生桌面编译成功；完整运行 make dev-stack-restart，确认三端受管理且就绪，原生窗口来自该 worktree 并可见。
- PR 仅包含 4 个功能代码文件，测试文件及本地验证资产未纳入提交。Windows WebView2 尚未实机回归。

Fixes #742
