### PR TITLE
fix(runtime): 修掉 Windows 构建的 cfg(unix) 门控常量，解除 v1.3.5 发版阻塞

### DIFF
--- a/crates/agent-gui/src-tauri/src/runtime/process.rs
+++ b/crates/agent-gui/src-tauri/src/runtime/process.rs
@@ -217,9 +217,13 @@ pub(crate) fn probe_process_start_time(_pid: u32) -> ProcessProbe {
     ProcessProbe::Unknown
 }
 
-/// `ps -o etime=` 只有秒级精度，启动时间换算允许 ±2s 误差。超出即认为这个 pid 已
-/// 被别的进程复用，不能再对它发信号。
-#[cfg(unix)]
+/// 启动时间比对的容差：超出即认为这个 pid 已被别的进程复用，不能再对它发信号。
+///
+/// unix 侧 `ps -o etime=` 只有秒级精度，换算出来的启动时间必然有抖动，所以这里必须
+/// 留出宽容度；windows 侧 `GetProcessTimes` 直接给出创建时间，精确到 100ns，同样的
+/// 宽容度只是稍宽一点，不会漏判 pid 复用。**这个常量必须在所有平台都可见**——它被
+/// 非 `cfg` 门控的 `terminate_process_tree_by_pid_if_same` 使用，只在 unix 下定义会让
+/// windows 构建直接报 E0425（CI 的 Rust 检查只跑 Linux，发现不了）。
 const PID_START_TIME_TOLERANCE_MS: i64 = 2_000;
 
 /// 按 pid 终止进程树，但先确认这个 pid 仍是当初启动的那个进程。


### PR DESCRIPTION
Closes #803

## 为什么会有这个 PR

打 tag v1.3.5 后 `Desktop Release` 的 Windows x64 job 在 `Build Windows bundles` 失败：

```
error[E0425]: cannot find value `PID_START_TIME_TOLERANCE_MS` in this scope
   --> crates\agent-gui\src-tauri\src\runtime\process.rs:246:56
```

#801 新增的这个常量写成了 `#[cfg(unix)]`，但使用它的
`terminate_process_tree_by_pid_if_same` 是跨平台函数。macOS / Linux 编译发现不了，
CI 的 `Tauri Rust Check` 也只跑 Linux —— 于是 PR 阶段全绿，代价是一次完整的失败发版。

## 改动

只改一个文件、一行有效逻辑：常量去掉 `#[cfg(unix)]`，并把注释补成说明为什么它必须在
所有平台可见（unix 侧 `ps -o etime=` 只有秒级精度才需要 ±2s 宽容度；windows 侧
`GetProcessTimes` 给的是精确创建时间，同一份宽容度只是稍宽，不会漏判 pid 复用）。

## 验证

- **Windows 目标类型检查**：本机没有 Windows SDK，整 crate 的 `--target
  x86_64-pc-windows-msvc` 检查会死在 `aws-lc-sys` 的 C 构建；因此把 `process.rs`
  单独放进一个最小 crate 做同目标检查 —— 修复前精确复现上面那处 E0425，修复后干净
  通过（说明该文件在 Windows 目标下已无其它 cfg 遗漏）。
- `cargo check --manifest-path crates/agent-gui/src-tauri/Cargo.toml --lib`：无 warning。
- `cargo test --lib runtime::process`：3/3 通过（含 `detached_child_is_reaped_instead_of_left_defunct`）。
- **cfg 门控审计**：#801 全部改动新增引用到的 `spawn_and_reap` / `spawn_child_reaper` /
  `terminate_process_tree_by_pid_if_same` / `process_start_time_ms` 都无门控，
  `fs.rs` / `git.rs` / `launcher.rs` 的新调用点也都在各自正确的平台分支里，
  此处是唯一的遗漏点。

## 后续

CI 缺 Windows Rust 检查这件事单列在 #803（workflow 文件改动需要 `workflow` scope，
本机凭据没有，需由具备该 scope 的人加）。

## 发布动作

合并后工作区外的发版流程：把 `v1.3.5` 指到这个提交并重新触发 `Desktop Release`
与 `Gateway Docker`（v1.3.5 尚未产出任何 GitHub Release，前者失败在 Windows 构建，
后者已成功）。