### PR TITLE
fix(deepseek): 按模型能力放开图片输入，flash 家族不再被当成纯文本

### DIFF
--- a/crates/agent-gui/src/lib/providers/deepSeekNative.ts
+++ b/crates/agent-gui/src/lib/providers/deepSeekNative.ts
@@ -15,7 +15,7 @@ import { createParser } from "eventsource-parser";
 import { inlineDeepSeekLargePastes } from "./deepSeekAttachments";
 import { resolveMaxTokens } from "./runtime/common";
 import { clampOpenAIReasoningEffort } from "./runtime/thinkingLevels";
-import { omitToolResultImages } from "./runtime/toolResultImageFallback";
+import { omitToolResultImagesForTextOnlyModel } from "./runtime/toolResultImageFallback";
 import type { StreamOptionsEx, ToolChoice } from "./runtime/types";
 
 export const DEEPSEEK_RESPONSES_API = "deepseek-responses";
@@ -93,26 +93,6 @@ function mapToolChoice(
   if (toolChoice === "any") return "required";
   if (toolChoice === "auto" || toolChoice === "none") return toolChoice;
   return { type: "function", name: toolChoice.name };
-}
-
-/**
- * User-attached images are rejected up front: pi-ai forwards them as
- * input_image unconditionally and DeepSeek's wire never accepts them.
- *
- * Tool-result images are deliberately NOT rejected here. They originate from
- * tools (Browser screenshot, Read on an image file) rather than the user, and
- * a thrown error would fail every later turn of the conversation because the
- * tool result stays in history. They are degraded to a text notice instead
- * (see omitToolResultImages).
- */
-function assertNoUserImageInput(context: Context) {
-  for (const message of context.messages) {
-    if (message.role === "user" && Array.isArray(message.content)) {
-      if (message.content.some((block) => block.type === "image")) {
-        throw new Error("DeepSeek Responses does not support image input.");
-      }
-    }
-  }
 }
 
 function createErrorAssistant(
@@ -249,7 +229,8 @@ function buildResponsesOptions(
 
 /**
  * DeepSeek's native Responses adapter. pi-ai owns OpenAI-compatible request and
- * SSE mechanics; this boundary adds DeepSeek attachment rules and preserves
+ * SSE mechanics; this boundary adds DeepSeek attachment rules, gates image
+ * passthrough on the model's declared input modalities, and preserves
  * server-side web_search_call items for stateless multi-turn replay.
  */
 export function streamDeepSeekResponses(
@@ -261,11 +242,13 @@ export function streamDeepSeekResponses(
 
   void (async () => {
     try {
-      assertNoUserImageInput(context);
-      // Forced (not gated on model.input): the DeepSeek wire never accepts
-      // image tool results, whatever capabilities the model object declares.
-      const textOnlyContext = omitToolResultImages(context, model.id);
-      const preparedContext = await inlineDeepSeekLargePastes(textOnlyContext, options.workdir);
+      // DeepSeek 的 Responses wire 现在接受图片（官方《图像理解》指南：input_image
+      // 可出现在 user / developer 消息以及 function_call_output 的 output 中），所以
+      // 这里不再有无条件的图片硬抛——那正是 #730 之前"一张图砖掉整个会话"的成因。
+      // 图片能力一律听 model.input：纯文本模型（Pro，或被用户覆盖成 ["text"] 的中转）
+      // 仍把工具结果图片降级为说明文字。
+      const imageAwareContext = omitToolResultImagesForTextOnlyModel(context, model);
+      const preparedContext = await inlineDeepSeekLargePastes(imageAwareContext, options.workdir);
       const responseCapture: DeepSeekResponseCapture = { outputByIndex: new Map() };
       const captureTasks: Promise<void>[] = [];
       const baseFetch = options.fetch ?? globalThis.fetch;

--- a/crates/agent-gui/src/lib/providers/nativeResponsesAttachments.ts
+++ b/crates/agent-gui/src/lib/providers/nativeResponsesAttachments.ts
@@ -75,8 +75,8 @@ type GeminiNativeAttachmentCandidate = {
  * 原生内联策略（按附件 kind 分层，五家 provider 统一）：
  *
  * - image：各家都是标准 block（input_image / image_url / image / inlineData），
- *   兼容中转也认，零往返成本，保留原生内联。codex / gemini 分支沿用原有的
- *   model.input 含 "image" 门控；anthropic 分支按 modelFactory 的约定不读
+ *   兼容中转也认，零往返成本，保留原生内联。codex / deepseek / gemini 分支沿用
+ *   原有的 model.input 含 "image" 门控；anthropic 分支按 modelFactory 的约定不读
  *   model.input（见 buildAnthropicNativeAttachmentContentPart）。
  * - pdf：document / input_file / inlineData 都是各家专有结构，第三方
  *   Anthropic/OpenAI/Gemini 兼容中转普遍不认（Kimi Coding、z.ai 等直接 400
@@ -96,6 +96,11 @@ function buildNativeUploadInstruction(requestLabel: string, inputLabel: string) 
 }
 
 const NATIVE_UPLOAD_INSTRUCTION = buildNativeUploadInstruction("OpenAI Responses", "input");
+
+const DEEPSEEK_NATIVE_UPLOAD_INSTRUCTION = buildNativeUploadInstruction(
+  "DeepSeek Responses",
+  "input",
+);
 
 const OPENAI_CHAT_COMPLETIONS_NATIVE_UPLOAD_INSTRUCTION = buildNativeUploadInstruction(
   "OpenAI Chat Completions",
@@ -165,6 +170,9 @@ function supportsNativePdfInline(model: Model<Api>, baseUrl: string | undefined)
       return hostname === "api.anthropic.com";
     case "google-generative-ai":
       return hostname === "generativelanguage.googleapis.com";
+    // deepseek-responses 有意落在这里：官方《图像理解》指南只把 file / input_file
+    // 用于图片（file_id 指向 Files API 上传的图），没有承诺 PDF 的 document 结构，
+    // 所以 DeepSeek 的 PDF 一律退回 Read 抽文本。
     default:
       return false;
   }
@@ -192,12 +200,19 @@ function normalizeMimeType(value: unknown) {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 
-function isOpenAIResponsesModel(model: Model<Api>) {
-  return model.api === "openai-responses";
-}
-
 function isOpenAICompletionsModel(model: Model<Api>) {
   return model.api === "openai-completions";
+}
+
+// DeepSeek 的 Responses 端点与 OpenAI 同形：{ input_image } 内容块、图片只允许出现
+// 在 user 消息（官方《图像理解》指南）。这里刻意不 import deepSeekNative 的
+// DEEPSEEK_RESPONSES_API：本模块由 node 测试用 esbuild loader 直接加载，引
+// deepSeekNative 会把 pi-ai 的 openai-responses 子路径一并拖进来，逼所有附件测试
+// 都补 mock。字面量的一致性由 providers/deepseek-native 测试锁住。
+const DEEPSEEK_RESPONSES_API_ID = "deepseek-responses";
+
+function isResponsesApiModel(model: Model<Api>) {
+  return model.api === "openai-responses" || model.api === DEEPSEEK_RESPONSES_API_ID;
 }
 
 function isAnthropicMessagesModel(model: Model<Api>) {
@@ -381,11 +396,15 @@ function normalizeUserContent(content: unknown): unknown[] {
   return [];
 }
 
-function applyNativeUploadInstruction(content: unknown[], inlinedFiles: PendingUploadedFile[]) {
+function applyNativeUploadInstruction(
+  content: unknown[],
+  inlinedFiles: PendingUploadedFile[],
+  nativeInstruction: string = NATIVE_UPLOAD_INSTRUCTION,
+) {
   return applyTypedNativeUploadInstruction({
     content,
     type: "input_text",
-    nativeInstruction: NATIVE_UPLOAD_INSTRUCTION,
+    nativeInstruction,
     inlinedFiles,
   });
 }
@@ -717,7 +736,7 @@ async function applyNativeAttachmentsToResponsesPayload(params: {
 }) {
   const payload = params.payload;
   if (!isRecord(payload) || !Array.isArray(payload.input)) return payload;
-  if (!params.workdir.trim() || !isOpenAIResponsesModel(params.model)) return payload;
+  if (!params.workdir.trim() || !isResponsesApiModel(params.model)) return payload;
 
   const attachmentBatches = getUserMessageNativeAttachmentBatches(params.context);
   if (!attachmentBatches.some((files) => files.length > 0)) return payload;
@@ -755,6 +774,9 @@ async function applyNativeAttachmentsToResponsesPayload(params: {
         ...applyNativeUploadInstruction(
           normalizeUserContent(item.content),
           nativeContent.inlinedFiles,
+          params.model.api === DEEPSEEK_RESPONSES_API_ID
+            ? DEEPSEEK_NATIVE_UPLOAD_INSTRUCTION
+            : NATIVE_UPLOAD_INSTRUCTION,
         ),
         ...nativeContent.parts,
       ],
@@ -960,9 +982,11 @@ export function attachOpenAIResponsesNativeAttachments<
   },
 ): TOptions {
   if (
-    (params.providerId !== "codex" && params.providerId !== "xai") ||
+    (params.providerId !== "codex" &&
+      params.providerId !== "xai" &&
+      params.providerId !== "deepseek") ||
     !params.context ||
-    !isOpenAIResponsesModel(params.model) ||
+    !isResponsesApiModel(params.model) ||
     !params.workdir?.trim()
   ) {
     return options;
@@ -1120,6 +1144,7 @@ export function attachGeminiGenerativeAINativeAttachments<
 
 export const __nativeResponsesAttachmentsTest = {
   NATIVE_UPLOAD_INSTRUCTION,
+  DEEPSEEK_NATIVE_UPLOAD_INSTRUCTION,
   OPENAI_CHAT_COMPLETIONS_NATIVE_UPLOAD_INSTRUCTION,
   ANTHROPIC_NATIVE_UPLOAD_INSTRUCTION,
   GEMINI_NATIVE_UPLOAD_INSTRUCTION,

--- a/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
+++ b/crates/agent-gui/src/lib/providers/runtime/modelFactory.ts
@@ -185,6 +185,21 @@ function resolveCodexModelInput(api: CodexApi, modelId: string): Model<Api>["inp
   return ["text"];
 }
 
+/**
+ * DeepSeek 只有 Flash 家族吃图片：官方《图像理解》指南明确 deepseek-flash 支持
+ * image_url / input_image / Files API file_id 三种传法，并注明旧模型名
+ * deepseek-v4-flash-vision-exp 已下线、其请求同样由最新 Flash 承接。Pro 与更早
+ * 的模型不跟着一起放开，避免产生虚假能力声明。
+ *
+ * 中转端点若实际不吃图，用设置里的 inputModalities 覆盖成 ["text"]：用户覆盖
+ * 优先于本推断（见 createModelFromConfig 的 inputOverride）。
+ */
+function resolveDeepSeekModelInput(modelId: string): Model<Api>["input"] {
+  const normalizedModelId = modelId.trim().toLowerCase();
+  if (!normalizedModelId) return ["text"];
+  return normalizedModelId.includes("flash") ? ["text", "image"] : ["text"];
+}
+
 function isOfficialOpenAIBaseUrl(baseUrl: string | undefined) {
   if (!baseUrl?.trim()) return false;
   try {
@@ -339,9 +354,9 @@ export function createModelFromConfig(
   // 输入模态的用户显式覆盖（如给未被内置白名单识别的多模态模型开启图片
   // 输入）；缺省走各 provider 的内置推断/已知模型目录。校验逻辑与设置加载
   // 共用同一个 normalizer，不信任调用方的静态类型。
-  // 只在附件发送确实受 model.input 门控的 provider 分支生效（codex/gemini）；
-  // deepseek 的 wire 层硬拒绝图片、anthropic 附件路径暂不读 model.input，
-  // 这两处不适用用户覆盖，避免产生虚假能力声明。
+  // 只在附件发送确实受 model.input 门控的 provider 分支生效（codex/gemini/
+  // deepseek）；anthropic 附件路径暂不读 model.input，那里不适用用户覆盖，
+  // 避免产生虚假能力声明。
   const inputOverride = normalizeInputModalities(modelConfig?.inputModalities);
 
   if (providerId === "deepseek") {
@@ -354,7 +369,7 @@ export function createModelFromConfig(
         officialHost: isOfficialDeepSeekBaseUrl(upstreamBaseUrl?.trim() || baseUrl),
       }),
       ...resolveModelThinkingFields(thinking, DEEPSEEK_THINKING_WIRE_VALUES),
-      input: ["text"],
+      input: inputOverride ?? resolveDeepSeekModelInput(modelId),
       cost: zeroCost,
       contextWindow,
       maxTokens,

--- a/crates/agent-gui/test/providers/deepseek-native.test.mjs
+++ b/crates/agent-gui/test/providers/deepseek-native.test.mjs
@@ -660,17 +660,18 @@ test("DeepSeek replay state is provider-scoped and requires a web search call", 
   assert.deepEqual(normalized.input, input);
 });
 
-test("DeepSeek rejects image input before sending a request", async () => {
-  let fetchCalled = false;
+test("DeepSeek sends user image input on the wire for vision-capable models", async () => {
+  const imageBase64 = "iVBORw0KGgoAAAANSUhEUg".repeat(32);
+  const calls = [];
   const stream = deepseek.streamDeepSeekResponses(
-    createModel(),
+    createModel({ input: ["text", "image"] }),
     createContext({
       messages: [
         {
           role: "user",
           content: [
             { type: "text", text: "describe" },
-            { type: "image", data: "AAAA", mimeType: "image/png" },
+            { type: "image", data: imageBase64, mimeType: "image/png" },
           ],
           timestamp: 1,
         },
@@ -678,18 +679,69 @@ test("DeepSeek rejects image input before sending a request", async () => {
     }),
     {
       apiKey: "sk-test",
-      fetch: async () => {
-        fetchCalled = true;
-        throw new Error("fetch should not run");
+      streamRetry: { disabled: true },
+      fetch: async (_url, init) => {
+        calls.push(JSON.parse(String(init.body)));
+        return responseFromEvents(
+          completedSearchResponseEvents({ includeFunctionCall: false }).events,
+        );
       },
     },
   );
-  const { events, result } = await consume(stream);
+  const { result } = await consume(stream);
 
-  assert.equal(fetchCalled, false);
-  assert.equal(events.at(-1).type, "error");
-  assert.equal(result.stopReason, "error");
-  assert.match(result.errorMessage, /does not support image input/);
+  assert.equal(result.stopReason, "stop", result.errorMessage);
+  assert.equal(calls.length, 1);
+  const userItem = calls[0].input.find((item) => item.role === "user");
+  assert.ok(userItem, "the user message must be on the wire");
+  const parts = userItem.content;
+  assert.deepEqual(
+    parts.map((part) => part.type),
+    ["input_text", "input_image"],
+  );
+  assert.equal(parts[1].image_url, `data:image/png;base64,${imageBase64}`);
+  assert.equal(parts[1].detail, "auto");
+});
+
+test("DeepSeek degrades user image input for text-only models instead of failing the request", async () => {
+  // 曾行为：fetch 之前直接抛 "DeepSeek Responses does not support image input"，
+  // 而用户消息留在历史里，此后每一轮都会以同一原因失败。现在图片能力听
+  // model.input，纯文本模型交给 pi-ai 降级成占位文本，请求照常发出。
+  const imageBase64 = "iVBORw0KGgoAAAANSUhEUg".repeat(32);
+  const calls = [];
+  const stream = deepseek.streamDeepSeekResponses(
+    createModel({ input: ["text"] }),
+    createContext({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "describe" },
+            { type: "image", data: imageBase64, mimeType: "image/png" },
+          ],
+          timestamp: 1,
+        },
+      ],
+    }),
+    {
+      apiKey: "sk-test",
+      streamRetry: { disabled: true },
+      fetch: async (_url, init) => {
+        calls.push(JSON.parse(String(init.body)));
+        return responseFromEvents(
+          completedSearchResponseEvents({ includeFunctionCall: false }).events,
+        );
+      },
+    },
+  );
+  const { result } = await consume(stream);
+
+  assert.equal(result.stopReason, "stop", result.errorMessage);
+  assert.equal(calls.length, 1);
+  const wire = JSON.stringify(calls[0]);
+  assert.ok(!wire.includes(imageBase64), "text-only wire must not carry image bytes");
+  assert.ok(!wire.includes("input_image"), "text-only wire must not declare image parts");
+  assert.match(wire, /model does not support images/);
 });
 
 test("DeepSeek degrades image tool results to text instead of failing the request", async () => {

--- a/crates/agent-gui/test/providers/native-responses-attachments.test.mjs
+++ b/crates/agent-gui/test/providers/native-responses-attachments.test.mjs
@@ -80,6 +80,127 @@ test("OpenAI Responses native attachment adapter adds input_image and input_file
   assert.equal(result.input[0].content[2].file_data, "data:application/pdf;base64,cGRm");
 });
 
+test("DeepSeek Responses native attachment adapter inlines images only", async () => {
+  // DeepSeek 的 Responses wire 与 OpenAI 同形，官方《图像理解》指南明确
+  // input_image 只允许出现在 user 消息里，file / input_file 只用于图片（没有
+  // 承诺 PDF 的 document 结构），所以图片内联、PDF 一律退回 Read。
+  const calls = [];
+  const loader = createLoader(async (command, args) => {
+    calls.push({ command, args });
+    if (args.kind === "image") {
+      return { mimeType: "image/png", data: "aW1hZ2U=", sizeBytes: 5 };
+    }
+    return { mimeType: "application/pdf", data: "cGRm", sizeBytes: 3 };
+  });
+  const uploadedFiles = loader.loadModule("@liveagent/ui/lib/chat/uploadedFiles.ts");
+  const nativeAttachments = loader.loadModule("src/lib/providers/nativeResponsesAttachments.ts");
+
+  const message = uploadedFiles.createUserMessageWithUploads("Inspect these", [
+    {
+      relativePath: "uploads/1/screenshot.png",
+      absolutePath: "/workspace/uploads/1/screenshot.png",
+      fileName: "screenshot.png",
+      kind: "image",
+      sizeBytes: 5,
+    },
+    {
+      relativePath: "uploads/1/report.pdf",
+      absolutePath: "/workspace/uploads/1/report.pdf",
+      fileName: "report.pdf",
+      kind: "pdf",
+      sizeBytes: 3,
+    },
+  ]);
+
+  const payload = {
+    input: [
+      {
+        role: "user",
+        content: [{ type: "input_text", text: message.content }],
+      },
+    ],
+  };
+  const result = await nativeAttachments.__nativeResponsesAttachmentsTest
+    .applyNativeAttachmentsToResponsesPayload({
+      payload,
+      context: { messages: [message] },
+      model: { api: "deepseek-responses", input: ["text", "image"] },
+      workdir: "/workspace",
+      baseUrl: "https://api.deepseek.com",
+    });
+
+  assert.equal(calls.length, 1, "the pdf must stay on the Read path");
+  assert.equal(calls[0].args.kind, "image");
+  assert.equal(result.input[0].content[0].type, "input_text");
+  assert.match(result.input[0].content[0].text, /included in this DeepSeek Responses request/);
+  assert.match(result.input[0].content[0].text, /screenshot\.png \(image, 5 B\); inlined/);
+  assert.doesNotMatch(result.input[0].content[0].text, /report\.pdf \(pdf, 3 B\); inlined/);
+  assert.deepEqual(
+    result.input[0].content.slice(1).map((part) => part.type),
+    ["input_image"],
+  );
+  assert.equal(result.input[0].content[1].image_url, "data:image/png;base64,aW1hZ2U=");
+  assert.equal(result.input[0].content[1].detail, "auto");
+});
+
+test("DeepSeek Responses native attachment adapter skips images for text-only models", async () => {
+  const calls = [];
+  const loader = createLoader(async (command, args) => {
+    calls.push({ command, args });
+    return { mimeType: "image/png", data: "aW1hZ2U=", sizeBytes: 5 };
+  });
+  const uploadedFiles = loader.loadModule("@liveagent/ui/lib/chat/uploadedFiles.ts");
+  const nativeAttachments = loader.loadModule("src/lib/providers/nativeResponsesAttachments.ts");
+
+  const message = uploadedFiles.createUserMessageWithUploads("Inspect this", [
+    {
+      relativePath: "uploads/1/screenshot.png",
+      absolutePath: "/workspace/uploads/1/screenshot.png",
+      fileName: "screenshot.png",
+      kind: "image",
+      sizeBytes: 5,
+    },
+  ]);
+  const payload = {
+    input: [{ role: "user", content: [{ type: "input_text", text: message.content }] }],
+  };
+  const result = await nativeAttachments.__nativeResponsesAttachmentsTest
+    .applyNativeAttachmentsToResponsesPayload({
+      payload,
+      context: { messages: [message] },
+      model: { api: "deepseek-responses", input: ["text"] },
+      workdir: "/workspace",
+      baseUrl: "https://api.deepseek.com",
+    });
+
+  assert.equal(calls.length, 0, "a text-only model must not read image bytes");
+  assert.equal(result, payload, "an unchanged payload keeps identity");
+});
+
+test("DeepSeek Responses native attachments hook is installed only for the deepseek provider", () => {
+  const nativeAttachments = createLoader(async () => ({})).loadModule(
+    "src/lib/providers/nativeResponsesAttachments.ts",
+  );
+  const params = {
+    context: { messages: [] },
+    model: { api: "deepseek-responses", input: ["text", "image"] },
+    workdir: "/workspace",
+    baseUrl: "https://api.deepseek.com",
+  };
+
+  const installed = nativeAttachments.attachOpenAIResponsesNativeAttachments(
+    {},
+    { ...params, providerId: "deepseek" },
+  );
+  assert.equal(typeof installed.onPayload, "function");
+
+  const skipped = nativeAttachments.attachOpenAIResponsesNativeAttachments(
+    {},
+    { ...params, providerId: "claude_code" },
+  );
+  assert.equal(skipped.onPayload, undefined);
+});
+
 test("OpenAI Chat Completions native attachment adapter adds image_url blocks", async () => {
   const calls = [];
   const loader = createLoader(async (command, args) => {

--- a/crates/agent-gui/test/settings/input-modalities.test.mjs
+++ b/crates/agent-gui/test/settings/input-modalities.test.mjs
@@ -5,8 +5,8 @@ import { createTsModuleLoader } from "../helpers/load-ts-module.mjs";
 // inputModalities（模型输入模态用户覆盖）的反漂移锁：
 // 1. normalizer 的过滤/补齐/规范顺序契约；
 // 2. 设置加载往返不丢字段；
-// 3. modelFactory 只在附件发送确实受 model.input 门控的分支（codex/gemini）
-//    应用覆盖，deepseek/anthropic 不适用（避免虚假能力声明）。
+// 3. modelFactory 只在附件发送确实受 model.input 门控的分支（codex/gemini/
+//    deepseek）应用覆盖，anthropic 不适用（避免虚假能力声明）。
 const loader = createTsModuleLoader();
 const { normalizeInputModalities, normalizeProviderModelConfig, normalizeProviderModelConfigs } =
   loader.loadModule("src/lib/settings/index.ts");
@@ -105,7 +105,7 @@ test(
     assert.equal(providerSupportsModelInputModalitiesOverride("codex"), true);
     assert.equal(providerSupportsModelInputModalitiesOverride("xai"), true);
     assert.equal(providerSupportsModelInputModalitiesOverride("gemini"), true);
-    assert.equal(providerSupportsModelInputModalitiesOverride("deepseek"), false);
+    assert.equal(providerSupportsModelInputModalitiesOverride("deepseek"), true);
     assert.equal(providerSupportsModelInputModalitiesOverride("claude_code"), false);
   },
 );
@@ -137,8 +137,35 @@ test("modelFactory: gemini custom model honors the override", () => {
   assert.deepEqual(model.input, ["text"]);
 });
 
-test("modelFactory: deepseek keeps the hard text-only constraint despite the override", () => {
-  const model = createModelFromConfig(
+test("modelFactory: deepseek infers image input from the model id and honors the override", () => {
+  // 官方《图像理解》指南只承诺 flash 家族吃图，Pro 与更早的模型不跟着放开。
+  const flash = createModelFromConfig(
+    "deepseek",
+    "deepseek-v4-flash",
+    "https://api.deepseek.com",
+  );
+  assert.deepEqual(flash.input, ["text", "image"]);
+
+  const pro = createModelFromConfig("deepseek", "deepseek-v4-pro", "https://api.deepseek.com");
+  assert.deepEqual(pro.input, ["text"]);
+
+  // 中转端点不吃图时用覆盖改回纯文本（覆盖优先于 id 推断）。
+  const forcedText = createModelFromConfig(
+    "deepseek",
+    "deepseek-v4-flash",
+    "https://relay.example.com",
+    undefined,
+    {
+      id: "deepseek-v4-flash",
+      contextWindow: 128000,
+      maxOutputToken: 32000,
+      inputModalities: ["text"],
+    },
+  );
+  assert.deepEqual(forcedText.input, ["text"]);
+
+  // 反向：用户明确知道自家端点支持时，也能给 Pro 开图。
+  const forcedImage = createModelFromConfig(
     "deepseek",
     "deepseek-v4-pro",
     "https://api.deepseek.com",
@@ -150,7 +177,7 @@ test("modelFactory: deepseek keeps the hard text-only constraint despite the ove
       inputModalities: ["text", "image"],
     },
   );
-  assert.deepEqual(model.input, ["text"]);
+  assert.deepEqual(forcedImage.input, ["text", "image"]);
 });
 
 test("modelFactory: anthropic custom model does not apply the override (attachments ignore model.input upstream)", () => {

--- a/crates/agent-ui/src/pages/settings/providerUtils.ts
+++ b/crates/agent-ui/src/pages/settings/providerUtils.ts
@@ -30,7 +30,15 @@ const REDACTED_USAGE_QUERY_SECRET_DISPLAY = "••••••••";
 export type ModelInputModalitiesMode = "auto" | "text" | "text-image";
 
 export function providerSupportsModelInputModalitiesOverride(providerId: ProviderId): boolean {
-  return providerId === "codex" || providerId === "xai" || providerId === "gemini";
+  return (
+    providerId === "codex" ||
+    providerId === "xai" ||
+    providerId === "gemini" ||
+    // deepseek：Responses wire 已接受 input_image（官方《图像理解》指南），模型
+    // 能力默认按 id 推断（flash 家族吃图、Pro 纯文本），中转端点不吃图时用覆盖
+    // 改回 ["text"]。
+    providerId === "deepseek"
+  );
 }
 
 export function getModelInputModalitiesMode(model: ProviderModelConfig): ModelInputModalitiesMode {


### PR DESCRIPTION
## Linked issue

Closes #795

## Summary

DeepSeek 官方《图像理解》指南已明确 `deepseek-flash` 吃图片（base64 data URL / 外部 URL / Files API `file_id` 三种传法；`input_image` 可出现在 user / developer 消息与 `function_call_output` 的 output 中），并注明旧模型名 `deepseek-v4-flash-vision-exp` 已下线、其请求由最新 Flash 承接。但 LiveAgent 从 #502 / #554 起把 DeepSeek 一律声明成纯文本，图片被拦在三处，请求侧完全用不上这个能力。

本次把"DeepSeek 不吃图"这个过期假设收敛掉，图片能力一律交给 `model.input` 决定：

- **`modelFactory.ts`（能力声明）**：deepseek 分支原本写死 `input: ["text"]`，并显式把 DeepSeek 排除在用户 `inputModalities` 覆盖之外（注释理由是"wire 层硬拒绝图片"）。改为按模型 id 推断——flash 家族 `["text", "image"]`、Pro 与更早模型仍 `["text"]`——并让覆盖生效。官方只承诺 flash 家族，所以不跟着一起放开 Pro，避免产生新的虚假能力声明；中转端点不吃图时用覆盖改回 `["text"]`。
- **`deepSeekNative.ts`（协议层）**：删掉 `assertNoUserImageInput` 的无条件硬抛，工具结果图片从"强制降级"改为按 `model.input` 门控。硬抛正是 #730 修过的那类故障成因：一张图之后，用户消息/工具结果永久留在历史里，每一轮都在本地被同一断言拦下，会话实质报废。纯文本模型（Pro，或被覆盖成 `["text"]` 的中转）仍降级为说明文字，pi-ai 也会给不支持的图片补占位文本，两条路都不会 400。
- **`nativeResponsesAttachments.ts`（附件内联）**：原本只放行 `codex` / `xai`。放行 DeepSeek，图片附件首次请求即以 `input_image` 内联（不再先让模型去 `Read` 本地路径再等一轮），并给 DeepSeek 用专属的 upload 指令文案（"DeepSeek Responses request"，此前会误写成 OpenAI）。PDF 仍退回 Read：指南只用 `file` 描述图片，没有承诺 PDF 的 document 结构，`supportsNativePdfInline` 有意让 `deepseek-responses` 走 default 分支。
- **`providerUtils.ts`（设置页）**：`providerSupportsModelInputModalitiesOverride` 加入 deepseek，设置里可对单个 DeepSeek 模型选择"自动 / 纯文本 / 文本+图片"。

刻意没动的地方：`toolResultImageFallback.ts` 的 helper 语义不变（只是调用点改成门控版）；`deepSeekAttachments.ts` 的大段粘贴内联不变。

## Change scope

- Modules: agent-gui / providers、agent-ui / settings
- Key paths:
  - `crates/agent-gui/src/lib/providers/runtime/modelFactory.ts`
  - `crates/agent-gui/src/lib/providers/deepSeekNative.ts`
  - `crates/agent-gui/src/lib/providers/nativeResponsesAttachments.ts`
  - `crates/agent-ui/src/pages/settings/providerUtils.ts`
  - `crates/agent-gui/test/providers/deepseek-native.test.mjs`
  - `crates/agent-gui/test/providers/native-responses-attachments.test.mjs`
  - `crates/agent-gui/test/settings/input-modalities.test.mjs`

## Screenshots / preview

无 UI 像素变化，因此没有 before/after 截图：本次唯一的界面可见效果是设置里 DeepSeek 模型的"输入模态"开关从隐藏变为可见（`ProviderModal` 复用 `providerSupportsModelInputModalitiesOverride`）。治理检查会因改动命中前端路径而要求配图，处理方式沿用 #730 的先例（该 PR 同为前端路径下的纯行为改动，被 bot 转 draft 后由维护者加 `governance-exempt`）。

以下为线格式层面的修复前后对照。

**修复前 —— 工具结果图片被强制降级，模型只看到说明文字：**

```text
[1 image omitted from this tool result]
1. image/png (~20.6 KB)
The active model (deepseek-flash) does not accept image input, so the image bytes were not sent.
Do not repeat the same image-producing action expecting to see it. Rely on text output instead (for example a page snapshot or file text), or ask the user to switch to a vision-capable model.
```

**修复前 —— 用户直接上传图片则在 fetch 之前抛错，请求根本不发出：**

```text
stopReason: "error"
errorMessage: "DeepSeek Responses does not support image input."
```

**修复后 —— 同一 context 走 `streamDeepSeekResponses`（mock fetch 截获请求体），图片作为 `input_image` 到达线上：**

```json
{
  "role": "user",
  "content": [
    { "type": "input_text", "text": "describe" },
    { "type": "input_image", "detail": "auto", "image_url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg…" }
  ]
}
```

**修复后 —— 工具结果里的截图保留在 `function_call_output` 的 output 中（指南允许该位置带 `input_image`），不再需要模型换模型；纯文本模型仍降级：**

```text
model.input = ["text", "image"]  → payload 含 input_image: true，含降级说明: false
model.input = ["text"]           → payload 含 input_image: false，含 pi-ai 占位文本 "(image omitted: model does not support images)": true
```

## Verification

- `cd crates/agent-gui && pnpm test:frontend` → 3088/3088 通过（与改动前同一套全量前端用例，无回归、无快照更新）。
- `cd crates/agent-gui && pnpm build`（`tsc && vite build`）通过；`pnpm lint`（biome check src/，333 文件）无问题。
- `cd crates/agent-gui && pnpm test:release` → 9/9 通过。
- `cd crates/agent-gateway/web && pnpm build && pnpm lint && pnpm test` → 718/718 通过（`providerUtils.ts` 属共享 @liveagent/ui，WebUI 侧一并验证；本地首次跑缺 jsdom，`pnpm install --filter @liveagent/gateway-webui...` 后全绿，与本次改动无关）。
- 新增 / 更新用例：
  - `deepseek-native.test.mjs`：把原「DeepSeek rejects image input before sending a request」换成两条——视觉模型下图片以 `input_image` 上线；纯文本模型下请求照常发出、线上无图片字节、由 pi-ai 补占位文本。原「工具结果图片降级」用例保持不变并继续通过（模型 `input: ["text"]`）。
  - `native-responses-attachments.test.mjs`：DeepSeek 图片内联、PDF 留在 Read 路径（断言只读了一次附件且是 image）、纯文本模型不读图片字节且 payload 保持同一性；另加一条锁定 `providerId === "deepseek"` 才装 hook。
  - `input-modalities.test.mjs`：原「deepseek keeps the hard text-only constraint despite the override」换成 id 推断 + 覆盖双向生效（flash 默认吃图、Pro 默认纯文本、覆盖可双向改），并把 `providerSupportsModelInputModalitiesOverride("deepseek")` 断言改为 true。

**未验证的部分（需要真实 key）**：本次没有对 `api.deepseek.com` 发真实请求（本地无可用 key），上游对 `deepseek-flash` 之外 id 的视觉支持边界（如 `deepseek-v4-pro`）也没有实测。若线上表现与 id 推断不符，用设置里的输入模态覆盖即可纠正，无需改代码。

## Pre-submit checklist

- [x] A requirement issue is linked（Closes #795）
- [x] Synced with the target branch; no merge conflicts（基于 63f655d0 新建分支）
- [x] The change is focused, with no unrelated modifications（工作区里 `desktop-release.yml` 的既有本地改动未纳入本 PR）
- [x] No secrets, tokens, or personal data included
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration. —— 无仓库文档描述这些能力声明，行为与理由写在对应代码注释里。**遗留一项**：模型目录快照（`catalog.generated.ts`）里 DeepSeek 仍标 `inputModalities: ["text"]`，设置页模态徽标会继续显示纯文本；该文件由 models.dev 生成（`scripts/generate-model-catalog.mjs` + 定时工作流），等上游数据更新即可，不影响请求路径。
