### PR TITLE
feat(models): match relay ids with a month-day date suffix against the catalog

### DIFF
--- a/crates/agent-gui/test/models/model-catalog.test.mjs
+++ b/crates/agent-gui/test/models/model-catalog.test.mjs
@@ -155,6 +155,27 @@ test("normalizeModelIdCandidates yields the decorated-id chain in order without 
   assert.deepEqual(catalog.normalizeModelIdCandidates("grok-4.5"), ["grok-4.5"]);
 });
 
+test("normalizeModelIdCandidates strips a month-day date suffix only when no full date is present", () => {
+  // 中转站给官方模型加四位月日后缀（deepseek-ai/deepseek-v4-pro-0813）。
+  assert.deepEqual(catalog.normalizeModelIdCandidates("deepseek-ai/deepseek-v4-pro-0813"), [
+    "deepseek-ai/deepseek-v4-pro-0813",
+    "deepseek-ai/deepseek-v4-pro",
+    "deepseek-v4-pro-0813",
+    "deepseek-v4-pro",
+  ]);
+  // 年份、型号数字不是月日，不剥。
+  assert.deepEqual(catalog.normalizeModelIdCandidates("gpt-4o-2024"), ["gpt-4o-2024"]);
+  assert.deepEqual(catalog.normalizeModelIdCandidates("model-1345"), ["model-1345"]);
+});
+
+test("a dated relay id resolves to the catalog entry, an exact dated id keeps its own entry", () => {
+  const relayed = catalog.findCatalogModelAcrossProviders("deepseek-ai/deepseek-v4-pro-0813");
+  assert.equal(relayed?.id, "deepseek-v4-pro");
+  assert.equal(relayed?.contextWindow, 1000000);
+  assert.equal(catalog.findCatalogModelAcrossProviders("deepseek-r1-0528")?.id, "deepseek-r1-0528");
+  assert.equal(catalog.findCatalogModelAcrossProviders("deepseek-r1-0601")?.id, "deepseek-r1");
+});
+
 test("findCatalogModel resolves exact and decorated ids across providers", () => {
   assert.equal(catalog.findCatalogModel("xai", "grok-4.5")?.id, "grok-4.5");
   // 候选链对全部供应商生效：大小写、[1m]、日期后缀、@版本。

--- a/crates/agent-ui/src/lib/models/modelCatalog.ts
+++ b/crates/agent-ui/src/lib/models/modelCatalog.ts
@@ -79,16 +79,26 @@ export function normalizeModelIdCandidates(modelId: string): string[] {
   push(withoutAtVersion);
   const withoutContextSuffix = withoutAtVersion.replace(/\[1m\]$/i, "");
   push(withoutContextSuffix);
-  push(withoutContextSuffix.replace(/-20\d{6}$/, ""));
+  for (const candidate of withoutDateSuffix(withoutContextSuffix)) push(candidate);
   // 中转聚合商常在模型 id 前加自家路径前缀（bailian/deepseek-v4-pro、
   // openrouter/xxx 等），目录里存的是裸 id。放链尾——所有精确形态、
   // 全部分区都查空后才尝试剥前缀，避免裸段误撞目录里无关的同名模型。
   const lastSegment = withoutContextSuffix.split("/").pop() ?? "";
   if (lastSegment !== withoutContextSuffix) {
     push(lastSegment);
-    push(lastSegment.replace(/-20\d{6}$/, ""));
+    for (const candidate of withoutDateSuffix(lastSegment)) push(candidate);
   }
   return candidates;
+}
+
+// 日期后缀有两种写法：完整的 -20260115 和中转站常用的四位月日 -0813 /
+// -0731（deepseek-ai/deepseek-v4-pro-0813）。四位形态只在没有完整日期
+// 时才剥，且只认合法的月日，避免把 -2024 之类的年份或型号数字误当日期。
+function withoutDateSuffix(modelId: string): string[] {
+  const withoutFullDate = modelId.replace(/-20\d{6}$/, "");
+  if (withoutFullDate !== modelId) return [withoutFullDate];
+  const withoutMonthDay = modelId.replace(/-(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])$/, "");
+  return withoutMonthDay !== modelId ? [withoutMonthDay] : [];
 }
 
 const catalogIndexByProvider = new Map<CatalogProviderId, Map<string, CatalogModelEntry>>();


### PR DESCRIPTION
Closes #794 (split out of #786, part 2 of that report: catalog matching for dated relay ids; part 1 stays tracked in #786)

## Problem

Relays often expose an official model as `<vendor>/<id>-MMDD`, e.g. `deepseek-ai/deepseek-v4-pro-0813`. `normalizeModelIdCandidates` in `crates/agent-ui/src/lib/models/modelCatalog.ts` already strips the vendor prefix and a full `-YYYYMMDD` date, but not the four-digit month-day form. The id therefore missed `deepseek-v4-pro` (contextWindow 1,000,000 / maxOutputToken 384,000) and `getProviderModelDefaults` fell back to the provider's default limits (400,000 / 142,000 in the report), which undercounts the window by about half and makes the auto-compaction threshold fire far too early.

## Change

- A trailing `-MMDD` is stripped as an additional candidate, only when no full date is present and only for a valid month and day (`-2024`, `-1345` and similar are left alone). This applies to the raw id and, at the end of the chain as before, to its last path segment.
- Candidate order is unchanged: exact forms first, so an id that exists in the catalog with its date (`deepseek-r1-0528`) keeps matching its own entry; `deepseek-r1-0601` resolves to `deepseek-r1`.

Not included: part 1 of the report (a configurable auto-compaction threshold). That is a settings surface in `crates/agent-gui/src/lib/chat/compaction/policy.ts` and worth its own change; this one only fixes the catalog miss that made the current threshold fire early.

## Tests

`crates/agent-gui/test/models/model-catalog.test.mjs`

- candidate chain for `deepseek-ai/deepseek-v4-pro-0813` (vendor prefix and month-day suffix, in order), and no stripping for `gpt-4o-2024` / `model-1345`;
- `findCatalogModelAcrossProviders("deepseek-ai/deepseek-v4-pro-0813")` resolves to `deepseek-v4-pro` with the 1,000,000 window, `deepseek-r1-0528` keeps its own entry, `deepseek-r1-0601` resolves to `deepseek-r1`.

`node scripts/run-node-tests.mjs --include-prefix model-catalog crates/agent-gui/test`: 12 pass (fails on `main` for the two new cases). `biome check` and `tsc --noEmit` in `crates/agent-ui` are clean.



## Screenshots / preview

No visual change: the change is a lookup helper in `crates/agent-ui/src/lib/models/modelCatalog.ts` (candidate chain for catalog matching) plus its unit tests. Nothing rendered differs; the effect is that the model's context window resolves to the catalog value instead of the provider fallback, which the test output pins.

Observable effect, in numbers rather than pixels, for `deepseek-ai/deepseek-v4-pro-0813`:

| | contextWindow | maxOutputToken | source |
| --- | --- | --- | --- |
| before | 400,000 | 142,000 | provider default (catalog miss) |
| after | 1,000,000 | 384,000 | catalog entry `deepseek-v4-pro` |

The governance check flags this PR because `crates/agent-ui/src/` is in its UI path list, but the file it touches has no rendered surface, so there is no before/after frame to capture. Happy to add anything else that would serve as evidence here.

