### PR TITLE
fix(fs): Windows 下文件树"打开所在目录"对含空格路径失效

### DIFF
--- a/crates/agent-gui/src-tauri/src/commands/workspace/fs.rs
+++ b/crates/agent-gui/src-tauri/src/commands/workspace/fs.rs
@@ -3433,9 +3433,17 @@ pub(crate) fn spawn_workspace_open_command(target: &Path, mode: &str) -> Result<
 
 #[cfg(target_os = "windows")]
 fn workspace_open_command(target: &Path, mode: &str) -> Command {
+    use std::os::windows::process::CommandExt;
+
     let mut command = Command::new("explorer.exe");
     if mode == "reveal" {
-        command.arg(format!("/select,{}", target.display()));
+        // explorer.exe 自行解析命令行:未加引号的路径会在第一个空格处被截断
+        // (例如 `D:\Videos\JianyingPro Materials\a.txt` 会被截成
+        // `D:\Videos\JianyingPro`,路径无效时 explorer 回退打开默认的
+        // "文档" 目录)。而 Rust 标准库默认的引号规则会把整个
+        // `/select,<path>` 包进引号,explorer 同样解析不了。这里用 raw_arg
+        // 绕过默认引号,只给路径部分加引号:`/select,"<path>"`。
+        command.raw_arg(format!("/select,\"{}\"", target.display()));
     } else {
         command.arg(target);
     }
@@ -4819,7 +4827,26 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(command.get_program(), std::ffi::OsStr::new("explorer.exe"));
-        assert_eq!(args, vec![r"/select,C:\work\Dangerous.bundle"]);
+        assert_eq!(args, vec![r#"/select,"C:\work\Dangerous.bundle""#]);
+    }
+
+    // 路径含空格时引号必须保住整个路径,否则 explorer 在空格处截断参数,
+    // 回退打开默认的 "文档" 目录(文件树"打开所在目录"空格路径 bug)。
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_reveal_quotes_paths_with_spaces() {
+        let target = Path::new(r"D:\Videos\JianyingPro Materials\clip 01.mp4");
+        let command = workspace_open_command(target, "reveal");
+        let args = command
+            .get_args()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(command.get_program(), std::ffi::OsStr::new("explorer.exe"));
+        assert_eq!(
+            args,
+            vec![r#"/select,"D:\Videos\JianyingPro Materials\clip 01.mp4""#]
+        );
     }
 
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]


### PR DESCRIPTION
Fixes #774

## 问题

Windows 下文件树右键"打开所在目录",如果路径里有空格,explorer 打开的是默认的"文档"目录,不是文件所在目录。

## 原因

reveal 走的是 `explorer.exe /select,<path>`,路径没加引号:

```rust
command.arg(format!("/select,{}", target.display()));
```

explorer.exe 自己解析命令行,未加引号的参数在第一个空格处截断。`D:\Videos\素材\Jianying\JianyingPro Materials\xxx.mp4` 被截成 `...\JianyingPro`,路径无效,explorer 回退打开"文档"目录。

直接给 `arg()` 传带引号的字符串也不行:Rust 标准库会把整个参数再包一层引号并转义内部引号,explorer 同样解析不了。

## 修复

用 Windows 专属的 `raw_arg` 绕过标准库的引号规则,只给路径部分加引号:

```rust
command.raw_arg(format!("/select,\"{}\"", target.display()));
```

生成的命令行为 `explorer.exe /select,"D:\...\JianyingPro Materials\xxx.mp4"`,explorer 能正确解析。

## 影响范围

- 仅 Windows Desktop 端的 reveal 模式;`open` 模式(单参数路径)标准库引号处理正确,不改
- `chat_file_links.rs` 的文件链接 reveal 复用同一个 `spawn_workspace_open_command`,一并修复
- macOS / Linux / Web 端不受影响

## 测试

- 更新 `windows_reveal_selects_directory_targets_in_explorer` 断言为带引号的形式
- 新增 `windows_reveal_quotes_paths_with_spaces`,用含空格路径验证引号包裹
- 两个测试在 Windows 本机通过;全量 lib 测试中的 23 个失败项经 stash 对比确认是本机环境的既有问题(sandbox/worktree/hook),与本次修改无关
- 本机实测:在 `D:\Videos\素材\Jianying\JianyingPro Materials` 工作区右键"打开所在目录",explorer 正确打开目录并选中文件

## 截图

### 修复前

<img width="244" height="168" alt="00-24-46" src="https://github.com/user-attachments/assets/a4b09ab9-6fe0-4dbe-b5ab-29e5e3c79a60" />

### 修复后

<img width="213" height="297" alt="00-26-45" src="https://github.com/user-attachments/assets/441363ea-ef1a-4e59-90cf-fe99c78985e4" />
