### PR TITLE
fix(tools): Bash 结果显式说明被 provider 超时上限杀掉

### DIFF
--- a/crates/agent-gui/src/lib/tools/shellTools.ts
+++ b/crates/agent-gui/src/lib/tools/shellTools.ts
@@ -734,9 +734,31 @@ export function createShellTools(params: {
     stdout: string;
     stderr: string;
     shellFamily?: string;
+    /** 本次运行是否被 shell 超时杀掉（`ShellRunResponse.timed_out`）。 */
+    timedOut?: boolean;
+    /** 实际生效的超时上限（res.effective_timeout_ms，回退到请求值）。 */
+    effectiveTimeoutMs?: number;
+    /** 当前 provider 的硬上限；等于 effectiveTimeoutMs 时说明是策略上限而非请求值。 */
+    timeoutCapMs?: number;
+    providerLabel?: string;
   }) {
     const combined = [params.command, params.stdout, params.stderr].join("\n");
     const hints: string[] = [];
+
+    if (params.timedOut) {
+      // 报告里的真实困惑："同一个构建为什么连续跑了三次、日志里看不到失败原因"。
+      // 超时杀进程时，命令自己的日志文件里当然什么都没有——它被外部 SIGKILL 了。
+      // 所以这里把"被杀的原因"写成模型和人都能直接读到的一行，并说明重跑同一
+      // 条命令不会有别的结果（这一层从来没有自动重试，重复执行都是模型自己发的）。
+      const limitMs = params.effectiveTimeoutMs ?? 0;
+      const capMs = params.timeoutCapMs ?? limitMs;
+      hints.push(
+        `Hint: This run was killed by the shell timeout (${limitMs}ms) — it did not crash, and the command itself reported no error. ` +
+          `The partial output above is everything it produced before the kill. ` +
+          `${params.providerLabel ?? "This provider"} caps Bash at ${capMs}ms, so re-running the identical command unchanged reaches the same limit: ` +
+          `redirect the output to a file and poll that file, split the work into steps that finish within ${capMs}ms, or pass an explicit timeout_ms (clamped to ${capMs}ms).`,
+      );
+    }
 
     if (
       runtimePlatform === "windows" &&
@@ -1582,6 +1604,10 @@ export function createShellTools(params: {
               stdout: res.stdout || "",
               stderr: res.stderr || "",
               shellFamily: res.shell_family,
+              timedOut: Boolean(res.timed_out),
+              effectiveTimeoutMs: res.effective_timeout_ms || timeout_ms,
+              timeoutCapMs: timeoutPolicy.maxTimeoutMs,
+              providerLabel: timeoutPolicy.providerLabel,
             })
           : "";
 

--- a/crates/agent-gui/test/tools/shell-tools.test.mjs
+++ b/crates/agent-gui/test/tools/shell-tools.test.mjs
@@ -1520,3 +1520,54 @@ test("resumable Bash blocks leading sleep polling but allows short or internal s
   );
   assert.equal(calls.length, 2);
 });
+
+test("Bash tool spells out a provider-capped timeout instead of leaving the kill unexplained", async () => {
+  // 实测报告里的困惑："同一个构建连续跑了三次，前两次日志里看不到失败原因"。
+  // 这一层从来没有自动重试——重复执行都是模型自己发起的；前两次是被 provider
+  // 的 30s 上限杀掉的，而被外部杀死的命令自己的日志里当然什么都没有。所以工具
+  // 结果必须把"这是超时被杀，不是崩溃/脚本报错"写清楚，并给出可行替代做法。
+  const loader = createTsModuleLoader({
+    mocks: {
+      "@tauri-apps/api/core": {
+        async invoke(command) {
+          assert.equal(command, "shell_run");
+          return {
+            exit_code: -1,
+            shell: "bash",
+            platform: "macos",
+            profile: "posix-bash",
+            shell_family: "posix",
+            stdout: "",
+            stderr: "",
+            stdout_truncated: false,
+            stderr_truncated: false,
+            timed_out: true,
+            cancelled: false,
+            effective_timeout_ms: 30_000,
+            duration_ms: 30_123,
+          };
+        },
+      },
+    },
+  });
+
+  const { createShellTools } = loader.loadModule("src/lib/tools/shellTools.ts");
+  const bundle = createShellTools({
+    workdir: "/repo",
+    providerId: "deepseek",
+    runtimePlatform: "macos",
+  });
+
+  const result = await bundle.executeToolCall(createBashCall("make build"));
+
+  assert.equal(result.isError, true);
+  assert.equal(result.details.timed_out, true);
+  const text = result.content[0].text;
+  assert.match(text, /timed_out: true/);
+  assert.match(text, /timeout_ms: 30000/);
+  assert.match(text, /killed by the shell timeout \(30000ms\)/);
+  assert.match(text, /it did not crash/);
+  assert.match(text, /DeepSeek caps Bash at 30000ms/);
+  assert.match(text, /re-running the identical command unchanged reaches the same limit/);
+  assert.match(text, /redirect the output to a file/);
+});


### PR DESCRIPTION
## Linked issue

Closes #799

## Summary

现场：同一个构建在无人工干预下连续执行三次，前两次的日志（`/tmp/wt-build.log`、
`/tmp/wt-build2.log`）里看不到失败原因，第三次才 `Build complete`。用户无法判断这是
"工具调用超时重试"、"上层 agent 重试"还是"进程崩溃重启"。

核对结论有两条：

1. **工具层没有任何自动重试**：`executeSingleToolCall`（`agentRunner.ts`）每个工具调用
   只尝试一次，错误变成 `toolResult`。所以"连续跑三次"是模型自己发起的重复调用。
2. **前两次是被 provider 上限杀掉的**：`bashTimeoutPolicy.ts` 中
   `CODEX_BASH_MAX_TIMEOUT_MS = 30_000`，codex / gemini / xai / **deepseek** 的默认值与
   上限同为 30s（只有 claude_code 是 120s 默认 / 600s 上限），而那次构建约 34s。
   被杀的命令自己的日志文件里当然什么都没有——它是被外部杀掉，而不是自己报错。

原来这件事只以 `timed_out: true` 一行呈现，既没说明"不是崩溃"，也没说明"原样重跑会撞
同一个上限"，模型于是把同一条命令又发了一遍。

**本次改动**：`buildShellFailureHint`（`crates/agent-gui/src/lib/tools/shellTools.ts`）
在 `timed_out` 时输出一条因果说明——被 shell 超时（N ms）杀掉、不是崩溃、命令本身没有报错、
该 provider 的硬上限是多少、原样重跑会撞同一个上限，以及可行替代做法（把输出重定向到文件后
轮询 / 拆成能在上限内完成的步骤 / 显式传 `timeout_ms`）。调用点把
`timed_out` / `effective_timeout_ms` / `timeoutPolicy.maxTimeoutMs` / `providerLabel` 传进去。

**没有改动超时策略本身**：是否放宽 codex/gemini/xai/deepseek 的 30s 上限（向 Claude Code 的
120s/600s 靠拢，或按命令类别区分）属于产品取舍，已在 #799 单列为待评估项。本 PR 只保证
"这次为什么被杀"在工具结果里说得清楚。

## Change scope

- Modules: agent-gui / tools
- Key paths:
  - `crates/agent-gui/src/lib/tools/shellTools.ts`
  - `crates/agent-gui/test/tools/shell-tools.test.mjs`

## Screenshots / preview

非 UI 改动，下面是工具结果文本的前后对照（同一 mock：`timed_out: true`、
`effective_timeout_ms: 30000`、provider = DeepSeek）。

```text
修复前（关键几行）：
# Shell
...
exit_code: -1
timed_out: true
timeout_ms: 30000
duration_ms: 30123

修复后追加：
Hint: This run was killed by the shell timeout (30000ms) — it did not crash, and the
command itself reported no error. The partial output above is everything it produced
before the kill. DeepSeek caps Bash at 30000ms, so re-running the identical command
unchanged reaches the same limit: redirect the output to a file and poll that file,
split the work into steps that finish within 30000ms, or pass an explicit timeout_ms
(clamped to 30000ms).
```

## Verification

- `cd crates/agent-gui && node test/tools/shell-tools.test.mjs` → **35/35 通过**，
  含新增用例 `Bash tool spells out a provider-capped timeout instead of leaving the kill unexplained`
  （断言 `timed_out: true`、`timeout_ms: 30000`、"killed by the shell timeout (30000ms)"、
  "it did not crash"、"DeepSeek caps Bash at 30000ms"、"re-running the identical command
  unchanged reaches the same limit"、"redirect the output to a file"）。
- `cd crates/agent-gui && pnpm test:frontend` → **3095/3095 通过**。
- `pnpm build`（tsc + vite）与 `pnpm lint`（biome，333 文件）通过。

## Pre-submit checklist

- [x] A requirement issue is linked（Closes #799）
- [x] Synced with the target branch; no merge conflicts
- [x] The change is focused, with no unrelated modifications
- [x] No secrets, tokens, or personal data included
- [x] Docs are updated for changes affecting user behavior, deployment, or configuration —— 工具描述本来就写明该 provider 的默认/上限；本次补的是运行结果里的因果说明
