### PR TITLE
fix(release): 发布说明改用 DeepSeek 官方 API 并收敛密钥来源

### DIFF
--- a/crates/agent-gui/test/backend/release-notes.test.mjs
+++ b/crates/agent-gui/test/backend/release-notes.test.mjs
@@ -98,8 +98,7 @@ test("AI release notes script falls back when no API key is configured", () => {
 
     const result = runNotesScript(["v0.1.6", outputPath, fallbackPath], {
       AI_RELEASE_NOTES_API_KEY: "",
-      PACKYCODE_API_KEY: "",
-      OPENAI_API_KEY: "",
+      DEEPSEEK_API_KEY: "",
     });
 
     assert.equal(
@@ -156,8 +155,7 @@ test("AI release notes script calls Chat Completions API and writes markdown", a
       AI_RELEASE_NOTES_BASE_URL: `http://${address.address}:${address.port}/v1`,
       AI_RELEASE_NOTES_MODEL: "gpt-test",
       AI_RELEASE_NOTES_TIMEOUT_MS: "2000",
-      PACKYCODE_API_KEY: "",
-      OPENAI_API_KEY: "",
+      DEEPSEEK_API_KEY: "",
     }, { cwd: dir });
 
     assert.equal(
@@ -227,8 +225,7 @@ test("AI release notes script falls back to Responses API when chat output is em
       AI_RELEASE_NOTES_BASE_URL: `http://${address.address}:${address.port}/v1`,
       AI_RELEASE_NOTES_MODEL: "gpt-test",
       AI_RELEASE_NOTES_TIMEOUT_MS: "2000",
-      PACKYCODE_API_KEY: "",
-      OPENAI_API_KEY: "",
+      DEEPSEEK_API_KEY: "",
     }, { cwd: dir });
 
     assert.equal(

--- a/scripts/release/create-ai-release-notes.mjs
+++ b/scripts/release/create-ai-release-notes.mjs
@@ -5,8 +5,8 @@ import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { parseReleaseVersion } from "./release-version.mjs";
 
-const DEFAULT_BASE_URL = "https://codex-api.packycode.com/v1";
-const DEFAULT_MODEL = "gpt-5.5";
+const DEFAULT_BASE_URL = "https://api.deepseek.com/v1";
+const DEFAULT_MODEL = "deepseek-flash";
 const DEFAULT_REASONING_EFFORT = "";
 const MAX_CONTEXT_CHARS = 22000;
 
@@ -294,11 +294,9 @@ async function createChatCompletion({ apiKey, baseUrl, model, prompt, reasoningE
 
 async function main() {
   const apiKey =
-    process.env.AI_RELEASE_NOTES_API_KEY?.trim() ||
-    process.env.PACKYCODE_API_KEY?.trim() ||
-    process.env.OPENAI_API_KEY?.trim();
+    process.env.AI_RELEASE_NOTES_API_KEY?.trim() || process.env.DEEPSEEK_API_KEY?.trim();
   if (!apiKey) {
-    writeFallback("missing AI_RELEASE_NOTES_API_KEY/PACKYCODE_API_KEY/OPENAI_API_KEY");
+    writeFallback("missing AI_RELEASE_NOTES_API_KEY/DEEPSEEK_API_KEY");
     return;
   }
 


### PR DESCRIPTION
## Linked issue

Closes #791

## Summary

发布流水线的 AI 说明生成自 v1.2.7 起持续失败：上游中转对非标准 Codex 客户端返回 403，脚本随即**静默回退**成 GitHub 按 label 自动生成的列表，对外说明因此只剩一个 `### Other Changes` 分组（v1.2.7 → v1.3.3 共 6 版受影响）。

本次把发布说明生成切到 DeepSeek 官方 API，并把密钥/端点/模型收敛为环境变量：

- 默认端点 `https://api.deepseek.com/v1`、默认模型 `deepseek-flash`；
- 密钥来源收敛为 `AI_RELEASE_NOTES_API_KEY` / `DEEPSEEK_API_KEY`，不再回退到 `PACKYCODE_API_KEY` / `OPENAI_API_KEY`。CI 里 `PACKYCODE_API_KEY` 一直存在，保留它会让「新 secret 缺失」这种情况把中转凭据打到 DeepSeek 端点并再次静默降级；现在缺 key 会明确报错；
- 端点与模型仍可被 `AI_RELEASE_NOTES_BASE_URL` / `AI_RELEASE_NOTES_MODEL` 仓库变量覆盖。

> 注：跟随本改动的另一处小清理（删除 `desktop-release.yml` 中已无用的 `PACKYCODE_API_KEY` env 行）**未包含在本 PR**——推送 workflow 文件需要 `workflow` scope，当前凭据不具备，将另行提交。

## Change scope

- Modules: release tooling（发布脚本与其用例）
- Key paths: `scripts/release/create-ai-release-notes.mjs`、`crates/agent-gui/test/backend/release-notes.test.mjs`

## Screenshots / preview

N/A —— 纯发布脚本改动，无 UI 变更。

## Verification

- `pnpm test:release`：9/9 通过（含 3 个 release notes 用例）；
- `pnpm check:script-tests`：12/12 通过；
- `git diff --check`：通过；
- 真实端点冒烟：以占位 key 请求 `https://api.deepseek.com/v1/chat/completions` 返回 `401 Authentication Fails`——说明端点、方法与请求体形状均被接受，仅密钥无效，随后按预期走 fallback（此前中转返回的是 502/403）。

## Pre-submit checklist

- [x] A requirement issue is linked
- [x] Synced with the target branch; no merge conflicts
- [x] The change is focused, with no unrelated modifications
- [x] No secrets, tokens, or personal data included
- [x] 无需文档改动：仓库现有文档未描述这些发布环境变量，脚本内的变量名与默认值已自解释
