### PR TITLE
fix(chat): 搜索打开会话时同步工作空间与侧栏定位

### DIFF
--- a/crates/agent-gateway/web/package.json
+++ b/crates/agent-gateway/web/package.json
@@ -53,6 +53,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "jsdom": "30.0.1",
     "postcss": "^8.5.8",
     "tailwindcss": "4.2.2",
     "typescript": "~7.0.2",

--- a/crates/agent-gateway/web/src/app/GatewayApp.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayApp.tsx
@@ -10,6 +10,7 @@ import { searchMentionConversations } from "@liveagent/ui/lib/chat/conversationS
 import { useMentionApps } from "@liveagent/ui/lib/chat/useMentionApps";
 import { useScrollFollow } from "@liveagent/ui/lib/chat-scroll/useScrollFollow";
 import { releaseProjectToolFromDock } from "@liveagent/ui/lib/projectTools/releaseProjectToolFromDock";
+import type { ConversationOpenRequest } from "@liveagent/ui/lib/sidebar/openController";
 import {
   type ConversationOpenState,
   createConversationOpenController,
@@ -460,6 +461,9 @@ function useGatewayAppController() {
   >(() => "");
   const {
     activateWorkspaceProject,
+    activateSearchConversationWorkspace,
+    clearSearchConversationWorkspace,
+    searchConversationWorkdir,
     activeWorkspaceProject,
     activeWorkspaceProjectPath,
     archivedWorkspaceProjectPathKeys,
@@ -509,13 +513,13 @@ function useGatewayAppController() {
   // established history window in the single open phase — messages above the
   // window edge stay unfetched until the user pages up. Deps go through refs
   // (assigned per render) so the controller instance stays stable.
-  const openInitialRef = useRef<(id: string) => Promise<"cache-hit" | "painted">>(() =>
-    Promise.resolve("painted"),
-  );
+  const openInitialRef = useRef<
+    (id: string, request?: ConversationOpenRequest) => Promise<"cache-hit" | "painted">
+  >(() => Promise.resolve("painted"));
   const openController = useMemo(
     () =>
       createConversationOpenController({
-        openInitial: (id) => openInitialRef.current(id),
+        openInitial: (id, request) => openInitialRef.current(id, request),
         onStateChange: setConversationOpenState,
       }),
     [],
@@ -1135,6 +1139,8 @@ function useGatewayAppController() {
     handleSidebarSelectConversation,
     startNewConversation,
   } = createGatewayConversationActions({
+    activateSearchConversationWorkspace,
+    clearSearchConversationWorkspace,
     activeView,
     activeWorkspaceProjectPath,
     api,
@@ -1414,7 +1420,11 @@ function useGatewayAppController() {
   const resourceWorkdir =
     sidebarConversationsById.get(displayedConversationId)?.cwd?.trim() ||
     conversationWorkdirsRef.current.get(displayedConversationId)?.trim() ||
-    (isAgentMode ? activeWorkspaceProjectPath || settings.system.workdir.trim() : "");
+    (searchConversationWorkdir === ""
+      ? ""
+      : isAgentMode
+        ? activeWorkspaceProjectPath || settings.system.workdir.trim()
+        : "");
   const {
     activeProviders,
     availableSkills,
@@ -1513,7 +1523,11 @@ function useGatewayAppController() {
   const displayedConversationWorkdir =
     currentConversationPersistedCwd ||
     currentConversationRuntimeWorkdir ||
-    (isAgentMode ? activeWorkspaceProjectPath || settings.system.workdir.trim() : "");
+    (searchConversationWorkdir === ""
+      ? ""
+      : isAgentMode
+        ? activeWorkspaceProjectPath || settings.system.workdir.trim()
+        : "");
   const searchMentionableConversations = useCallback(
     (query: string) =>
       searchMentionConversations({

--- a/crates/agent-gateway/web/src/app/GatewayAppView.tsx
+++ b/crates/agent-gateway/web/src/app/GatewayAppView.tsx
@@ -1276,7 +1276,7 @@ export function GatewayAppView({ viewModel }: { viewModel: GatewayAppViewModel }
               showProjects={isAgentMode && status?.online === true}
               projects={workspaceProjects}
               workspaceProjectGroups={settings.system.workspaceProjectGroups}
-              activeProjectId={activeWorkspaceProject?.id}
+              activeProjectId={activeWorkspaceProject?.id ?? ""}
               missingProjectPathKeys={missingWorkspaceProjectPathKeys}
               projectsCollapsed={settings.customSettings.chatSidebar.projectsCollapsed}
               workspaceFolderDropActive={workspaceFolderDropActive}

--- a/crates/agent-gateway/web/src/app/gatewayConversationActions.ts
+++ b/crates/agent-gateway/web/src/app/gatewayConversationActions.ts
@@ -6,6 +6,7 @@ import type {
 import { createTextComposerDraft } from "@liveagent/ui/lib/chat/composerDraft";
 import type { ConversationMentionReference } from "@liveagent/ui/lib/chat/mentionReferences";
 import type { PendingUploadedFile } from "@liveagent/ui/lib/chat/uploadedFiles";
+import type { ConversationOpenOptions } from "@liveagent/ui/lib/sidebar/openController";
 import type { SidebarStore } from "@liveagent/ui/lib/sidebar/store";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 
@@ -23,6 +24,8 @@ import { isMobileSidebarLayout } from "./historyUtils";
 import type { SendChatFn } from "./types";
 
 type CreateGatewayConversationActionsOptions = {
+  activateSearchConversationWorkspace: (cwd?: string) => void;
+  clearSearchConversationWorkspace: () => void;
   activeView: ApplicationViewId;
   activeWorkspaceProjectPath: string;
   api: GatewayWebSocketClient | null;
@@ -44,7 +47,10 @@ type CreateGatewayConversationActionsOptions = {
   isConversationBusy: (conversationId: string) => boolean;
   isLocalDraftConversationId: (conversationId: string) => boolean;
   markVisibleConversationRevision: () => number;
-  openController: { cancel: () => void; open: (conversationId: string) => void };
+  openController: {
+    cancel: () => void;
+    open: (conversationId: string, options?: ConversationOpenOptions) => void;
+  };
   pendingDisplayedConversationAutoBottomRef: MutableRefObject<string | null>;
   prepareComposerForConversationChange: () => void;
   protectedConversationRef: MutableRefObject<string>;
@@ -89,6 +95,7 @@ export function createGatewayConversationActions(options: CreateGatewayConversat
     options.composerDraftOwnerRef.current = "";
     options.composerRef.current?.clear();
     const nextWorkdir = startOptions?.workdir?.trim() || "";
+    if (!options.isAgentMode || nextWorkdir) options.clearSearchConversationWorkspace();
     if (nextWorkdir) options.conversationWorkdirsRef.current.set(nextConversationId, nextWorkdir);
     options.conversationIdRef.current = nextConversationId;
     options.selectedHistoryIdRef.current = nextConversationId;
@@ -118,11 +125,26 @@ export function createGatewayConversationActions(options: CreateGatewayConversat
     });
   };
 
-  const handleSidebarSelectConversation = (id: string) => {
+  const handleSidebarSelectConversation = (id: string, openOptions?: ConversationOpenOptions) => {
     if (isMobileSidebarLayout()) options.setSidebarOpen(false);
     options.setActiveView("chat");
     const targetConversationId = id.trim();
     if (!targetConversationId) return;
+    if (openOptions?.source === "search") {
+      options.openController.open(targetConversationId, {
+        source: "search",
+        beforeCommit: (conversation) => {
+          options.activateSearchConversationWorkspace(conversation.cwd);
+          options.sidebarStore.upsertLocal(conversation, { reveal: true });
+          options.prepareComposerForConversationChange();
+        },
+        afterCommit: () => {
+          options.restoreCachedComposerDraft(targetConversationId);
+          openOptions.afterCommit?.();
+        },
+      });
+      return;
+    }
     const currentConversationId = options.getVisibleComposerConversationId().trim();
     if (currentConversationId !== targetConversationId) {
       options.prepareComposerForConversationChange();

--- a/crates/agent-gateway/web/src/app/gatewayHistoryWindowActions.ts
+++ b/crates/agent-gateway/web/src/app/gatewayHistoryWindowActions.ts
@@ -1,3 +1,4 @@
+import type { ConversationOpenRequest } from "@liveagent/ui/lib/sidebar/openController";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import {
   adoptHistoryWindowState,
@@ -12,6 +13,7 @@ import type { ChatEntry } from "@/lib/chatUi";
 import type { GatewayWebSocketClient } from "@/lib/gatewaySocket";
 import type { HistoryDetail } from "@/lib/gatewayTypes";
 import { parseHistoryMessagesJsonAsync } from "@/lib/historyParser";
+import { normalizeGatewayConversationSummary } from "@/lib/sidebar/webSidebarBackend";
 import { asErrorMessage } from "./chatEventUtils";
 import { HISTORY_DETAIL_INITIAL_MAX_MESSAGES } from "./constants";
 import { resolveVisibleConversationId } from "./historyUtils";
@@ -150,29 +152,37 @@ type OpenConversationInitialOptions = {
 };
 
 export function createOpenConversationInitial(options: OpenConversationInitialOptions) {
-  return async (conversationId: string): Promise<"cache-hit" | "painted"> => {
+  return async (
+    conversationId: string,
+    request?: ConversationOpenRequest,
+  ): Promise<"cache-hit" | "painted"> => {
+    const fromSearch = request?.source === "search";
     const currentApi = options.api;
     if (!currentApi) throw new Error("Gateway client is not ready.");
     const loadSequence = options.invalidateHistoryLoad();
     const selectionRevision = options.markVisibleConversationRevision();
     const isStale = () =>
       options.historyLoadSequenceRef.current !== loadSequence ||
-      options.visibleConversationRevisionRef.current !== selectionRevision;
+      options.visibleConversationRevisionRef.current !== selectionRevision ||
+      request?.isCurrent() === false;
     const previousId = options.getDisplayedConversationId();
     const isChanging = previousId !== conversationId;
-    options.pendingDisplayedConversationAutoBottomRef.current = conversationId;
-    if (isChanging && previousId) {
-      options.transcriptStoreRegistry.peek(previousId)?.foldSettledTurns();
-    }
-    options.protectedConversationRef.current = conversationId;
-    options.conversationIdRef.current = conversationId;
-    options.selectedHistoryIdRef.current = conversationId;
-    options.setConversationId(conversationId);
-    options.setSelectedHistoryId(conversationId);
-    if (isChanging) {
-      options.setChatError(null);
-      options.setSelectedHistory(null);
-    }
+    const selectConversation = () => {
+      options.pendingDisplayedConversationAutoBottomRef.current = conversationId;
+      if (isChanging && previousId) {
+        options.transcriptStoreRegistry.peek(previousId)?.foldSettledTurns();
+      }
+      options.protectedConversationRef.current = conversationId;
+      options.conversationIdRef.current = conversationId;
+      options.selectedHistoryIdRef.current = conversationId;
+      options.setConversationId(conversationId);
+      options.setSelectedHistoryId(conversationId);
+      if (isChanging) {
+        options.setChatError(null);
+        options.setSelectedHistory(null);
+      }
+    };
+    if (!fromSearch) selectConversation();
     try {
       const planned = planHistoryWindowRequest(
         options.historyWindowStatesRef.current.get(conversationId),
@@ -192,21 +202,30 @@ export function createOpenConversationInitial(options: OpenConversationInitialOp
       const parsed = await parseHistoryMessagesJsonAsync(detail.messages_json);
       const entries = detail.has_more === true ? trimLeadingHeadlessEntries(parsed) : parsed;
       if (isStale()) return "painted";
+      if (fromSearch) {
+        if (!detail.conversation || detail.conversation.id !== conversationId) {
+          throw new Error("History response is missing the requested conversation.");
+        }
+        request?.beforeCommit?.(normalizeGatewayConversationSummary(detail.conversation));
+        selectConversation();
+      }
       options.setSelectedHistory(detail);
       options.transcriptStoreRegistry
         .get(conversationId)
         .applyHistorySnapshot(entries, { mode: "replace" });
       const detailWorkdir = detail.conversation?.cwd?.trim();
-      if (detailWorkdir) options.conversationWorkdirsRef.current.set(conversationId, detailWorkdir);
+      options.conversationWorkdirsRef.current.set(conversationId, detailWorkdir ?? "");
+      request?.afterCommit?.();
       return "painted";
     } catch (error) {
       if (!isStale()) {
         const message = asErrorMessage(error, options.localeErrorMessage);
-        options.setSelectedHistory({
-          conversation_id: conversationId,
-          messages_json: message,
-          has_more: false,
-        });
+        if (!fromSearch)
+          options.setSelectedHistory({
+            conversation_id: conversationId,
+            messages_json: message,
+            has_more: false,
+          });
         options.setChatError(message);
       }
       throw error;

--- a/crates/agent-gateway/web/src/app/hooks/useGatewayWorkspaceProjects.ts
+++ b/crates/agent-gateway/web/src/app/hooks/useGatewayWorkspaceProjects.ts
@@ -61,9 +61,24 @@ export function useGatewayWorkspaceProjects({
 }: UseGatewayWorkspaceProjectsOptions) {
   const [workspaceCloneTasks, setWorkspaceCloneTasks] = useState<WorkspaceCloneTask[]>([]);
   const dismissedWorkspaceCloneTaskIds = useRef(new Set<string>());
-  const [activeWorkspaceProjectId, setActiveWorkspaceProjectId] = useState<string>(
+  const [searchNavigation, setSearchNavigation] = useState<{
+    mode: typeof settings.system.executionMode;
+    cwd: string;
+  } | null>(null);
+  const clearSearchConversationWorkspace = useCallback(() => setSearchNavigation(null), []);
+  const searchCwd =
+    searchNavigation?.mode === settings.system.executionMode ? searchNavigation.cwd : undefined;
+  const [activeWorkspaceProjectId, setActiveWorkspaceProjectIdState] = useState<string>(
     () => settings.system.activeWorkspaceProjectId?.trim() || DEFAULT_WORKSPACE_PROJECT_ID,
   );
+  const setActiveWorkspaceProjectId = useCallback<Dispatch<SetStateAction<string>>>((id) => {
+    setSearchNavigation(null);
+    setActiveWorkspaceProjectIdState(id);
+  }, []);
+  useEffect(() => {
+    if (searchNavigation && searchNavigation.mode !== settings.system.executionMode)
+      setSearchNavigation(null);
+  }, [searchNavigation, settings.system.executionMode]);
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
   const [workspaceCreateModalOpen, setWorkspaceCreateModalOpen] = useState(false);
 
@@ -86,8 +101,11 @@ export function useGatewayWorkspaceProjects({
     return active.length > 0 ? active : workspaceProjects;
   }, [archivedWorkspaceProjectPathKeys, workspaceProjects]);
   const activeWorkspaceProject = useMemo(
-    () => findWorkspaceProject(selectableWorkspaceProjects, activeWorkspaceProjectId),
-    [activeWorkspaceProjectId, selectableWorkspaceProjects],
+    () =>
+      searchCwd === ""
+        ? undefined
+        : findWorkspaceProject(selectableWorkspaceProjects, activeWorkspaceProjectId),
+    [activeWorkspaceProjectId, selectableWorkspaceProjects, searchCwd],
   );
   const activeWorkspaceProjectPath = activeWorkspaceProject?.path.trim() ?? "";
 
@@ -95,17 +113,21 @@ export function useGatewayWorkspaceProjects({
     if (activeWorkspaceProject?.id && activeWorkspaceProject.id !== activeWorkspaceProjectId) {
       setActiveWorkspaceProjectId(activeWorkspaceProject.id);
     }
-  }, [activeWorkspaceProject?.id, activeWorkspaceProjectId]);
+  }, [activeWorkspaceProject?.id, activeWorkspaceProjectId, setActiveWorkspaceProjectId]);
 
   useEffect(() => {
     sidebarStore.setScope(
-      settings.system.executionMode !== "text"
-        ? activeWorkspaceProjectPath
-          ? { kind: "workdir", cwd: activeWorkspaceProjectPath }
-          : { kind: "none" }
-        : { kind: "unscoped" },
+      searchCwd !== undefined
+        ? searchCwd
+          ? { kind: "workdir", cwd: searchCwd }
+          : { kind: "unscoped" }
+        : settings.system.executionMode !== "text"
+          ? activeWorkspaceProjectPath
+            ? { kind: "workdir", cwd: activeWorkspaceProjectPath }
+            : { kind: "none" }
+          : { kind: "unscoped" },
     );
-  }, [activeWorkspaceProjectPath, settings.system.executionMode, sidebarStore]);
+  }, [activeWorkspaceProjectPath, settings.system.executionMode, sidebarStore, searchCwd]);
 
   const setWorkspaceProjectDirectoryMissing = useCallback(
     (project: WorkspaceProject, missing: boolean) => {
@@ -157,7 +179,11 @@ export function useGatewayWorkspaceProjects({
   );
 
   const activateWorkspaceProject = useCallback(
-    (project: WorkspaceProject, options?: { startConversation?: boolean }) => {
+    (
+      project: WorkspaceProject,
+      options?: { startConversation?: boolean; preserveMissing?: boolean },
+    ) => {
+      setSearchNavigation(null);
       const pathKey = project.path.trim();
       if (!pathKey) return null;
       const normalizedPathKey = workspaceProjectPathKey(pathKey);
@@ -207,9 +233,11 @@ export function useGatewayWorkspaceProjects({
               hiddenWorkspaceProjectPaths: prev.system.hiddenWorkspaceProjectPaths.filter(
                 (path) => workspaceProjectPathKey(path) !== normalizedPathKey,
               ),
-              missingWorkspaceProjectPaths: prev.system.missingWorkspaceProjectPaths.filter(
-                (path) => workspaceProjectPathKey(path) !== normalizedPathKey,
-              ),
+              missingWorkspaceProjectPaths: options?.preserveMissing
+                ? prev.system.missingWorkspaceProjectPaths
+                : prev.system.missingWorkspaceProjectPaths.filter(
+                    (path) => workspaceProjectPathKey(path) !== normalizedPathKey,
+                  ),
               archivedWorkspaceProjectPaths: prev.system.archivedWorkspaceProjectPaths.filter(
                 (path) => workspaceProjectPathKey(path) !== normalizedPathKey,
               ),
@@ -227,7 +255,39 @@ export function useGatewayWorkspaceProjects({
       }
       return null;
     },
-    [setActiveView, setSettings, startNewConversationRef, workspaceProjects],
+    [
+      setActiveView,
+      setSettings,
+      startNewConversationRef,
+      workspaceProjects,
+      setActiveWorkspaceProjectId,
+    ],
+  );
+
+  // Reading persisted history does not require the original directory to exist.
+  const activateSearchConversationWorkspace = useCallback(
+    (cwd?: string) => {
+      const path = cwd?.trim() ?? "";
+      if (
+        path &&
+        workspaceProjectPathKey(path) !== workspaceProjectPathKey(activeWorkspaceProjectPath)
+      ) {
+        const project =
+          workspaceProjects.find(
+            (item) => workspaceProjectPathKey(item.path) === workspaceProjectPathKey(path),
+          ) ?? createWorkspaceProjectFromPath(path, "history");
+        activateWorkspaceProject(project, { preserveMissing: true });
+      }
+      setSearchNavigation({ mode: settings.system.executionMode, cwd: path });
+      sidebarStore.setScope(path ? { kind: "workdir", cwd: path } : { kind: "unscoped" });
+    },
+    [
+      activeWorkspaceProjectPath,
+      workspaceProjects,
+      activateWorkspaceProject,
+      settings.system.executionMode,
+      sidebarStore,
+    ],
   );
 
   const handleSelectWorkspaceProject = useCallback(
@@ -571,6 +631,9 @@ export function useGatewayWorkspaceProjects({
 
   return {
     activateWorkspaceProject,
+    activateSearchConversationWorkspace,
+    clearSearchConversationWorkspace,
+    searchConversationWorkdir: searchCwd,
     activeWorkspaceProject,
     activeWorkspaceProjectPath,
     archivedWorkspaceProjectPathKeys,

--- a/crates/agent-gateway/web/test/search-workspace-navigation.test.mjs
+++ b/crates/agent-gateway/web/test/search-workspace-navigation.test.mjs
@@ -1,0 +1,363 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { createWebModuleLoader } from "../../test/helpers/load-web-module.mjs";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", { url: "http://localhost/" });
+for (const key of [
+  "window",
+  "document",
+  "navigator",
+  "HTMLElement",
+  "Element",
+  "Node",
+  "Event",
+  "CustomEvent",
+]) {
+  Object.defineProperty(globalThis, key, { value: dom.window[key], configurable: true });
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+window.matchMedia = () => ({ matches: false });
+const loader = createWebModuleLoader({
+  mocks: {
+    react: React,
+    "@/lib/historyParser": { parseHistoryMessagesJsonAsync: async (value) => JSON.parse(value) },
+  },
+});
+const { useGatewayWorkspaceProjects } = loader.loadModule(
+  "src/app/hooks/useGatewayWorkspaceProjects.ts",
+);
+const { createOpenConversationInitial } = loader.loadModule(
+  "src/app/gatewayHistoryWindowActions.ts",
+);
+const { createGatewayConversationActions } = loader.loadModule(
+  "src/app/gatewayConversationActions.ts",
+);
+const { createSidebarStore } = loader.loadModule("@liveagent/ui/lib/sidebar/store.ts");
+const { createConversationOpenController } = loader.loadModule(
+  "@liveagent/ui/lib/sidebar/openController.ts",
+);
+const { getDefaultSettings } = loader.loadModule("src/lib/settings/index.ts");
+const ref = (current) => ({ current });
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+const summary = (id, cwd, updatedAt = 1) => ({
+  id,
+  cwd,
+  title: id,
+  providerId: "p",
+  model: "m",
+  createdAt: 1,
+  updatedAt,
+});
+
+async function harness(t, { mode = "tools", archived = [], missing = [] } = {}) {
+  const pending = new Map();
+  const transport = {
+    getHistory: (id) => new Promise((resolve, reject) => pending.set(id, { resolve, reject })),
+  };
+  const store = createSidebarStore(
+    {
+      listConversations: async (_page, _size, scope) => ({
+        items: [summary("recent", scope.kind === "workdir" ? scope.cwd : undefined, 100)],
+        totalCount: 30,
+      }),
+      listWorkdirs: async () => [],
+      subscribeEvents: () => () => {},
+    },
+    { pageSize: 1 },
+  );
+  const currentId = ref("a"),
+    selectedId = ref("a"),
+    sequence = ref(0),
+    revision = ref(0);
+  const workdirs = ref(new Map([["a", "/repo/a"]]));
+  let setCurrentSettings;
+  let api,
+    actions,
+    selectedHistory = { conversation_id: "a" },
+    settingsWrites = 0,
+    draftsSaved = 0,
+    restored = 0;
+  const drafts = new Map([["a", "keep this draft"]]);
+  const defaults = getDefaultSettings();
+  let settings = {
+    ...defaults,
+    system: {
+      ...defaults.system,
+      workdir: "/repo/a",
+      executionMode: mode,
+      workspaceProjects: ["a", "b", "c"].map((id) => ({
+        id,
+        path: "/repo/" + id,
+        name: id,
+        kind: "manual",
+        createdAt: 1,
+        updatedAt: 1,
+      })),
+      activeWorkspaceProjectId: "a",
+      archivedWorkspaceProjectPaths: archived,
+      missingWorkspaceProjectPaths: missing,
+    },
+  };
+  const common = {
+    api: transport,
+    conversationIdRef: currentId,
+    conversationWorkdirsRef: workdirs,
+    getDisplayedConversationId: () => currentId.current,
+    historyLoadSequenceRef: sequence,
+    historyWindowStatesRef: ref(new Map()),
+    invalidateHistoryLoad: () => ++sequence.current,
+    localeErrorMessage: "open failed",
+    markVisibleConversationRevision: () => ++revision.current,
+    pendingDisplayedConversationAutoBottomRef: ref(null),
+    protectedConversationRef: ref("a"),
+    selectedHistoryIdRef: selectedId,
+    setChatError() {},
+    setConversationId: (id) => {
+      currentId.current = id;
+    },
+    setSelectedHistory: (detail) => {
+      selectedHistory = detail;
+    },
+    setSelectedHistoryId: (id) => {
+      selectedId.current = id;
+    },
+    transcriptStoreRegistry: { peek: () => undefined, get: () => ({ applyHistorySnapshot() {} }) },
+    visibleConversationRevisionRef: revision,
+  };
+  const openInitial = createOpenConversationInitial(common);
+  const controller = createConversationOpenController({ openInitial, onStateChange() {} });
+  function Host() {
+    const [value, setValue] = React.useState(settings);
+    settings = value;
+    setCurrentSettings = setValue;
+    api = useGatewayWorkspaceProjects({
+      api: transport,
+      displayedConversationWorkdirRef: ref("/repo/a"),
+      settings: value,
+      setSettings: (update) => {
+        settingsWrites++;
+        setValue(update);
+      },
+      sidebarStore: store,
+      sidebarWorkdirs: [],
+      setActiveView() {},
+      setRightDockOpen() {},
+      setSidebarOpen() {},
+      startNewConversationRef: ref(() => assert.fail("search created a conversation")),
+    });
+    actions = createGatewayConversationActions({
+      ...common,
+      activateSearchConversationWorkspace: api.activateSearchConversationWorkspace,
+      setActiveView() {},
+      setSidebarOpen() {},
+      getVisibleComposerConversationId: () => currentId.current,
+      prepareComposerForConversationChange: () => {
+        draftsSaved++;
+      },
+      openController: controller,
+      sidebarStore: store,
+      restoreCachedComposerDraft: () => {
+        restored++;
+      },
+      isLocalDraftConversationId: () => false,
+    });
+    return null;
+  }
+  const root = createRoot(document.createElement("div"));
+  await act(async () => root.render(React.createElement(Host)));
+  await act(async () => {
+    store.start();
+    await tick();
+  });
+  t.after(async () => {
+    controller.cancel();
+    store.stop();
+    await act(async () => root.unmount());
+  });
+  return {
+    store,
+    controller,
+    workdirs,
+    get api() {
+      return api;
+    },
+    get settings() {
+      return settings;
+    },
+    get id() {
+      return currentId.current;
+    },
+    get writes() {
+      return settingsWrites;
+    },
+    get resets() {
+      return restored;
+    },
+    get draftsSaved() {
+      return draftsSaved;
+    },
+    get selectedHistory() {
+      return selectedHistory;
+    },
+    drafts,
+    select: async (id, source = "search") =>
+      act(async () =>
+        actions.handleSidebarSelectConversation(id, source === "search" ? { source } : undefined),
+      ),
+    complete: async (id, cwd) =>
+      act(async () => {
+        pending
+          .get(id)
+          .resolve({
+            conversation_id: id,
+            conversation: { id, cwd, title: id, created_at: 1, updated_at: 1 },
+            messages_json: "[]",
+            has_more: false,
+          });
+        await tick();
+      }),
+    fail: async (id) =>
+      act(async () => {
+        pending.get(id).reject(new Error("read failed"));
+        await tick();
+      }),
+    setMode: async (executionMode) =>
+      act(async () =>
+        setCurrentSettings((prev) => ({ ...prev, system: { ...prev.system, executionMode } })),
+      ),
+  };
+}
+
+test("gateway commits authoritative workspace and retains a result beyond the first page", async (t) => {
+  const h = await harness(t);
+  await act(async () => h.store.upsertLocal(summary("b", "/stale/path")));
+  await h.select("b");
+  assert.equal(h.id, "a");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/a");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.id, "b");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/b");
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd:/repo/b");
+  await act(async () => h.store.refresh());
+  assert.ok(h.store.getSnapshot().conversations.some((item) => item.id === h.id));
+  assert.equal(h.drafts.get("a"), "keep this draft");
+  assert.equal(h.writes, 1);
+  assert.equal(h.draftsSaved, 1);
+});
+
+test("gateway same-workspace search performs no settings write", async (t) => {
+  const h = await harness(t);
+  await h.select("other-a");
+  await h.complete("other-a", "/repo/a");
+  assert.equal(h.writes, 0);
+  assert.equal(h.id, "other-a");
+});
+
+test("gateway slow B cannot override C and failure leaves the previous navigation intact", async (t) => {
+  const h = await harness(t);
+  await h.select("b");
+  await h.select("c");
+  await h.complete("c", "/repo/c");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.id, "c");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/c");
+  await h.select("bad");
+  await h.fail("bad");
+  assert.equal(h.id, "c");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/c");
+  assert.equal(h.writes, 1);
+  assert.equal(h.resets, 1);
+  assert.equal(h.draftsSaved, 1);
+});
+
+test("gateway cancellation prevents workspace, transcript and composer commits", async (t) => {
+  const h = await harness(t);
+  await h.select("b");
+  h.controller.cancel();
+  await h.complete("b", "/repo/b");
+  assert.equal(h.id, "a");
+  assert.equal(h.writes, 0);
+  assert.equal(h.resets, 0);
+  assert.equal(h.draftsSaved, 0);
+});
+
+test("gateway empty authoritative cwd clears stale scope and project highlight", async (t) => {
+  const h = await harness(t);
+  await act(async () => h.store.upsertLocal(summary("text", "/repo/a")));
+  await h.select("text");
+  await h.complete("text", undefined);
+  assert.equal(h.id, "text");
+  assert.equal(h.api.activeWorkspaceProject, undefined);
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd-empty");
+  assert.ok(h.store.getSnapshot().conversations.some((item) => item.id === "text"));
+  assert.equal(h.store.peek("text").cwd, undefined);
+  assert.equal(h.writes, 0);
+  assert.equal(h.api.searchConversationWorkdir, "");
+});
+
+test("gateway text mode supports unscoped history and cross-workspace navigation", async (t) => {
+  const h = await harness(t, { mode: "text" });
+  await h.select("text");
+  await h.complete("text", undefined);
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd-empty");
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd:/repo/b");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/b");
+});
+
+test("gateway archived or missing directories remain readable without clearing the missing marker", async (t) => {
+  const h = await harness(t, { archived: ["/repo/b"], missing: ["/repo/b"] });
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/b");
+  assert.ok(h.settings.system.missingWorkspaceProjectPaths.includes("/repo/b"));
+  assert.ok(!h.settings.system.archivedWorkspaceProjectPaths.includes("/repo/b"));
+});
+
+test("gateway ordinary conversation selection does not activate another workspace", async (t) => {
+  const h = await harness(t);
+  await h.select("b", "sidebar");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.id, "b");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/a");
+  assert.equal(h.writes, 0);
+});
+
+test("gateway workspace selection and mode changes release the search-only scope", async (t) => {
+  const h = await harness(t);
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  await act(async () => h.api.setActiveWorkspaceProjectId("c"));
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/c");
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd:/repo/c");
+  await h.select("text");
+  await h.complete("text", undefined);
+  await h.setMode("text");
+  await h.setMode("tools");
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd:/repo/c");
+});
+
+test("gateway retry after failure uses the newest result and repeated selection avoids settings writes", async (t) => {
+  const h = await harness(t);
+  await h.select("b");
+  await h.fail("b");
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.id, "b");
+  assert.equal(h.writes, 1);
+  assert.equal(h.drafts.get("a"), "keep this draft");
+});
+
+test("gateway search scope can be cleared before creating a text-mode draft", async (t) => {
+  const h = await harness(t, { mode: "text" });
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  await act(async () => h.api.clearSearchConversationWorkspace());
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd-empty");
+});

--- a/crates/agent-gui/src/pages/ChatPage.tsx
+++ b/crates/agent-gui/src/pages/ChatPage.tsx
@@ -42,6 +42,10 @@ import { useMentionApps } from "@liveagent/ui/lib/chat/useMentionApps";
 import { setPreferredMonacoNlsLocale } from "@liveagent/ui/lib/monacoNls";
 import { releaseProjectToolFromDock } from "@liveagent/ui/lib/projectTools/releaseProjectToolFromDock";
 import { useRightDockSettings } from "@liveagent/ui/lib/projectTools/useRightDockSettings";
+import type {
+  ConversationOpenOptions,
+  ConversationOpenRequest,
+} from "@liveagent/ui/lib/sidebar/openController";
 import {
   type ConversationOpenState,
   createConversationOpenController,
@@ -366,6 +370,9 @@ export function ChatPage(props: ChatPageProps) {
     sidebarScope,
     historyScopeKey,
     activateWorkspaceProject,
+    activateSearchConversationWorkspace,
+    clearSearchConversationWorkspace,
+    searchConversationWorkdir,
     handleSelectWorkspaceProject,
     handleNewConversationForProject,
     handleBrowseWorkspaceProjectInFileTree,
@@ -532,16 +539,17 @@ export function ChatPage(props: ChatPageProps) {
   const currentConversationHistoryUpdatedAtRef = useRef<number | null>(null);
   const locallySyncedHistoryUpdatedAtRef = useRef(new Map<string, number>());
   const gatewayBridgeHistorySummaryRef = useRef(new Map<string, ChatHistorySummary>());
-  const openInitialActionRef = useRef<(id: string) => Promise<"cache-hit" | "painted">>(
-    async () => "painted",
-  );
+  const openInitialActionRef = useRef<
+    (id: string, request?: ConversationOpenRequest) => Promise<"cache-hit" | "painted">
+  >(async () => "painted");
   const hydrateConversationActionRef = useRef<(id: string) => Promise<void>>(async () => undefined);
   const loadEarlierHistoryActionRef = useRef<(id: string) => Promise<void>>(async () => undefined);
   const cleanupDeletedConversationActionRef = useRef<(id: string) => void>(() => undefined);
   const openController = useMemo(
     () =>
       createConversationOpenController({
-        openInitial: (conversationId) => openInitialActionRef.current(conversationId),
+        openInitial: (conversationId, request) =>
+          openInitialActionRef.current(conversationId, request),
         onStateChange: setConversationOpenState,
       }),
     [],
@@ -729,7 +737,11 @@ export function ChatPage(props: ChatPageProps) {
   const displayedConversationWorkdir =
     currentConversationPersistedCwd ||
     currentConversationRuntimeWorkdir ||
-    (isAgentMode ? activeWorkspaceProjectPath || workdir : "");
+    (searchConversationWorkdir === ""
+      ? ""
+      : isAgentMode
+        ? activeWorkspaceProjectPath || workdir
+        : "");
   const searchMentionableConversations = useCallback(
     (query: string) =>
       searchMentionConversations({
@@ -1777,6 +1789,7 @@ export function ChatPage(props: ChatPageProps) {
   }, []);
 
   const handleNewConversation = useCallback(() => {
+    if (!isAgentMode || activeWorkspaceProjectPath) clearSearchConversationWorkspace();
     openController.cancel();
     prepareComposerForConversationChange();
     startNewConversationActionRef.current({
@@ -1784,6 +1797,7 @@ export function ChatPage(props: ChatPageProps) {
     });
   }, [
     activeWorkspaceProjectPath,
+    clearSearchConversationWorkspace,
     isAgentMode,
     openController,
     prepareComposerForConversationChange,
@@ -1799,15 +1813,32 @@ export function ChatPage(props: ChatPageProps) {
   isDraftConversationRef.current = isDraftConversation;
 
   const handleSelectConversation = useCallback(
-    (id: string) => {
+    (id: string, options?: ConversationOpenOptions) => {
       const targetConversationId = id.trim();
       if (!targetConversationId) {
         return;
       }
-      prepareComposerForConversationChange();
-      openController.open(targetConversationId);
+      if (options?.source === "search") {
+        openController.open(targetConversationId, {
+          source: "search",
+          afterCommit: options.afterCommit,
+          beforeCommit: (conversation) => {
+            activateSearchConversationWorkspace(conversation.cwd);
+            sidebarStore.upsertLocal(conversation, { reveal: true });
+            prepareComposerForConversationChange();
+          },
+        });
+      } else {
+        prepareComposerForConversationChange();
+        openController.open(targetConversationId);
+      }
     },
-    [openController, prepareComposerForConversationChange],
+    [
+      activateSearchConversationWorkspace,
+      openController,
+      prepareComposerForConversationChange,
+      sidebarStore,
+    ],
   );
 
   // 托盘/快捷键动作参数的 ref 镜像：监听 effect 是 []-dep，闭包内一律
@@ -2254,7 +2285,7 @@ export function ChatPage(props: ChatPageProps) {
     controller: conversationSurfaceController,
     changedFilesActions,
     checkpointRewind: {
-      project: activeWorkspaceProject,
+      project: activeWorkspaceProject ?? null,
       disabled: !currentConversationId || isSending,
       onRewound: (info) => {
         // 显式回退通知:让用户明确知道工作区刚被回退过。文件工具缓存
@@ -3931,7 +3962,7 @@ export function ChatPage(props: ChatPageProps) {
         showProjects={isAgentMode}
         projects={workspaceProjects}
         workspaceProjectGroups={workspaceProjectGroups}
-        activeProjectId={activeWorkspaceProject?.id}
+        activeProjectId={activeWorkspaceProject?.id ?? ""}
         missingProjectPathKeys={missingWorkspaceProjectPathKeys}
         projectsCollapsed={settings.customSettings.chatSidebar.projectsCollapsed}
         workspaceFolderDropActive={isWorkspaceFolderDropActive}
@@ -3961,9 +3992,9 @@ export function ChatPage(props: ChatPageProps) {
           }
           handleNewConversation();
         }}
-        onSelectConversation={(id) => {
+        onSelectConversation={(id, options) => {
           setActiveView("chat");
-          handleSelectConversation(id);
+          handleSelectConversation(id, options);
         }}
         onConversationDeleted={handleConversationDeleted}
         onConversationCwdChanged={handleConversationCwdChanged}

--- a/crates/agent-gui/src/pages/chat/history/useConversationHistoryActions.ts
+++ b/crates/agent-gui/src/pages/chat/history/useConversationHistoryActions.ts
@@ -1,4 +1,5 @@
 import type { Message } from "@earendil-works/pi-ai";
+import type { ConversationOpenRequest } from "@liveagent/ui/lib/sidebar/openController";
 import type { SidebarStore } from "@liveagent/ui/lib/sidebar/store";
 import { type Dispatch, type MutableRefObject, type SetStateAction, useRef } from "react";
 import {
@@ -204,9 +205,15 @@ export function useConversationHistoryActions(params: UseConversationHistoryActi
     return nextIdentity.conversationId;
   }
 
-  async function openInitial(id: string): Promise<"cache-hit" | "painted"> {
+  async function openInitial(
+    id: string,
+    request?: ConversationOpenRequest,
+  ): Promise<"cache-hit" | "painted"> {
+    const fromSearch = request?.source === "search";
     const loadSequence = conversationLoadSequenceRef.current + 1;
     conversationLoadSequenceRef.current = loadSequence;
+    const isStale = () =>
+      conversationLoadSequenceRef.current !== loadSequence || request?.isCurrent() === false;
     // Bucketed per conversation: hydrating replaces this id's stale fail mark
     // and never touches another conversation's phase.
     hydration.markHydrating(id);
@@ -219,7 +226,7 @@ export function useConversationHistoryActions(params: UseConversationHistoryActi
       } catch {
         hydration.markHydrating(id);
       }
-      if (conversationLoadSequenceRef.current !== loadSequence) {
+      if (isStale()) {
         return "painted";
       }
     }
@@ -230,7 +237,7 @@ export function useConversationHistoryActions(params: UseConversationHistoryActi
       visibleConversationId,
       buildRuntimeEntryFromVisibleState(),
     );
-    resetVisibleTransientState();
+    if (!fromSearch) resetVisibleTransientState();
 
     const prefetched = backgroundHydrationRef.current.get(id);
     if (prefetched) {
@@ -239,14 +246,14 @@ export function useConversationHistoryActions(params: UseConversationHistoryActi
       } catch {
         hydration.markHydrating(id);
       }
-      if (conversationLoadSequenceRef.current !== loadSequence) {
+      if (isStale()) {
         hydration.clearHydrating(id);
         return "painted";
       }
     }
 
     const cached = conversationRuntimeCacheRef.current.get(id);
-    if (cached) {
+    if (cached && !fromSearch) {
       const historyItem = sidebarStore.peek(id);
       const isPendingHistoryItem = historyItem?.isPending === true;
       // A conversation the sidebar store has never seen is an unpersisted
@@ -276,33 +283,47 @@ export function useConversationHistoryActions(params: UseConversationHistoryActi
         maxMessages: CHAT_HISTORY_WINDOW_MESSAGES,
         includeActiveSegment: true,
       });
-      if (conversationLoadSequenceRef.current !== loadSequence) {
+      if (isStale()) {
         hydration.clearHydrating(id);
         return "painted";
       }
 
       if (!record.activeSegment) throw new Error("历史窗口缺少活跃分段");
       const state = buildConversationStateFromWindow(record);
-      const entry = createConversationRuntimeEntry({
-        state,
-        sessionId: record.conversation.sessionId ?? record.conversation.id,
-        createdAt: record.conversation.createdAt,
-        workdir: record.conversation.cwd,
-        selectedModel: resolveConversationSelectedModel(record.conversation.selectedModelJson),
-      });
+      // Runtime may have advanced while metadata was loading (including streaming turns).
+      const latestCached = fromSearch ? conversationRuntimeCacheRef.current.get(id) : undefined;
+      const reuseCached =
+        latestCached &&
+        (latestCached.isSending || conversationPersistenceCursorRef.current.has(id));
+      const entry = reuseCached
+        ? { ...latestCached, workdir: record.conversation.cwd }
+        : createConversationRuntimeEntry({
+            state,
+            sessionId: record.conversation.sessionId ?? record.conversation.id,
+            createdAt: record.conversation.createdAt,
+            workdir: record.conversation.cwd,
+            selectedModel: resolveConversationSelectedModel(record.conversation.selectedModelJson),
+          });
+      if (fromSearch) {
+        request?.beforeCommit?.(record.conversation);
+        resetVisibleTransientState();
+      }
       activateConversation({
         conversationId: record.conversation.id,
         entry,
-        persistenceCursor: {
-          activeSegmentIndex: record.activeSegment.segmentIndex,
-          activeSegmentId: record.activeSegment.segmentId,
-        },
+        persistenceCursor: reuseCached
+          ? conversationPersistenceCursorRef.current.get(id)
+          : {
+              activeSegmentIndex: record.activeSegment.segmentIndex,
+              activeSegmentId: record.activeSegment.segmentId,
+            },
         clearError: true,
       });
       hydration.clearHydrating(id);
+      request?.afterCommit?.();
       return "painted";
     } catch (err) {
-      if (conversationLoadSequenceRef.current === loadSequence) {
+      if (!isStale()) {
         const msg = err instanceof Error ? err.message : String(err);
         // Failure is scoped to this conversation: another pane's concurrent
         // success or failure cannot clear or overwrite it.

--- a/crates/agent-gui/src/pages/chat/workspace/useWorkspaceProjects.ts
+++ b/crates/agent-gui/src/pages/chat/workspace/useWorkspaceProjects.ts
@@ -80,9 +80,22 @@ export function useWorkspaceProjects(params: UseWorkspaceProjectsParams) {
     () => mergeWorkspaceProjectsWithHistory(settings.system, sidebarWorkdirs),
     [sidebarWorkdirs, settings.system],
   );
-  const [activeWorkspaceProjectId, setActiveWorkspaceProjectId] = useState<string>(
+  const [searchNavigation, setSearchNavigation] = useState<{
+    mode: typeof isAgentMode;
+    cwd: string;
+  } | null>(null);
+  const clearSearchConversationWorkspace = useCallback(() => setSearchNavigation(null), []);
+  const searchCwd = searchNavigation?.mode === isAgentMode ? searchNavigation.cwd : undefined;
+  const [activeWorkspaceProjectId, setActiveWorkspaceProjectIdState] = useState<string>(
     () => settings.system.activeWorkspaceProjectId?.trim() || DEFAULT_WORKSPACE_PROJECT_ID,
   );
+  const setActiveWorkspaceProjectId = useCallback<Dispatch<SetStateAction<string>>>((id) => {
+    setSearchNavigation(null);
+    setActiveWorkspaceProjectIdState(id);
+  }, []);
+  useEffect(() => {
+    if (searchNavigation && searchNavigation.mode !== isAgentMode) setSearchNavigation(null);
+  }, [searchNavigation, isAgentMode]);
   const missingWorkspaceProjectPathKeys = useMemo(
     () => new Set(settings.system.missingWorkspaceProjectPaths.map(workspaceProjectPathKey)),
     [settings.system.missingWorkspaceProjectPaths],
@@ -100,23 +113,30 @@ export function useWorkspaceProjects(params: UseWorkspaceProjectsParams) {
     return active.length > 0 ? active : workspaceProjects;
   }, [archivedWorkspaceProjectPathKeys, workspaceProjects]);
   const activeWorkspaceProject = useMemo(
-    () => findWorkspaceProject(selectableWorkspaceProjects, activeWorkspaceProjectId),
-    [activeWorkspaceProjectId, selectableWorkspaceProjects],
+    () =>
+      searchCwd === ""
+        ? undefined
+        : findWorkspaceProject(selectableWorkspaceProjects, activeWorkspaceProjectId),
+    [activeWorkspaceProjectId, selectableWorkspaceProjects, searchCwd],
   );
   useEffect(() => {
     if (activeWorkspaceProject?.id && activeWorkspaceProject.id !== activeWorkspaceProjectId) {
       setActiveWorkspaceProjectId(activeWorkspaceProject.id);
     }
-  }, [activeWorkspaceProject?.id, activeWorkspaceProjectId]);
+  }, [activeWorkspaceProject?.id, activeWorkspaceProjectId, setActiveWorkspaceProjectId]);
   const activeWorkspaceProjectPath = activeWorkspaceProject?.path.trim() ?? "";
   const sidebarScope = useMemo<SidebarScope>(
     () =>
-      isAgentMode
-        ? activeWorkspaceProjectPath
-          ? { kind: "workdir", cwd: activeWorkspaceProjectPath }
-          : { kind: "none" }
-        : { kind: "unscoped" },
-    [activeWorkspaceProjectPath, isAgentMode],
+      searchCwd !== undefined
+        ? searchCwd
+          ? { kind: "workdir", cwd: searchCwd }
+          : { kind: "unscoped" }
+        : isAgentMode
+          ? activeWorkspaceProjectPath
+            ? { kind: "workdir", cwd: activeWorkspaceProjectPath }
+            : { kind: "none" }
+          : { kind: "unscoped" },
+    [activeWorkspaceProjectPath, isAgentMode, searchCwd],
   );
   useEffect(() => {
     sidebarStore.setScope(sidebarScope);
@@ -183,7 +203,11 @@ export function useWorkspaceProjects(params: UseWorkspaceProjectsParams) {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Action refs deliberately provide the latest conversation-transition handlers without changing this callback identity.
   const activateWorkspaceProject = useCallback(
-    (project: WorkspaceProject, options?: { startConversation?: boolean }) => {
+    (
+      project: WorkspaceProject,
+      options?: { startConversation?: boolean; preserveMissing?: boolean },
+    ) => {
+      setSearchNavigation(null);
       const pathKey = project.path.trim();
       if (!pathKey) return null;
       const normalizedPathKey = workspaceProjectPathKey(pathKey);
@@ -252,9 +276,11 @@ export function useWorkspaceProjects(params: UseWorkspaceProjectsParams) {
             hiddenWorkspaceProjectPaths: prev.system.hiddenWorkspaceProjectPaths.filter(
               (path) => workspaceProjectPathKey(path) !== normalizedPathKey,
             ),
-            missingWorkspaceProjectPaths: prev.system.missingWorkspaceProjectPaths.filter(
-              (path) => workspaceProjectPathKey(path) !== normalizedPathKey,
-            ),
+            missingWorkspaceProjectPaths: options?.preserveMissing
+              ? prev.system.missingWorkspaceProjectPaths
+              : prev.system.missingWorkspaceProjectPaths.filter(
+                  (path) => workspaceProjectPathKey(path) !== normalizedPathKey,
+                ),
             // Activating a workspace always brings it back from the archive.
             archivedWorkspaceProjectPaths: prev.system.archivedWorkspaceProjectPaths.filter(
               (path) => workspaceProjectPathKey(path) !== normalizedPathKey,
@@ -274,6 +300,32 @@ export function useWorkspaceProjects(params: UseWorkspaceProjectsParams) {
       return null;
     },
     [setSettings, workspaceProjects, activeWorkspaceProjectId, settings.system],
+  );
+
+  // Reading persisted history does not require the original directory to exist.
+  const activateSearchConversationWorkspace = useCallback(
+    (cwd?: string) => {
+      const path = cwd?.trim() ?? "";
+      if (
+        path &&
+        workspaceProjectPathKey(path) !== workspaceProjectPathKey(activeWorkspaceProjectPath)
+      ) {
+        const project =
+          workspaceProjects.find(
+            (item) => workspaceProjectPathKey(item.path) === workspaceProjectPathKey(path),
+          ) ?? createWorkspaceProjectFromPath(path, "history");
+        activateWorkspaceProject(project, { preserveMissing: true });
+      }
+      setSearchNavigation({ mode: isAgentMode, cwd: path });
+      sidebarStore.setScope(path ? { kind: "workdir", cwd: path } : { kind: "unscoped" });
+    },
+    [
+      activeWorkspaceProjectPath,
+      workspaceProjects,
+      activateWorkspaceProject,
+      isAgentMode,
+      sidebarStore,
+    ],
   );
 
   const handleSelectWorkspaceProject = useCallback(
@@ -683,6 +735,9 @@ export function useWorkspaceProjects(params: UseWorkspaceProjectsParams) {
     historyScopeKey,
     checkWorkspaceProjectDirectory,
     activateWorkspaceProject,
+    activateSearchConversationWorkspace,
+    clearSearchConversationWorkspace,
+    searchConversationWorkdir: searchCwd,
     handleSelectWorkspaceProject,
     handleNewConversationForProject,
     handleBrowseWorkspaceProjectInFileTree,

--- a/crates/agent-gui/test/chat/search-sidebar-reveal.test.mjs
+++ b/crates/agent-gui/test/chat/search-sidebar-reveal.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDomTestEnv } from "../helpers/dom-test-env.mjs";
+import React from "react";
+
+let dialogProps;
+const scrolls = [];
+const virtualizer = {
+  getVirtualItems: () => [],
+  getTotalSize: () => 3200,
+  scrollToIndex: (index) => scrolls.push(index),
+  measureElement() {},
+};
+const icons = [
+  "AlertCircle",
+  "Blend",
+  "Cable",
+  "Check",
+  "ChevronRight",
+  "CirclePlus",
+  "Folder",
+  "FolderClosed",
+  "FolderOpen",
+  "ListChecks",
+  "Loader2",
+  "PanelLeftClose",
+  "Plus",
+  "Search",
+  "Settings",
+  "Share2",
+  "Trash2",
+  "X",
+];
+const env = await createDomTestEnv({
+  mocks: {
+    "@liveagent/ui/components/IconSet": Object.fromEntries(icons.map((name) => [name, () => null])),
+    "@liveagent/ui/components/ui/button": {
+      Button: ({ children, onClick, ...props }) =>
+        React.createElement(
+          "button",
+          { onClick, "aria-expanded": props["aria-expanded"], "data-testid": props["data-testid"] },
+          children,
+        ),
+    },
+    "@liveagent/ui/components/ui/confirm-dialog": {
+      useConfirmDialog: () => ({ requestConfirmDialog: async () => false }),
+    },
+    "@liveagent/ui/components/ui/dropdown-menu": Object.fromEntries(
+      ["DropdownMenu", "DropdownMenuContent", "DropdownMenuItem", "DropdownMenuTrigger"].map(
+        (name) => [name, ({ children }) => React.createElement("div", null, children)],
+      ),
+    ),
+    "@liveagent/ui/components/ui/input": { Input: (props) => React.createElement("input", props) },
+    "@liveagent/ui/i18n/index": { useLocale: () => ({ t: (key) => key, locale: "en" }) },
+    "@tanstack/react-virtual": { useVirtualizer: () => virtualizer },
+    "./ChatHistorySidebarRows": {
+      HistoryRow: () => null,
+      ProjectRow: () => null,
+      ProjectGroupHeader: () => null,
+    },
+    "./ConversationSearchDialog": {
+      ConversationSearchDialog: (props) => {
+        dialogProps = props;
+        return null;
+      },
+    },
+  },
+});
+const { act, createRoot } = env;
+window.matchMedia = () => ({ matches: false, addEventListener() {}, removeEventListener() {} });
+HTMLElement.prototype.scrollTo = () => {};
+const { ChatHistorySidebar } = env.loadModule(
+  "@liveagent/ui/components/chat/ChatHistorySidebar.tsx",
+);
+const items = Array.from({ length: 100 }, (_, index) => ({
+  id: String(index),
+  title: String(index),
+  cwd: "/repo/b",
+  createdAt: 1,
+  updatedAt: index,
+  providerId: "p",
+  model: "m",
+}));
+
+test("search completion reveals a collapsed virtual list once without saving sidebar preferences", async () => {
+  const container = document.createElement("div"),
+    root = createRoot(container);
+  let props = {
+    items,
+    currentConversationId: "a",
+    busyConversationIds: new Map(),
+    runningConversationIds: new Set(),
+    listStatus: "ready",
+    scopeKey: "cwd:/repo/a",
+    totalItems: 100,
+    hasMore: false,
+    isLoadingMore: false,
+    isOpen: true,
+    recentCollapsed: true,
+    canShareConversations: false,
+    renamingId: null,
+    renameDraft: "",
+    activeProjectId: "a",
+    onRecentCollapsedChange: () => assert.fail("search saved sidebar preferences"),
+  };
+  let completion;
+  props.onSelectConversation = (_id, options) => {
+    completion = options.afterCommit;
+  };
+  try {
+    await act(async () => root.render(React.createElement(ChatHistorySidebar, props)));
+    await act(async () => dialogProps.onSelectConversation("99", { source: "search" }));
+    assert.equal(scrolls.length, 0);
+    props = { ...props, currentConversationId: "99", scopeKey: "cwd:/repo/b", items: [items[99]], listStatus: "syncing" };
+    await act(async () => {
+      root.render(React.createElement(ChatHistorySidebar, props));
+      completion();
+    });
+    assert.deepEqual(scrolls, [], "wait for the target position after the first page arrives");
+    props = { ...props, items, listStatus: "ready" };
+    await act(async () => root.render(React.createElement(ChatHistorySidebar, props)));
+    assert.deepEqual(scrolls, [99]);
+    const list = container.querySelector(".chat-history-list");
+    assert.equal(list.parentElement.getAttribute("aria-hidden"), "false");
+    props = { ...props, items: [...items] };
+    await act(async () => root.render(React.createElement(ChatHistorySidebar, props)));
+    assert.deepEqual(
+      scrolls,
+      [99],
+      "background list refresh must not pull the user back to the row",
+    );
+  } finally {
+    await act(async () => root.unmount());
+  }
+});

--- a/crates/agent-gui/test/chat/search-workspace-navigation.test.mjs
+++ b/crates/agent-gui/test/chat/search-workspace-navigation.test.mjs
@@ -1,0 +1,452 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDomTestEnv } from "../helpers/dom-test-env.mjs";
+
+let readHistory;
+const env = await createDomTestEnv({
+  mocks: {
+    "../../../lib/chat/history/chatHistory": {
+      getChatHistoryWindow: (options) => readHistory(options.id),
+      buildConversationStateFromWindow: (record) => record.state,
+    },
+  },
+});
+const { React, act, createRoot } = env;
+const { useConversationHistoryActions } = env.loadModule(
+  "src/pages/chat/history/useConversationHistoryActions.ts",
+);
+const { useWorkspaceProjects } = env.loadModule("src/pages/chat/workspace/useWorkspaceProjects.ts");
+const { createSidebarStore } = env.loadModule("@liveagent/ui/lib/sidebar/store.ts");
+const { createConversationOpenController } = env.loadModule(
+  "@liveagent/ui/lib/sidebar/openController.ts",
+);
+const { createConversationStateFromContext } = env.loadModule(
+  "src/lib/chat/conversation/conversationState.ts",
+);
+const { getDefaultSettings } = env.loadModule("src/lib/settings/index.ts");
+const ref = (current) => ({ current });
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+const summary = (id, cwd, updatedAt = 1) => ({
+  id,
+  cwd,
+  title: id,
+  providerId: "p",
+  model: "m",
+  createdAt: 1,
+  updatedAt,
+});
+
+async function harness(t, { mode = "tools", archived = [], missing = [] } = {}) {
+  const pending = new Map();
+  readHistory = (id) => new Promise((resolve, reject) => pending.set(id, { resolve, reject }));
+  const store = createSidebarStore(
+    {
+      listConversations: async (_page, _size, scope) => ({
+        items: [summary("recent", scope.kind === "workdir" ? scope.cwd : undefined, 100)],
+        totalCount: 30,
+      }),
+      listWorkdirs: async () => [],
+      subscribeEvents: () => () => {},
+    },
+    { pageSize: 1 },
+  );
+  const currentId = ref("a");
+  const cache = ref(new Map());
+  const cursors = ref(new Map());
+  const sequence = ref(0);
+  let visibleState = createConversationStateFromContext({
+    messages: [],
+    systemPrompt: "",
+    tools: [],
+  });
+  let api, history, setCurrentSettings;
+  let settingsWrites = 0,
+    resets = 0,
+    draftsSaved = 0;
+  const drafts = new Map([["a", "keep this draft"]]);
+  const defaults = getDefaultSettings();
+  let settings = {
+    ...defaults,
+    system: {
+      ...defaults.system,
+      workdir: "/repo/a",
+      executionMode: mode,
+      workspaceProjects: ["a", "b", "c"].map((id) => ({
+        id,
+        path: "/repo/" + id,
+        name: id,
+        kind: "manual",
+        createdAt: 1,
+        updatedAt: 1,
+      })),
+      activeWorkspaceProjectId: "a",
+      archivedWorkspaceProjectPaths: archived,
+      missingWorkspaceProjectPaths: missing,
+    },
+  };
+  const controller = createConversationOpenController({
+    openInitial: (id, request) => history.openInitial(id, request),
+    onStateChange: () => {},
+  });
+  function Host() {
+    const [value, setValue] = React.useState(settings);
+    settings = value;
+    setCurrentSettings = setValue;
+    api = useWorkspaceProjects({
+      settings: value,
+      setSettings: (update) => {
+        settingsWrites++;
+        setValue(update);
+      },
+      sidebarStore: store,
+      isAgentMode: value.system.executionMode !== "text",
+      workdir: "/repo/a",
+      t: (key) => key,
+      setErrorMessage: () => {},
+      setActiveView: () => {},
+      setRightDockOpen: () => {},
+      startNewConversationActionRef: ref(() => assert.fail("search created a conversation")),
+      prepareComposerForConversationChangeActionRef: ref(() =>
+        assert.fail("workspace started a conversation"),
+      ),
+    });
+    history = useConversationHistoryActions({
+      conversationState: visibleState,
+      currentConversationIdRef: currentId,
+      conversationRuntimeCacheRef: cache,
+      conversationPersistenceCursorRef: cursors,
+      conversationLoadSequenceRef: sequence,
+      sidebarStore: store,
+      titleJobRef: ref(null),
+      t: (key) => key,
+      isConversationRunning: () => false,
+      buildRuntimeEntryFromVisibleState: () => ({
+        state: visibleState,
+        sessionId: currentId.current,
+        createdAt: 1,
+        workdir: "/repo/a",
+        isSending: false,
+      }),
+      syncVisibleConversationRuntime: (_id, entry) => {
+        visibleState = entry.state;
+      },
+      resetVisibleTransientState: () => {
+        resets++;
+      },
+      setCurrentConversationId: (id) => {
+        currentId.current = id;
+      },
+      resolveConversationSelectedModel: () => undefined,
+      setErrorMessage: () => {},
+      deleteConversationArtifacts: () => {},
+      hydration: { markHydrating() {}, clearHydrating() {}, markFailed() {} },
+    });
+    return null;
+  }
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(Host));
+  });
+  await act(async () => {
+    store.start();
+    await tick();
+  });
+  t.after(async () => {
+    controller.cancel();
+    store.stop();
+    await act(async () => root.unmount());
+  });
+  return {
+    store,
+    cache,
+    cursors,
+    controller,
+    get api() {
+      return api;
+    },
+    get settings() {
+      return settings;
+    },
+    get id() {
+      return currentId.current;
+    },
+    get writes() {
+      return settingsWrites;
+    },
+    get resets() {
+      return resets;
+    },
+    get draftsSaved() {
+      return draftsSaved;
+    },
+    drafts,
+    select: async (id, source = "search") =>
+      act(async () =>
+        controller.open(
+          id,
+          source === "search"
+            ? {
+                source,
+                beforeCommit: (conversation) => {
+                  api.activateSearchConversationWorkspace(conversation.cwd);
+                  store.upsertLocal(conversation, { reveal: true });
+                  draftsSaved++;
+                },
+              }
+            : undefined,
+        ),
+      ),
+    complete: async (id, cwd) =>
+      act(async () => {
+        pending
+          .get(id)
+          .resolve({
+            conversation: summary(id, cwd),
+            activeSegment: { segmentIndex: 0, segmentId: "s" },
+            state: createConversationStateFromContext({
+              messages: [],
+              systemPrompt: "",
+              tools: [],
+            }),
+          });
+        await tick();
+      }),
+    fail: async (id) =>
+      act(async () => {
+        pending.get(id).reject(new Error("read failed"));
+        await tick();
+      }),
+    setMode: async (executionMode) =>
+      act(async () =>
+        setCurrentSettings((prev) => ({ ...prev, system: { ...prev.system, executionMode } })),
+      ),
+  };
+}
+
+test("desktop commits authoritative workspace and retains a result beyond the first page", async (t) => {
+  const h = await harness(t);
+  await act(async () => h.store.upsertLocal(summary("b", "/stale/path")));
+  await h.select("b");
+  assert.equal(h.id, "a");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/a");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.id, "b");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/b");
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd:/repo/b");
+  await act(async () => h.store.refresh());
+  assert.ok(h.store.getSnapshot().conversations.some((item) => item.id === h.id));
+  assert.equal(h.drafts.get("a"), "keep this draft");
+  assert.equal(h.writes, 1);
+  assert.equal(h.draftsSaved, 1);
+});
+
+test("desktop same-workspace search performs no settings write", async (t) => {
+  const h = await harness(t);
+  await h.select("other-a");
+  await h.complete("other-a", "/repo/a");
+  assert.equal(h.writes, 0);
+  assert.equal(h.id, "other-a");
+});
+
+test("desktop slow B cannot override C and failure leaves the previous navigation intact", async (t) => {
+  const h = await harness(t);
+  await h.select("b");
+  await h.select("c");
+  await h.complete("c", "/repo/c");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.id, "c");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/c");
+  await h.select("bad");
+  await h.fail("bad");
+  assert.equal(h.id, "c");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/c");
+  assert.equal(h.writes, 1);
+  assert.equal(h.resets, 1);
+  assert.equal(h.draftsSaved, 1);
+});
+
+test("desktop cancellation prevents workspace, transcript and composer commits", async (t) => {
+  const h = await harness(t);
+  await h.select("b");
+  h.controller.cancel();
+  await h.complete("b", "/repo/b");
+  assert.equal(h.id, "a");
+  assert.equal(h.writes, 0);
+  assert.equal(h.resets, 0);
+  assert.equal(h.draftsSaved, 0);
+});
+
+test("desktop empty authoritative cwd clears stale scope and project highlight", async (t) => {
+  const h = await harness(t);
+  await act(async () => h.store.upsertLocal(summary("text", "/repo/a")));
+  await h.select("text");
+  await h.complete("text", undefined);
+  assert.equal(h.id, "text");
+  assert.equal(h.api.activeWorkspaceProject, undefined);
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd-empty");
+  assert.ok(h.store.getSnapshot().conversations.some((item) => item.id === "text"));
+  assert.equal(h.store.peek("text").cwd, undefined);
+  assert.equal(h.writes, 0);
+  assert.equal(h.api.searchConversationWorkdir, "");
+});
+
+for (const gesture of ["click", "Enter"]) {
+  test("persisted search result forwards search navigation intent using " + gesture, async () => {
+    let searches = 0;
+    const domEnv = await createDomTestEnv({
+      mocks: {
+        "@liveagent/ui/components/IconSet": Object.fromEntries(
+          ["Clock3", "Loader2", "MessageSquareText", "Pin", "Search"].map((key) => [
+            key,
+            () => null,
+          ]),
+        ),
+        "@liveagent/ui/components/ui/dialog": Object.fromEntries(
+          ["Dialog", "DialogContent", "DialogDescription", "DialogTitle"].map((key) => [
+            key,
+            ({ children }) => React.createElement("div", null, children),
+          ]),
+        ),
+        "@liveagent/ui/components/ui/input": {
+          Input: (props) => React.createElement("input", props),
+        },
+        "@liveagent/ui/i18n/index": { useLocale: () => ({ t: (key) => key, locale: "en" }) },
+        "@liveagent/ui/lib/chat/conversationSearch": {
+          searchPersistedConversations: async () => {
+            searches++;
+            return [{ id: "b", title: "result in B", cwd: "/repo/b", updatedAt: 1 }];
+          },
+        },
+      },
+    });
+    const { ConversationSearchDialog } = domEnv.loadModule(
+      "@liveagent/ui/components/chat/ConversationSearchDialog.tsx",
+    );
+    HTMLElement.prototype.scrollIntoView = () => {};
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container),
+      calls = [];
+    try {
+      await act(async () =>
+        root.render(
+          React.createElement(ConversationSearchDialog, {
+            open: true,
+            conversations: [],
+            currentWorkdir: "/repo/a",
+            onOpenChange() {},
+            onSelectConversation: (id, options) => calls.push({ id, options }),
+          }),
+        ),
+      );
+      const input = container.querySelector("input");
+      await act(async () => {
+        Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set.call(
+          input,
+          "needle",
+        );
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      await act(async () => new Promise((resolve) => setTimeout(resolve, 220)));
+      assert.equal(searches, 1);
+      await act(async () => {
+        if (gesture === "click") container.querySelector('[role="option"]').click();
+        else input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      });
+      assert.deepEqual(calls, [{ id: "b", options: { source: "search" } }]);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+      domEnv.cleanup();
+      globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    }
+  });
+}
+
+test("desktop text mode supports unscoped history and cross-workspace navigation", async (t) => {
+  const h = await harness(t, { mode: "text" });
+  await h.select("text");
+  await h.complete("text", undefined);
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd-empty");
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd:/repo/b");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/b");
+});
+
+test("desktop archived or missing directories remain readable without clearing the missing marker", async (t) => {
+  const h = await harness(t, { archived: ["/repo/b"], missing: ["/repo/b"] });
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/b");
+  assert.ok(h.settings.system.missingWorkspaceProjectPaths.includes("/repo/b"));
+  assert.ok(!h.settings.system.archivedWorkspaceProjectPaths.includes("/repo/b"));
+});
+
+test("desktop preserves live runtime updates while refreshing cached history metadata", async (t) => {
+  const h = await harness(t);
+  h.cache.current.set("b", {
+    state: { marker: "before" },
+    isSending: true,
+    sessionId: "b",
+    createdAt: 1,
+    workdir: "/stale",
+  });
+  await h.select("b");
+  const live = {
+    state: { marker: "new streaming token" },
+    isSending: true,
+    sessionId: "b",
+    createdAt: 1,
+    workdir: "/stale",
+  };
+  h.cache.current.set("b", live);
+  await h.complete("b", "/repo/b");
+  assert.equal(h.cache.current.get("b").state, live.state);
+  assert.equal(h.cache.current.get("b").workdir, "/repo/b");
+});
+
+test("desktop ordinary conversation selection does not activate another workspace", async (t) => {
+  const h = await harness(t);
+  await h.select("b", "sidebar");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.id, "b");
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/a");
+  assert.equal(h.writes, 0);
+});
+
+test("desktop workspace selection and mode changes release the search-only scope", async (t) => {
+  const h = await harness(t);
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  await act(async () => h.api.setActiveWorkspaceProjectId("c"));
+  assert.equal(h.api.activeWorkspaceProjectPath, "/repo/c");
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd:/repo/c");
+  await h.select("text");
+  await h.complete("text", undefined);
+  await h.setMode("text");
+  await h.setMode("tools");
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd:/repo/c");
+});
+
+test("desktop retry after failure uses the newest result and repeated selection avoids settings writes", async (t) => {
+  const h = await harness(t);
+  await h.select("b");
+  await h.fail("b");
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  assert.equal(h.id, "b");
+  assert.equal(h.writes, 1);
+  assert.equal(h.drafts.get("a"), "keep this draft");
+});
+
+test("desktop search scope can be cleared before creating a text-mode draft", async (t) => {
+  const h = await harness(t, { mode: "text" });
+  await h.select("b");
+  await h.complete("b", "/repo/b");
+  await act(async () => h.api.clearSearchConversationWorkspace());
+  assert.equal(h.store.getSnapshot().scopeKey, "cwd-empty");
+});

--- a/crates/agent-gui/test/chat/sidebar-conversation-search-ui.test.mjs
+++ b/crates/agent-gui/test/chat/sidebar-conversation-search-ui.test.mjs
@@ -43,7 +43,7 @@ test("conversation search uses the configurable desktop shortcut action end to e
 
 test("conversation search opens history directly instead of creating a composer reference", () => {
   assert.match(dialogSource, /searchPersistedConversations/);
-  assert.match(dialogSource, /onSelectConversation\(id\)/);
+  assert.match(dialogSource, /source: "search"/);
   assert.match(dialogSource, /chat\.pinnedConversations/);
   assert.match(dialogSource, /chat\.recentConversation/);
   assert.match(dialogSource, /item\.searchPreview/);

--- a/crates/agent-ui/src/components/chat/ChatHistorySidebar.tsx
+++ b/crates/agent-ui/src/components/chat/ChatHistorySidebar.tsx
@@ -50,6 +50,7 @@ import {
   useRef,
   useState,
 } from "react";
+import type { ConversationOpenOptions } from "../../lib/sidebar/openController";
 import type { SidebarConversation } from "../../lib/sidebar/types";
 import {
   buildWorkspaceProjectSections,
@@ -195,7 +196,7 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
     projectsCollapsed = false,
     workspaceFolderDropActive = false,
     workspaceFolderDropHandlers,
-    recentCollapsed = false,
+    recentCollapsed: persistedRecentCollapsed = false,
     onProjectsCollapsedChange,
     onRecentCollapsedChange,
     onCreateProject,
@@ -244,6 +245,12 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
   const { t } = useLocale();
 
   const [conversationSearchOpen, setConversationSearchOpen] = useState(false);
+  const [revealedSearchConversationId, setRevealedSearchConversationId] = useState<string | null>(
+    null,
+  );
+  const pendingSearchScrollRef = useRef<string | null>(null);
+  const recentCollapsed =
+    revealedSearchConversationId === currentConversationId ? false : persistedRecentCollapsed;
   const lastConversationSearchRequestKeyRef = useRef(conversationSearchRequestKey);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [selectionMode, setSelectionMode] = useState(false);
@@ -348,12 +355,26 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
       ),
     [busyConversationIds, items, runningConversationIds, sectionsDisabled],
   );
-  const handleSelectConversation = useStableEvent((id: string) => {
-    if (!sectionsDisabled) {
-      selectionAnchorRef.current = id;
-      onSelectConversation(id);
-    }
-  });
+  const handleSelectConversation = useStableEvent(
+    (id: string, options?: ConversationOpenOptions) => {
+      if (!sectionsDisabled) {
+        selectionAnchorRef.current = id;
+        onSelectConversation(
+          id,
+          options?.source === "search"
+            ? {
+                ...options,
+                afterCommit: () => {
+                  pendingSearchScrollRef.current = id;
+                  setRevealedSearchConversationId(id);
+                  options.afterCommit?.();
+                },
+              }
+            : options,
+        );
+      }
+    },
+  );
   const handleStartRenaming = useStableEvent((item: SidebarConversation) => {
     if (!sectionsDisabled) {
       onStartRenaming(item);
@@ -439,6 +460,7 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
   });
   const handleRecentCollapsedChange = useStableEvent(() => {
     if (!sectionsDisabled) {
+      setRevealedSearchConversationId(null);
       onRecentCollapsedChange?.(!recentCollapsed);
     }
   });
@@ -954,6 +976,29 @@ export const ChatHistorySidebar = memo(function ChatHistorySidebar(props: ChatHi
   useEffect(() => {
     historyScrollRef.current?.scrollTo({ top: 0 });
   }, [scopeKey]);
+
+  useEffect(() => {
+    if (
+      !isOpen ||
+      listStatus !== "ready" ||
+      revealedSearchConversationId !== currentConversationId ||
+      recentCollapsed ||
+      pendingSearchScrollRef.current !== currentConversationId
+    )
+      return;
+    const index = items.findIndex((item) => item.id === revealedSearchConversationId);
+    if (index < 0) return;
+    historyVirtualizer.scrollToIndex(index, { align: "auto" });
+    pendingSearchScrollRef.current = null;
+  }, [
+    currentConversationId,
+    historyVirtualizer,
+    isOpen,
+    items,
+    listStatus,
+    recentCollapsed,
+    revealedSearchConversationId,
+  ]);
 
   useEffect(() => {
     if (

--- a/crates/agent-ui/src/components/chat/ChatHistorySidebarTypes.ts
+++ b/crates/agent-ui/src/components/chat/ChatHistorySidebarTypes.ts
@@ -4,6 +4,7 @@ import type {
   SidebarBatchDeleteResult,
 } from "@liveagent/ui/lib/sidebar/batchDelete";
 import type { ReactNode } from "react";
+import type { ConversationOpenOptions } from "../../lib/sidebar/openController";
 import type { SidebarConversation } from "../../lib/sidebar/types";
 import type { WorkspaceProjectGroup } from "../../lib/workspaceProjectTypes";
 
@@ -95,7 +96,7 @@ export type ChatHistorySidebarProps = {
   // collapsed group at the end of the list.
   archivedProjectPathKeys?: ReadonlySet<string>;
   onNewConversation: () => void;
-  onSelectConversation: (id: string) => void;
+  onSelectConversation: (id: string, options?: ConversationOpenOptions) => void;
   /** Workbench drag intent from a conversation row title (desktop pointer). */
   onConversationWorkbenchDragIntent?: (
     item: SidebarConversation,

--- a/crates/agent-ui/src/components/chat/ConversationSearchDialog.tsx
+++ b/crates/agent-ui/src/components/chat/ConversationSearchDialog.tsx
@@ -13,6 +13,7 @@ import {
 } from "@liveagent/ui/lib/chat/conversationSearch";
 import { cn } from "@liveagent/ui/lib/shared/utils";
 import { Fragment, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ConversationOpenOptions } from "../../lib/sidebar/openController";
 import type { SidebarConversation } from "../../lib/sidebar/types";
 
 type ConversationSearchDialogProps = {
@@ -20,7 +21,7 @@ type ConversationSearchDialogProps = {
   onOpenChange: (open: boolean) => void;
   conversations: readonly SidebarConversation[];
   currentWorkdir?: string;
-  onSelectConversation: (id: string) => void;
+  onSelectConversation: (id: string, options?: ConversationOpenOptions) => void;
 };
 
 type SearchStatus = "idle" | "loading" | "ready" | "error";
@@ -190,7 +191,9 @@ export function ConversationSearchDialog({
 
   const selectConversation = (id: string) => {
     onOpenChange(false);
-    onSelectConversation(id);
+    const isLocalDraft =
+      !normalizedQuery && conversations.some((item) => item.id === id && item.isPending);
+    onSelectConversation(id, isLocalDraft ? undefined : { source: "search" });
   };
 
   return (

--- a/crates/agent-ui/src/lib/sidebar/openController.ts
+++ b/crates/agent-ui/src/lib/sidebar/openController.ts
@@ -1,3 +1,15 @@
+import type { SidebarConversation } from "./types";
+
+export type ConversationOpenOptions = {
+  source?: "search";
+  beforeCommit?: (conversation: SidebarConversation) => void;
+  afterCommit?: () => void;
+};
+
+export type ConversationOpenRequest = ConversationOpenOptions & {
+  isCurrent: () => boolean;
+};
+
 export type ConversationOpenPhase = "idle" | "opening" | "ready" | "failed";
 
 export type ConversationOpenState = {
@@ -8,14 +20,17 @@ export type ConversationOpenState = {
 };
 
 export type ConversationOpenController = {
-  open(conversationId: string): void;
+  open(conversationId: string, options?: ConversationOpenOptions): void;
   cancel(): void;
   getSequence(): number;
   getState(): ConversationOpenState;
 };
 
 export type ConversationOpenControllerDeps = {
-  openInitial(conversationId: string): Promise<"cache-hit" | "painted">;
+  openInitial(
+    conversationId: string,
+    request?: ConversationOpenRequest,
+  ): Promise<"cache-hit" | "painted">;
   onStateChange(state: ConversationOpenState): void;
   overlayDelayMs?: number;
 };
@@ -49,7 +64,7 @@ export function createConversationOpenController(
   };
 
   return {
-    open: (conversationId) => {
+    open: (conversationId, options) => {
       sequence += 1;
       const requestSequence = sequence;
       clearOverlayTimer();
@@ -61,7 +76,7 @@ export function createConversationOpenController(
       }, overlayDelayMs);
 
       deps
-        .openInitial(conversationId)
+        .openInitial(conversationId, { ...options, isCurrent: () => requestSequence === sequence })
         .then(() => {
           if (requestSequence !== sequence) return;
           clearOverlayTimer();

--- a/crates/agent-ui/src/lib/sidebar/store.ts
+++ b/crates/agent-ui/src/lib/sidebar/store.ts
@@ -81,7 +81,7 @@ export type SidebarStore = {
   setCwd(id: string, cwd: string): Promise<boolean>;
   remove(id: string): Promise<boolean>;
   clearMutationError(id: string): void;
-  upsertLocal(conversation: SidebarConversation): void;
+  upsertLocal(conversation: SidebarConversation, options?: { reveal?: boolean }): void;
   removeLocal(conversationId: string): void;
   applyRunningPatch(patch: {
     conversationId: string;
@@ -188,8 +188,11 @@ export function createSidebarStore(
     return ids;
   };
 
+  let revealedConversationId: string | null = null;
+
   const retainedConversationIds = () => {
     const ids = new Set<string>(snapshot.mutations.keys());
+    if (revealedConversationId) ids.add(revealedConversationId);
     for (const id of backend.getProtectedConversationIds?.() ?? []) {
       const trimmed = id.trim();
       if (trimmed) ids.add(trimmed);
@@ -830,8 +833,13 @@ export function createSidebarStore(
       commit({ mutationErrors });
     },
 
-    upsertLocal: (conversation) => {
-      const merged = mergeSidebarConversation(byId.get(conversation.id), conversation);
+    upsertLocal: (conversation, options) => {
+      if (options?.reveal) revealedConversationId = conversation.id;
+      const existing = byId.get(conversation.id);
+      const merged = mergeSidebarConversation(
+        options?.reveal && existing ? { ...existing, cwd: conversation.cwd } : existing,
+        conversation,
+      );
       byId = new Map(byId);
       byId.set(merged.id, merged);
       const inScope = conversationMatchesScope(merged, scope);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 6.0.1
         version: 6.0.1(vite@8.0.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
+      jsdom:
+        specifier: 30.0.1
+        version: 30.0.1
       postcss:
         specifier: 8.5.8
         version: 8.5.8


### PR DESCRIPTION
## Linked issue

Closes #752

## Summary

从工作空间 A 搜索并打开 B 的历史会话时，主面板会切到 B，但左侧工作空间、最近会话列表和当前行仍停留在 A。本次修复让 Desktop 和 Gateway WebUI 在历史读取成功后，一起提交目标会话、工作空间和侧栏状态。

- 以加载后的持久化 cwd 为准；保留目标会话摘要，使不在最近首屏的搜索结果也能显示并高亮。
- 打开成功后临时展开最近会话并定位目标行，不写入折叠偏好，后续刷新不重复抢占滚动。
- 用请求序列和取消状态阻止过期响应覆盖新选择；读取失败或取消时保留原导航上下文和草稿。
- 覆盖同工作空间、无 cwd、text mode、归档或缺失目录、失败重试和重复选择；保留普通侧栏和 Workbench 导航语义。

## Change scope

- Modules: agent-ui、agent-gui、agent-gateway/web。
- 共享搜索弹窗、侧栏 store、打开控制器和目标行定位。
- Desktop / WebUI 的历史加载、工作空间激活和搜索范围恢复。
- 新增 3 个行为测试文件（26 个用例），更新原搜索 UI 断言。
- WebUI 增加 jsdom 开发依赖，并同步 pnpm lockfile，以便独立 CI job 运行行为测试。

## Screenshots / preview

<img width="1280" height="762" alt="17-25-32" src="https://github.com/user-attachments/assets/161c353d-c429-42b4-b461-ec8db1039dc8" />

### 跨工作空间搜索与跳转

<!-- 在这里上传从工作空间 A 搜索并打开 B 会话后的截图：主面板、项目高亮、最近列表与当前行应一致。 -->

### 最近会话展开与目标行定位

<!-- 在这里上传折叠最近会话后，通过搜索打开旧会话并自动定位目标行的截图或录屏。 -->

## Verification

人工验收：用户已于 2026-09-05 明确确认当前分支修改通过人工验证，并授权提交、推送和创建 PR。未额外声称 Gateway 浏览器人工验收或故障注入场景已由用户执行。

本次提交前复核：

| 检查 | 结果 |
| --- | --- |
| pnpm --dir crates/agent-gui build | 通过；有大 chunk 提示 |
| pnpm --dir crates/agent-gateway/web build | 通过 |
| node --test crates/agent-gui/test/chat/search-workspace-navigation.test.mjs crates/agent-gui/test/chat/search-sidebar-reveal.test.mjs crates/agent-gateway/web/test/search-workspace-navigation.test.mjs | 26/26 通过 |
| pnpm --dir crates/agent-gateway/web test | 708/708 通过 |
| pnpm --dir crates/agent-gui test:frontend，加载只读 CRLF 归一化 preload | 3003/3003 通过；未修改源码或断言 |
| 在各包目录对本次 13 个源码文件运行 biome check --error-on-warnings | 通过 |
| node scripts/check-ui-boundaries.mjs，加载相同只读 CRLF 归一化 preload | 通过 |
| git diff --check / git diff --cached --check | 通过 |

已有实现阶段验证记录及限制：

- Windows 原工作区的 GUI 全量测试有 5 项既有 CRLF 字面断言失败；preload 仅在读取返回字符串时把 CRLF 转为 LF，原断言完整运行。上述 3003/3003 是采用该方式的本次复核结果。
- GUI/WebUI 原始全量 lint 受既有 CRLF 影响；实现阶段只读 LF 复核分别覆盖 332 / 148 个文件，无错误。共享 UI 的 491 个文件中有 7 个未改动文件存在既有格式差异。本次重新运行并通过的是 13 个改动源码文件检查，未把全量原始 lint 记为通过。
- scripts/check-mirror.mjs 已由上游 #399 删除并替换为共享 UI 边界检查，因此旧命令未运行。
- 未运行 Rust/Go 本地 build/test，本次没有对应源码改动。
- 自动化专用场景通过注入历史响应、控制 Promise 完成顺序或直接调用 hook/store 验证，包括竞态、读取拒绝、取消、权威 cwd、首屏外保留和 settings 写入次数；这些不记作人工验收。
- GitHub CI 以此 PR 的 checks 为准。

## Dependencies

Depends-On: none
Stack-Root: #763

## Pre-submit checklist

- [x] 已关联问题 #752。
- [x] 基线为上游 main 的 be86449f5b4c609ad485138348ea5618b0c8777b，提交前已核对远端，无依赖 PR。
- [x] 仅提交本次修复、测试及其开发依赖变更。
- [x] 本地启动脚本、个人规则、研究资料和工作日志未纳入提交。
- [x] 未提交密钥、token 或个人数据。
- [x] 人工验收已由用户确认通过。
- [ ] 补充截图后完成上游 UI 预览要求。
