### PR TITLE
fix(chat): remove assistant avatar from message rows

### DIFF
--- a/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
+++ b/crates/agent-gateway/web/src/components/GatewayTranscript.tsx
@@ -1,5 +1,4 @@
 import {
-  AssistantAvatar,
   AssistantBubble,
   LiveAssistantStatus,
 } from "@liveagent/ui/components/chat/AssistantBubble";
@@ -885,7 +884,7 @@ const GatewayTranscriptListRegion = memo(function GatewayTranscriptListRegion(pr
               style={{ transform: `translateY(${virtualRow.start}px)` }}
             >
               <div className="flex w-full max-w-full items-start gap-3">
-                <AssistantAvatar />
+                <div aria-hidden="true" className="h-7 w-7 shrink-0" />
                 <div className="min-w-0 flex-1 space-y-2 pt-1">
                   <div className="flex w-full items-center py-1">
                     <LiveAssistantStatus

--- a/crates/agent-gui/src/pages/chat/components/AssistantBubble.tsx
+++ b/crates/agent-gui/src/pages/chat/components/AssistantBubble.tsx
@@ -1,4 +1,3 @@
-import { AssistantAvatar } from "@liveagent/ui/components/chat/AssistantAvatar";
 import { LiveAssistantStatus } from "@liveagent/ui/components/chat/AssistantStatus";
 import { AssistantWorkTrace } from "@liveagent/ui/components/chat/AssistantWorkTrace";
 import type { AssistantTurnLayoutEntry } from "@liveagent/ui/components/chat/assistant-bubble/assistantBubbleUtils";
@@ -13,8 +12,6 @@ import { cn } from "@liveagent/ui/lib/shared/utils";
 import { memo } from "react";
 import type { RetryAttemptRecord } from "../../../lib/chat/conversation/liveTranscriptStore";
 import type { AssistantUnitRow } from "../transcript/rowModel";
-
-export { AssistantAvatar } from "@liveagent/ui/components/chat/AssistantAvatar";
 
 export const AssistantBubbleUnit = memo(function AssistantBubbleUnit(props: {
   row: AssistantUnitRow;
@@ -63,11 +60,7 @@ export const AssistantBubbleUnit = memo(function AssistantBubbleUnit(props: {
 
   return (
     <div className="flex w-full max-w-full items-start gap-3">
-      {row.showAvatar ? (
-        <AssistantAvatar />
-      ) : (
-        <div aria-hidden="true" className="h-7 w-7 shrink-0" />
-      )}
+      <div aria-hidden="true" className="h-7 w-7 shrink-0" />
       <div className={cn("min-w-0 flex-1 space-y-2", row.showAvatar ? "pt-0.5" : "")}>
         {row.mutable && retryAttempts && retryAttempts.length > 0 ? (
           <RetryDetailsBlock attempts={retryAttempts} />

--- a/crates/agent-gui/src/pages/chat/transcript/AssistantRenderUnit.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/AssistantRenderUnit.tsx
@@ -7,7 +7,7 @@ import { cn } from "@liveagent/ui/lib/shared/utils";
 import { memo, useMemo } from "react";
 import type { HistoryMessageRef } from "../../../lib/chat/conversation/conversationState";
 import type { RetryAttemptRecord } from "../../../lib/chat/conversation/liveTranscriptStore";
-import { AssistantAvatar, AssistantBubbleUnit } from "../components/AssistantBubble";
+import { AssistantBubbleUnit } from "../components/AssistantBubble";
 import { AssistantRowFooter } from "./RowActions";
 import type { AssistantFooterRenderUnit, AssistantUnitRow } from "./rowModel";
 
@@ -72,19 +72,10 @@ const AssistantFooterUnit = memo(function AssistantFooterUnit(props: {
     >
       {changedFiles ? (
         <div className="flex w-full max-w-full items-start gap-3">
-          {showAvatar ? (
-            <AssistantAvatar />
-          ) : (
-            <div aria-hidden="true" className="h-7 w-7 shrink-0" />
-          )}
+          <div aria-hidden="true" className="h-7 w-7 shrink-0" />
           <div className={cn("min-w-0 flex-1", showAvatar ? "pt-0.5" : "")}>
             <ChangedFilesCard summary={changedFiles} />
           </div>
-        </div>
-      ) : showAvatar ? (
-        <div className="flex w-full max-w-full items-start gap-3">
-          <AssistantAvatar />
-          <div className="min-w-0 flex-1" />
         </div>
       ) : null}
       <AssistantRowFooter

--- a/crates/agent-ui/src/components/chat/AssistantBubble.tsx
+++ b/crates/agent-ui/src/components/chat/AssistantBubble.tsx
@@ -2,11 +2,9 @@ import type { UiRound } from "@liveagent/ui/lib/chat/assistantBubbleAdapter";
 import { collectChangedFiles } from "@liveagent/ui/lib/chat/changedFiles";
 import type { ChatFileLink } from "@liveagent/ui/lib/chat/chatFileLinks";
 import { memo, useMemo } from "react";
-import { AssistantAvatar } from "./AssistantAvatar";
 import { AssistantTurnContent } from "./assistant-bubble/RoundContent";
 import { ChangedFilesCard } from "./ChangedFilesCard";
 
-export { AssistantAvatar } from "./AssistantAvatar";
 export {
   AssistantStatus,
   CompactingText,
@@ -62,7 +60,7 @@ export const AssistantBubble = memo(function AssistantBubble(props: {
 
   return (
     <div className="assistant-bubble-shell flex w-full max-w-full items-start gap-3">
-      <AssistantAvatar className="assistant-bubble-avatar" />
+      <div className="assistant-bubble-avatar h-7 w-7 shrink-0" aria-hidden="true" />
       <div className="assistant-bubble-content min-w-0 flex-1 space-y-2 pt-0.5">
         <AssistantTurnContent
           rounds={rounds}


### PR DESCRIPTION
## Linked issue

Closes #756

## Summary

Remove the blue LiveAgent assistant avatar from every assistant message row in the desktop GUI and Gateway WebUI while preserving the existing avatar-column width for message and action alignment. Empty-state branding remains unchanged.

## Change scope

- Modules: agent-ui / agent-gui / agent-gateway WebUI
- Key paths:
  - `crates/agent-ui/src/components/chat/AssistantBubble.tsx`
  - `crates/agent-gui/src/pages/chat/components/AssistantBubble.tsx`
  - `crates/agent-gui/src/pages/chat/transcript/AssistantRenderUnit.tsx`
  - `crates/agent-gateway/web/src/components/GatewayTranscript.tsx`

## Screenshots / preview
<img width="1537" height="1087" alt="Clipboard_Screenshot_1788585211" src="https://github.com/user-attachments/assets/1a3c4c98-3cab-43a5-975e-3fb457753565" />


GUI preview was started locally at `http://127.0.0.1:5174/`. Automated browser screenshot capture was blocked by the current browser approval gate, so no screenshot file is attached.

## Verification

- `pnpm lint:gui`
- `pnpm lint:webui` (passes with one pre-existing `!important` warning in `crates/agent-gateway/web/src/index.css`)
- `pnpm build:gui`
- `pnpm build:webui`
- `git diff --check`

## Pre-submit checklist

- [x] A requirement issue is linked.
- [x] Synced with the target branch; no merge conflicts.
- [x] The change is focused, with no unrelated modifications.
- [x] No secrets, tokens, or personal data included.
- [ ] Docs are updated for changes affecting user behavior, deployment, or configuration.
