### PR TITLE
fix(chat): 历史切换后宽度手柄失效及输入区宽度/遮挡系列修复

### DIFF
--- a/crates/agent-gateway/web/src/app/GatewayAppView.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayAppView.tsx
@@ -856,6 +856,9 @@ export function GatewayAppView({ viewModel }: { viewModel: GatewayAppViewModel }
             settings.locale === "en-US" ? "Resize conversation content" : "调整对话正文宽度"
           }
           resetLabel={settings.locale === "en-US" ? "Double-click to reset" : "双击恢复默认宽度"}
+          // The history overlay below is a blocking panel layer above the
+          // handles; suspend them for exactly as long as it is mounted (#749).
+          suspended={conversationOpenState.showOverlay}
         />
         {displayedTranscriptRowCount > 0 && !conversationOpenState.showOverlay ? (
           <FloorNavRail
@@ -1573,6 +1576,7 @@ export function GatewayAppView({ viewModel }: { viewModel: GatewayAppViewModel }
                                     ? "Double-click to reset"
                                     : "双击恢复默认宽度"
                                 }
+                                suspended={conversationOpenState.showOverlay}
                               />
                               {displayedTranscriptRowCount > 0 &&
                               !conversationOpenState.showOverlay ? (

--- a/crates/agent-gateway/web/src/styles/base-chat.css
+++ b/crates/agent-gateway/web/src/styles/base-chat.css
@@ -581,13 +581,12 @@ html[data-liveagent-webui="gateway"] [role="textbox"]:focus-visible {
   min-width: 0;
   flex: 1;
   flex-direction: column;
-  /* Two deliberately separate columns, both defaulting to 768px: the composer
-     keeps a fixed width while the transcript is user-resizable, so widening
-     the conversation never drags the input box along. Only the composer layer
-     may read --gateway-chat-column-width; the transcript reads
-     --chat-transcript-content-width, which TranscriptWidthControls overwrites
-     inline on .gateway-transcript-stage. */
-  --gateway-chat-column-width: 768px;
+  /* One shared column width: the composer column follows the user-resizable
+     transcript width, matching desktop (ChatComposerBar's desktop branch reads
+     the same variable for the card column). TranscriptWidthControls overwrites
+     --chat-transcript-content-width inline on .gateway-transcript-stage, and
+     the composer layer is a descendant of the stage, so it inherits every
+     update, drag frames included. */
   --chat-transcript-content-width: 768px;
   --gateway-chat-column-gutter: 16px;
   --gateway-chat-composer-bottom: 16px;
@@ -694,6 +693,10 @@ html[data-liveagent-webui="gateway"] [role="textbox"]:focus-visible {
   overscroll-behavior: contain;
 }
 
+/* Blocking on purpose: the panel layer sits above the shared width handles
+   (z-index 10). GatewayAppView suspends TranscriptWidthControls for exactly as
+   long as this is mounted, so no handle hides beneath it and the handles return
+   with its exit (#749). */
 .gateway-history-switch-overlay {
   position: absolute;
   inset: 0;
@@ -750,7 +753,7 @@ html[data-liveagent-webui="gateway"] [role="textbox"]:focus-visible {
   display: grid;
   grid-template-columns:
     minmax(var(--gateway-chat-column-gutter, 16px), 1fr)
-    minmax(0, min(var(--gateway-chat-column-width, 768px), 100%))
+    minmax(0, min(var(--chat-transcript-content-width, 768px), 100%))
     minmax(var(--gateway-chat-column-gutter, 16px), 1fr);
   max-height: 100%;
   padding-bottom: var(--gateway-chat-composer-bottom, 16px);

--- a/crates/agent-gateway/web/test/composer-width-follows-transcript.test.mjs
+++ b/crates/agent-gateway/web/test/composer-width-follows-transcript.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// web 验证反馈：桌面端拖宽正文时输入框跟随（ChatComposerBar 桌面分支的卡片列
+// 直接读 --chat-transcript-content-width），web 端却停在固定 768px——
+// .gateway-composer-layer 的网格列此前刻意读独立的 --gateway-chat-column-width。
+// 现在两端一致：composer 列与转录列共用同一个变量。composer 层挂在
+// .gateway-transcript-stage 内部，TranscriptWidthControls 写在 stage 上的内联值
+// （含拖拽逐帧更新）由 CSS 继承直接到达。本文件锁住这组耦合。
+
+const chatStyles = readFileSync(new URL("../src/styles/base-chat.css", import.meta.url), "utf8");
+const appViewSource = readFileSync(
+  new URL("../src/app/GatewayAppView.tsx", import.meta.url),
+  "utf8",
+);
+const paneHostSource = readFileSync(
+  new URL("../src/app/workbench/GatewayConversationPaneHost.tsx", import.meta.url),
+  "utf8",
+);
+const composerSource = readFileSync(
+  new URL("../../../agent-ui/src/pages/chat/ChatComposerBar.tsx", import.meta.url),
+  "utf8",
+);
+
+test("composer 列与转录列读同一个宽度变量", () => {
+  const layer = chatStyles.match(/\.gateway-composer-layer \{[\s\S]*?\n\}/);
+  assert.ok(layer, ".gateway-composer-layer 规则存在");
+  assert.match(layer[0], /min\(var\(--chat-transcript-content-width, 768px\), 100%\)/);
+  assert.doesNotMatch(
+    chatStyles,
+    /--gateway-chat-column-width/,
+    "固定列宽变量已退役，不允许再引入第二个宽度来源",
+  );
+});
+
+test("两条路径的 ChatComposerBar 都渲染在 stage 之内，宽度变量可继承", () => {
+  for (const [name, source] of [
+    ["GatewayAppView", appViewSource],
+    ["GatewayConversationPaneHost", paneHostSource],
+  ]) {
+    const stageIndex = source.indexOf('className="gateway-transcript-stage"');
+    assert.ok(stageIndex >= 0, `${name} 应有 gateway-transcript-stage`);
+    const composerIndex = source.indexOf("<ChatComposerBar", stageIndex);
+    assert.ok(composerIndex > stageIndex, `${name} 的 ChatComposerBar 应在 stage section 内`);
+  }
+  // 桌面分支对照：卡片列 max-width 读同一变量，web 端行为以此为准。
+  assert.match(
+    composerSource,
+    /max-w-\[calc\(var\(--chat-transcript-content-width,768px\)-4\.75rem\)\]/,
+  );
+});
+
+test("层底部的实底条两端共用：盖住 16px 悬浮留白，正文不能从裙边下方漏出", () => {
+  const start = composerSource.indexOf("ref={composerLayerRef}");
+  const end = composerSource.indexOf("ref={composerColumnRef}");
+  assert.ok(start > 0 && end > start, "composer 层与卡片列的锚点存在");
+  const region = composerSource.slice(start, end);
+  assert.ok(
+    region.includes('className="pointer-events-none absolute inset-x-0 bottom-0 bg-background"'),
+    "层底部应有全宽实底条",
+  );
+  assert.ok(!region.includes('surface === "desktop" ? ('), "实底条不许退回桌面独占");
+});

--- a/crates/agent-gateway/web/test/transcript-width-history-overlay.test.mjs
+++ b/crates/agent-gateway/web/test/transcript-width-history-overlay.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// #749 的 WebUI 侧同步：`.gateway-history-switch-overlay` 用 --layer-panel（20）
+// 压在共享宽度手柄（z-10）之上。这里不改层级，而是让 GatewayAppView 在遮罩挂载
+// 期间挂起手柄，遮罩离开的同一次 commit 里手柄恢复。本文件锁住这组配对。
+
+const appViewSource = readFileSync(
+  new URL("../src/app/GatewayAppView.tsx", import.meta.url),
+  "utf8",
+);
+const overlaySource = readFileSync(
+  new URL("../src/app/HistorySwitchLoadingOverlay.tsx", import.meta.url),
+  "utf8",
+);
+const chatStyles = readFileSync(new URL("../src/styles/base-chat.css", import.meta.url), "utf8");
+const controlsSource = readFileSync(
+  new URL("../../../agent-ui/src/pages/chat/transcript/TranscriptWidthControls.tsx", import.meta.url),
+  "utf8",
+);
+
+test("web suspends the width handles for exactly as long as the history overlay is mounted", () => {
+  const usages = appViewSource.match(/<TranscriptWidthControls[\s\S]*?\/>/g) ?? [];
+  assert.equal(usages.length, 2, "workbench pane host and legacy stage both mount the controls");
+  for (const usage of usages) {
+    assert.match(usage, /suspended=\{conversationOpenState\.showOverlay\}/);
+  }
+  const overlayMounts =
+    appViewSource.match(/conversationOpenState\.showOverlay \? \(\s*<HistorySwitchLoadingOverlay/g) ??
+    [];
+  assert.equal(overlayMounts.length, 2, "the overlay is gated by the same state in both paths");
+});
+
+test("web history overlay stays a blocking panel layer above the handles", () => {
+  assert.match(
+    chatStyles,
+    /\.gateway-history-switch-overlay \{[^}]*z-index: var\(--layer-panel\);/,
+  );
+  assert.doesNotMatch(overlaySource, /pointer-events-none/);
+  assert.match(
+    controlsSource,
+    /"transcript-width-controls pointer-events-none absolute inset-y-0 left-1\/2 z-10/,
+  );
+});
+
+test("the shared controls keep a readable root while hidden", () => {
+  assert.match(controlsSource, /data-transcript-width-state=\{controlsState\}/);
+  assert.match(controlsSource, /hidden=\{!handlesVisible\}/);
+  assert.match(controlsSource, /suspended\?: boolean;/);
+});

--- a/crates/agent-gui/src/pages/chat/transcript/ChatTranscript.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/ChatTranscript.tsx
@@ -140,6 +140,12 @@ export const ChatTranscript = memo(function ChatTranscript(props: ChatTranscript
     shouldReserveTranscriptBottomSpace &&
     shouldDeferTranscriptReveal &&
     settledConversationId !== conversationId;
+  // Loading overlays own the stage while mounted. The width handles suspend
+  // behind them (an opaque skeleton leaves nothing to grab, and a focusable
+  // separator must not hide under a blocking layer) and come back in the very
+  // commit the overlay leaves, re-measured against the pane as it is then —
+  // no unrelated layout change is needed to wake them (#749).
+  const isTranscriptBusy = isHistorySwitching || isTranscriptSettling;
 
   useLayoutEffect(() => {
     followRef.current = scrollFollowHandle;
@@ -328,6 +334,7 @@ export const ChatTranscript = memo(function ChatTranscript(props: ChatTranscript
         onWidthChange={onContentWidthChange}
         resizeLabel={resizeTranscriptLabel}
         resetLabel={resetTranscriptWidthLabel}
+        suspended={isTranscriptBusy}
       />
       {!showNoModelsState && !showStartChatState && !isTranscriptSettling ? (
         <FloorNavRail
@@ -390,7 +397,7 @@ export const ChatTranscript = memo(function ChatTranscript(props: ChatTranscript
             document.body,
           )
         : null}
-      {isHistorySwitching || isTranscriptSettling ? <HistorySwitchLoadingOverlay /> : null}
+      {isTranscriptBusy ? <HistorySwitchLoadingOverlay /> : null}
     </div>
   );
 });

--- a/crates/agent-gui/src/pages/chat/transcript/TranscriptLoadingStates.tsx
+++ b/crates/agent-gui/src/pages/chat/transcript/TranscriptLoadingStates.tsx
@@ -1,6 +1,10 @@
 import { useLocale } from "@liveagent/ui/i18n/index";
 import { PaneLoadingSkeleton } from "../../../components/app/PaneLoadingSkeleton";
 
+// Full-pane, opaque and hit-blocking on purpose: it sits at z-30 above every
+// transcript control. ChatTranscript suspends TranscriptWidthControls for as
+// long as this is mounted, so no handle hides beneath it and the handles
+// return with its exit (#749).
 export function HistorySwitchLoadingOverlay() {
   const { t } = useLocale();
   const label = t("chat.loadingConversation");

--- a/crates/agent-gui/test/chat/conversation-stats-bar.test.mjs
+++ b/crates/agent-gui/test/chat/conversation-stats-bar.test.mjs
@@ -304,3 +304,29 @@ test("approvalBar 可见时状态栏让位（ChatComposerBar 插槽互斥）", (
     "statsBar 插槽必须保持 approvalBar 互斥，且只在 ring 展示模式下不挂载（§4.7 三档）",
   );
 });
+
+test("读数下是全宽毛玻璃裙边：盖住整行并上探填掉卡片圆角外的缺口", async () => {
+  // 验证反馈：正文滚进输入区下方时，读数与底下的文字重叠到难以辨认，卡片
+  // 圆角外侧的弧形缺口也会漏出正文。裙边与卡片同宽，-top-8（= rounded-4xl
+  // 半径 2rem）藏到卡片身后，-z-10 保证压在卡片之下、正文之上。
+  const { container, unmount } = await render(sampleStats());
+  const skirt = container.querySelector('[role="status"] > div[aria-hidden="true"]');
+  assert.ok(skirt, "读数下应有一层毛玻璃裙边");
+  for (const cls of [
+    "pointer-events-none",
+    "absolute inset-x-0 -top-8 bottom-0 -z-10",
+    "bg-background/70",
+    "backdrop-blur-md",
+  ]) {
+    assert.ok(skirt.className.includes(cls), `裙边缺少 ${cls}：${skirt.className}`);
+  }
+  // 用户反馈：裙边自带的底部圆角又会在两角漏字——裙边不做圆角，方角全覆盖。
+  assert.equal(skirt.className.includes("rounded"), false, "裙边不许带圆角");
+  await unmount();
+
+  // 空态占位不带裙边：无数据时不显示一条空的毛玻璃。
+  const empty = await render(null);
+  assert.equal(empty.container.querySelector('[role="status"]'), null);
+  assert.equal(empty.container.firstElementChild.children.length, 0);
+  await empty.unmount();
+});

--- a/crates/agent-gui/test/chat/measurements-lru.test.mjs
+++ b/crates/agent-gui/test/chat/measurements-lru.test.mjs
@@ -46,18 +46,20 @@ test("keyboard width controls do not detach transcript scroll follow", () => {
   assert.ok(transcriptWidthControlsSource.includes(SCROLL_FOLLOW_IGNORE_KEYS_ATTRIBUTE));
 });
 
-test("width handle hit targets stay localized around the visible grip", () => {
+test("width handle hit targets span the full transcript height", () => {
+  // #749 follow-up: the 96px-tall, 12px-wide grips were hard to acquire, so
+  // the transparent hit area now spans the whole column edge at 17px wide.
+  // Only the hit target grew — the visible pill stays small.
   const handleClass = transcriptWidthControlsSource.match(
     /group pointer-events-auto absolute ([^"]+) touch-none cursor-col-resize/,
   );
   assert.ok(handleClass, "transcript width handle class not found");
-  assert.match(handleClass[1], /top-1\/2/);
-  assert.match(handleClass[1], /h-24/);
-  assert.match(handleClass[1], /-translate-y-1\/2/);
+  assert.match(handleClass[1], /inset-y-0/);
+  assert.match(handleClass[1], /w-\[17px\]/);
   assert.equal(
-    handleClass[1].includes("inset-y-0"),
+    handleClass[1].includes("h-24"),
     false,
-    "a transparent width handle must not intercept the full transcript height",
+    "the old localized-height classes must not come back alongside inset-y-0",
   );
 });
 

--- a/crates/agent-gui/test/chat/transcript-width-controls-history-switch.test.mjs
+++ b/crates/agent-gui/test/chat/transcript-width-controls-history-switch.test.mjs
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { createDomTestEnv } from "../helpers/dom-test-env.mjs";
+
+// #749：打开历史会话后宽度手柄不可用，收起侧栏才恢复。源码里有两条分支能造成
+// 同一表象：(1) 历史加载遮罩（z-30、不透传指针）在挂载期间压住 z-10 的手柄；
+// (2) 宿主 ≤ 624px 时组件整体不渲染，只有 ResizeObserver 再次送达才恢复。
+// 本测试用 jsdom + 真实 react-dom 验证修复后的不变量：
+// - 遮罩挂载期间手柄挂起；遮罩离开的同一次 commit 里手柄回来，且宿主被同步重测；
+// - 宿主跨过 624/625px 阈值时手柄由观察器自动隐藏/恢复；
+// - 无关的父级重渲染不改变手柄状态；
+// - 根节点常驻并带 data-transcript-width-state，运行时能直接读出手柄被哪道闸关掉。
+
+const env = await createDomTestEnv();
+const { React, act, createRoot } = env;
+const doc = env.dom.window.document;
+
+// jsdom 没有 ResizeObserver：桩记录被观察的宿主，测试按需"送达一次尺寸变化"。
+const observers = [];
+class ResizeObserverStub {
+  constructor(callback) {
+    this.callback = callback;
+    this.targets = new Set();
+    observers.push(this);
+  }
+  observe(target) {
+    this.targets.add(target);
+  }
+  unobserve(target) {
+    this.targets.delete(target);
+  }
+  disconnect() {
+    this.targets.clear();
+  }
+}
+globalThis.ResizeObserver = ResizeObserverStub;
+
+const { TranscriptWidthControls, CHAT_TRANSCRIPT_WIDTH_CSS_VAR } = env.loadModule(
+  "@liveagent/ui/pages/chat/transcript/TranscriptWidthControls.tsx",
+);
+const widthModel = env.loadModule("@liveagent/ui/lib/transcript-width/transcriptWidthModel.ts");
+
+const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => resolve()));
+
+// 与 ChatTranscript 同构：宽度 owner → 转录根（hostRef）→ 控件是根的子节点。
+function Stage(props) {
+  const hostRef = React.useRef(null);
+  return React.createElement(
+    "div",
+    { "data-chat-width-owner": "", "data-testid": "owner" },
+    React.createElement(
+      "div",
+      { ref: hostRef, "data-testid": "host" },
+      React.createElement(TranscriptWidthControls, {
+        hostRef,
+        width: props.width,
+        onWidthChange: props.onWidthChange,
+        resizeLabel: "Resize",
+        resetLabel: "Reset",
+        suspended: props.suspended,
+      }),
+    ),
+  );
+}
+
+async function mountStage({ stageWidth, width = 768, suspended = false, onWidthChange }) {
+  const container = doc.createElement("div");
+  doc.body.appendChild(container);
+  const root = createRoot(container);
+  const stage = { width: stageWidth };
+  const handleWidthChange = onWidthChange ?? (() => {});
+  const render = async (overrides = {}) => {
+    await act(async () => {
+      root.render(
+        React.createElement(Stage, {
+          width,
+          onWidthChange: handleWidthChange,
+          suspended,
+          ...overrides,
+        }),
+      );
+    });
+  };
+  await render();
+  const host = container.querySelector('[data-testid="host"]');
+  // 宿主实测宽度由测试控制；挂载 RAF 此刻还没跑，第一次测量就读到它。
+  host.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    width: stage.width,
+    height: 600,
+    right: stage.width,
+    bottom: 600,
+    toJSON() {
+      return {};
+    },
+  });
+  await act(async () => {
+    await nextFrame();
+  });
+  return {
+    container,
+    host,
+    stage,
+    owner: container.querySelector('[data-testid="owner"]'),
+    controls: () => container.querySelector(".transcript-width-controls"),
+    separator: () => container.querySelector('[role="separator"]'),
+    render,
+    deliverResize: async () => {
+      await act(async () => {
+        for (const observer of observers) {
+          for (const target of observer.targets) {
+            observer.callback([{ target }], observer);
+          }
+        }
+        await nextFrame();
+      });
+    },
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+test("the controls state names the first gate that hides the handles", () => {
+  const { resolveTranscriptWidthControlsState: state, MIN_CHAT_TRANSCRIPT_WIDTH } = widthModel;
+  assert.equal(state({ suspended: false, mediaHidden: false, maxWidth: 936 }), "ready");
+  assert.equal(state({ suspended: true, mediaHidden: true, maxWidth: 560 }), "suspended");
+  assert.equal(state({ suspended: false, mediaHidden: true, maxWidth: 936 }), "media-hidden");
+  assert.equal(
+    state({ suspended: false, mediaHidden: false, maxWidth: MIN_CHAT_TRANSCRIPT_WIDTH }),
+    "stage-narrow",
+  );
+});
+
+test("a stage below the hide threshold keeps the root mounted with a readable reason", async () => {
+  const stage = await mountStage({ stageWidth: 600 });
+  assert.equal(stage.separator(), null, "no handle can widen a 560px-max stage");
+  const controls = stage.controls();
+  assert.ok(controls, "controls root stays mounted while the handles are hidden");
+  assert.equal(controls.dataset.transcriptWidthState, "stage-narrow");
+  assert.equal(controls.dataset.transcriptWidthMax, String(widthModel.MIN_CHAT_TRANSCRIPT_WIDTH));
+  assert.equal(controls.hidden, true);
+  // 变量仍被钳到舞台上限：宿主 600 → 上限 560。
+  assert.equal(stage.owner.style.getPropertyValue(CHAT_TRANSCRIPT_WIDTH_CSS_VAR), "560px");
+  await stage.unmount();
+});
+
+test("crossing the threshold restores the handles through the stage observer alone", async () => {
+  const stage = await mountStage({ stageWidth: 600 });
+  assert.equal(stage.separator(), null);
+
+  stage.stage.width = 900;
+  await stage.deliverResize();
+
+  const separator = stage.separator();
+  assert.ok(separator, "separator returns once the stage can host more than the minimum");
+  assert.equal(separator.getAttribute("aria-valuemax"), "836");
+  assert.equal(stage.controls().dataset.transcriptWidthState, "ready");
+  assert.equal(stage.controls().hidden, false);
+  assert.equal(stage.owner.style.getPropertyValue(CHAT_TRANSCRIPT_WIDTH_CSS_VAR), "768px");
+  await stage.unmount();
+});
+
+test("handles suspend behind a loading overlay and return, re-measured, when it lifts", async () => {
+  const stage = await mountStage({ stageWidth: 1000 });
+  assert.equal(stage.separator().getAttribute("aria-valuemax"), "936");
+
+  await stage.render({ suspended: true });
+  assert.equal(stage.separator(), null, "nothing is grabbable under an opaque overlay");
+  assert.equal(stage.controls().dataset.transcriptWidthState, "suspended");
+  assert.equal(stage.controls().hidden, true);
+
+  // 遮罩期间 Pane 变宽，但观察器没有送达（模拟被吞掉/尚未派发的通知）。
+  stage.stage.width = 1100;
+  await stage.render({ suspended: false });
+
+  const separator = stage.separator();
+  assert.ok(separator, "separator is back in the commit that removed the overlay");
+  assert.equal(
+    separator.getAttribute("aria-valuemax"),
+    "1036",
+    "reveal re-measures the stage synchronously instead of trusting the pre-overlay ceiling",
+  );
+  assert.equal(stage.controls().dataset.transcriptWidthState, "ready");
+  await stage.unmount();
+});
+
+test("an overlay arriving mid-drag commits the dragged width and drops the listeners", async () => {
+  const committed = [];
+  const stage = await mountStage({ stageWidth: 1000, onWidthChange: (w) => committed.push(w) });
+  const handle = stage.separator();
+
+  await act(async () => {
+    handle.dispatchEvent(
+      new env.dom.window.MouseEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX: 500,
+      }),
+    );
+  });
+  assert.equal(doc.body.style.cursor, "col-resize");
+  await act(async () => {
+    env.dom.window.dispatchEvent(
+      new env.dom.window.MouseEvent("pointermove", { bubbles: true, clientX: 540 }),
+    );
+  });
+
+  await stage.render({ suspended: true });
+
+  // 右侧手柄拖 40px → 宽度 +80 → 848，落在 936 的舞台上限之内。
+  assert.deepEqual(committed, [848]);
+  assert.equal(doc.body.style.cursor, "", "drag cleanup restored the body cursor");
+  assert.equal(stage.separator(), null);
+  await stage.unmount();
+});
+
+test("an unrelated parent re-render leaves the handle state alone", async () => {
+  const stage = await mountStage({ stageWidth: 1000 });
+  const before = stage.separator();
+  assert.ok(before);
+
+  await stage.render();
+
+  assert.ok(Object.is(stage.separator(), before), "same separator node survives the re-render");
+  assert.equal(stage.separator().getAttribute("aria-valuemax"), "936");
+  assert.equal(stage.controls().dataset.transcriptWidthState, "ready");
+  await stage.unmount();
+});
+
+test("desktop pairs the history overlay with the suspended handles in one condition", () => {
+  const transcriptSource = readFileSync(
+    new URL("../../src/pages/chat/transcript/ChatTranscript.tsx", import.meta.url),
+    "utf8",
+  );
+  const overlaySource = readFileSync(
+    new URL("../../src/pages/chat/transcript/TranscriptLoadingStates.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    transcriptSource,
+    /const isTranscriptBusy = isHistorySwitching \|\| isTranscriptSettling;/,
+  );
+  assert.match(
+    transcriptSource,
+    /<TranscriptWidthControls[\s\S]*?suspended=\{isTranscriptBusy\}[\s\S]*?\/>/,
+  );
+  assert.match(transcriptSource, /\{isTranscriptBusy \? <HistorySwitchLoadingOverlay \/> : null\}/);
+  // 遮罩仍在手柄之上且拦截指针：选择"挂起手柄"而非"提升 z-index"，两端一致。
+  assert.match(overlaySource, /className="absolute inset-0 z-30"/);
+  assert.doesNotMatch(overlaySource, /pointer-events-none/);
+});
+
+test.after(() => {
+  env.cleanup();
+});

--- a/crates/agent-ui/src/components/chat/ConversationStatsBar.tsx
+++ b/crates/agent-ui/src/components/chat/ConversationStatsBar.tsx
@@ -202,41 +202,46 @@ export function ConversationStatsBar(props: {
 
   return (
     // role="status" 提供语义；数字变化不做 aria-live 播报（流式期间会刷屏）。
-    // overflow-hidden 兜底：tooltip trigger 是 shrink-0，极窄时宁可裁剪也不撑破布局。
-    <div
-      role="status"
-      aria-live="off"
-      aria-label={fullText}
-      className="@container flex h-5 w-full items-center justify-center overflow-hidden"
-    >
-      <LabelTooltip label={tooltip}>
-        {compactAvailable ? (
-          <ConfirmActionPopover
-            title={t("chat.manualCompactTitle")}
-            description={t("chat.manualCompactDescription")}
-            confirmLabel={t("chat.manualCompactConfirm")}
-            tone="default"
-            side="top"
-            align="center"
-            open={confirmOpen}
-            onOpenChange={setConfirmOpen}
-            onConfirm={() => void onManualCompactConfirm?.()}
-          >
-            {(open) => (
-              <button
-                type="button"
-                onClick={open}
-                aria-label={t("chat.manualCompactTitle")}
-                className="flex min-w-0 cursor-pointer items-center rounded-full px-1.5 outline-hidden transition-[background-color] hover:bg-muted/50 focus-visible:bg-muted/50"
-              >
-                {row}
-              </button>
-            )}
-          </ConfirmActionPopover>
-        ) : (
-          row
-        )}
-      </LabelTooltip>
+    <div role="status" aria-live="off" aria-label={fullText} className="relative h-5 w-full">
+      {/* 毛玻璃裙边：读数浮在会滚动的正文上方，正文滚进输入区下面时会和底下的
+          文字重叠到难以辨认，输入卡片圆角外侧的弧形缺口也会漏出正文。裙边与
+          卡片同宽，上探 2rem（= 卡片 rounded-4xl 的半径）藏到卡片身后，把弧形
+          缺口一并盖住；-z-10 让它压在卡片之下、正文之上。空态占位分支不带这层。 */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 -top-8 bottom-0 -z-10 bg-background/70 backdrop-blur-md"
+      />
+      {/* overflow-hidden 兜底：tooltip trigger 是 shrink-0，极窄时宁可裁剪也不撑破布局。 */}
+      <div className="@container flex h-5 w-full items-center justify-center overflow-hidden">
+        <LabelTooltip label={tooltip}>
+          {compactAvailable ? (
+            <ConfirmActionPopover
+              title={t("chat.manualCompactTitle")}
+              description={t("chat.manualCompactDescription")}
+              confirmLabel={t("chat.manualCompactConfirm")}
+              tone="default"
+              side="top"
+              align="center"
+              open={confirmOpen}
+              onOpenChange={setConfirmOpen}
+              onConfirm={() => void onManualCompactConfirm?.()}
+            >
+              {(open) => (
+                <button
+                  type="button"
+                  onClick={open}
+                  aria-label={t("chat.manualCompactTitle")}
+                  className="flex min-w-0 cursor-pointer items-center rounded-full px-1.5 outline-hidden transition-[background-color] hover:bg-muted/50 focus-visible:bg-muted/50"
+                >
+                  {row}
+                </button>
+              )}
+            </ConfirmActionPopover>
+          ) : (
+            row
+          )}
+        </LabelTooltip>
+      </div>
     </div>
   );
 }

--- a/crates/agent-ui/src/lib/transcript-width/transcriptWidthModel.ts
+++ b/crates/agent-ui/src/lib/transcript-width/transcriptWidthModel.ts
@@ -60,6 +60,24 @@ export function areWidthControlsUsable(maxWidth: number): boolean {
   return maxWidth > MIN_CHAT_TRANSCRIPT_WIDTH;
 }
 
+// The one gate that currently hides the handles, checked in this order.
+// Rendered as `data-transcript-width-state` on the controls root so a runtime
+// look at the DOM names the reason — a loading overlay owns the stage, the
+// pointer/viewport media query hides them, or the stage cannot host more than
+// the minimum — without instrumenting the component (#749).
+export type TranscriptWidthControlsState = "ready" | "suspended" | "media-hidden" | "stage-narrow";
+
+export function resolveTranscriptWidthControlsState(input: {
+  suspended: boolean;
+  mediaHidden: boolean;
+  maxWidth: number;
+}): TranscriptWidthControlsState {
+  if (input.suspended) return "suspended";
+  if (input.mediaHidden) return "media-hidden";
+  if (!areWidthControlsUsable(input.maxWidth)) return "stage-narrow";
+  return "ready";
+}
+
 // Width for a drag of `deltaX` on `side`. The column is centered, so moving
 // one edge by d changes the width by 2d — that is what keeps the handle
 // under the pointer.

--- a/crates/agent-ui/src/pages/chat/ChatComposerBar.tsx
+++ b/crates/agent-ui/src/pages/chat/ChatComposerBar.tsx
@@ -1240,13 +1240,14 @@ export const ChatComposerBar = memo(function ChatComposerBar(props: ChatComposer
         hidden && "hidden",
       )}
     >
-      {surface === "desktop" ? (
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-x-0 bottom-0 bg-background"
-          style={{ height: "1rem" }}
-        />
-      ) : null}
+      {/* 层底 16px 悬浮留白（desktop pb-4 / web --gateway-chat-composer-bottom）
+          的兜底实底条：读数裙边只盖到读数行底边，滚动中的正文会从这条缝里
+          露出来。两端共用，不做 surface 分支。 */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 bottom-0 bg-background"
+        style={{ height: "1rem" }}
+      />
       {/* Desktop aligns to the assistant message body, not the avatar rail:
           transcript px-5 + 28px avatar + 12px gap + px-5 = 80px removed;
           the remaining body is right-shifted 20px inside the centered column.

--- a/crates/agent-ui/src/pages/chat/transcript/TranscriptWidthControls.tsx
+++ b/crates/agent-ui/src/pages/chat/transcript/TranscriptWidthControls.tsx
@@ -12,7 +12,6 @@ import {
 
 import { cn } from "../../../lib/shared/utils";
 import {
-  areWidthControlsUsable,
   clampWidthToStage,
   DEFAULT_CHAT_TRANSCRIPT_WIDTH,
   MIN_CHAT_TRANSCRIPT_WIDTH,
@@ -20,6 +19,7 @@ import {
   resolveDragWidth,
   resolveKeyboardWidth,
   resolveStageMaxWidth,
+  resolveTranscriptWidthControlsState,
   TRANSCRIPT_HORIZONTAL_SAFE_SPACE,
   TRANSCRIPT_WIDTH_CONTROLS_HIDDEN_MEDIA_QUERY,
   type TranscriptResizeSide,
@@ -40,6 +40,15 @@ type TranscriptWidthControlsProps = {
   onWidthChange: (width: number) => void;
   resizeLabel: string;
   resetLabel: string;
+  /**
+   * True while a loading overlay covers the stage (history switch, first
+   * layout settle). The handles unmount — an opaque overlay leaves nothing to
+   * grab, and a focusable separator must not hide beneath a blocking layer —
+   * while the stage observer keeps the width variable clamped. They return in
+   * the same commit the overlay leaves, re-measured against the stage as it is
+   * then, so no unrelated layout change is needed to wake them.
+   */
+  suspended?: boolean;
 };
 
 function subscribeControlsHidden(onChange: () => void) {
@@ -72,13 +81,16 @@ function applyWidth(host: HTMLElement | null, width: number) {
 }
 
 export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
-  const { hostRef, width, onWidthChange, resizeLabel, resetLabel } = props;
+  const { hostRef, width, onWidthChange, resizeLabel, resetLabel, suspended = false } = props;
   const [maxWidth, setMaxWidth] = useState(() => resolveStageMaxWidth(null));
   const [resizingWidth, setResizingWidth] = useState<number | null>(null);
   const pendingWidthRef = useRef(width);
   const resizingRef = useRef(false);
   const resizeFrameRef = useRef<number | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
+  // Ends the drag in flight — listeners off, pending width committed. Null
+  // while no drag is running.
+  const endResizeRef = useRef<(() => void) | null>(null);
   // Read by the stage observer, which must outlive individual width commits.
   const widthRef = useRef(width);
   widthRef.current = width;
@@ -90,6 +102,12 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
     readControlsHidden,
     () => true,
   );
+  const controlsState = resolveTranscriptWidthControlsState({
+    suspended,
+    mediaHidden: controlsHidden,
+    maxWidth,
+  });
+  const handlesVisible = controlsState === "ready";
 
   useLayoutEffect(() => {
     // Mid-drag the pointer owns the variable; that drag's commit reconciles it.
@@ -97,22 +115,42 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
     applyWidth(hostRef.current, clampWidthToStage(width, maxWidth));
   }, [hostRef, maxWidth, resizingWidth, width]);
 
+  // One measurement shared by mount, reveal, window resize and the stage
+  // observer: reads the stage as it is right now, stores the ceiling and
+  // re-clamps the variable unless a drag currently owns it.
+  const measureStage = useCallback(() => {
+    const host = hostRef.current;
+    const nextMaxWidth = measureStageMaxWidth(host);
+    setMaxWidth(nextMaxWidth);
+    if (!resizingRef.current) {
+      applyWidth(host, clampWidthToStage(widthRef.current, nextMaxWidth));
+    }
+  }, [hostRef]);
+
+  // Mount and every reveal measure synchronously, before paint. A pane that
+  // changed size behind a loading overlay would otherwise keep the ceiling
+  // measured before the overlay, and a stale narrow ceiling keeps the handles
+  // hidden until some unrelated layout change wakes the observer (#749). On a
+  // first mount whose host ref is not attached yet the measurement falls back
+  // to the unmeasured ceiling and the observer below corrects it on its first
+  // delivery.
+  useLayoutEffect(() => {
+    if (suspended) return;
+    measureStage();
+  }, [measureStage, suspended]);
+
   // Keyed off the host alone on purpose: re-arming the observer on every width
   // commit would tear it down and rebuild it mid-interaction for nothing.
   useEffect(() => {
     const host = hostRef.current;
     let frameId = 0;
-    const updateMaxWidth = () => {
+    const measureOnFrame = () => {
       frameId = 0;
-      const nextMaxWidth = measureStageMaxWidth(host);
-      setMaxWidth(nextMaxWidth);
-      if (!resizingRef.current) {
-        applyWidth(host, clampWidthToStage(widthRef.current, nextMaxWidth));
-      }
+      measureStage();
     };
     const scheduleUpdate = () => {
       if (frameId !== 0) return;
-      frameId = requestAnimationFrame(updateMaxWidth);
+      frameId = requestAnimationFrame(measureOnFrame);
     };
     scheduleUpdate();
     window.addEventListener("resize", scheduleUpdate);
@@ -124,7 +162,14 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
       if (frameId !== 0) cancelAnimationFrame(frameId);
       observer?.disconnect();
     };
-  }, [hostRef]);
+  }, [hostRef, measureStage]);
+
+  // An overlay landing mid-drag ends the drag where the pointer is: the window
+  // listeners would otherwise keep resizing a stage the user can no longer
+  // see, holding a handle that is about to unmount.
+  useEffect(() => {
+    if (suspended) endResizeRef.current?.();
+  }, [suspended]);
 
   useEffect(
     () => () => {
@@ -194,6 +239,7 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
         document.body.style.userSelect = previousUserSelect;
         resizingRef.current = false;
         cleanupRef.current = null;
+        endResizeRef.current = null;
       };
 
       const handleMove = (moveEvent: PointerEvent) => {
@@ -206,6 +252,7 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
       };
 
       cleanupRef.current = cleanup;
+      endResizeRef.current = handleEnd;
       window.addEventListener("pointermove", handleMove);
       window.addEventListener("pointerup", handleEnd);
       window.addEventListener("pointercancel", handleEnd);
@@ -228,14 +275,16 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
     commitWidth(DEFAULT_CHAT_TRANSCRIPT_WIDTH);
   }, [commitWidth]);
 
-  if (controlsHidden || !areWidthControlsUsable(maxWidth)) return null;
-
   const handleTitle = `${resizeLabel} · ${resetLabel}`;
 
   // Only the right handle is exposed to assistive tech. Both handles drive one
   // value, and aria-value* is only meaningful on a focusable separator — so
   // the left handle stays a pointer-only affordance instead of advertising
   // values nothing can focus to change.
+  //
+  // The transparent hit target spans the pane's full height at 17px wide —
+  // the original 96px-tall, 12px-wide grips were hard to acquire (#749
+  // follow-up). Only the hit area grew; the visible pill stays small.
   const renderHandle = (side: TranscriptResizeSide) => {
     const isPrimary = side === "right";
     return (
@@ -258,14 +307,14 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
         onPointerDown={(event) => handleResizeStart(side, event)}
         onDoubleClick={resetWidth}
         className={cn(
-          "group pointer-events-auto absolute top-1/2 z-10 h-24 max-h-full w-3 -translate-y-1/2 touch-none cursor-col-resize border-0 bg-transparent p-0 focus-visible:outline-none",
+          "group pointer-events-auto absolute inset-y-0 z-10 flex w-[17px] touch-none cursor-col-resize items-center justify-center border-0 bg-transparent p-0 focus-visible:outline-none",
           isPrimary ? "right-0 translate-x-1/2" : "left-0 -translate-x-1/2",
         )}
       >
         <span
           aria-hidden="true"
           className={cn(
-            "absolute left-1/2 top-1/2 h-10 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/25 opacity-0 shadow-sm transition-[height,background-color,opacity] duration-150",
+            "h-10 w-0.5 rounded-full bg-muted-foreground/25 opacity-0 shadow-sm transition-[height,background-color,opacity] duration-150",
             "group-hover:h-16 group-hover:bg-primary/60 group-hover:opacity-100 group-focus-visible:h-16 group-focus-visible:bg-primary group-focus-visible:opacity-100",
             resizingWidth !== null && "h-20 bg-primary opacity-100",
           )}
@@ -277,14 +326,21 @@ export function TranscriptWidthControls(props: TranscriptWidthControlsProps) {
   return (
     <div
       className="transcript-width-controls pointer-events-none absolute inset-y-0 left-1/2 z-10 -translate-x-1/2"
+      // The root stays mounted in every state and names the gate that hides
+      // the handles, so a runtime look at a pane that lost them tells the
+      // gates apart instead of finding nothing to inspect (#749). `hidden`
+      // keeps the empty root out of layout, hit testing and the a11y tree.
+      data-transcript-width-state={controlsState}
+      data-transcript-width-max={maxWidth}
+      hidden={!handlesVisible}
       style={{
         width: `var(${CHAT_TRANSCRIPT_WIDTH_CSS_VAR}, ${DEFAULT_CHAT_TRANSCRIPT_WIDTH}px)`,
         maxWidth: `calc(100% - ${TRANSCRIPT_HORIZONTAL_SAFE_SPACE}px)`,
       }}
     >
-      {renderHandle("left")}
-      {renderHandle("right")}
-      {resizingWidth !== null ? (
+      {handlesVisible ? renderHandle("left") : null}
+      {handlesVisible ? renderHandle("right") : null}
+      {handlesVisible && resizingWidth !== null ? (
         <div className="absolute left-1/2 top-2 -translate-x-1/2 rounded-md border border-border/70 bg-background px-2 py-1 text-[11px] font-medium tabular-nums text-muted-foreground shadow-sm">
           {effectiveWidth} px
         </div>

--- a/docs/worklog/transcript-width-handles-history-switch.md
+++ b/docs/worklog/transcript-width-handles-history-switch.md
@@ -1,0 +1,69 @@
+# 历史会话打开后宽度手柄失效（#749）
+
+## 现象
+
+Issue #749：桌面端左侧会话栏展开时，从最近会话打开一个历史会话，正文左右边界 hover 与拖拽都没有反应；收起左侧栏后手柄恢复。报告缺两项运行时数据：失效时会话 Pane 的实际宽度、历史加载遮罩是否还在 DOM 里。
+
+## 分支
+
+分支：`fix/transcript-width-controls-after-history-switch`，基线 `main@be86449f`（v1.3.1）。改动集中在共享宽度手柄组件及其两端接入点，未触碰打开会话的状态机。
+
+## 源码结论
+
+两条分支都能产生同一表象，源码层面都已确认：
+
+1. 遮罩分支。`HistorySwitchLoadingOverlay` 是 `absolute inset-0 z-30`、不透传指针，在 DOM 里排在 `z-10` 的 `TranscriptWidthControls` 之后。遮罩挂载期间手柄不可能被命中。WebUI 的 `.gateway-history-switch-overlay`（`--layer-panel` = 20）与手柄（10）是同一结构。遮罩本身是 `bg-background` 不透明骨架屏，如果它一直挂着，用户看到的是骨架而非正文，所以它解释"遮罩可见时点不到"，解释不了遮罩消失后的持续失效。
+2. 阈值分支。`resolveStageMaxWidth` 先减 64px 安全间距、下限 560，`areWidthControlsUsable` 只在上限大于 560 时为真，于是宿主 ≤ 624px 时组件返回 `null`，DOM 里没有任何痕迹。"2560 × 1528 最大化"很可能是物理尺寸：2560×1600 面板在 Windows 150% / 200% 缩放下，CSS 视口只有 1707 / 1280px，再扣掉 272px 侧栏和右侧 dock（320–720px）或分屏，会话 Pane 正好落在 624 这道坎附近。收起侧栏加回 272px 就跨过阈值，与"收起后恢复"吻合。
+
+没有找到 `maxWidth` 卡在旧值的路径：ResizeObserver 挂在稳定的转录根上；切换历史会话不会重挂 `ChatTranscript`（只有 `TranscriptList` 按会话 key 重挂）；CSS 变量只有一个 owner；`controlsHidden` 每次渲染都重读 `matchMedia`。
+
+## 决策
+
+Issue 的开放问题：遮罩可见时是否允许调宽度。答案是不允许。不透明骨架下没有可抓的边界，可聚焦的 `role="separator"` 也不应藏在拦截层下面。因此不提升手柄的 z-index，而是在遮罩挂载期间挂起手柄，并要求遮罩离开的同一次 commit 里手柄回来。
+
+## 改动
+
+- `crates/agent-ui/src/lib/transcript-width/transcriptWidthModel.ts`：新增 `resolveTranscriptWidthControlsState`，按 suspended → media-hidden → stage-narrow → ready 的顺序给出当前关掉手柄的那道闸。
+- `crates/agent-ui/src/pages/chat/transcript/TranscriptWidthControls.tsx`：
+  - 新增 `suspended` 属性。挂起时不渲染手柄，进行中的拖拽以当前宽度结束提交；观察器继续运行，CSS 变量持续钳位。
+  - 挂载与每次揭示都在 layout effect 里同步重测宿主，遮罩期间 Pane 尺寸变了也能在恢复的那一帧拿到正确上限，不再依赖后续无关的布局变化唤醒观察器。
+  - 根节点在所有状态下常驻，带 `data-transcript-width-state` 与 `data-transcript-width-max`，隐藏态用 `hidden` 移出布局、命中与无障碍树。
+- `crates/agent-gui/src/pages/chat/transcript/ChatTranscript.tsx`：`isTranscriptBusy = isHistorySwitching || isTranscriptSettling`，同时驱动遮罩与 `suspended`。
+- `crates/agent-gateway/web/src/app/GatewayAppView.tsx`：两处 `TranscriptWidthControls` 传 `suspended={conversationOpenState.showOverlay}`；`base-chat.css` 补注释。
+- 测试：`crates/agent-gui/test/chat/transcript-width-controls-history-switch.test.mjs`（jsdom + 真实 react-dom）、`crates/agent-gateway/web/test/transcript-width-history-overlay.test.mjs`（源码与 CSS 静态断言）。
+
+## 调试客户端验证
+
+1. 保持左侧栏展开，从最近会话打开一个历史会话，等骨架屏消失。
+2. 打开 DevTools，在 Console 执行：
+
+```js
+const controls = document.querySelector(".transcript-width-controls");
+({
+  state: controls?.dataset.transcriptWidthState,
+  stageMax: controls?.dataset.transcriptWidthMax,
+  hostWidth: controls?.parentElement.getBoundingClientRect().width,
+  overlayMounted: !!document.querySelector("[data-pane-loading-skeleton]"),
+  separatorMax: document.querySelector('[role="separator"]')?.getAttribute("aria-valuemax"),
+  dpr: window.devicePixelRatio,
+  viewport: window.innerWidth,
+});
+```
+
+3. 读法：
+   - `state === "ready"`：手柄在 DOM 里。把鼠标移到正文列左右边界任意高度（命中区全高、17px 宽），应出现 col-resize 光标与指示条，可拖动。
+   - `state === "stage-narrow"`：宿主 CSS 宽度 ≤ 624px，手柄按设计隐藏。对照 `hostWidth`、`dpr`、右侧 dock 与分屏；收起侧栏后应变为 `ready`。
+   - `state === "suspended"` 而 `overlayMounted` 为 false：遮罩状态与手柄状态脱节，属于新问题，请连同 `hostWidth` 一起反馈。
+   - `state === "media-hidden"`：`(max-width: 820px), (pointer: coarse)` 命中，检查 `viewport` 与主指针类型。
+4. 再收起、展开一次左侧栏，`state` 与 `separatorMax` 应只随 `hostWidth` 变化。
+
+## 未做
+
+- 没有下调 624px 阈值或 64px 安全间距。若验证结果是 `stage-narrow`，那是窄 Pane 下的既定行为，是否调整阈值另议。
+- 没有改动 `openController` 与首屏 settle 逻辑，静态分析未发现遮罩卡住的路径。
+
+## 后续调整：扩大手柄触发区（2026-09-05）
+
+调试客户端验证通过后的反馈：手柄 96px 高、12px 宽的命中区太小，难触发。按要求把透明命中区改为全高，宽度 12px → 17px（`inset-y-0` + `w-[17px]`，与 `DetailsResizeHandle`、`RightDockPanel` 两个全高 col-resize 手柄同构）。可见的小竖条外观与悬停/拖拽加亮规格不变，只有命中区变大。
+
+代价：正文列左右边缘各约 8.5px 的全高条带被手柄接管指针，从最边缘像素起始的文本选取会被挡住——这是全高命中区的固有取舍。`measurements-lru.test.mjs` 中原本锁定"命中区局部化"的测试反转为锁定全高 + 17px。

--- a/docs/worklog/web-composer-width-and-stats-glass.md
+++ b/docs/worklog/web-composer-width-and-stats-glass.md
@@ -1,0 +1,50 @@
+# WebUI 验证反馈：输入框宽度不跟随、上下文用量读数被穿透
+
+## 背景
+
+#749 修复（`fix/transcript-width-controls-after-history-switch` 分支）在 web 端验证时发现两个新问题：
+
+1. 拖动正文宽度手柄时只有转录列变宽，输入框停在 768px；桌面端两者是联动的。
+2. 正文滚动到输入区下方时，输入卡片下缘的会话统计读数（轮·步｜上下文占用｜token 等）与底下的正文文字重叠，几乎不可读。
+
+## 问题 1：composer 列宽
+
+根因是 `base-chat.css` 里一个刻意的旧决策：`.gateway-chat-frame` 定义了两个独立列宽变量，composer 层网格读固定的 `--gateway-chat-column-width: 768px`，转录列才读可调的 `--chat-transcript-content-width`（原注释明说"widening the conversation never drags the input box along"）。桌面端没有这层分离——`ChatComposerBar` 桌面分支的卡片列 `max-w` 直接读转录宽度变量。
+
+按用户要求反转该决策：
+
+- `.gateway-composer-layer` 网格中列改读 `min(var(--chat-transcript-content-width, 768px), 100%)`，与 `.gateway-transcript-shell` 同一公式，composer 列与转录列像素级同宽。
+- 删除 `--gateway-chat-column-width` 定义，注释改写为说明共享列宽。
+- 不需要动 TSX：两条路径（`GatewayAppView` 传统 stage、`GatewayConversationPaneHost` workbench Pane）的 `ChatComposerBar` 都渲染在 `.gateway-transcript-stage` 内部，`TranscriptWidthControls` 写在 stage 上的内联变量（拖拽期间逐帧更新）经 CSS 继承直接到达 composer 层。
+
+## 问题 2：统计读数毛玻璃
+
+`ConversationStatsBar`（共享组件，桌面/web 同用）此前只是裸文字行，浮在滚动正文上没有任何背衬；桌面端仅在层底部有 1rem 的实底条，也盖不到读数行本身。
+
+改动：非空态的读数外包一层壳——`rounded-full bg-background/90 backdrop-blur-md`（90% 不透明背景 + 12px 高斯模糊），按用户要求的"毛玻璃、不透明度 90% 左右"。空态占位分支不带这层，无数据时不会显示一个空药丸。可点击（手动压缩）分支的 hover 高亮在壳内，仍可见。两端同时受益。
+
+## 改动清单
+
+- `crates/agent-gateway/web/src/styles/base-chat.css`：列宽变量合一（见上）。
+- `crates/agent-ui/src/components/chat/ConversationStatsBar.tsx`：毛玻璃壳。
+- `crates/agent-gateway/web/test/composer-width-follows-transcript.test.mjs`（新增）：锁 composer 列读转录变量、旧变量不许回归、两条路径的 composer 都在 stage 内。
+- `crates/agent-gui/test/chat/conversation-stats-bar.test.mjs`：追加毛玻璃壳断言（含空态不出空药丸）。
+
+## 验证
+
+- WebUI：打开会话，拖正文宽度手柄——输入卡片应与正文同步变宽/变窄（拖拽过程中逐帧跟随）；把正文滚到输入区下方，统计读数应清晰浮在毛玻璃药丸上。
+- 桌面端：统计读数同样带毛玻璃底；宽度联动行为不变。
+
+## 后续调整：药丸 → 全宽裙边（2026-09-05）
+
+桌面端验证反馈：药丸只包住读数文字，读数两侧和输入卡片圆角外侧的弧形缺口仍会漏出正文。改为全宽毛玻璃"裙边"：与输入卡片同宽，`-top-8` 上探 2rem（等于卡片 `rounded-4xl` 的半径）藏到卡片身后，把弧形缺口一并盖住，底部用 `rounded-b-2xl` 收边；`-z-10` 保证它压在卡片之下（桌面端卡片带 `z-10`、列有 transform，web 端卡片 z-auto，两端层序都成立）、正文之上。读数行本身不再带背景，手动压缩的 hover 高亮仍在裙边上可见；空态占位分支不带裙边。`conversation-stats-bar.test.mjs` 的毛玻璃断言同步改为锁裙边（全宽、上探、-z-10，断言用 includes 避免正则转义陷阱）。
+
+2026-09-05 追记：按验证反馈把裙边不透明度从 90% 下调至 80%（`bg-background/80`），模糊半径不变。
+
+2026-09-05 追记：再下调至 70%（`bg-background/70`）试效果。
+
+2026-09-05 追记：裙边自身的 `rounded-b-2xl` 又在底部两角漏字，去掉——裙边改为方角矩形，圆角只保留输入卡片自己的。
+
+2026-09-05 追记：web 裙边下方仍漏字——composer 层底部有 16px 悬浮留白（`--gateway-chat-composer-bottom`），桌面端靠一条 desktop 独占的全宽实底条兜住，web 没有对应物。把这条实底条改为两端共用（`ChatComposerBar.tsx`），并在 `composer-width-follows-transcript.test.mjs` 加断言防回归。
+
+2026-09-05 追记：web 端验证注意——WebUI 经 `go:embed all:web/dist` 编译进 gateway 二进制（`crates/agent-gateway/embed.go`），无磁盘回退；改前端后必须重跑 `start-gateway.bat`（它会重建 dist 并重编 gateway），只刷新浏览器拿到的永远是旧内嵌资产。本次"实底条已改但刷新无效"即此原因。


### PR DESCRIPTION
## 概述

从 #749 出发的修复，连同调试客户端 / WebUI 验证过程中发现的三组输入区与宽度问题一起处理，桌面端与 WebUI 两端同步。

Closes #749

## 改动

### 1. 历史会话切换后正文宽度手柄失效（#749）

- 共享 `TranscriptWidthControls` 新增 `suspended`：加载遮罩挂载期间手柄挂起——不透明骨架下没有可抓的边界，可聚焦的 `role="separator"` 也不应藏在拦截层之下，因此选择挂起手柄而非提升 z-index；遮罩离开的同一次 commit 里同步重测宿主并恢复手柄，不再依赖无关布局变化唤醒观察器。拖拽中途遇挂起，按当前宽度提交并卸掉窗口监听。
- 根节点在所有状态常驻，带 `data-transcript-width-state`（`ready / suspended / media-hidden / stage-narrow`）与 `data-transcript-width-max`：issue 里缺的运行时数据（失效时到底是被哪道闸关掉）以后在 DevTools 一眼可查。
- 桌面 `ChatTranscript` 以同一个 `isTranscriptBusy` 驱动遮罩与挂起；WebUI 两处 usage 传 `conversationOpenState.showOverlay`。
- 未动 624px 阈值与 64px 安全间距（`stage-narrow` 是窄 Pane 既定行为，是否调阈值另议）；未动 openController / 首屏 settle 逻辑。

### 2. 手柄触发区扩大（验证反馈）

- 命中区 96×12px → 全高 ×17px（`inset-y-0 w-[17px]`，与 `DetailsResizeHandle`、`RightDockPanel` 两个全高 col-resize 手柄同构）；可见小竖条外观与悬停/拖拽加亮不变。
- 取舍：正文列左右边缘各约 8.5px 全高条带被手柄接管指针，从最边缘像素起始的文本选取会被挡。

### 3. WebUI 输入框宽度跟随正文（对齐桌面端）

- 反转 `base-chat.css` 里"composer 列固定 768px、正文列独立可调"的旧决策：`.gateway-composer-layer` 网格列改读 `min(var(--chat-transcript-content-width, 768px), 100%)`（与转录列同公式），删除 `--gateway-chat-column-width`。
- 无需动 TSX：两条路径（传统 stage 与 workbench Pane）的 `ChatComposerBar` 都渲染在 `.gateway-transcript-stage` 内部，宽度手柄写在 stage 上的内联变量（拖拽期间逐帧更新）经 CSS 继承直达 composer 层。

### 4. 会话统计读数被滚动正文穿透（验证反馈）

- 共享 `ConversationStatsBar` 读数下加全宽毛玻璃裙边：`bg-background/70` + `backdrop-blur-md`，方角（自身圆角会在两角漏字），`-top-8` 上探 2rem（= 输入卡片 `rounded-4xl` 半径）藏到卡片身后填掉圆角外的弧形缺口，`-z-10` 压在卡片之下、正文之上；空态占位不渲染裙边。
- composer 层底部 16px 悬浮留白的兜底实底条由桌面独占改为两端共用——WebUI 此前会从裙边下方漏字。

## 测试

- 新增：`crates/agent-gui/test/chat/transcript-width-controls-history-switch.test.mjs`（jsdom + 真实 react-dom，7 例：阈值穿越、挂起/恢复同步重测、拖拽中挂起提交、无关重渲染不变等）；`crates/agent-gateway/web/test/transcript-width-history-overlay.test.mjs`（3 例）；`crates/agent-gateway/web/test/composer-width-follows-transcript.test.mjs`（3 例）。
- 断言随行为反转：`measurements-lru.test.mjs`（原"命中区不许全高"→ 锁全高 + 17px）、`conversation-stats-bar.test.mjs`（+裙边断言，含空态不出空裙边、不许带圆角）。
- 结果：WebUI 全套 703/703；桌面 chat 目录 1294/1298——4 个失败为本机 CRLF 工作区既有问题，已在干净 `main@be86449f` 基线 worktree 复现确认，与本 PR 无关；`@liveagent/ui`、agent-gui、gateway web 三端 `tsc` 通过；biome lint/format 干净。

Screenshots / preview
<img width="2152" height="1408" alt="image" src="https://github.com/user-attachments/assets/f81c9d3c-9a6b-48f2-8064-80f3ec85b578" />


## 文档

- `docs/worklog/transcript-width-handles-history-switch.md`：#749 双分支根因（遮罩层级 + DPI/dock 推理）、决策（遮罩期间不允许调宽）、调试客户端验证清单（含 DevTools 读数片段）。
- `docs/worklog/web-composer-width-and-stats-glass.md`：宽度跟随与毛玻璃裙边的决策与迭代记录（含"WebUI 经 go:embed 内嵌、验证必须重编 gateway"的注意事项）。

## 关联

- 调查中另发现 macOS 端 AskUserQuestion 卡片正文被裁切的问题，已单独提 #761（本 PR 不处理）。
